### PR TITLE
docs: minor updates on cleartext mode

### DIFF
--- a/docs/gitbook/src/guides/local-development.md
+++ b/docs/gitbook/src/guides/local-development.md
@@ -5,15 +5,15 @@ description: How to use the cleartext relayer for local Hardhat nodes and custom
 
 # Local Development
 
-The SDK ships `RelayerCleartext`, a drop-in replacement for `RelayerWeb` and `RelayerNode` that operates in cleartext mode. Values are stored as plaintext on-chain — no KMS, no gateway, no WASM. Use it for local Hardhat nodes, custom testnets, or any chain where you deploy fhEVM contracts in cleartext mode.
+The SDK ships `RelayerCleartext`, a drop-in relayer that replaces FHE operations with cleartext operations. Values are stored as plaintext on-chain — no KMS, no gateway, no WASM. Use it for local Hardhat nodes, custom testnets, or any chain where you deploy fhEVM contracts in cleartext mode.
 
-`RelayerCleartext` implements the same `RelayerSDK` interface, so the rest of your code stays unchanged.
+`RelayerCleartext` implements the same `RelayerSDK` interface as `RelayerWeb` and `RelayerNode`, so the rest of your code stays unchanged.
 
 {% hint style="warning" %}
 Cleartext mode is blocked on Ethereum Mainnet (chain 1) and Sepolia (chain 11155111). It is intended for development and testing only.
 {% endhint %}
 
-## Steps
+## SDK setup
 
 ### 1. Install packages
 
@@ -24,16 +24,24 @@ npm install @zama-fhe/sdk viem
 ### 2. Import from the `/cleartext` sub-path
 
 ```ts
-import { RelayerCleartext, hoodiCleartextConfig } from "@zama-fhe/sdk/cleartext";
+import { RelayerCleartext, hardhatCleartextConfig } from "@zama-fhe/sdk/cleartext";
 import { ZamaSDK, memoryStorage } from "@zama-fhe/sdk";
 import { ViemSigner } from "@zama-fhe/sdk/viem";
 ```
 
 ### 3. Create the relayer with a preset
 
-For the Hoodi testnet, use the built-in `hoodiCleartextConfig` preset:
+For a local Hardhat network, use the built-in `hardhatCleartextConfig` preset:
 
 ```ts
+const relayer = new RelayerCleartext(hardhatCleartextConfig);
+```
+
+Zama provides a cleartext deployment for the Hoodi testnet, via `hoodiCleartextConfig`:
+
+```ts
+import { RelayerCleartext, hoodiCleartextConfig } from "@zama-fhe/sdk/cleartext";
+
 const relayer = new RelayerCleartext(hoodiCleartextConfig);
 ```
 
@@ -59,7 +67,7 @@ const balance = await token.balanceOf();
 
 ### 5. (Optional) Create a custom config for your own chain
 
-If you deploy fhEVM contracts on a custom chain, build a `CleartextConfig` manually. Each field maps to a contract address from your deployment:
+If you deploy fhEVM contracts on a custom chain or at different addresses than the default ones, build a `CleartextConfig` manually. Each field maps to a contract address from your deployment:
 
 ```ts
 import { RelayerCleartext } from "@zama-fhe/sdk/cleartext";
@@ -68,7 +76,7 @@ import type { CleartextConfig } from "@zama-fhe/sdk/cleartext";
 const myChainConfig: CleartextConfig = {
   chainId: 12345,
   network: "http://localhost:8545", // RPC URL or EIP-1193 provider
-  gatewayChainId: 10901, // Chain ID of the gateway (usually same as Hardhat default)
+  gatewayChainId: 10901,
 
   // Contract addresses from your own deployment
   aclContractAddress: "0x...",
@@ -91,11 +99,11 @@ const relayer = new RelayerCleartext(myChainConfig);
 | `gatewayChainId`                            | The chain ID where gateway contracts are deployed |
 
 {% hint style="info" %}
-Usually, you want to use the same `gatewayChainId` and verifying contracts as the Hardhat defaults. You can also pass optional `kmsSignerPrivateKey` and `inputSignerPrivateKey` fields to override the default mock signers.
+Usually, you want to use the same `gatewayChainId` and verifying contract addresses as the Hardhat defaults. You can also provide optional `kmsSignerPrivateKey` and `inputSignerPrivateKey` fields for custom EIP-712 verification signers.
 {% endhint %}
 
 ## Next steps
 
-- [RelayerCleartext reference](/reference/sdk/RelayerCleartext) — full config options and `CleartextConfig` type
+- [RelayerCleartext reference](/reference/sdk/RelayerCleartext) — full constructor options and `CleartextConfig` type
 - [Configuration](/guides/configuration) — production setup with `RelayerWeb` or `RelayerNode`
 - [Network Presets](/reference/sdk/network-presets) — preset configs for Mainnet, Sepolia, and Hardhat


### PR DESCRIPTION
I intentionally did not mention how to spin up a new deployment of the cleartext contracts on a hardhat node: I am still not exactly sure how this should be done; if we should add an `anvil` config; and how to link it to a durable solution. For now it's in https://github.com/zama-ai/forge-fhevm, but let's set this for a future task. Maybe it should be in the main docs instead.