### PR TITLE
docs: Fix broken shields images

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,6 @@
-## PR Title
+# Summary
 
-Use a Conventional Commit title, for example:
-
-- `fix: handle relayer timeout in worker`
-- `feat(sdk): add encrypted balance helper`
-- `chore(ci): pin GitHub Actions by SHA`
-
-Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `chore`, `test`, `build`, `ci`, `revert`, `style`.
-
-## Summary
-
-Describe what changed and why.
+<!-- What changed? Keep it short and concrete. -->
 
 ## Scope
 
@@ -20,26 +10,16 @@ Describe what changed and why.
 - [ ] CI/workflows
 - [ ] Docs
 
-## Testing
+## Validation
 
-List what you ran and the result.
+<!-- What did you run/check before opening this PR? -->
+<!-- Example: pnpm typecheck, pnpm lint, pnpm test:coverage, pnpm e2e:test -->
 
-```bash
-pnpm typecheck
-pnpm lint
-pnpm format:check
-pnpm test:coverage
-```
+## Related
 
-Add any extra commands used (for example E2E commands) and relevant output notes.
+<!-- Link issue(s) / related PR(s), if any. -->
+<!-- Example: Closes #123 -->
 
-## Breaking Changes
+## Demo (if possible)
 
-- [ ] No breaking changes
-- [ ] Breaking change (describe below)
-
-If breaking, include migration notes.
-
-## Linked Issues
-
-Closes #
+<!-- Screenshot or short video/GIF for UI/UX changes. -->

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ![Latest dev release](https://img.shields.io/npm/v/%40zama-fhe%2Fsdk/alpha?label=dev%20release)
 ![Latest dev release last updated](https://img.shields.io/npm/last-update/%40zama-fhe%2Fsdk/alpha)
 ![NPM License](https://img.shields.io/npm/l/%40zama-fhe%2Fsdk)
-![GitHub Actions Workflow Status - Tests](https://img.shields.io/github/actions/workflow/status/zama-ai/sdk/test.yml?branch=main&label=tests)
+![GitHub Actions Workflow Status - Unit Tests](https://img.shields.io/github/actions/workflow/status/zama-ai/sdk/vitest.yml?label=unit%20tests)
+![GitHub Actions Workflow Status - Playwright](https://img.shields.io/github/actions/workflow/status/zama-ai/sdk/playwright.yml?label=e2e%20tests)
 
 TypeScript SDKs for privacy-preserving ERC-20 token operations using [Fully Homomorphic Encryption on Zama Protocol](https://docs.zama.org/protocol/protocol/overview). Shield, transfer, and unshield tokens with encrypted balances — no one sees your amounts on-chain.
 


### PR DESCRIPTION
# Summary
<!-- What changed? Keep it short and concrete. -->
Shields badges are broken because the test workflow file was split into two files in #18 

## Scope

- [ ] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-app`
- [ ] CI/workflows
- [x] Docs

## Validation

<!-- What did you run/check before opening this PR? -->
<!-- Example: pnpm typecheck, pnpm lint, pnpm test:coverage, pnpm e2e:test -->
Should work theoretically, hard to test due to closed repo

## Related

<!-- Link issue(s) / related PR(s), if any. -->
<!-- Example: Closes #123 -->

## Demo (if possible)

<!-- Screenshot or short video/GIF for UI/UX changes. -->
