### PR TITLE
refactor: remove lock/unlock/isUnlocked API

### DIFF
--- a/packages/sdk/src/token/__tests__/credentials-manager.test.ts
+++ b/packages/sdk/src/token/__tests__/credentials-manager.test.ts
@@ -357,14 +357,21 @@ describe("CredentialsManager", () => {
       await store.setItem(storeKey, "corrupted-json{{{");
       expect(await manager.isExpired()).toBe(false);
     });
+
+    it("works without session signature (checks timestamp only)", async () => {
+      await manager.get("0xtoken" as Address);
+
+      // Should still report not expired without needing the signature
+      expect(await manager.isExpired()).toBe(false);
+    });
   });
 
-  it("clear() also clears the session signature", async () => {
+  it("clear() also clears the session signature and storage", async () => {
     await manager.get("0xtoken" as Address);
 
     await manager.clear();
 
-    // Storage should also be empty
+    // Storage should be empty
     const stored = await store.getItem(storeKey);
     expect(stored).toBeNull();
   });


### PR DESCRIPTION
## Summary
- Remove `lock()`, `unlock()`, and `isUnlocked()` methods from `CredentialsManager`
- Remove associated `CredentialsLocked` / `CredentialsUnlocked` events from SDK events
- Remove related tests and clean up test references

## Test plan
- [x] Typecheck passes
- [x] Removed tests for deleted methods
- [x] Updated existing tests that referenced removed methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)