### PR TITLE
fix: use real hardhat-deployed addresses, add missing transferBatcher approval

### DIFF
--- a/packages/playwright/fixtures/test.ts
+++ b/packages/playwright/fixtures/test.ts
@@ -4,18 +4,20 @@ import { createTestClient, formatUnits, http, publicActions, walletActions } fro
 import { privateKeyToAccount } from "viem/accounts";
 import { hardhat } from "viem/chains";
 import { mockRelayerSdk } from "./fhevm";
+import deployments from "../../../hardhat/deployments.json" with { type: "json" };
+import type { Address } from "viem";
 
 const privateKey = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const;
 
 const account = privateKeyToAccount(privateKey);
 
 const contracts = {
-  USDT: "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
-  cUSDT: "0xBA12646CC07ADBe43F8bD25D83FB628D29C8A762",
-  USDC: "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
-  cUSDC: "0x3B02fF1e626Ed7a8fd6eC5299e2C54e1421B626B",
-  transferBatcher: "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
-  feeManager: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+  USDT: deployments.USDT as Address,
+  cUSDT: deployments.cUSDT as Address,
+  USDC: deployments.erc20 as Address,
+  cUSDC: deployments.cToken as Address,
+  transferBatcher: deployments.transferBatcher as Address,
+  feeManager: deployments.feeManager as Address,
 } as const;
 
 /** Fee: ceiling division of (amount * 100) / 10000 — matches FeeManager.sol */

--- a/packages/playwright/tests/batch-transfer.spec.ts
+++ b/packages/playwright/tests/batch-transfer.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from "../fixtures";
+import { WRAPPER_ABI } from "../../sdk/src/abi/wrapper.abi";
 
-test("should shield USDT then batch transfer to two recipients", async ({ page, contracts }) => {
+test("should shield USDT then batch transfer to two recipients", async ({
+  page,
+  contracts,
+  viemClient,
+}) => {
   const shieldAmount = 500n;
   const transferAmount1 = 50n;
   const transferAmount2 = 50n;
@@ -11,6 +16,14 @@ test("should shield USDT then batch transfer to two recipients", async ({ page, 
   await page.getByTestId("amount-input").fill(shieldAmount.toString());
   await page.getByTestId("shield-button").click();
   await expect(page.getByTestId("shield-success")).toContainText("Tx: 0x");
+
+  // Approve the TransferBatcher as an operator on the cToken
+  await viemClient.writeContract({
+    address: contracts.cUSDT as `0x${string}`,
+    abi: WRAPPER_ABI,
+    functionName: "setOperator",
+    args: [contracts.transferBatcher as `0x${string}`, Math.floor(Date.now() / 1000) + 86400],
+  });
 
   // Navigate to batch transfer page
   await page.goto(

--- a/packages/test-components/src/batch-transfer-form.tsx
+++ b/packages/test-components/src/batch-transfer-form.tsx
@@ -40,7 +40,7 @@ export function BatchTransferForm({
 
         const encrypted = await encrypt.mutateAsync({
           values: [amount1, amount2],
-          contractAddress: tokenAddress,
+          contractAddress: batcherAddress,
           userAddress,
         });
 

--- a/packages/test-nextjs/src/constants.ts
+++ b/packages/test-nextjs/src/constants.ts
@@ -1,12 +1,13 @@
 import type { Address } from "@zama-fhe/react-sdk";
+import deployments from "../../../hardhat/deployments.json";
 
 export const CONTRACTS = {
-  USDT: "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6" as Address, // USDT (ERC-20)
-  cUSDT: "0xBA12646CC07ADBe43F8bD25D83FB628D29C8A762" as Address, // cUSDT
-  USDC: "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
-  cUSDC: "0x3B02fF1e626Ed7a8fd6eC5299e2C54e1421B626B",
-  feeManager: "0x5FbDB2315678afecb367f032d93F642f64180aa3" as Address,
-  transferBatcher: "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
+  USDT: deployments.USDT as Address,
+  cUSDT: deployments.cUSDT as Address,
+  USDC: deployments.erc20 as Address,
+  cUSDC: deployments.cToken as Address,
+  feeManager: deployments.feeManager as Address,
+  transferBatcher: deployments.transferBatcher as Address,
 } as const;
 
 export const CONFIDENTIAL_TOKEN_ADDRESSES: Address[] = [

--- a/packages/test-vite/src/constants.ts
+++ b/packages/test-vite/src/constants.ts
@@ -1,26 +1,27 @@
 import type { Address } from "@zama-fhe/react-sdk";
+import deployments from "../../../hardhat/deployments.json";
 
 export const CONFIDENTIAL_TOKEN_ADDRESSES: Address[] = [
-  "0xBA12646CC07ADBe43F8bD25D83FB628D29C8A762", // cUSDT
-  "0x3B02fF1e626Ed7a8fd6eC5299e2C54e1421B626B", // cUSDC
+  deployments.cUSDT as Address, // cUSDT
+  deployments.cToken as Address, // cUSDC
 ];
 
 export const ERC20_TOKENS: { address: Address; wrapper: Address }[] = [
   {
-    address: "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6", // USDT
-    wrapper: "0xBA12646CC07ADBe43F8bD25D83FB628D29C8A762", // cUSDT
+    address: deployments.USDT as Address, // USDT
+    wrapper: deployments.cUSDT as Address, // cUSDT
   },
   {
-    address: "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853", // USDC
-    wrapper: "0x3B02fF1e626Ed7a8fd6eC5299e2C54e1421B626B", // cUSDC
+    address: deployments.erc20 as Address, // USDC
+    wrapper: deployments.cToken as Address, // cUSDC
   },
 ];
 
 export const DEFAULTS = {
-  token: "0x610178dA211FEF7D417bC0e6FeD39F05609AD788" as Address, // USDT (ERC-20)
-  wrapper: "0xBA12646CC07ADBe43F8bD25D83FB628D29C8A762" as Address, // cUSDT
-  confidentialToken: "0xBA12646CC07ADBe43F8bD25D83FB628D29C8A762" as Address, // cUSDT
-  feeManager: "0x5FbDB2315678afecb367f032d93F642f64180aa3" as Address,
+  token: deployments.USDT, // USDT (ERC-20)
+  wrapper: deployments.cUSDT, // cUSDT
+  confidentialToken: deployments.cUSDT, // cUSDT
+  feeManager: deployments.feeManager,
 };
 
-export const TRANSFER_BATCHER_ADDRESS = "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82" as Address;
+export const TRANSFER_BATCHER_ADDRESS = deployments.transferBatcher;


### PR DESCRIPTION
Fix batcher test that had missing approval for operator.
Use the deployments.json file from hardhat submodule instead of hardcoded addresses.
Address the issue with e2e tests not passing.