### PR TITLE
fix(sdk): extend contract addresses instead of regenerating keypair

### DIFF
--- a/packages/sdk/src/token/__tests__/credentials-manager.test.ts
+++ b/packages/sdk/src/token/__tests__/credentials-manager.test.ts
@@ -59,7 +59,7 @@ describe("CredentialsManager", () => {
     expect(relayer.generateKeypair).toHaveBeenCalledOnce();
   });
 
-  it("re-signs when new contract not in signed list", async ({
+  it("re-signs when new contract not in signed list but reuses keypair", async ({
     relayer,
     signer,
     credentialManager,
@@ -67,10 +67,16 @@ describe("CredentialsManager", () => {
     setupMocks(relayer, signer);
 
     await credentialManager.allow(TOKEN_A);
-    await credentialManager.allow(TOKEN_A, TOKEN_B);
+    const creds = await credentialManager.allow(TOKEN_A, TOKEN_B);
 
-    expect(relayer.generateKeypair).toHaveBeenCalledTimes(2);
+    // Keypair is reused — only one generation
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    // Re-signed with the extended address set
     expect(signer.signTypedData).toHaveBeenCalledTimes(2);
+    // Merged contract addresses include both tokens (checksummed by getAddress)
+    const normalized = creds.contractAddresses.map((a: string) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
   }, 30000);
 
   it("persists credentials to store with hashed key", async ({
@@ -598,6 +604,225 @@ describe("session allow/revoke", () => {
     await manager2.revoke();
 
     expect(events).toContain(ZamaSDKEvents.CredentialsRevoked);
+  });
+});
+
+describe("contract address extension", () => {
+  const TOKEN_C = "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC" as Address;
+
+  it("extends contracts with active session, reusing keypair", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    const first = await credentialManager.allow(TOKEN_A);
+    const extended = await credentialManager.allow(TOKEN_A, TOKEN_B);
+
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    expect(signer.signTypedData).toHaveBeenCalledTimes(2);
+    // Same keypair
+    expect(extended.publicKey).toBe(first.publicKey);
+    expect(extended.privateKey).toBe(first.privateKey);
+    // Merged addresses
+    const normalized = extended.contractAddresses.map((a) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
+  });
+
+  it("extends contracts after revoke (no session path)", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    await credentialManager.allow(TOKEN_A);
+    await credentialManager.revoke();
+    const extended = await credentialManager.allow(TOKEN_A, TOKEN_B);
+
+    // Keypair reused — only one generation
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    // Original sign + old-address sign for decrypt + merged-address sign for extend
+    expect(signer.signTypedData).toHaveBeenCalledTimes(3);
+    const normalized = extended.contractAddresses.map((a) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
+  });
+
+  it("extends contracts after page reload (new session storage, no session)", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+
+    const manager1 = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+    await manager1.allow(TOKEN_A);
+
+    // Simulate reload: new session storage, same persistent storage
+    const manager2 = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+    const extended = await manager2.allow(TOKEN_A, TOKEN_B);
+
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    // Original sign + old-address sign for decrypt + merged-address sign for extend
+    expect(signer.signTypedData).toHaveBeenCalledTimes(3);
+    const normalized = extended.contractAddresses.map((a) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
+  });
+
+  it("caches extended credentials — third call with same set does not re-sign", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    await credentialManager.allow(TOKEN_A);
+    await credentialManager.allow(TOKEN_A, TOKEN_B);
+    await credentialManager.allow(TOKEN_A, TOKEN_B);
+
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    // Only 2 signatures: initial + extend. Third call is cached.
+    expect(signer.signTypedData).toHaveBeenCalledTimes(2);
+  });
+
+  it("persists extended credentials across instances", async ({
+    relayer,
+    signer,
+    storage,
+    sessionStorage,
+    createCredentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    const manager1 = createCredentialManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage,
+      keypairTTL: 86400,
+    });
+    await manager1.allow(TOKEN_A);
+    await manager1.allow(TOKEN_A, TOKEN_B);
+
+    // New instance, same storage backends
+    const manager2 = createCredentialManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage,
+      keypairTTL: 86400,
+    });
+    await manager2.allow(TOKEN_A, TOKEN_B);
+
+    // No additional keypair or signature — all cached
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    expect(signer.signTypedData).toHaveBeenCalledTimes(2);
+  });
+
+  it("extends incrementally: A → A,B → A,B,C", async ({ relayer, signer, credentialManager }) => {
+    setupMocks(relayer, signer);
+
+    await credentialManager.allow(TOKEN_A);
+    await credentialManager.allow(TOKEN_A, TOKEN_B);
+    const final = await credentialManager.allow(TOKEN_A, TOKEN_B, TOKEN_C);
+
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    // 3 signatures: initial + extend to B + extend to C
+    expect(signer.signTypedData).toHaveBeenCalledTimes(3);
+    const normalized = final.contractAddresses.map((a) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
+    expect(normalized).toContain(TOKEN_C.toLowerCase());
+  });
+
+  it("subset of already-allowed contracts does not re-sign", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    await credentialManager.allow(TOKEN_A, TOKEN_B);
+    await credentialManager.allow(TOKEN_A); // subset
+
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    expect(signer.signTypedData).toHaveBeenCalledOnce();
+  });
+
+  it("fully regenerates when credentials are time-expired even with missing contracts", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+
+    const manager = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+    const storeKey = await CredentialsManager.computeStoreKey(
+      await signer.getAddress(),
+      await signer.getChainId(),
+    );
+
+    await manager.allow(TOKEN_A);
+
+    // Tamper stored data to simulate time expiration
+    const stored = await storage.get(storeKey);
+    const parsed = { ...(stored as Record<string, unknown>) };
+    parsed.startTimestamp = Math.floor(Date.now() / 1000) - 8 * 86400;
+    await storage.set(storeKey, parsed);
+
+    const manager2 = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+    await manager2.allow(TOKEN_A, TOKEN_B);
+
+    // Time-expired → full regeneration, not extension
+    expect(relayer.generateKeypair).toHaveBeenCalledTimes(2);
+  }, 30000);
+
+  it("EIP-712 is created with the merged contract set", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    await credentialManager.allow(TOKEN_A);
+    await credentialManager.allow(TOKEN_A, TOKEN_B);
+
+    // Second createEIP712 call should include both tokens
+    const secondCall = vi.mocked(relayer.createEIP712).mock.calls[1]!;
+    const contractAddresses = secondCall[1] as Address[];
+    const normalized = contractAddresses.map((a) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
   });
 });
 

--- a/packages/sdk/src/token/__tests__/readonly-token.test.ts
+++ b/packages/sdk/src/token/__tests__/readonly-token.test.ts
@@ -6,6 +6,7 @@ import type { GenericSigner, GenericStorage } from "../token.types";
 import type { RelayerSDK } from "../../relayer/relayer-sdk";
 
 import { DecryptionFailedError } from "../errors";
+import { saveCachedBalance } from "../balance-cache";
 import { getAddress, type Address } from "viem";
 
 const VALID_HANDLE2 = ("0x" + "cd".repeat(32)) as Address;
@@ -456,6 +457,118 @@ describe("ReadonlyToken", () => {
           handles: [handle as Address, VALID_HANDLE2 as Address],
         }),
       ).rejects.toThrow(/tokens\.length.*must equal.*handles\.length/);
+    });
+  });
+
+  describe("batchDecryptBalances (cache-aware allow)", () => {
+    const TOKEN2 = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address;
+
+    it("skips allow() entirely when all balances are cached", async ({
+      relayer,
+      signer,
+      storage,
+      sessionStorage,
+      tokenAddress,
+      handle,
+    }) => {
+      const token = createReadonlyToken({
+        relayer,
+        signer,
+        storage,
+        sessionStorage,
+        tokenAddress,
+        handle,
+      });
+      const token2 = new ReadonlyToken({
+        relayer,
+        signer,
+        storage,
+        sessionStorage,
+        address: TOKEN2,
+      });
+
+      const signerAddress = await signer.getAddress();
+
+      // Pre-populate cache for both tokens
+      await saveCachedBalance({
+        storage,
+        tokenAddress,
+        owner: signerAddress,
+        handle: handle as Address,
+        value: 1000n,
+      });
+      await saveCachedBalance({
+        storage,
+        tokenAddress: TOKEN2,
+        owner: signerAddress,
+        handle: VALID_HANDLE2,
+        value: 2000n,
+      });
+
+      const result = await ReadonlyToken.batchDecryptBalances([token, token2], {
+        handles: [handle as Address, VALID_HANDLE2],
+      });
+
+      expect(result.get(tokenAddress)).toBe(1000n);
+      expect(result.get(getAddress(TOKEN2))).toBe(2000n);
+      // No credentials needed — no keypair generation or signing
+      expect(relayer.generateKeypair).not.toHaveBeenCalled();
+      expect(signer.signTypedData).not.toHaveBeenCalled();
+    });
+
+    it("calls allow() only with uncached token addresses", async ({
+      relayer,
+      signer,
+      storage,
+      sessionStorage,
+      tokenAddress,
+      handle,
+    }) => {
+      const token = createReadonlyToken({
+        relayer,
+        signer,
+        storage,
+        sessionStorage,
+        tokenAddress,
+        handle,
+      });
+      const token2 = new ReadonlyToken({
+        relayer,
+        signer,
+        storage,
+        sessionStorage,
+        address: TOKEN2,
+      });
+
+      const signerAddress = await signer.getAddress();
+
+      // Pre-populate cache only for token1
+      await saveCachedBalance({
+        storage,
+        tokenAddress,
+        owner: signerAddress,
+        handle: handle as Address,
+        value: 1000n,
+      });
+
+      vi.mocked(relayer.userDecrypt).mockResolvedValueOnce({
+        [VALID_HANDLE2]: 2000n,
+      } as never);
+
+      const result = await ReadonlyToken.batchDecryptBalances([token, token2], {
+        handles: [handle as Address, VALID_HANDLE2],
+      });
+
+      expect(result.get(tokenAddress)).toBe(1000n);
+      expect(result.get(getAddress(TOKEN2))).toBe(2000n);
+      // Credentials generated only for the uncached token
+      expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+      expect(signer.signTypedData).toHaveBeenCalledOnce();
+      // createEIP712 called with only token2's address
+      const eip712Call = vi.mocked(relayer.createEIP712).mock.calls[0]!;
+      const signedAddresses = eip712Call[1] as Address[];
+      expect(signedAddresses).toHaveLength(1);
+      expect(signedAddresses[0]!.toLowerCase()).toBe(TOKEN2.toLowerCase());
     });
   });
 

