### PR TITLE
feat(react-sdk): auto-persist pending unshield state in hooks

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -11,6 +11,8 @@ jobs:
   delete-caches:
     name: "Delete Actions caches"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: "Wipe Github Actions cache"

--- a/examples/react-ethers/src/global.d.ts
+++ b/examples/react-ethers/src/global.d.ts
@@ -1,7 +1,5 @@
+import type { Eip1193Provider } from "ethers";
+
 interface Window {
-  ethereum?: {
-    request(args: { method: string; params?: unknown[] }): Promise<unknown>;
-    on(event: string, handler: (...args: unknown[]) => void): void;
-    removeListener(event: string, handler: (...args: unknown[]) => void): void;
-  };
+  ethereum?: Eip1193Provider;
 }

--- a/examples/react-ethers/src/providers.tsx
+++ b/examples/react-ethers/src/providers.tsx
@@ -3,33 +3,45 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RelayerWeb, ZamaProvider, indexedDBStorage } from "@zama-fhe/react-sdk";
 import { EthersSigner } from "@zama-fhe/react-sdk/ethers";
-import { BrowserProvider } from "ethers";
-import type { ReactNode } from "react";
+import { Eip1193Provider } from "ethers";
+import { type ReactNode, useEffect, useMemo } from "react";
+
+declare global {
+  interface Window {
+    ethereum: Eip1193Provider;
+  }
+}
 
 const MAINNET_RPC_URL = process.env.NEXT_PUBLIC_MAINNET_RPC_URL!;
 const SEPOLIA_RPC_URL = process.env.NEXT_PUBLIC_SEPOLIA_RPC_URL!;
 
