### PR TITLE
chore(security): resolve CodeQL code scanning alerts (Vibe Kanban)

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -4,6 +4,9 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
+permissions:
+  actions: write
+
 jobs:
   delete-caches:
     name: "Delete Actions caches"

--- a/packages/sdk/src/worker/relayer-sdk.worker.ts
+++ b/packages/sdk/src/worker/relayer-sdk.worker.ts
@@ -224,17 +224,20 @@ async function fetchScript(cdnUrl: string): Promise<string> {
 }
 
 async function loadSdkScript(cdnUrl: string, integrity?: string): Promise<void> {
+  // Validate CDN URL immediately before any script loading (defense-in-depth).
+  const validatedUrl = validateCdnUrl(cdnUrl);
+
   if (isBrowserExtension()) {
     // Extensions: blob: URLs are forbidden. Use importScripts directly —
     // the CDN origin must be allowed in the extension's CSP manifest.
     if (integrity) {
-      await verifyIntegrity(await fetchScript(cdnUrl), integrity);
+      await verifyIntegrity(await fetchScript(validatedUrl), integrity);
     }
-    return self.importScripts(cdnUrl);
+    return self.importScripts(validatedUrl);
   }
 
   // Web apps: fetch + blob URL avoids MIME-type and eval CSP issues.
-  const scriptContent = await fetchScript(cdnUrl);
+  const scriptContent = await fetchScript(validatedUrl);
 
   if (integrity) {
     await verifyIntegrity(scriptContent, integrity);
@@ -257,9 +260,6 @@ async function handleInit(request: InitRequest): Promise<void> {
   const { cdnUrl, fhevmConfig, csrfToken, integrity } = payload;
 
   try {
-    // Validate CDN URL before any script loading
-    validateCdnUrl(cdnUrl);
-
     // Extract relayerUrl from config for fetch interception
     relayerUrlBase = fhevmConfig.relayerUrl ?? "";
     csrfTokenBase = csrfToken;


### PR DESCRIPTION
## Summary

- **Add explicit workflow permissions** to `cleanup-cache.yml` — scopes the GitHub Actions token to `actions: write` only, following the principle of least privilege (resolves CodeQL alert: missing workflow permissions)
- **Move CDN URL validation into `loadSdkScript`** — relocates the `validateCdnUrl()` call from `handleInit` into `loadSdkScript` itself so validation happens immediately before `importScripts`, providing defense-in-depth and satisfying CodeQL's taint analysis (resolves CodeQL alert: client-side unvalidated URL redirection)

## Why

GitHub CodeQL flagged two code scanning issues:

1. The `cleanup-cache.yml` workflow had no `permissions` block, running with default (broad) token permissions
2. `self.importScripts(cdnUrl)` in the worker was flagged as an unvalidated URL redirection — the URL *was* validated, but in a separate function (`handleInit`), so CodeQL's dataflow analysis couldn't trace the validation to the sink

## Implementation details

- The `loadSdkScript` function now validates its own input via `validateCdnUrl()` and uses the validated return value (`validatedUrl`) throughout, making the function safe to call from any callsite
- The redundant `validateCdnUrl()` call in `handleInit` was removed since `loadSdkScript` now handles it
- All 778 tests pass, TypeScript type-checks clean, lint passes

This PR was written using [Vibe Kanban](https://vibekanban.com)