--- a/packages/sdk/src/token/credentials-manager.ts
+++ b/packages/sdk/src/token/credentials-manager.ts
@@ -141,17 +141,35 @@ export class CredentialsManager {
               this.#emit({ type: ZamaSDKEvents.CredentialsAllowed, contractAddresses });
               return creds;
             }
+            // Keypair still time-valid but missing contracts — extend and re-sign
+            if (this.#isTimeValid(creds)) {
+              return this.#extendContracts({
+                storeKey,
+                credentials: creds,
+                requiredContracts: contractAddresses,
+              });
+            }
             this.#emit({ type: ZamaSDKEvents.CredentialsExpired, contractAddresses });
           }
         }
         // No session signature or TTL expired — need to re-sign
-        if (this.#isValidWithoutDecrypt(encrypted, contractAddresses)) {
-          const signature = await this.#sign(encrypted);
-          await this.#setSessionEntry(storeKey, signature);
-          const creds = await this.#decryptCredentials(encrypted, signature);
-          this.#emit({ type: ZamaSDKEvents.CredentialsCached, contractAddresses });
-          this.#emit({ type: ZamaSDKEvents.CredentialsAllowed, contractAddresses });
-          return creds;
+        if (this.#isTimeValid(encrypted)) {
+          if (this.#coversContracts(encrypted.contractAddresses, contractAddresses)) {
+            const signature = await this.#sign(encrypted);
+            await this.#setSessionEntry(storeKey, signature);
+            const creds = await this.#decryptCredentials(encrypted, signature);
+            this.#emit({ type: ZamaSDKEvents.CredentialsCached, contractAddresses });
+            this.#emit({ type: ZamaSDKEvents.CredentialsAllowed, contractAddresses });
+            return creds;
+          }
+          // Time-valid but missing contracts and no session — sign with old addresses to decrypt, then extend
+          const oldSignature = await this.#sign(encrypted);
+          const creds = await this.#decryptCredentials(encrypted, oldSignature);
+          return this.#extendContracts({
+            storeKey,
+            credentials: creds,
+            requiredContracts: contractAddresses,
+          });
         }
         this.#emit({ type: ZamaSDKEvents.CredentialsExpired, contractAddresses });
       }