-const provider = new BrowserProvider(window.ethereum!);
-
-const signer = new EthersSigner({ signer: provider });
-
-const relayer = new RelayerWeb({
-  getChainId: () => signer.getChainId(),
-  transports: {
-    [1]: {
-      network: MAINNET_RPC_URL,
-      relayerUrl: "http://localhost:3000/api/relayer",
-    },
-    [11155111]: {
-      network: SEPOLIA_RPC_URL,
-      relayerUrl: "http://localhost:3000/api/relayer",
-    },
-  },
-});
-
 const queryClient = new QueryClient();
 
 export function Providers({ children }: { children: ReactNode }) {
+  const signer = useMemo(() => new EthersSigner({ ethereum: window.ethereum }), []);
+  const relayer = useMemo(
+    () =>
+      new RelayerWeb({
+        getChainId: () => signer.getChainId(),
+        transports: {
+          [1]: {
+            network: MAINNET_RPC_URL,
+            relayerUrl: "http://localhost:3000/api/relayer",
+          },
+          [11155111]: {
+            network: SEPOLIA_RPC_URL,
+            relayerUrl: "http://localhost:3000/api/relayer",
+          },
+        },
+      }),
+    [],
+  );
+
+  useEffect(() => {
+    const unsubscribe = signer.subscribe(() => queryClient.invalidateQueries());
+    return () => unsubscribe();
+  }, [signer]);
+
   return (
     <QueryClientProvider client={queryClient}>
       <ZamaProvider relayer={relayer} storage={indexedDBStorage} signer={signer}>

--- a/examples/react-viem/src/global.d.ts
+++ b/examples/react-viem/src/global.d.ts
@@ -1,7 +1,5 @@
+import type { EIP1193Provider } from "viem";
+
 interface Window {
-  ethereum?: {
-    request(args: { method: string; params?: unknown[] }): Promise<unknown>;
-    on(event: string, handler: (...args: unknown[]) => void): void;
-    removeListener(event: string, handler: (...args: unknown[]) => void): void;
-  };
+  ethereum?: EIP1193Provider;
 }

--- a/examples/react-viem/src/providers.tsx
+++ b/examples/react-viem/src/providers.tsx
@@ -3,42 +3,59 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RelayerWeb, ZamaProvider, indexedDBStorage } from "@zama-fhe/react-sdk";
 import { ViemSigner } from "@zama-fhe/react-sdk/viem";
-import type { ReactNode } from "react";
-import { createPublicClient, createWalletClient, custom, http } from "viem";
+import { type ReactNode, useEffect, useMemo } from "react";
+import { createPublicClient, EIP1193Provider, http } from "viem";
 import { mainnet, sepolia } from "viem/chains";
+
+declare global {
+  interface Window {
+    ethereum: EIP1193Provider;
+  }
+}
 
 const MAINNET_RPC_URL = process.env.NEXT_PUBLIC_MAINNET_RPC_URL!;
 const SEPOLIA_RPC_URL = process.env.NEXT_PUBLIC_SEPOLIA_RPC_URL!;
-
-export const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
 
 export const publicClient = createPublicClient({
   chain: sepolia,
   transport: http(SEPOLIA_RPC_URL),
 });
 
-const signer = new ViemSigner({ walletClient, publicClient });
-
-const relayer = new RelayerWeb({
-  getChainId: () => walletClient.getChainId(),
-  transports: {
-    [mainnet.id]: {
-      network: MAINNET_RPC_URL,
-      relayerUrl: "http://localhost:3000/api/relayer",
-    },
-    [sepolia.id]: {
-      network: SEPOLIA_RPC_URL,
-      relayerUrl: "http://localhost:3000/api/relayer",
-    },
-  },
-});
-
 const queryClient = new QueryClient();
 
 export function Providers({ children }: { children: ReactNode }) {
+  const signer = useMemo(
+    () =>
+      new ViemSigner({
+        ethereum: window.ethereum,
+        chain: sepolia,
+        rpcUrl: SEPOLIA_RPC_URL,
+      }),
+    [],
+  );
+  const relayer = useMemo(
+    () =>
+      new RelayerWeb({
+        getChainId: () => signer.getChainId(),
+        transports: {
+          [mainnet.id]: {
+            network: MAINNET_RPC_URL,
+            relayerUrl: "http://localhost:3000/api/relayer",
+          },
+          [sepolia.id]: {
+            network: SEPOLIA_RPC_URL,
+            relayerUrl: "http://localhost:3000/api/relayer",
+          },
+        },
+      }),
+    [],
+  );
+
+  useEffect(() => {
+    const unsubscribe = signer.subscribe(() => queryClient.invalidateQueries());
+    return () => unsubscribe();
+  }, [signer]);
+
   return (
     <QueryClientProvider client={queryClient}>
       <ZamaProvider relayer={relayer} storage={indexedDBStorage} signer={signer}>

--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -98,6 +98,7 @@ import { NetworkType } from '@zama-fhe/sdk';
 import { NoCiphertextError } from '@zama-fhe/sdk';
 import { OnChainEvent } from '@zama-fhe/sdk';
 import { parseActivityFeed } from '@zama-fhe/sdk';
+import { PendingUnshieldScope } from '@zama-fhe/sdk';
 import { PropsWithChildren } from 'react';
 import { PublicDecryptResult } from '@zama-fhe/sdk';
 import { rateContract } from '@zama-fhe/sdk';
@@ -543,6 +544,8 @@ export { NoCiphertextError }
 export { OnChainEvent }
 
 export { parseActivityFeed }
+
+export { PendingUnshieldScope }
 
 export { PublicDecryptResult }
 

--- a/packages/react-sdk/src/__tests__/unshield-storage.test.ts
+++ b/packages/react-sdk/src/__tests__/unshield-storage.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import type { GenericStringStorage, Hex, PendingUnshieldScope } from "@zama-fhe/sdk";
+import { wrapUnshieldCallbacks } from "../token/unshield-storage";
+import { createMockStorage } from "./test-utils";
+
+const SCOPE: PendingUnshieldScope = {
+  accountAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  chainId: 31337,
+  wrapperAddress: "0x1111111111111111111111111111111111111111",
+};
+const TX_HASH = "0xdeadbeef" as Hex;
+
+describe("wrapUnshieldCallbacks", () => {
+  it("saves pending unshield on onUnwrapSubmitted", async () => {
+    const storage = createMockStorage();
+    const wrapped = wrapUnshieldCallbacks(storage, SCOPE);
+
+    wrapped.onUnwrapSubmitted!(TX_HASH);
+
+    // Fire-and-forget — flush microtasks so the storage promise settles
+    await vi.waitFor(() => {
+      expect(storage.setItem).toHaveBeenCalledWith(
+        expect.stringContaining(SCOPE.wrapperAddress.toLowerCase()),
+        TX_HASH,
+      );
+    });
+  });
+
+  it("storage key includes account and chainId", async () => {
+    const storage = createMockStorage();
+    const wrapped = wrapUnshieldCallbacks(storage, SCOPE);
+
+    wrapped.onUnwrapSubmitted!(TX_HASH);
+
+    await vi.waitFor(() => {
+      const call = vi.mocked(storage.setItem).mock.calls[0]!;
+      const key = call[0];
+      expect(key).toContain(SCOPE.accountAddress.toLowerCase());
+      expect(key).toContain(String(SCOPE.chainId));
+      expect(key).toContain(SCOPE.wrapperAddress.toLowerCase());
+    });
+  });
+
+  it("clears pending unshield on onFinalizeSubmitted", async () => {
+    const storage = createMockStorage();
+    const wrapped = wrapUnshieldCallbacks(storage, SCOPE);
+
+    wrapped.onFinalizeSubmitted!(TX_HASH);
+
+    await vi.waitFor(() => {
+      expect(storage.removeItem).toHaveBeenCalledWith(
+        expect.stringContaining(SCOPE.wrapperAddress.toLowerCase()),
+      );
+    });
+  });
+
+  it("forwards callbacks to user-provided handlers", () => {
+    const storage = createMockStorage();
+    const userCallbacks = {
+      onUnwrapSubmitted: vi.fn(),
+      onFinalizing: vi.fn(),
+      onFinalizeSubmitted: vi.fn(),
+    };
+    const wrapped = wrapUnshieldCallbacks(storage, SCOPE, userCallbacks);
+
+    wrapped.onUnwrapSubmitted!(TX_HASH);
+    wrapped.onFinalizing!();
+    wrapped.onFinalizeSubmitted!(TX_HASH);
+
+    expect(userCallbacks.onUnwrapSubmitted).toHaveBeenCalledWith(TX_HASH);
+    expect(userCallbacks.onFinalizing).toHaveBeenCalled();
+    expect(userCallbacks.onFinalizeSubmitted).toHaveBeenCalledWith(TX_HASH);
+  });
+
+  it("does not throw when storage rejects", () => {
+    const storage: GenericStringStorage = {
+      getItem: vi.fn().mockRejectedValue(new Error("storage down")),
+      setItem: vi.fn().mockRejectedValue(new Error("storage down")),
+      removeItem: vi.fn().mockRejectedValue(new Error("storage down")),
+    };
+    const wrapped = wrapUnshieldCallbacks(storage, SCOPE);
+
+    // Should not throw — rejections are caught internally
+    expect(() => wrapped.onUnwrapSubmitted!(TX_HASH)).not.toThrow();
+    expect(() => wrapped.onFinalizeSubmitted!(TX_HASH)).not.toThrow();
+  });
+});

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -105,6 +105,7 @@ export type {
 
 // Re-export pending-unshield persistence utilities
 export { savePendingUnshield, loadPendingUnshield, clearPendingUnshield } from "@zama-fhe/sdk";
+export type { PendingUnshieldScope } from "@zama-fhe/sdk";
 
 // Re-export event constants
 export { ZamaSDKEvents } from "@zama-fhe/sdk";

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -9,6 +9,7 @@
 
 // Provider
 export { ZamaProvider, useZamaSDK } from "./provider";
+export type { ZamaProviderProps } from "./provider";
 
 // SDK method hooks
 export { useEncrypt, encryptMutationOptions } from "./relayer/use-encrypt";
@@ -349,7 +350,11 @@ export type {
   ContractCallConfig,
   TransactionReceipt,
   TransactionResult,
+  SignerChangeEvent,
+  ReactiveSignerMixin,
+  ReactiveSigner,
 } from "@zama-fhe/sdk";
+export { isReactiveSigner } from "@zama-fhe/sdk";
 export {
   ZamaError,
   ZamaErrorCode,

--- a/packages/react-sdk/src/provider.tsx
+++ b/packages/react-sdk/src/provider.tsx
@@ -10,7 +10,7 @@ import { ZamaSDK } from "@zama-fhe/sdk";
 import { createContext, type PropsWithChildren, useContext, useEffect, useMemo } from "react";
 
 /** Props for {@link ZamaProvider}. */
-interface ZamaProviderProps extends PropsWithChildren {
+export interface ZamaProviderProps extends PropsWithChildren {
   /** FHE relayer backend (RelayerWeb for browser, RelayerNode for server). */
   relayer: RelayerSDK;
   /** Wallet signer (ViemSigner, EthersSigner, or custom GenericSigner). */

--- a/packages/react-sdk/src/token/unshield-storage.ts
+++ b/packages/react-sdk/src/token/unshield-storage.ts
@@ -1,0 +1,24 @@
+import type { GenericStringStorage, UnshieldCallbacks, Address, Hex } from "@zama-fhe/sdk";
+import { savePendingUnshield, clearPendingUnshield } from "@zama-fhe/sdk";
+
+/**
+ * Wrap user-provided unshield callbacks to automatically persist/clear
+ * the pending unshield state in storage.
+ */
+export function wrapUnshieldCallbacks(
+  storage: GenericStringStorage,
+  wrapperAddress: Address,
+  callbacks?: UnshieldCallbacks,
+): UnshieldCallbacks {
+  return {
+    onUnwrapSubmitted: async (txHash: Hex) => {
+      await savePendingUnshield(storage, wrapperAddress, txHash);
+      callbacks?.onUnwrapSubmitted?.(txHash);
+    },
+    onFinalizing: () => callbacks?.onFinalizing?.(),
+    onFinalizeSubmitted: async (txHash: Hex) => {
+      await clearPendingUnshield(storage, wrapperAddress);
+      callbacks?.onFinalizeSubmitted?.(txHash);
+    },
+  };
+}

--- a/packages/react-sdk/src/token/unshield-storage.ts
+++ b/packages/react-sdk/src/token/unshield-storage.ts
@@ -1,23 +1,32 @@
-import type { GenericStringStorage, UnshieldCallbacks, Address, Hex } from "@zama-fhe/sdk";
+import type {
+  GenericStringStorage,
+  UnshieldCallbacks,
+  Hex,
+  PendingUnshieldScope,
+} from "@zama-fhe/sdk";
 import { savePendingUnshield, clearPendingUnshield } from "@zama-fhe/sdk";
 
 /**
  * Wrap user-provided unshield callbacks to automatically persist/clear
  * the pending unshield state in storage.
+ *
+ * Callbacks are kept synchronous (matching {@link UnshieldCallbacks} types)
+ * so they work correctly with the core SDK's `safeCallback` wrapper.
+ * Storage operations are fire-and-forget with caught rejections.
  */
 export function wrapUnshieldCallbacks(
   storage: GenericStringStorage,
-  wrapperAddress: Address,
+  scope: PendingUnshieldScope,
   callbacks?: UnshieldCallbacks,
 ): UnshieldCallbacks {
   return {
-    onUnwrapSubmitted: async (txHash: Hex) => {
-      await savePendingUnshield(storage, wrapperAddress, txHash);
+    onUnwrapSubmitted: (txHash: Hex) => {
+      savePendingUnshield(storage, scope, txHash).catch(() => {});
       callbacks?.onUnwrapSubmitted?.(txHash);
     },
     onFinalizing: () => callbacks?.onFinalizing?.(),
-    onFinalizeSubmitted: async (txHash: Hex) => {
-      await clearPendingUnshield(storage, wrapperAddress);
+    onFinalizeSubmitted: (txHash: Hex) => {
+      clearPendingUnshield(storage, scope).catch(() => {});
       callbacks?.onFinalizeSubmitted?.(txHash);
     },
   };

--- a/packages/react-sdk/src/token/use-resume-unshield.ts
+++ b/packages/react-sdk/src/token/use-resume-unshield.ts
@@ -70,7 +70,11 @@ export function useResumeUnshield(
     mutationFn: ({ unwrapTxHash, callbacks }) => token.resumeUnshield(unwrapTxHash, callbacks),
     ...options,
     onSuccess: async (data, variables, onMutateResult, context) => {
-      await clearPendingUnshield(sdk.storage, wrapperAddress);
+      const [accountAddress, chainId] = await Promise.all([
+        sdk.signer.getAddress(),
+        sdk.signer.getChainId(),
+      ]);
+      await clearPendingUnshield(sdk.storage, { accountAddress, chainId, wrapperAddress });
       context.client.invalidateQueries({
         queryKey: confidentialHandleQueryKeys.token(config.tokenAddress),
       });

--- a/packages/react-sdk/src/token/use-resume-unshield.ts
+++ b/packages/react-sdk/src/token/use-resume-unshield.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, UseMutationOptions } from "@tanstack/react-query";
 import type { Address, Hex, TransactionResult, UnshieldCallbacks, Token } from "@zama-fhe/sdk";
+import { clearPendingUnshield } from "@zama-fhe/sdk";
 import {
   confidentialBalanceQueryKeys,
   confidentialBalancesQueryKeys,
@@ -11,6 +12,7 @@ import {
 } from "./balance-query-keys";
 import { underlyingAllowanceQueryKeys } from "./use-underlying-allowance";
 import { useToken, type UseZamaConfig } from "./use-token";
+import { useZamaSDK } from "../provider";
 
 /** Parameters passed to the `mutate` function of {@link useResumeUnshield}. */
 export interface ResumeUnshieldParams {
@@ -39,6 +41,9 @@ export function resumeUnshieldMutationOptions(token: Token) {
  * Useful when the user submitted the unwrap but the finalize step was
  * interrupted (e.g. page reload, network error).
  *
+ * Automatically clears the pending unshield state from storage on
+ * successful finalization.
+ *
  * Errors are {@link ZamaError} subclasses — use `instanceof` to handle specific failures:
  * - {@link DecryptionFailedError} — public decryption failed during finalize
  * - {@link TransactionRevertedError} — on-chain transaction reverted
@@ -57,10 +62,16 @@ export function useResumeUnshield(
   options?: UseMutationOptions<TransactionResult, Error, ResumeUnshieldParams, Address>,
 ) {
   const token = useToken(config);
+  const sdk = useZamaSDK();
+  const wrapperAddress = config.wrapperAddress ?? config.tokenAddress;
 
   return useMutation<TransactionResult, Error, ResumeUnshieldParams, Address>({
     mutationKey: ["resumeUnshield", config.tokenAddress],
-    mutationFn: ({ unwrapTxHash, callbacks }) => token.resumeUnshield(unwrapTxHash, callbacks),
+    mutationFn: async ({ unwrapTxHash, callbacks }) => {
+      const result = await token.resumeUnshield(unwrapTxHash, callbacks);
+      await clearPendingUnshield(sdk.storage, wrapperAddress);
+      return result;
+    },
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       context.client.invalidateQueries({

--- a/packages/react-sdk/src/token/use-resume-unshield.ts
+++ b/packages/react-sdk/src/token/use-resume-unshield.ts
@@ -67,13 +67,10 @@ export function useResumeUnshield(
 
   return useMutation<TransactionResult, Error, ResumeUnshieldParams, Address>({
     mutationKey: ["resumeUnshield", config.tokenAddress],
-    mutationFn: async ({ unwrapTxHash, callbacks }) => {
-      const result = await token.resumeUnshield(unwrapTxHash, callbacks);
-      await clearPendingUnshield(sdk.storage, wrapperAddress);
-      return result;
-    },
+    mutationFn: ({ unwrapTxHash, callbacks }) => token.resumeUnshield(unwrapTxHash, callbacks),
     ...options,
-    onSuccess: (data, variables, onMutateResult, context) => {
+    onSuccess: async (data, variables, onMutateResult, context) => {
+      await clearPendingUnshield(sdk.storage, wrapperAddress);
       context.client.invalidateQueries({
         queryKey: confidentialHandleQueryKeys.token(config.tokenAddress),
       });

--- a/packages/react-sdk/src/token/use-unshield-all.ts
+++ b/packages/react-sdk/src/token/use-unshield-all.ts
@@ -60,8 +60,14 @@ export function useUnshieldAll(
 
   return useMutation<TransactionResult, Error, UnshieldAllParams | void, Address>({
     mutationKey: ["unshieldAll", config.tokenAddress],
-    mutationFn: (params) =>
-      token.unshieldAll(wrapUnshieldCallbacks(sdk.storage, wrapperAddress, params?.callbacks)),
+    mutationFn: async (params) => {
+      const [accountAddress, chainId] = await Promise.all([
+        sdk.signer.getAddress(),
+        sdk.signer.getChainId(),
+      ]);
+      const scope = { accountAddress, chainId, wrapperAddress };
+      return token.unshieldAll(wrapUnshieldCallbacks(sdk.storage, scope, params?.callbacks));
+    },
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       context.client.invalidateQueries({

--- a/packages/react-sdk/src/token/use-unshield-all.ts
+++ b/packages/react-sdk/src/token/use-unshield-all.ts
@@ -11,6 +11,8 @@ import {
 } from "./balance-query-keys";
 import { underlyingAllowanceQueryKeys } from "./use-underlying-allowance";
 import { useToken, type UseZamaConfig } from "./use-token";
+import { useZamaSDK } from "../provider";
+import { wrapUnshieldCallbacks } from "./unshield-storage";
 
 /**
  * TanStack Query mutation options factory for unshield-all.
@@ -35,6 +37,10 @@ export function unshieldAllMutationOptions(token: Token) {
  * Unshield the entire balance and finalize in one call.
  * Orchestrates: unwrapAll → wait for receipt → parse event → finalize.
  *
+ * Automatically persists the unwrap tx hash to storage so the unshield can
+ * be resumed after interruptions (e.g. page reload). The pending state is
+ * cleared on successful finalization.
+ *
  * @param config - Token and wrapper addresses.
  * @param options - React Query mutation options.
  *
@@ -49,10 +55,13 @@ export function useUnshieldAll(
   options?: UseMutationOptions<TransactionResult, Error, UnshieldAllParams | void, Address>,
 ) {
   const token = useToken(config);
+  const sdk = useZamaSDK();
+  const wrapperAddress = config.wrapperAddress ?? config.tokenAddress;
 
   return useMutation<TransactionResult, Error, UnshieldAllParams | void, Address>({
     mutationKey: ["unshieldAll", config.tokenAddress],
-    mutationFn: (params) => token.unshieldAll(params?.callbacks),
+    mutationFn: (params) =>
+      token.unshieldAll(wrapUnshieldCallbacks(sdk.storage, wrapperAddress, params?.callbacks)),
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       context.client.invalidateQueries({

--- a/packages/react-sdk/src/token/use-unshield.ts
+++ b/packages/react-sdk/src/token/use-unshield.ts
@@ -11,6 +11,8 @@ import {
 } from "./balance-query-keys";
 import { underlyingAllowanceQueryKeys } from "./use-underlying-allowance";
 import { useToken, type UseZamaConfig } from "./use-token";
+import { useZamaSDK } from "../provider";
+import { wrapUnshieldCallbacks } from "./unshield-storage";
 
 /** Parameters passed to the `mutate` function of {@link useUnshield}. */
 export interface UnshieldParams {
@@ -37,6 +39,10 @@ export function unshieldMutationOptions(token: Token) {
  * Unshield a specific amount and finalize in one call.
  * Orchestrates: unwrap → wait for receipt → parse event → finalize.
  *
+ * Automatically persists the unwrap tx hash to storage so the unshield can
+ * be resumed after interruptions (e.g. page reload). The pending state is
+ * cleared on successful finalization.
+ *
  * Errors are {@link ZamaError} subclasses — use `instanceof` to handle specific failures:
  * - {@link SigningRejectedError} — user rejected the wallet prompt
  * - {@link EncryptionFailedError} — FHE encryption failed during unwrap
@@ -57,10 +63,13 @@ export function useUnshield(
   options?: UseMutationOptions<TransactionResult, Error, UnshieldParams, Address>,
 ) {
   const token = useToken(config);
+  const sdk = useZamaSDK();
+  const wrapperAddress = config.wrapperAddress ?? config.tokenAddress;
 
   return useMutation<TransactionResult, Error, UnshieldParams, Address>({
     mutationKey: ["unshield", config.tokenAddress],
-    mutationFn: ({ amount, callbacks }) => token.unshield(amount, callbacks),
+    mutationFn: ({ amount, callbacks }) =>
+      token.unshield(amount, wrapUnshieldCallbacks(sdk.storage, wrapperAddress, callbacks)),
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       context.client.invalidateQueries({

--- a/packages/react-sdk/src/token/use-unshield.ts
+++ b/packages/react-sdk/src/token/use-unshield.ts
@@ -68,8 +68,14 @@ export function useUnshield(
 
   return useMutation<TransactionResult, Error, UnshieldParams, Address>({
     mutationKey: ["unshield", config.tokenAddress],
-    mutationFn: ({ amount, callbacks }) =>
-      token.unshield(amount, wrapUnshieldCallbacks(sdk.storage, wrapperAddress, callbacks)),
+    mutationFn: async ({ amount, callbacks }) => {
+      const [accountAddress, chainId] = await Promise.all([
+        sdk.signer.getAddress(),
+        sdk.signer.getChainId(),
+      ]);
+      const scope = { accountAddress, chainId, wrapperAddress };
+      return token.unshield(amount, wrapUnshieldCallbacks(sdk.storage, scope, callbacks));
+    },
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       context.client.invalidateQueries({

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -1075,7 +1075,7 @@ export interface BatchTransferData {
 }
 
 // @public
-export function clearPendingUnshield(storage: GenericStringStorage, wrapperAddress: Address): Promise<void>;
+export function clearPendingUnshield(storage: GenericStringStorage, scope: PendingUnshieldScope): Promise<void>;
 
 // @public
 export function confidentialBalanceOfContract(tokenAddress: Address, userAddress: Address): {
@@ -17678,7 +17678,7 @@ export function isOperatorContract(tokenAddress: Address, holder: Address, spend
 export { KmsDelegatedUserDecryptEIP712Type }
 
 // @public
-export function loadPendingUnshield(storage: GenericStringStorage, wrapperAddress: Address): Promise<Hex | null>;
+export function loadPendingUnshield(storage: GenericStringStorage, scope: PendingUnshieldScope): Promise<Hex | null>;
 
 // @public
 export const MainnetConfig: FhevmInstanceConfig;
@@ -17749,6 +17749,13 @@ export type OnChainEvent = ConfidentialTransferEvent | WrappedEvent | UnwrapRequ
 
 // @public
 export function parseActivityFeed(logs: readonly (RawLog & Partial<ActivityLogMetadata>)[], userAddress: string): ActivityItem[];
+
+// @public
+export interface PendingUnshieldScope {
+    accountAddress: Address;
+    chainId: number;
+    wrapperAddress: Address;
+}
 
 // @public
 export interface PublicDecryptResult {
@@ -19346,7 +19353,7 @@ export interface RelayerWebConfig {
 }
 
 // @public
-export function savePendingUnshield(storage: GenericStringStorage, wrapperAddress: Address, unwrapTxHash: Hex): Promise<void>;
+export function savePendingUnshield(storage: GenericStringStorage, scope: PendingUnshieldScope, unwrapTxHash: Hex): Promise<void>;
 
 // @public
 export const SepoliaConfig: FhevmInstanceConfig;

--- a/packages/sdk/src/ethers/__tests__/ethers-reactive.test.ts
+++ b/packages/sdk/src/ethers/__tests__/ethers-reactive.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SignerChangeEvent } from "../../token/token.types";
+import { isReactiveSigner } from "../../token/token.types";
+import type { EthersEIP1193SignerConfig } from "../ethers-signer";
+
+// ── Mock EIP-1193 provider with event emitter ───────────
+
+type Handler = (...args: unknown[]) => void;
+
+type MockEIP1193 = EthersEIP1193SignerConfig["ethereum"] & {
+  emit: (event: string, ...args: unknown[]) => void;
+};
+
+function createMockEIP1193(): MockEIP1193 {
+  const handlers = new Map<string, Set<Handler>>();
+
+  return {
+    request: vi.fn().mockResolvedValue(null) as MockEIP1193["request"],
+    on(event: string, handler: Handler) {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event)!.add(handler);
+    },
+    removeListener(event: string, handler: Handler) {
+      handlers.get(event)?.delete(handler);
+    },
+    emit(event: string, ...args: unknown[]) {
+      for (const handler of handlers.get(event) ?? []) handler(...args);
+    },
+  };
+}
+
+// ── Mock ethers ─────────────────────────────────────────
+
+const { mockGetAddress, mockGetSigner } = vi.hoisted(() => {
+  const mockGetAddress = vi.fn().mockResolvedValue("0xAddress");
+  const mockGetNetwork = vi.fn().mockResolvedValue({ chainId: 11155111n });
+  const mockGetSigner = vi.fn().mockResolvedValue({
+    getAddress: mockGetAddress,
+    provider: { getNetwork: mockGetNetwork, waitForTransaction: vi.fn() },
+    signTypedData: vi.fn().mockResolvedValue("0xsig"),
+  });
+  return { mockGetAddress, mockGetSigner };
+});
+
+function MockBrowserProvider() {
+  return { getSigner: mockGetSigner };
+}
+
+vi.mock("ethers", () => ({
+  ethers: {
+    Contract: vi.fn(),
+    BrowserProvider: MockBrowserProvider,
+  },
+  BrowserProvider: MockBrowserProvider,
+}));
+
+// ── Import after mock ───────────────────────────────────
+
+import { EthersSigner } from "../ethers-signer";
+
+// ── Tests ───────────────────────────────────────────────
+
+describe("EthersSigner (EIP-1193 reactive mode)", () => {
+  let ethereum: ReturnType<typeof createMockEIP1193>;
+  let signer: EthersSigner;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ethereum = createMockEIP1193();
+    signer = new EthersSigner({ ethereum });
+  });
+
+  it("isReactiveSigner returns true for EIP-1193 signer", () => {
+    expect(isReactiveSigner(signer)).toBe(true);
+  });
+
+  it("subscribe fires on accountsChanged", () => {
+    const listener = vi.fn();
+    signer.subscribe(listener);
+
+    ethereum.emit("accountsChanged", ["0xNewAddr"]);
+
+    expect(listener).toHaveBeenCalledOnce();
+    const event: SignerChangeEvent = listener.mock.calls[0]![0];
+    expect(event).toEqual({ type: "accountsChanged", accounts: ["0xNewAddr"] });
+  });
+
+  it("subscribe fires on chainChanged", () => {
+    const listener = vi.fn();
+    signer.subscribe(listener);
+
+    ethereum.emit("chainChanged", "0x1");
+
+    expect(listener).toHaveBeenCalledOnce();
+    const event: SignerChangeEvent = listener.mock.calls[0]![0];
+    expect(event).toEqual({ type: "chainChanged", chainId: "0x1" });
+  });
+
+  it("subscribe fires on disconnect", () => {
+    const listener = vi.fn();
+    signer.subscribe(listener);
+
+    ethereum.emit("disconnect");
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0]![0]).toEqual({ type: "disconnect" });
+  });
+
+  it("unsubscribe stops notifications", () => {
+    const listener = vi.fn();
+    const unsubscribe = signer.subscribe(listener);
+
+    unsubscribe();
+    ethereum.emit("accountsChanged", ["0xNew"]);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("getAddress delegates to rebuilt signer after accountsChanged", async () => {
+    const address = await signer.getAddress();
+    expect(address).toBe("0xAddress");
+
+    // Trigger account change — signer rebuilds
+    mockGetAddress.mockResolvedValueOnce("0xUpdatedAddress");
+    ethereum.emit("accountsChanged", ["0xUpdatedAddress"]);
+
+    const newAddress = await signer.getAddress();
+    expect(newAddress).toBe("0xUpdatedAddress");
+  });
+
+  it("unsubscribe detaches EIP-1193 events when last listener removed", () => {
+    const listener = vi.fn();
+    const unsubscribe = signer.subscribe(listener);
+
+    unsubscribe();
+
+    ethereum.emit("accountsChanged", ["0xNew"]);
+    ethereum.emit("chainChanged", "0x1");
+    ethereum.emit("disconnect");
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("EthersSigner (static mode)", () => {
+  it("isReactiveSigner returns true (subscribe exists)", () => {
+    const mockSigner = {
+      getAddress: vi.fn().mockResolvedValue("0xAddr"),
+      provider: { getNetwork: vi.fn() },
+    };
+    const signer = new EthersSigner({ signer: mockSigner as never });
+
+    expect(isReactiveSigner(signer)).toBe(true);
+    const unsub = signer.subscribe(vi.fn());
+    expect(typeof unsub).toBe("function");
+    unsub(); // should not throw
+  });
+
+  it("subscribe listener is never called (no EIP-1193 events)", () => {
+    const mockSigner = {
+      getAddress: vi.fn().mockResolvedValue("0xAddr"),
+      provider: { getNetwork: vi.fn() },
+    };
+    const signer = new EthersSigner({ signer: mockSigner as never });
+
+    const listener = vi.fn();
+    signer.subscribe(listener);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/ethers/ethers-signer.ts
+++ b/packages/sdk/src/ethers/ethers-signer.ts
@@ -3,9 +3,12 @@ import type {
   ContractCallConfig,
   TransactionReceipt,
   Hex,
+  SignerChangeEvent,
+  ReactiveSignerMixin,
 } from "../token/token.types";
 import type { Address, EIP712TypedData } from "../relayer/relayer-sdk.types";
 import { ethers, type BrowserProvider, type Signer } from "ethers";
+import type { Eip1193Provider } from "ethers";
 
 /** Validate and narrow a string to the `Hex` branded type. */
 function toHex(s: string): Hex {
@@ -13,33 +16,64 @@ function toHex(s: string): Hex {
   return s as Hex;
 }
 
-/** Configuration for {@link EthersSigner}. */
-export interface EthersSignerConfig {
+/** Static configuration: pre-built ethers provider or signer. */
+export interface EthersStaticSignerConfig {
   signer: BrowserProvider | Signer;
+}
+
+/** EIP-1193 configuration: reactive signer built from a wallet provider. */
+export interface EthersEIP1193SignerConfig {
+  ethereum: Eip1193Provider & {
+    on(event: string, handler: (...args: unknown[]) => void): void;
+    removeListener(event: string, handler: (...args: unknown[]) => void): void;
+  };
+}
+
+/** Configuration for {@link EthersSigner}. */
+export type EthersSignerConfig = EthersStaticSignerConfig | EthersEIP1193SignerConfig;
+
+function isEIP1193Config(config: EthersSignerConfig): config is EthersEIP1193SignerConfig {
+  return "ethereum" in config;
 }
 
 /**
  * GenericSigner backed by ethers.
  *
- * Accepts either a `BrowserProvider` (signer resolved lazily via `getSigner()`)
- * or a `Signer` directly (e.g. `Wallet` for Node.js scripts).
+ * Supports two modes:
+ * - **Static**: pass a `BrowserProvider` (signer resolved lazily via `getSigner()`)
+ *   or a `Signer` directly (e.g. `Wallet` for Node.js scripts).
+ * - **EIP-1193**: pass an `ethereum` provider — a `BrowserProvider` is created
+ *   automatically and re-resolved on `accountsChanged` / `chainChanged` events.
  *
- * @param config - {@link EthersSignerConfig} with signer or provider
+ * In both modes, `subscribe()` is available (no-op in static mode).
+ * The returned unsubscribe function detaches EIP-1193 listeners when the last listener is removed.
  */
-export class EthersSigner implements GenericSigner {
-  private signerPromise: Promise<Signer>;
+export class EthersSigner implements GenericSigner, ReactiveSignerMixin {
+  #signerPromise: Promise<Signer>;
+  #ethereum: EthersEIP1193SignerConfig["ethereum"] | null = null;
+  #listeners = new Set<(event: SignerChangeEvent) => void>();
+  // Bound handlers for EIP-1193 event cleanup
+  #handleAccountsChanged: ((accounts: unknown) => void) | null = null;
+  #handleChainChanged: ((chainId: unknown) => void) | null = null;
+  #handleDisconnect: (() => void) | null = null;
 
   constructor(config: EthersSignerConfig) {
-    const providerOrSigner = config.signer;
-    if ("getSigner" in providerOrSigner) {
-      this.signerPromise = providerOrSigner.getSigner();
+    if (isEIP1193Config(config)) {
+      this.#ethereum = config.ethereum;
+      this.#signerPromise = this.#buildSigner();
+      this.#attachEvents();
     } else {
-      this.signerPromise = Promise.resolve(providerOrSigner);
+      const providerOrSigner = config.signer;
+      if ("getSigner" in providerOrSigner) {
+        this.#signerPromise = providerOrSigner.getSigner();
+      } else {
+        this.#signerPromise = Promise.resolve(providerOrSigner);
+      }
     }
   }
 
   async getChainId(): Promise<number> {
-    const signer = await this.signerPromise;
+    const signer = await this.#signerPromise;
     const provider = signer.provider;
     if (!provider) throw new TypeError("Signer has no provider");
     const network = await provider.getNetwork();
@@ -47,12 +81,12 @@ export class EthersSigner implements GenericSigner {
   }
 
   async getAddress(): Promise<Address> {
-    const signer = await this.signerPromise;
+    const signer = await this.#signerPromise;
     return toHex(await signer.getAddress()) as Address;
   }
 
   async signTypedData(typedData: EIP712TypedData): Promise<Hex> {
-    const signer = await this.signerPromise;
+    const signer = await this.#signerPromise;
     const { domain, types, message } = typedData;
     const { EIP712Domain: _, ...sigTypes } = types;
     const sig = await signer.signTypedData(domain, sigTypes, message);
@@ -60,7 +94,7 @@ export class EthersSigner implements GenericSigner {
   }
 
   async writeContract<C extends ContractCallConfig>(config: C): Promise<Hex> {
-    const signer = await this.signerPromise;
+    const signer = await this.#signerPromise;
     const contract = new ethers.Contract(config.address, config.abi as ethers.InterfaceAbi, signer);
     const overrides: Record<string, unknown> = {};
     if (config.value !== undefined) overrides.value = config.value;
@@ -69,13 +103,13 @@ export class EthersSigner implements GenericSigner {
   }
 
   async readContract<T, C extends ContractCallConfig>(config: C): Promise<T> {
-    const signer = await this.signerPromise;
+    const signer = await this.#signerPromise;
     const contract = new ethers.Contract(config.address, config.abi as ethers.InterfaceAbi, signer);
     return contract[config.functionName]!(...config.args) as Promise<T>;
   }
 
   async waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt> {
-    const signer = await this.signerPromise;
+    const signer = await this.#signerPromise;
     const provider = signer.provider;
     if (!provider) throw new TypeError("Signer has no provider");
     const receipt = await provider.waitForTransaction(hash);
@@ -86,5 +120,66 @@ export class EthersSigner implements GenericSigner {
         data: log.data,
       })),
     };
+  }
+
+  subscribe(listener: (event: SignerChangeEvent) => void): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+      if (this.#listeners.size === 0) this.#detachEvents();
+    };
+  }
+
+  // ── Private helpers ──────────────────────────────────────
+
+  #buildSigner(): Promise<Signer> {
+    const provider = new ethers.BrowserProvider(this.#ethereum!);
+    return provider.getSigner();
+  }
+
+  #rebuild(): void {
+    this.#signerPromise = this.#buildSigner();
+  }
+
+  #emit(event: SignerChangeEvent): void {
+    for (const listener of this.#listeners) listener(event);
+  }
+
+  #attachEvents(): void {
+    const ethereum = this.#ethereum!;
+
+    this.#handleAccountsChanged = (accounts: unknown) => {
+      this.#rebuild();
+      this.#emit({ type: "accountsChanged", accounts: accounts as string[] });
+    };
+
+    this.#handleChainChanged = (chainId: unknown) => {
+      this.#rebuild();
+      this.#emit({ type: "chainChanged", chainId: chainId as string });
+    };
+
+    this.#handleDisconnect = () => {
+      this.#emit({ type: "disconnect" });
+    };
+
+    ethereum.on("accountsChanged", this.#handleAccountsChanged);
+    ethereum.on("chainChanged", this.#handleChainChanged);
+    ethereum.on("disconnect", this.#handleDisconnect);
+  }
+
+  #detachEvents(): void {
+    if (!this.#ethereum) return;
+    if (this.#handleAccountsChanged) {
+      this.#ethereum.removeListener("accountsChanged", this.#handleAccountsChanged);
+      this.#handleAccountsChanged = null;
+    }
+    if (this.#handleChainChanged) {
+      this.#ethereum.removeListener("chainChanged", this.#handleChainChanged);
+      this.#handleChainChanged = null;
+    }
+    if (this.#handleDisconnect) {
+      this.#ethereum.removeListener("disconnect", this.#handleDisconnect);
+      this.#handleDisconnect = null;
+    }
   }
 }

--- a/packages/sdk/src/ethers/index.ts
+++ b/packages/sdk/src/ethers/index.ts
@@ -5,7 +5,12 @@
  * @packageDocumentation
  */
 
-export { EthersSigner, type EthersSignerConfig } from "./ethers-signer";
+export {
+  EthersSigner,
+  type EthersSignerConfig,
+  type EthersStaticSignerConfig,
+  type EthersEIP1193SignerConfig,
+} from "./ethers-signer";
 export {
   readConfidentialBalanceOfContract,
   readWrapperForTokenContract,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -59,6 +59,7 @@ export {
   loadPendingUnshield,
   clearPendingUnshield,
 } from "./token/pending-unshield";
+export type { PendingUnshieldScope } from "./token/pending-unshield";
 export type {
   Address,
   Hex,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -70,7 +70,11 @@ export type {
   TransactionReceipt,
   TransactionResult,
   UnshieldCallbacks,
+  SignerChangeEvent,
+  ReactiveSignerMixin,
+  ReactiveSigner,
 } from "./token/token.types";
+export { isReactiveSigner } from "./token/token.types";
 export { ZamaSDKEvents } from "./events/sdk-events";
 export type {
   ZamaSDKEventType,

--- a/packages/sdk/src/token/__tests__/pending-unshield.test.ts
+++ b/packages/sdk/src/token/__tests__/pending-unshield.test.ts
@@ -5,34 +5,63 @@ import {
   loadPendingUnshield,
   clearPendingUnshield,
 } from "../pending-unshield";
+import type { PendingUnshieldScope } from "../pending-unshield";
 import type { Address, Hex } from "../token.types";
 
+const ACCOUNT = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as Address;
 const WRAPPER = "0x1111111111111111111111111111111111111111" as Address;
+const CHAIN_ID = 31337;
 const TX_HASH = "0xabc123" as Hex;
+
+const scope: PendingUnshieldScope = {
+  accountAddress: ACCOUNT,
+  chainId: CHAIN_ID,
+  wrapperAddress: WRAPPER,
+};
 
 describe("pending-unshield persistence", () => {
   it("returns null when no pending unshield exists", async () => {
     const storage = new MemoryStorage();
-    expect(await loadPendingUnshield(storage, WRAPPER)).toBeNull();
+    expect(await loadPendingUnshield(storage, scope)).toBeNull();
   });
 
   it("saves and loads a pending unshield tx hash", async () => {
     const storage = new MemoryStorage();
-    await savePendingUnshield(storage, WRAPPER, TX_HASH);
-    expect(await loadPendingUnshield(storage, WRAPPER)).toBe(TX_HASH);
+    await savePendingUnshield(storage, scope, TX_HASH);
+    expect(await loadPendingUnshield(storage, scope)).toBe(TX_HASH);
   });
 
   it("clears a pending unshield tx hash", async () => {
     const storage = new MemoryStorage();
-    await savePendingUnshield(storage, WRAPPER, TX_HASH);
-    await clearPendingUnshield(storage, WRAPPER);
-    expect(await loadPendingUnshield(storage, WRAPPER)).toBeNull();
+    await savePendingUnshield(storage, scope, TX_HASH);
+    await clearPendingUnshield(storage, scope);
+    expect(await loadPendingUnshield(storage, scope)).toBeNull();
   });
 
   it("isolates by wrapper address", async () => {
     const storage = new MemoryStorage();
-    const OTHER = "0x2222222222222222222222222222222222222222" as Address;
-    await savePendingUnshield(storage, WRAPPER, TX_HASH);
-    expect(await loadPendingUnshield(storage, OTHER)).toBeNull();
+    const otherScope: PendingUnshieldScope = {
+      ...scope,
+      wrapperAddress: "0x2222222222222222222222222222222222222222" as Address,
+    };
+    await savePendingUnshield(storage, scope, TX_HASH);
+    expect(await loadPendingUnshield(storage, otherScope)).toBeNull();
+  });
+
+  it("isolates by account address", async () => {
+    const storage = new MemoryStorage();
+    const otherScope: PendingUnshieldScope = {
+      ...scope,
+      accountAddress: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as Address,
+    };
+    await savePendingUnshield(storage, scope, TX_HASH);
+    expect(await loadPendingUnshield(storage, otherScope)).toBeNull();
+  });
+
+  it("isolates by chain ID", async () => {
+    const storage = new MemoryStorage();
+    const otherScope: PendingUnshieldScope = { ...scope, chainId: 1 };
+    await savePendingUnshield(storage, scope, TX_HASH);
+    expect(await loadPendingUnshield(storage, otherScope)).toBeNull();
   });
 });

--- a/packages/sdk/src/token/pending-unshield.ts
+++ b/packages/sdk/src/token/pending-unshield.ts
@@ -2,8 +2,18 @@ import type { Address, GenericStringStorage, Hex } from "./token.types";
 
 const STORAGE_PREFIX = "zama:pending-unshield:";
 
-function storageKey(wrapperAddress: Address): string {
-  return `${STORAGE_PREFIX}${wrapperAddress.toLowerCase()}`;
+/** Identity scoping so pending-unshield state never collides across accounts/chains. */
+export interface PendingUnshieldScope {
+  /** Connected wallet address. */
+  accountAddress: Address;
+  /** Chain ID of the connected network. */
+  chainId: number;
+  /** Wrapper contract address. */
+  wrapperAddress: Address;
+}
+
+function storageKey({ chainId, accountAddress, wrapperAddress }: PendingUnshieldScope): string {
+  return `${STORAGE_PREFIX}${chainId}:${accountAddress.toLowerCase()}:${wrapperAddress.toLowerCase()}`;
 }
 
 /**
@@ -12,10 +22,10 @@ function storageKey(wrapperAddress: Address): string {
  */
 export async function savePendingUnshield(
   storage: GenericStringStorage,
-  wrapperAddress: Address,
+  scope: PendingUnshieldScope,
   unwrapTxHash: Hex,
 ): Promise<void> {
-  await storage.setItem(storageKey(wrapperAddress), unwrapTxHash);
+  await storage.setItem(storageKey(scope), unwrapTxHash);
 }
 
 /**
@@ -23,9 +33,9 @@ export async function savePendingUnshield(
  */
 export async function loadPendingUnshield(
   storage: GenericStringStorage,
-  wrapperAddress: Address,
+  scope: PendingUnshieldScope,
 ): Promise<Hex | null> {
-  return (await storage.getItem(storageKey(wrapperAddress))) as Hex | null;
+  return (await storage.getItem(storageKey(scope))) as Hex | null;
 }
 
 /**
@@ -33,7 +43,7 @@ export async function loadPendingUnshield(
  */
 export async function clearPendingUnshield(
   storage: GenericStringStorage,
-  wrapperAddress: Address,
+  scope: PendingUnshieldScope,
 ): Promise<void> {
-  await storage.removeItem(storageKey(wrapperAddress));
+  await storage.removeItem(storageKey(scope));
 }

--- a/packages/sdk/src/token/token.types.ts
+++ b/packages/sdk/src/token/token.types.ts
@@ -58,6 +58,26 @@ export interface GenericSigner {
   waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt>;
 }
 
+/** Wallet lifecycle event fired by a reactive signer. */
+export type SignerChangeEvent =
+  | { type: "accountsChanged"; accounts: string[] }
+  | { type: "chainChanged"; chainId: string }
+  | { type: "disconnect" };
+
+/** Mixin that makes a signer reactive to wallet lifecycle events. */
+export interface ReactiveSignerMixin {
+  /** Register a listener for wallet change events. Returns an unsubscribe function. */
+  subscribe(listener: (event: SignerChangeEvent) => void): () => void;
+}
+
+/** A signer that reacts to wallet lifecycle events. */
+export type ReactiveSigner = GenericSigner & ReactiveSignerMixin;
+
+/** Runtime type guard for reactive signers. */
+export function isReactiveSigner(signer: GenericSigner): signer is ReactiveSigner {
+  return typeof (signer as ReactiveSigner).subscribe === "function";
+}
+
 /** Pluggable key-value store for persisting FHE credentials. */
 export interface GenericStringStorage {
   getItem(key: string): Promise<string | null>;

--- a/packages/sdk/src/viem/__tests__/viem-reactive.test.ts
+++ b/packages/sdk/src/viem/__tests__/viem-reactive.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { EIP1193Provider } from "viem";
+import type { SignerChangeEvent } from "../../token/token.types";
+import { isReactiveSigner } from "../../token/token.types";
+import { ViemSigner } from "../viem-signer";
+
+// ── Mock EIP-1193 provider with event emitter ───────────
+
+type Handler = (...args: unknown[]) => void;
+
+type MockEIP1193 = EIP1193Provider & { emit: (event: string, ...args: unknown[]) => void };
+
+function createMockEIP1193(): MockEIP1193 {
+  const handlers = new Map<string, Set<Handler>>();
+
+  return {
+    request: vi.fn().mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "eth_chainId") return "0xaa36a7";
+      if (method === "eth_accounts") return ["0xNewAddress"];
+      return null;
+    }),
+    on(event: string, handler: Handler) {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event)!.add(handler);
+    },
+    removeListener(event: string, handler: Handler) {
+      handlers.get(event)?.delete(handler);
+    },
+    emit(event: string, ...args: unknown[]) {
+      for (const handler of handlers.get(event) ?? []) handler(...args);
+    },
+  } as unknown as MockEIP1193;
+}
+
+// ── Mock viem client factories ──────────────────────────
+
+vi.mock("viem", async () => {
+  const actual = await vi.importActual<typeof import("viem")>("viem");
+  return {
+    ...actual,
+    createWalletClient: vi.fn().mockReturnValue({
+      account: { address: "0xMockWalletAddress", type: "json-rpc" },
+      chain: { id: 11155111, name: "sepolia" },
+      signTypedData: vi.fn().mockResolvedValue("0xsig"),
+      writeContract: vi.fn().mockResolvedValue("0xtx"),
+    }),
+    createPublicClient: vi.fn().mockReturnValue({
+      getChainId: vi.fn().mockResolvedValue(11155111),
+      readContract: vi.fn().mockResolvedValue("0x"),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue({ logs: [] }),
+    }),
+  };
+});
+
+// ── Tests ───────────────────────────────────────────────
+
+describe("ViemSigner (EIP-1193 reactive mode)", () => {
+  let ethereum: ReturnType<typeof createMockEIP1193>;
+  let signer: ViemSigner;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ethereum = createMockEIP1193();
+    signer = new ViemSigner({
+      ethereum,
+      chain: { id: 11155111, name: "Sepolia" } as import("viem").Chain,
+    });
+  });
+
+  it("isReactiveSigner returns true for EIP-1193 signer", () => {
+    expect(isReactiveSigner(signer)).toBe(true);
+  });
+
+  it("subscribe fires on accountsChanged", () => {
+    const listener = vi.fn();
+    signer.subscribe(listener);
+
+    ethereum.emit("accountsChanged", ["0xNewAddr"]);
+
+    expect(listener).toHaveBeenCalledOnce();
+    const event: SignerChangeEvent = listener.mock.calls[0]![0];
+    expect(event).toEqual({ type: "accountsChanged", accounts: ["0xNewAddr"] });
+  });
+
+  it("subscribe fires on chainChanged", () => {
+    const listener = vi.fn();
+    signer.subscribe(listener);
+
+    ethereum.emit("chainChanged", "0x1");
+
+    expect(listener).toHaveBeenCalledOnce();
+    const event: SignerChangeEvent = listener.mock.calls[0]![0];
+    expect(event).toEqual({ type: "chainChanged", chainId: "0x1" });
+  });
+
+  it("subscribe fires on disconnect", () => {
+    const listener = vi.fn();
+    signer.subscribe(listener);
+
+    ethereum.emit("disconnect");
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0]![0]).toEqual({ type: "disconnect" });
+  });
+
+  it("unsubscribe stops notifications", () => {
+    const listener = vi.fn();
+    const unsubscribe = signer.subscribe(listener);
+
+    unsubscribe();
+    ethereum.emit("accountsChanged", ["0xNew"]);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("getAddress falls back to eth_accounts RPC in EIP-1193 mode", async () => {
+    // Create a signer with a walletClient that has no account
+    const { createWalletClient } = await import("viem");
+    vi.mocked(createWalletClient).mockReturnValueOnce({
+      account: undefined,
+      chain: { id: 11155111, name: "sepolia" },
+      signTypedData: vi.fn(),
+      writeContract: vi.fn(),
+    } as never);
+
+    const noAccountSigner = new ViemSigner({
+      ethereum,
+      chain: { id: 11155111, name: "Sepolia" } as import("viem").Chain,
+    });
+
+    const address = await noAccountSigner.getAddress();
+    expect(address).toBe("0xNewAddress");
+    expect(ethereum.request).toHaveBeenCalledWith({ method: "eth_accounts" });
+  });
+
+  it("unsubscribe detaches EIP-1193 events when last listener removed", () => {
+    const listener = vi.fn();
+    const unsubscribe = signer.subscribe(listener);
+
+    unsubscribe();
+
+    ethereum.emit("accountsChanged", ["0xNew"]);
+    ethereum.emit("chainChanged", "0x1");
+    ethereum.emit("disconnect");
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("ViemSigner (static mode)", () => {
+  const mockWalletClient = {
+    account: { address: "0xStaticAddr", type: "json-rpc" },
+    chain: { id: 1, name: "mainnet" },
+    signTypedData: vi.fn(),
+    writeContract: vi.fn(),
+  } as never;
+
+  const mockPublicClient = {
+    getChainId: vi.fn().mockResolvedValue(1),
+    readContract: vi.fn(),
+    waitForTransactionReceipt: vi.fn(),
+  } as never;
+
+  it("isReactiveSigner returns true (subscribe exists)", () => {
+    const signer = new ViemSigner({
+      walletClient: mockWalletClient,
+      publicClient: mockPublicClient,
+    });
+
+    expect(isReactiveSigner(signer)).toBe(true);
+    const unsub = signer.subscribe(vi.fn());
+    expect(typeof unsub).toBe("function");
+    unsub(); // should not throw
+  });
+
+  it("subscribe listener is never called (no EIP-1193 events)", () => {
+    const signer = new ViemSigner({
+      walletClient: mockWalletClient,
+      publicClient: mockPublicClient,
+    });
+
+    const listener = vi.fn();
+    signer.subscribe(listener);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/viem/index.ts
+++ b/packages/sdk/src/viem/index.ts
@@ -5,7 +5,12 @@
  * @packageDocumentation
  */
 
-export { ViemSigner, type ViemSignerConfig } from "./viem-signer";
+export {
+  ViemSigner,
+  type ViemSignerConfig,
+  type ViemStaticSignerConfig,
+  type ViemEIP1193SignerConfig,
+} from "./viem-signer";
 export {
   readConfidentialBalanceOfContract,
   readWrapperForTokenContract,

--- a/packages/sdk/src/viem/viem-signer.ts
+++ b/packages/sdk/src/viem/viem-signer.ts
@@ -3,48 +3,93 @@ import type {
   ContractCallConfig,
   TransactionReceipt,
   Hex,
+  SignerChangeEvent,
+  ReactiveSignerMixin,
 } from "../token/token.types";
-import type { PublicClient, WalletClient } from "viem";
+import type { PublicClient, WalletClient, Chain, EIP1193Provider } from "viem";
 import type { Address, EIP712TypedData } from "../relayer/relayer-sdk.types";
+import { createPublicClient, createWalletClient, custom, http } from "viem";
 import { writeContract } from "viem/actions";
 
-/** Configuration for {@link ViemSigner}. */
-export interface ViemSignerConfig {
+/** Static configuration: pre-built viem clients. */
+export interface ViemStaticSignerConfig {
   walletClient: WalletClient;
   publicClient: PublicClient;
+}
+
+/** EIP-1193 configuration: reactive signer built from a wallet provider. */
+export interface ViemEIP1193SignerConfig {
+  ethereum: EIP1193Provider;
+  chain: Chain;
+  rpcUrl?: string;
+}
+
+/** Configuration for {@link ViemSigner}. */
+export type ViemSignerConfig = ViemStaticSignerConfig | ViemEIP1193SignerConfig;
+
+function isEIP1193Config(config: ViemSignerConfig): config is ViemEIP1193SignerConfig {
+  return "ethereum" in config;
 }
 
 /**
  * GenericSigner backed by viem.
  *
- * @param config - {@link ViemSignerConfig} with walletClient and publicClient
+ * Supports two modes:
+ * - **Static**: pass pre-built `walletClient` and `publicClient`.
+ * - **EIP-1193**: pass an `ethereum` provider — clients are built automatically
+ *   and rebuilt on `accountsChanged` / `chainChanged` events.
+ *
+ * In both modes, `subscribe()` is available (no-op in static mode).
+ * The returned unsubscribe function detaches EIP-1193 listeners when the last listener is removed.
  */
-export class ViemSigner implements GenericSigner {
-  private readonly walletClient: WalletClient;
-  private readonly publicClient: PublicClient;
+export class ViemSigner implements GenericSigner, ReactiveSignerMixin {
+  #walletClient: WalletClient;
+  #publicClient: PublicClient;
+  #ethereum: EIP1193Provider | null = null;
+  #chain: Chain | null = null;
+  #rpcUrl: string | undefined;
+  #listeners = new Set<(event: SignerChangeEvent) => void>();
+  // Bound handlers for EIP-1193 event cleanup
+  #handleAccountsChanged: ((accounts: unknown) => void) | null = null;
+  #handleChainChanged: ((chainId: unknown) => void) | null = null;
+  #handleDisconnect: (() => void) | null = null;
 
   constructor(config: ViemSignerConfig) {
-    this.walletClient = config.walletClient;
-    this.publicClient = config.publicClient;
+    if (isEIP1193Config(config)) {
+      this.#ethereum = config.ethereum;
+      this.#chain = config.chain;
+      this.#rpcUrl = config.rpcUrl;
+      this.#walletClient = this.#buildWalletClient();
+      this.#publicClient = this.#buildPublicClient();
+      this.#attachEvents();
+    } else {
+      this.#walletClient = config.walletClient;
+      this.#publicClient = config.publicClient;
+    }
   }
 
   async getChainId(): Promise<number> {
-    return this.publicClient.getChainId();
+    return this.#publicClient.getChainId();
   }
 
   async getAddress(): Promise<Address> {
-    const account = this.walletClient.account;
-    if (!account) {
-      throw new TypeError("Invalid address");
+    const account = this.#walletClient.account;
+    if (account) return account.address;
+
+    // EIP-1193 mode: walletClient may not have an account set yet
+    if (this.#ethereum) {
+      const accounts = (await this.#ethereum.request({ method: "eth_accounts" })) as string[];
+      if (accounts.length > 0) return accounts[0] as Address;
     }
-    return account.address;
+
+    throw new TypeError("Invalid address");
   }
 
   async signTypedData(typedData: EIP712TypedData): Promise<Hex> {
-    const account = this.walletClient.account;
+    const account = this.#walletClient.account;
     if (!account) throw new TypeError("WalletClient has no account");
     const { EIP712Domain: _, ...sigTypes } = typedData.types;
-    return this.walletClient.signTypedData({
+    return this.#walletClient.signTypedData({
       account,
       primaryType: Object.keys(sigTypes)[0]!,
       types: sigTypes,
@@ -54,20 +99,91 @@ export class ViemSigner implements GenericSigner {
   }
 
   async writeContract<C extends ContractCallConfig = ContractCallConfig>(config: C): Promise<Hex> {
-    const account = this.walletClient.account;
+    const account = this.#walletClient.account;
     if (!account) throw new TypeError("WalletClient has no account");
-    return this.walletClient.writeContract({
-      chain: this.walletClient.chain,
+    return this.#walletClient.writeContract({
+      chain: this.#walletClient.chain,
       account,
       ...config,
     } as Parameters<typeof writeContract>[1]);
   }
 
   async readContract<T, C extends ContractCallConfig = ContractCallConfig>(config: C): Promise<T> {
-    return this.publicClient.readContract(config) as Promise<T>;
+    return this.#publicClient.readContract(config) as Promise<T>;
   }
 
   async waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt> {
-    return this.publicClient.waitForTransactionReceipt({ hash });
+    return this.#publicClient.waitForTransactionReceipt({ hash });
+  }
+
+  subscribe(listener: (event: SignerChangeEvent) => void): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+      if (this.#listeners.size === 0) this.#detachEvents();
+    };
+  }
+
+  // ── Private helpers ──────────────────────────────────────
+
+  #buildWalletClient(): WalletClient {
+    return createWalletClient({
+      chain: this.#chain!,
+      transport: custom(this.#ethereum!),
+    });
+  }
+
+  #buildPublicClient(): PublicClient {
+    return createPublicClient({
+      chain: this.#chain!,
+      transport: this.#rpcUrl ? http(this.#rpcUrl) : custom(this.#ethereum!),
+    });
+  }
+
+  #rebuild(): void {
+    this.#walletClient = this.#buildWalletClient();
+    this.#publicClient = this.#buildPublicClient();
+  }
+
+  #emit(event: SignerChangeEvent): void {
+    for (const listener of this.#listeners) listener(event);
+  }
+
+  #attachEvents(): void {
+    const ethereum = this.#ethereum!;
+
+    this.#handleAccountsChanged = (accounts: unknown) => {
+      this.#rebuild();
+      this.#emit({ type: "accountsChanged", accounts: accounts as string[] });
+    };
+
+    this.#handleChainChanged = (chainId: unknown) => {
+      this.#rebuild();
+      this.#emit({ type: "chainChanged", chainId: chainId as string });
+    };
+
+    this.#handleDisconnect = () => {
+      this.#emit({ type: "disconnect" });
+    };
+
+    ethereum.on("accountsChanged", this.#handleAccountsChanged);
+    ethereum.on("chainChanged", this.#handleChainChanged);
+    ethereum.on("disconnect", this.#handleDisconnect);
+  }
+
+  #detachEvents(): void {
+    if (!this.#ethereum) return;
+    if (this.#handleAccountsChanged) {
+      this.#ethereum.removeListener("accountsChanged", this.#handleAccountsChanged);
+      this.#handleAccountsChanged = null;
+    }
+    if (this.#handleChainChanged) {
+      this.#ethereum.removeListener("chainChanged", this.#handleChainChanged);
+      this.#handleChainChanged = null;
+    }
+    if (this.#handleDisconnect) {
+      this.#ethereum.removeListener("disconnect", this.#handleDisconnect);
+      this.#handleDisconnect = null;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `useUnshield`, `useUnshieldAll`, and `useResumeUnshield` now automatically save/clear the pending unwrap tx hash in storage
- Consumers no longer need to manually wire `savePendingUnshield`/`clearPendingUnshield` via callbacks
- Added `wrapUnshieldCallbacks` internal helper that wraps user callbacks with storage persistence

## Test plan
- [x] Typecheck passes
- [x] All 740 tests pass (44 test files)
- [ ] Manual test: unshield flow persists tx hash to storage automatically
- [ ] Manual test: page reload + resumeUnshield works without consumer-side storage wiring
- [ ] Manual test: user-provided callbacks still fire after storage operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)