### PR TITLE
fix: preserve address case for relayer SDK checksum validation

### DIFF
--- a/packages/sdk/src/__tests__/utils-normalize.test.ts
+++ b/packages/sdk/src/__tests__/utils-normalize.test.ts
@@ -2,22 +2,22 @@ import { describe, it, expect } from "vitest";
 import { normalizeAddress } from "../utils";
 
 describe("normalizeAddress", () => {
-  it("lowercases a checksummed address", () => {
+  it("preserves a checksummed address", () => {
     const checksummed = "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B";
     const result = normalizeAddress(checksummed, "test");
-    expect(result).toBe("0xab5801a7d398351b8be11c439e05c5b3259aec9b");
+    expect(result).toBe(checksummed);
   });
 
-  it("returns already-lowercase address unchanged", () => {
+  it("returns a lowercase address unchanged", () => {
     const lower = "0x1111111111111111111111111111111111111111";
     const result = normalizeAddress(lower, "test");
     expect(result).toBe(lower);
   });
 
-  it("lowercases mixed-case address", () => {
+  it("preserves mixed-case address", () => {
     const mixed = "0xABCDEF1234567890abcdef1234567890ABCDEF12";
     const result = normalizeAddress(mixed, "test");
-    expect(result).toBe("0xabcdef1234567890abcdef1234567890abcdef12");
+    expect(result).toBe(mixed);
   });
 
   it("throws for invalid address (too short)", () => {

--- a/packages/sdk/src/token/__tests__/token-new-features.test.ts
+++ b/packages/sdk/src/token/__tests__/token-new-features.test.ts
@@ -318,7 +318,7 @@ describe("Address normalization (P6)", () => {
     signer = createMockSigner();
   });
 
-  it("normalizes token address to lowercase in constructor", () => {
+  it("preserves token address case in constructor", () => {
     const token = new Token({
       sdk: sdk as unknown as RelayerSDK,
       signer,
@@ -326,10 +326,10 @@ describe("Address normalization (P6)", () => {
       address: "0xABCDEF1234567890ABCDEF1234567890ABCDEF12" as Address,
     });
 
-    expect(token.address).toBe("0xabcdef1234567890abcdef1234567890abcdef12");
+    expect(token.address).toBe("0xABCDEF1234567890ABCDEF1234567890ABCDEF12");
   });
 
-  it("normalizes wrapper address to lowercase in constructor", () => {
+  it("preserves wrapper address case in constructor", () => {
     const token = new Token({
       sdk: sdk as unknown as RelayerSDK,
       signer,
@@ -338,7 +338,7 @@ describe("Address normalization (P6)", () => {
       wrapper: "0xABCDEF1234567890ABCDEF1234567890ABCDEF12" as Address,
     });
 
-    expect(token.wrapper).toBe("0xabcdef1234567890abcdef1234567890abcdef12");
+    expect(token.wrapper).toBe("0xABCDEF1234567890ABCDEF1234567890ABCDEF12");
   });
 
   it("defaults wrapper to normalized address when not provided", () => {

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -17,12 +17,16 @@ export function assertAddress(value: string, name: string): asserts value is Add
 }
 
 /**
- * Validate and lowercase an address for consistent comparison.
- * Call at public API entry points so internal code can rely on lowercase addresses.
+ * Validate an address and return it unchanged.
+ * Call at public API entry points so invalid addresses are caught early.
+ *
+ * Addresses are **not** lowercased — the relayer SDK requires EIP-55
+ * checksummed addresses for encrypt / decrypt calls.
+ * Use case-insensitive comparison (`.toLowerCase()`) when comparing addresses.
  */
 export function normalizeAddress(addr: string, name: string): Address {
   assertAddress(addr, name);
-  return addr.toLowerCase() as Address;
+  return addr as Address;
 }
 
 export function assertObject(


### PR DESCRIPTION
## Summary
- `normalizeAddress()` was lowercasing addresses, which broke the relayer SDK's EIP-55 checksum validation in `createEncryptedInput()`
- The relayer SDK (`@zama-fhe/relayer-sdk` v0.4.1) uses ethers' `getAddress()` for strict checksummed comparison — lowercased addresses always fail
- Changed `normalizeAddress()` to validate format only, preserving the original case so checksummed addresses from wallets/libraries flow through correctly

## Test plan
- [x] All 733 existing tests pass
- [x] Updated `utils-normalize.test.ts` to expect preserved case
- [x] Updated `token-new-features.test.ts` address normalization tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)