@@ -207,7 +225,7 @@ export class CredentialsManager {
       this.#assertEncryptedCredentials(encrypted);
 
       const requiredContracts = contractAddress ? [contractAddress] : [];
-      return !this.#isValidWithoutDecrypt(encrypted, requiredContracts);
+      return !this.#isValid(encrypted, requiredContracts);
     } catch {
       return false;
     }
@@ -316,31 +334,90 @@ export class CredentialsManager {
     assertString(data.encryptedPrivateKey.ciphertext, "encryptedPrivateKey.ciphertext");
   }
 
-  #isValid(creds: StoredCredentials, requiredContracts: Address[]): boolean {
-    const nowSeconds = Math.floor(Date.now() / 1000);
-    const expiresAt = creds.startTimestamp + creds.durationDays * 86400;
-    if (nowSeconds >= expiresAt) return false;
-
-    const signedSet = new Set(creds.contractAddresses.map(getAddress));
-    return requiredContracts.every((addr) => signedSet.has(getAddress(addr)));
+  #isValid(
+    creds: { startTimestamp: number; durationDays: number; contractAddresses: Address[] },
+    requiredContracts: Address[],
+  ): boolean {
+    if (!this.#isTimeValid(creds)) return false;
+    return this.#coversContracts(creds.contractAddresses, requiredContracts);
   }
 
-  #isValidWithoutDecrypt(encrypted: EncryptedCredentials, requiredContracts: Address[]): boolean {
+  /** Check if credentials are still within their keypair TTL. */
+  #isTimeValid(creds: { startTimestamp: number; durationDays: number }): boolean {
     const nowSeconds = Math.floor(Date.now() / 1000);
-    const expiresAt = encrypted.startTimestamp + encrypted.durationDays * 86400;
-    if (nowSeconds >= expiresAt) return false;
-    const signedSet = new Set(encrypted.contractAddresses.map(getAddress));
-    return requiredContracts.every((addr) => signedSet.has(getAddress(addr)));
+    const expiresAt = creds.startTimestamp + creds.durationDays * 86400;
+    return nowSeconds < expiresAt;
+  }
+
+  /** Check if the signed address set covers all required addresses. */
+  #coversContracts(signedAddresses: Address[], requiredContracts: Address[]): boolean {
+    const signedSet = new Set(signedAddresses.map((a) => a.toLowerCase()));
+    return requiredContracts.every((addr) => signedSet.has(addr.toLowerCase()));
   }
 
   async #sign(encrypted: EncryptedCredentials): Promise<Hex> {
