### PR TITLE
docs: Clarify NPM support [SDK-31]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 - [ ] `@zama-fhe/sdk`
 - [ ] `@zama-fhe/react-sdk`
-- [ ] `@zama-fhe/test-app`
+- [ ] `@zama-fhe/test-components`
 - [ ] `@zama-fhe/test-nextjs`
 - [ ] `@zama-fhe/test-vite`
 - [ ] CI/workflows

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ The examples below use a backend proxy (`relayerUrl`) to keep your API key serve
 ```bash
 # Core SDK (vanilla TypeScript)
 pnpm add @zama-fhe/sdk
+# or: npm install @zama-fhe/sdk / yarn add @zama-fhe/sdk
 
 # React hooks
 pnpm add @zama-fhe/react-sdk @tanstack/react-query
+# or: npm install @zama-fhe/react-sdk @tanstack/react-query / yarn add @zama-fhe/react-sdk @tanstack/react-query
 ```
 
 ### Read extended documentation

--- a/docs/gitbook/src/README.md
+++ b/docs/gitbook/src/README.md
@@ -25,6 +25,8 @@ pnpm add @zama-fhe/react-sdk @tanstack/react-query
 
 # Vanilla TypeScript / Node.js
 pnpm add @zama-fhe/sdk
+
+# (or substitute npm install / yarn add)
 ```
 
 ## Your first confidential transfer in 30 seconds

--- a/docs/gitbook/src/guides/quick-start.md
+++ b/docs/gitbook/src/guides/quick-start.md
@@ -25,6 +25,10 @@ The most common setup for dApps. You'll need wagmi, React Query, and the React S
 
 ```bash
 pnpm add @zama-fhe/react-sdk @tanstack/react-query wagmi viem
+# or
+npm install @zama-fhe/react-sdk @tanstack/react-query wagmi viem
+# or
+yarn add @zama-fhe/react-sdk @tanstack/react-query wagmi viem
 ```
 
 ### 1. Set up providers
@@ -109,6 +113,10 @@ For vanilla TypeScript apps that use viem for wallet interactions.
 
 ```bash
 pnpm add @zama-fhe/sdk viem
+# or
+npm install @zama-fhe/sdk viem
+# or
+yarn add @zama-fhe/sdk viem
 ```
 
 ```ts
@@ -158,6 +166,10 @@ Same flow, different signer adapter.
 
 ```bash
 pnpm add @zama-fhe/sdk ethers
+# or
+npm install @zama-fhe/sdk ethers
+# or
+yarn add @zama-fhe/sdk ethers
 ```
 
 ```ts
@@ -192,6 +204,10 @@ For backend services, scripts, and bots. Uses native worker threads instead of a
 
 ```bash
 pnpm add @zama-fhe/sdk viem @zama-fhe/relayer-sdk
+# or
+npm install @zama-fhe/sdk viem @zama-fhe/relayer-sdk
+# or
+yarn add @zama-fhe/sdk viem @zama-fhe/relayer-sdk
 ```
 
 ```ts

--- a/docs/gitbook/src/guides/react-sdk/overview.md
+++ b/docs/gitbook/src/guides/react-sdk/overview.md
@@ -6,6 +6,10 @@ The React SDK (`@zama-fhe/react-sdk`) gives you hooks for confidential token ope
 
 ```bash
 pnpm add @zama-fhe/react-sdk @tanstack/react-query
+# or
+npm install @zama-fhe/react-sdk @tanstack/react-query
+# or
+yarn add @zama-fhe/react-sdk @tanstack/react-query
 ```
 
 You **don't** need to install `@zama-fhe/sdk` separately — it's included and re-exported, so you import everything from one place.
@@ -17,6 +21,7 @@ Then add your Web3 library:
 pnpm add wagmi viem    # wagmi (most common for React dApps)
 pnpm add viem          # viem only
 pnpm add ethers        # ethers only
+# (or substitute npm install / yarn add)
 ```
 
 ## Minimal example

--- a/docs/gitbook/src/guides/sdk/overview.md
+++ b/docs/gitbook/src/guides/sdk/overview.md
@@ -6,6 +6,10 @@ The core SDK (`@zama-fhe/sdk`) lets you shield, transfer, and unshield confident
 
 ```bash
 pnpm add @zama-fhe/sdk
+# or
+npm install @zama-fhe/sdk
+# or
+yarn add @zama-fhe/sdk
 ```
 
 You also need a Web3 library. Pick one:
@@ -18,12 +22,17 @@ pnpm add viem
 pnpm add ethers
 
 # Option C: implement GenericSigner yourself (no extra dep)
+# (or substitute npm install / yarn add)
 ```
 
 For Node.js, you'll additionally need `@zama-fhe/relayer-sdk`:
 
 ```bash
 pnpm add @zama-fhe/relayer-sdk
+# or
+npm install @zama-fhe/relayer-sdk
+# or
+yarn add @zama-fhe/relayer-sdk
 ```
 
 ## Three things to set up

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -6,6 +6,10 @@ React hooks for confidential token operations, built on [React Query](https://ta
 
 ```bash
 pnpm add @zama-fhe/react-sdk @tanstack/react-query
+# or
+npm install @zama-fhe/react-sdk @tanstack/react-query
+# or
+yarn add @zama-fhe/react-sdk @tanstack/react-query
 ```
 
 `@zama-fhe/sdk` is included as a direct dependency — no need to install it separately.

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -67,9 +67,7 @@
       "optional": true
     }
   },
-  "packageManager": "pnpm@10.30.2",
   "engines": {
-    "node": ">=22",
-    "pnpm": ">=10"
+    "node": ">=22"
   }
 }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -6,6 +6,10 @@ A TypeScript SDK for building privacy-preserving token applications using Fully 
 
 ```bash
 pnpm add @zama-fhe/sdk
+# or
+npm install @zama-fhe/sdk
+# or
+yarn add @zama-fhe/sdk
 ```
 
 ### Peer dependencies

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -80,9 +80,7 @@
       "optional": true
     }
   },
-  "packageManager": "pnpm@10.30.2",
   "engines": {
-    "node": ">=22",
-    "pnpm": ">=10"
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
# Summary

Support npm and yarn consumers by removing pnpm-specific fields from published packages and adding npm/yarn install alternatives to all documentation.

- Removed `engines.pnpm` and `packageManager` from `packages/sdk/package.json` and `packages/react-sdk/package.json` (root monorepo keeps them)
- Updated all install commands across READMEs and gitbook docs to show pnpm, npm, and yarn alternatives
- Added `@zama-fhe/test-components` to the PR template scope checklist

## Scope

- [x] `@zama-fhe/sdk`
- [x] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-components`
- [ ] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [ ] CI/workflows
- [x] Docs

## Validation

- Verified no remaining pnpm-only install instructions in consumer-facing docs
- Confirmed `engines.pnpm` and `packageManager` removed from both published package.json files
- No code changes — `workspace:*` is resolved by pnpm at publish time

## Related

<!-- Link issue(s) / related PR(s), if any. -->

## Demo (if possible)

N/A — docs and package.json only