### PR TITLE
ci: Fix issue with release failures due to invalid PR reference

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@
 ## Related
 
 <!-- Link issue(s) / related PR(s), if any. -->
-<!-- Example: Closes #123 -->
+<!-- Example: Closes issue-number> -->
 
 ## Demo (if possible)
 


### PR DESCRIPTION
# Summary
Semantic Release was failing due to an invalid PR number reference in the default PR template. Removing that example reference should fix this.

## Scope

- [ ] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [x] CI/workflows
- [x] Docs

## Validation
Tested with dry-run locally.

## Related
N/A

## Demo (if possible)

<!-- Screenshot or short video/GIF for UI/UX changes. -->
N/A