+    return this.#signWithContracts(encrypted, encrypted.contractAddresses);
+  }
+
+  /** Sign an EIP-712 authorization for the given contract addresses using the stored keypair metadata. */
+  async #signWithContracts(
+    keypairMeta: { publicKey: Hex; startTimestamp: number; durationDays: number },
+    contractAddresses: Address[],
+  ): Promise<Hex> {
     const eip712 = await this.#relayer.createEIP712(
-      encrypted.publicKey,
-      encrypted.contractAddresses,
-      encrypted.startTimestamp,
-      encrypted.durationDays,
+      keypairMeta.publicKey,
+      contractAddresses,
+      keypairMeta.startTimestamp,
+      keypairMeta.durationDays,
     );
     return this.#signer.signTypedData(eip712);
+  }
+
+  /** Merge two contract address lists into a deduplicated sorted array. */
+  #mergeContracts(existing: Address[], incoming: Address[]): Address[] {
+    const map = new Map<string, Address>();
+    for (const addr of [...existing, ...incoming]) {
+      const key = addr.toLowerCase();
+      if (!map.has(key)) map.set(key, getAddress(addr));
+    }
+    return [...map.values()].sort();
+  }
+
+  /**
+   * Extend credentials with additional contract addresses: re-sign with the
+   * merged set and persist, reusing the existing keypair.
+   */
+  async #extendContracts({
+    storeKey,
+    credentials,
+    requiredContracts,
+  }: {
+    storeKey: string;
+    credentials: StoredCredentials;
+    requiredContracts: Address[];
+  }): Promise<StoredCredentials> {
+    const merged = this.#mergeContracts(credentials.contractAddresses, requiredContracts);
+    const signature = await this.#signWithContracts(credentials, merged);
+    await this.#setSessionEntry(storeKey, signature);
+
+    const extended: StoredCredentials = {
+      ...credentials,
+      contractAddresses: merged,
+      signature,
+    };
+    await this.#persistExtended(storeKey, extended);
+    this.#emit({ type: ZamaSDKEvents.CredentialsAllowed, contractAddresses: requiredContracts });
+    return extended;
+  }
+
+  /** Re-encrypt and persist updated credentials. */
+  async #persistExtended(storeKey: string, creds: StoredCredentials): Promise<void> {
+    try {
+      const encrypted = await this.#encryptCredentials(creds);
+      await this.#storage.set(storeKey, encrypted);
+    } catch {
+      // Store write failed — credentials still usable in memory
+    }
   }
 
   // ── Credential generation ───────────────────────────────────

--- a/packages/sdk/src/token/credentials-manager.ts
+++ b/packages/sdk/src/token/credentials-manager.ts
@@ -405,13 +405,13 @@ export class CredentialsManager {
       contractAddresses: merged,
       signature,
     };
-    await this.#persistExtended(storeKey, extended);
+    await this.#persistCredentials(storeKey, extended);
     this.#emit({ type: ZamaSDKEvents.CredentialsAllowed, contractAddresses: requiredContracts });
     return extended;
   }
 
-  /** Re-encrypt and persist updated credentials. */
-  async #persistExtended(storeKey: string, creds: StoredCredentials): Promise<void> {
+  /** Re-encrypt and persist credentials (best-effort — failures are swallowed). */
+  async #persistCredentials(storeKey: string, creds: StoredCredentials): Promise<void> {
     try {
       const encrypted = await this.#encryptCredentials(creds);
       await this.#storage.set(storeKey, encrypted);
@@ -462,12 +462,7 @@ export class CredentialsManager {
         durationDays,
       };
 
-      try {
-        const encrypted = await this.#encryptCredentials(creds);
-        await this.#storage.set(storeKey, encrypted);
-      } catch {
-        // Store write failed — credentials still usable in memory
-      }
+      await this.#persistCredentials(storeKey, creds);
 
       this.#emit({ type: ZamaSDKEvents.CredentialsCreated, contractAddresses });
       return creds;

--- a/packages/sdk/src/token/readonly-token.ts
+++ b/packages/sdk/src/token/readonly-token.ts
@@ -281,14 +281,11 @@ export class ReadonlyToken {
       );
     }
 
-    const allAddresses = tokens.map((t) => t.address);
-    const creds = await tokens[0]!.credentials.allow(...allAddresses);
-
     const tokenStorage = tokens[0]!.storage;
     const results = new Map<Address, bigint>();
-    const errors: Array<{ address: Address; error: Error }> = [];
-    const decryptFns: Array<() => Promise<void>> = [];
 
+    // Determine which tokens actually need decryption (not zero, not cached).
+    const uncached: Array<{ token: ReadonlyToken; handle: Address }> = [];
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i]!;
       const handle = resolvedHandles[i]!;
@@ -298,18 +295,31 @@ export class ReadonlyToken {
         continue;
       }
 
-      // Check persistent cache — avoids re-decryption after page reload.
       const cached = await loadCachedBalance({
         storage: tokenStorage,
         tokenAddress: token.address,
         owner: signerAddress,
         handle,
       });
+
       if (cached !== null) {
         results.set(token.address, cached);
         continue;
       }
 
+      uncached.push({ token, handle });
+    }
+
+    // All balances resolved from cache — no credentials needed.
+    if (uncached.length === 0) return results;
+
+    const uncachedAddresses = uncached.map((entry) => entry.token.address);
+    const creds = await tokens[0]!.credentials.allow(...uncachedAddresses);
+
+    const errors: Array<{ address: Address; error: Error }> = [];
+    const decryptFns: Array<() => Promise<void>> = [];
+
+    for (const { token, handle } of uncached) {
       decryptFns.push(() =>
         sdk
           .userDecrypt({


### PR DESCRIPTION
## Summary
- When `allow()` is called with contracts not covered by existing credentials (e.g. individual token decrypt followed by "Reveal All"), the keypair is now reused and re-signed with the merged contract set instead of doing a full keypair regeneration
- Added `#extendContracts`, `#mergeContracts`, `#persistExtended`, `#signWithContracts` helper methods to `CredentialsManager`
- Split `#isValid` into `#isTimeValid` and `#coversContracts` for finer-grained checks
- Uses lowercase comparison for address matching to avoid EIP-55 checksum inconsistencies
- Added 9 comprehensive tests covering contract extension scenarios (active session, revoke, page reload, caching, persistence, incremental extension, subset, time-expiry, EIP-712 verification)

## Test plan
- [x] All 967 tests pass across 112 test files
- [x] New contract extension tests cover: active session reuse, revoke path, page reload path, caching after extend, cross-instance persistence, incremental A→A,B→A,B,C extension, subset no-op, time-expiry full regen, EIP-712 merged set verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)