### PR TITLE
refactor(sdk): simplify internals, add caching, and extend contract addresses

### DIFF
--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -677,9 +677,9 @@ export class ReadonlyToken {
     name(): Promise<string>;
     // (undocumented)
     protected readConfidentialBalanceOf(owner: Address): Promise<Handle>;
-    revoke(...contractAddresses: Address[]): Promise<void>;
     // (undocumented)
-    protected readonly sdk: RelayerSDK;
+    protected readonly relayer: RelayerSDK;
+    revoke(...contractAddresses: Address[]): Promise<void>;
     // (undocumented)
     readonly signer: GenericSigner;
     protected get storage(): GenericStorage;
@@ -1338,7 +1338,7 @@ export const ZERO_HANDLE: "0x000000000000000000000000000000000000000000000000000
 
 // Warnings were encountered during analysis:
 //
-// dist/activity-DMDQPBKI.d.ts:913:3 - (ae-forgotten-export) The symbol "Handle" needs to be exported by the entry point index.d.ts
+// dist/activity-DJsMcYYP.d.ts:913:3 - (ae-forgotten-export) The symbol "Handle" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -19363,9 +19363,9 @@ export class ReadonlyToken {
     name(): Promise<string>;
     // (undocumented)
     protected readConfidentialBalanceOf(owner: Address): Promise<Handle>;
-    revoke(...contractAddresses: Address[]): Promise<void>;
     // (undocumented)
-    protected readonly sdk: RelayerSDK;
+    protected readonly relayer: RelayerSDK;
+    revoke(...contractAddresses: Address[]): Promise<void>;
     // (undocumented)
     readonly signer: GenericSigner;
     protected get storage(): GenericStorage;

--- a/packages/sdk/src/token/__tests__/credentials-manager.test.ts
+++ b/packages/sdk/src/token/__tests__/credentials-manager.test.ts
@@ -813,31 +813,52 @@ describe("contract address extension", () => {
     expect(normalized).toContain(getAddress(TOKEN_A));
     expect(normalized).toContain(getAddress(TOKEN_B));
   });
-});
 
-describe("storeKey caching", () => {
-  it("caches the SHA-256 store key across multiple allow() calls", async ({
+  it("concurrent extensions don't drop contract addresses", async ({
     relayer,
     signer,
     credentialManager,
   }) => {
     setupMocks(relayer, signer);
-    const digestSpy = vi.spyOn(crypto.subtle, "digest");
 
     await credentialManager.allow(TOKEN_A);
-    const digestCallsAfterFirst = digestSpy.mock.calls.filter(
-      ([algo]) => algo === "SHA-256",
-    ).length;
+
+    // Launch two extensions concurrently with different contracts
+    const [resultB, resultC] = await Promise.all([
+      credentialManager.allow(TOKEN_A, TOKEN_B),
+      credentialManager.allow(TOKEN_A, TOKEN_C),
+    ]);
+
+    // The last result should cover all three contracts (no address dropped)
+    const finalContracts = resultC.contractAddresses.map((a) => getAddress(a));
+    expect(finalContracts).toContain(getAddress(TOKEN_A));
+    expect(finalContracts).toContain(getAddress(TOKEN_B));
+    expect(finalContracts).toContain(getAddress(TOKEN_C));
+
+    // First concurrent result covers at least A and B
+    const firstContracts = resultB.contractAddresses.map((a) => getAddress(a));
+    expect(firstContracts).toContain(getAddress(TOKEN_A));
+    expect(firstContracts).toContain(getAddress(TOKEN_B));
+  });
+});
+
+describe("storeKey caching", () => {
+  it("caches the store key across multiple allow() calls", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+    const computeSpy = vi.spyOn(CredentialsManager, "computeStoreKey");
 
     await credentialManager.allow(TOKEN_A);
-    const digestCallsAfterSecond = digestSpy.mock.calls.filter(
-      ([algo]) => algo === "SHA-256",
-    ).length;
+    expect(computeSpy).toHaveBeenCalledOnce();
 
-    // Second allow() should not trigger another SHA-256 digest for the store key
-    expect(digestCallsAfterSecond).toBe(digestCallsAfterFirst);
+    await credentialManager.allow(TOKEN_A);
+    // Second allow() should not recompute the store key
+    expect(computeSpy).toHaveBeenCalledOnce();
 
-    digestSpy.mockRestore();
+    computeSpy.mockRestore();
   });
 
   it("reuses cached store key for isExpired() after allow()", async ({
@@ -846,22 +867,16 @@ describe("storeKey caching", () => {
     credentialManager,
   }) => {
     setupMocks(relayer, signer);
+    const computeSpy = vi.spyOn(CredentialsManager, "computeStoreKey");
 
     await credentialManager.allow(TOKEN_A);
-
-    // Reset call counts to measure only isExpired() calls
-    vi.mocked(signer.getAddress).mockClear();
-    vi.mocked(signer.getChainId).mockClear();
-    const digestSpy = vi.spyOn(crypto.subtle, "digest");
+    expect(computeSpy).toHaveBeenCalledOnce();
 
     await credentialManager.isExpired();
+    // isExpired() should reuse the cached store key
+    expect(computeSpy).toHaveBeenCalledOnce();
 
-    // getAddress/getChainId are still called (to build identity string for comparison),
-    // but SHA-256 digest should NOT be called again because the cache hits
-    const sha256Calls = digestSpy.mock.calls.filter(([algo]) => algo === "SHA-256").length;
-    expect(sha256Calls).toBe(0);
-
-    digestSpy.mockRestore();
+    computeSpy.mockRestore();
   });
 
   it("invalidates store key cache when signer address changes", async ({
@@ -878,23 +893,21 @@ describe("storeKey caching", () => {
       sessionStorage: createMockStorage(),
       keypairTTL: 86400,
     });
+    const computeSpy = vi.spyOn(CredentialsManager, "computeStoreKey");
 
     await manager.allow(TOKEN_A);
+    expect(computeSpy).toHaveBeenCalledOnce();
 
     // Change the signer address
     vi.mocked(signer.getAddress).mockResolvedValue(
       "0xdDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd" as Address,
     );
 
-    const digestSpy = vi.spyOn(crypto.subtle, "digest");
-
     await manager.allow(TOKEN_A);
+    // Should have recomputed the store key for the new address
+    expect(computeSpy).toHaveBeenCalledTimes(2);
 
-    // Should have recomputed the store key (new SHA-256 call)
-    const sha256Calls = digestSpy.mock.calls.filter(([algo]) => algo === "SHA-256").length;
-    expect(sha256Calls).toBeGreaterThanOrEqual(1);
-
-    digestSpy.mockRestore();
+    computeSpy.mockRestore();
   });
 
   it("invalidates store key cache when chain ID changes", async ({
@@ -911,20 +924,18 @@ describe("storeKey caching", () => {
       sessionStorage: createMockStorage(),
       keypairTTL: 86400,
     });
+    const computeSpy = vi.spyOn(CredentialsManager, "computeStoreKey");
 
     await manager.allow(TOKEN_A);
+    expect(computeSpy).toHaveBeenCalledOnce();
 
     // Change the chain ID
     vi.mocked(signer.getChainId).mockResolvedValue(1);
 
-    const digestSpy = vi.spyOn(crypto.subtle, "digest");
-
     await manager.allow(TOKEN_A);
+    expect(computeSpy).toHaveBeenCalledTimes(2);
 
-    const sha256Calls = digestSpy.mock.calls.filter(([algo]) => algo === "SHA-256").length;
-    expect(sha256Calls).toBeGreaterThanOrEqual(1);
-
-    digestSpy.mockRestore();
+    computeSpy.mockRestore();
   });
 
   it("reuses the same store key when signer address casing changes", async ({
@@ -941,26 +952,25 @@ describe("storeKey caching", () => {
       sessionStorage: createMockStorage(),
       keypairTTL: 86400,
     });
+    const computeSpy = vi.spyOn(CredentialsManager, "computeStoreKey");
 
     await manager.allow(TOKEN_A);
-
-    const digestSpy = vi.spyOn(crypto.subtle, "digest");
+    expect(computeSpy).toHaveBeenCalledOnce();
 
     vi.mocked(signer.getAddress).mockResolvedValue(
       "0x2222222222222222222222222222222222ABCDEF" as Address,
     );
 
     await manager.allow(TOKEN_A);
+    // getAddress normalization means casing change doesn't invalidate cache
+    expect(computeSpy).toHaveBeenCalledOnce();
 
-    const sha256Calls = digestSpy.mock.calls.filter(([algo]) => algo === "SHA-256").length;
-    expect(sha256Calls).toBe(0);
-
-    digestSpy.mockRestore();
+    computeSpy.mockRestore();
   });
 });
 
 describe("deriveKey caching", () => {
-  it("caches the PBKDF2 derived key across decrypt and encrypt operations", async ({
+  it("does not re-derive the encryption key when extending contracts with same signature", async ({
     relayer,
     signer,
     storage,
@@ -975,10 +985,8 @@ describe("deriveKey caching", () => {
       keypairTTL: 86400,
     });
 
-    // First call creates and encrypts credentials (deriveKey called for encrypt)
+    // First call creates and encrypts credentials
     await manager.allow(TOKEN_A);
-
-    const deriveKeySpy = vi.spyOn(crypto.subtle, "deriveKey");
 
     // Simulate reload: new manager reads from storage and decrypts
     const manager2 = new CredentialsManager({
@@ -990,21 +998,18 @@ describe("deriveKey caching", () => {
     });
     await manager2.allow(TOKEN_A);
 
-    const firstDeriveCalls = deriveKeySpy.mock.calls.length;
+    const deriveKeySpy = vi.spyOn(crypto.subtle, "deriveKey");
 
-    // Extend to TOKEN_B — forces decrypt (to read existing) + encrypt (to persist extended).
-    // Both #deriveKey calls use the same signature+address, so the cache should hit.
+    // Extend to TOKEN_B — the signature (mock-deterministic "0xsig789") and
+    // address haven't changed, so the cached derived key should be reused.
     await manager2.allow(TOKEN_A, TOKEN_B);
 
-    const secondDeriveCalls = deriveKeySpy.mock.calls.length;
-
-    // deriveKey should NOT have been called again because signature+address are the same
-    expect(secondDeriveCalls).toBe(firstDeriveCalls);
+    expect(deriveKeySpy).not.toHaveBeenCalled();
 
     deriveKeySpy.mockRestore();
   });
 
-  it("recomputes derived key when signature changes", async ({
+  it("re-derives the encryption key when signature changes", async ({
     relayer,
     signer,
     storage,
@@ -1023,10 +1028,11 @@ describe("deriveKey caching", () => {
 
     const deriveKeySpy = vi.spyOn(crypto.subtle, "deriveKey");
 
-    // Change signature for re-sign
+    // Change signature — simulates a wallet that produces a different sig
     vi.mocked(signer.signTypedData).mockResolvedValue("0xnewsig999");
 
-    // New manager forces re-sign with new signature
+    // New manager forces re-sign with new signature, which fails to decrypt
+    // the stored credentials (wrong key), causing full regeneration
     const manager2 = new CredentialsManager({
       relayer,
       signer,
@@ -1034,9 +1040,6 @@ describe("deriveKey caching", () => {
       sessionStorage: createMockStorage(),
       keypairTTL: 86400,
     });
-
-    // This will fail to decrypt with the wrong signature, causing regeneration
-    // which triggers a new deriveKey call for encryption
     await manager2.allow(TOKEN_A);
 
     expect(deriveKeySpy).toHaveBeenCalled();

--- a/packages/sdk/src/token/__tests__/credentials-manager.test.ts
+++ b/packages/sdk/src/token/__tests__/credentials-manager.test.ts
@@ -601,6 +601,281 @@ describe("session allow/revoke", () => {
   });
 });
 
+describe("storeKey caching", () => {
+  it("caches the SHA-256 store key across multiple allow() calls", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+    const digestSpy = vi.spyOn(crypto.subtle, "digest");
+
+    await credentialManager.allow(TOKEN_A);
+    const digestCallsAfterFirst = digestSpy.mock.calls.filter(
+      ([algo]) => algo === "SHA-256",
+    ).length;
+
+    await credentialManager.allow(TOKEN_A);
+    const digestCallsAfterSecond = digestSpy.mock.calls.filter(
+      ([algo]) => algo === "SHA-256",
+    ).length;
+
+    // Second allow() should not trigger another SHA-256 digest for the store key
+    expect(digestCallsAfterSecond).toBe(digestCallsAfterFirst);
+
+    digestSpy.mockRestore();
+  });
+
+  it("reuses cached store key for isExpired() after allow()", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    await credentialManager.allow(TOKEN_A);
+
+    // Reset call counts to measure only isExpired() calls
+    vi.mocked(signer.getAddress).mockClear();
+    vi.mocked(signer.getChainId).mockClear();
+    const digestSpy = vi.spyOn(crypto.subtle, "digest");
+
+    await credentialManager.isExpired();
+
+    // getAddress/getChainId are still called (to build identity string for comparison),
+    // but SHA-256 digest should NOT be called again because the cache hits
+    const sha256Calls = digestSpy.mock.calls.filter(([algo]) => algo === "SHA-256").length;
+    expect(sha256Calls).toBe(0);
+
+    digestSpy.mockRestore();
+  });
+
+  it("invalidates store key cache when signer address changes", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+    const manager = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+
+    await manager.allow(TOKEN_A);
+
+    // Change the signer address
+    vi.mocked(signer.getAddress).mockResolvedValue(
+      "0xdDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd" as Address,
+    );
+
+    const digestSpy = vi.spyOn(crypto.subtle, "digest");
+
+    await manager.allow(TOKEN_A);
+
+    // Should have recomputed the store key (new SHA-256 call)
+    const sha256Calls = digestSpy.mock.calls.filter(([algo]) => algo === "SHA-256").length;
+    expect(sha256Calls).toBeGreaterThanOrEqual(1);
+
+    digestSpy.mockRestore();
+  });
+
+  it("invalidates store key cache when chain ID changes", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+    const manager = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+
+    await manager.allow(TOKEN_A);
+
+    // Change the chain ID
+    vi.mocked(signer.getChainId).mockResolvedValue(1);
+
+    const digestSpy = vi.spyOn(crypto.subtle, "digest");
+
+    await manager.allow(TOKEN_A);
+
+    const sha256Calls = digestSpy.mock.calls.filter(([algo]) => algo === "SHA-256").length;
+    expect(sha256Calls).toBeGreaterThanOrEqual(1);
+
+    digestSpy.mockRestore();
+  });
+});
+
+describe("deriveKey caching", () => {
+  it("caches the PBKDF2 derived key across decrypt operations", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+    const manager = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+
+    // First call creates and encrypts credentials (deriveKey called for encrypt)
+    await manager.allow(TOKEN_A);
+
+    const deriveKeySpy = vi.spyOn(crypto.subtle, "deriveKey");
+
+    // Simulate reload: new manager reads from storage and decrypts
+    const manager2 = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+    await manager2.allow(TOKEN_A);
+
+    const firstDeriveCalls = deriveKeySpy.mock.calls.length;
+
+    // Third call on same manager2 — should use cached derived key
+    // Need to add TOKEN_B to force re-sign (otherwise in-memory cache returns)
+    // Instead, revoke to force re-sign path which re-decrypts
+    await manager2.revoke();
+    await manager2.allow(TOKEN_A);
+
+    const secondDeriveCalls = deriveKeySpy.mock.calls.length;
+
+    // deriveKey should NOT have been called again because signature+address are the same
+    expect(secondDeriveCalls).toBe(firstDeriveCalls);
+
+    deriveKeySpy.mockRestore();
+  });
+
+  it("recomputes derived key when signature changes", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+    const manager = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+
+    await manager.allow(TOKEN_A);
+
+    const deriveKeySpy = vi.spyOn(crypto.subtle, "deriveKey");
+
+    // Change signature for re-sign
+    vi.mocked(signer.signTypedData).mockResolvedValue("0xnewsig999");
+
+    // New manager forces re-sign with new signature
+    const manager2 = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+
+    // This will fail to decrypt with the wrong signature, causing regeneration
+    // which triggers a new deriveKey call for encryption
+    await manager2.allow(TOKEN_A);
+
+    expect(deriveKeySpy).toHaveBeenCalled();
+
+    deriveKeySpy.mockRestore();
+  });
+});
+
+describe("unified #isValid", () => {
+  it("isExpired validates EncryptedCredentials from storage (without decryption)", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+    const manager = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+
+    await manager.allow(TOKEN_A);
+
+    // New manager without session — isExpired reads EncryptedCredentials directly
+    const manager2 = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+
+    // Should report not expired (credentials are fresh)
+    expect(await manager2.isExpired()).toBe(false);
+    // Should report expired for uncovered contract
+    expect(await manager2.isExpired(TOKEN_B)).toBe(true);
+  });
+
+  it("isExpired handles expired EncryptedCredentials without needing to decrypt", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+    const manager = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+    const storeKey = await computeStoreKey(await signer.getAddress());
+
+    await manager.allow(TOKEN_A);
+
+    // Tamper stored data to simulate expiration
+    const stored = await storage.get(storeKey);
+    const parsed = { ...(stored as Record<string, unknown>) };
+    parsed.startTimestamp = Math.floor(Date.now() / 1000) - 8 * 86400;
+    await storage.set(storeKey, parsed);
+
+    const manager2 = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+
+    // No decrypt calls should be needed — #isValid works on EncryptedCredentials directly
+    const decryptSpy = vi.spyOn(crypto.subtle, "decrypt");
+    expect(await manager2.isExpired()).toBe(true);
+    expect(decryptSpy).not.toHaveBeenCalled();
+
+    decryptSpy.mockRestore();
+  });
+});
+
 describe("KeypairExpiredError", () => {
   it("has the correct error code", () => {
     const error = new KeypairExpiredError("credentials expired");

--- a/packages/sdk/src/token/__tests__/credentials-manager.test.ts
+++ b/packages/sdk/src/token/__tests__/credentials-manager.test.ts
@@ -862,14 +862,11 @@ describe("contract address extension", () => {
     // After the initial allow(), record the order of set() calls during
     // the extension. storage.set = ciphertext write, sessionStorage.set = session write.
     const writeOrder: string[] = [];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const storageMock = storage as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sessionMock = sessionStorage as any;
-    storageMock.set = vi.fn(async () => {
+
+    storage.set = vi.fn(async () => {
       writeOrder.push("ciphertext");
     });
-    sessionMock.set = vi.fn(async () => {
+    sessionStorage.set = vi.fn(async () => {
       writeOrder.push("session");
     });
 

--- a/packages/sdk/src/token/__tests__/credentials-manager.test.ts
+++ b/packages/sdk/src/token/__tests__/credentials-manager.test.ts
@@ -59,7 +59,7 @@ describe("CredentialsManager", () => {
     expect(relayer.generateKeypair).toHaveBeenCalledOnce();
   });
 
-  it("re-signs when new contract not in signed list", async ({
+  it("re-signs when new contract not in signed list but reuses keypair", async ({
     relayer,
     signer,
     credentialManager,
@@ -67,10 +67,16 @@ describe("CredentialsManager", () => {
     setupMocks(relayer, signer);
 
     await credentialManager.allow(TOKEN_A);
-    await credentialManager.allow(TOKEN_A, TOKEN_B);
+    const creds = await credentialManager.allow(TOKEN_A, TOKEN_B);
 
-    expect(relayer.generateKeypair).toHaveBeenCalledTimes(2);
+    // Keypair is reused — only one generation
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    // Re-signed with the extended address set
     expect(signer.signTypedData).toHaveBeenCalledTimes(2);
+    // Merged contract addresses include both tokens (checksummed by getAddress)
+    const normalized = creds.contractAddresses.map((a: string) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
   }, 30000);
 
   it("persists credentials to store with hashed key", async ({
@@ -598,6 +604,225 @@ describe("session allow/revoke", () => {
     await manager2.revoke();
 
     expect(events).toContain(ZamaSDKEvents.CredentialsRevoked);
+  });
+});
+
+describe("contract address extension", () => {
+  const TOKEN_C = "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC" as Address;
+
+  it("extends contracts with active session, reusing keypair", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    const first = await credentialManager.allow(TOKEN_A);
+    const extended = await credentialManager.allow(TOKEN_A, TOKEN_B);
+
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    expect(signer.signTypedData).toHaveBeenCalledTimes(2);
+    // Same keypair
+    expect(extended.publicKey).toBe(first.publicKey);
+    expect(extended.privateKey).toBe(first.privateKey);
+    // Merged addresses
+    const normalized = extended.contractAddresses.map((a) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
+  });
+
+  it("extends contracts after revoke (no session path)", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    await credentialManager.allow(TOKEN_A);
+    await credentialManager.revoke();
+    const extended = await credentialManager.allow(TOKEN_A, TOKEN_B);
+
+    // Keypair reused — only one generation
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    // Original sign + old-address sign for decrypt + merged-address sign for extend
+    expect(signer.signTypedData).toHaveBeenCalledTimes(3);
+    const normalized = extended.contractAddresses.map((a) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
+  });
+
+  it("extends contracts after page reload (new session storage, no session)", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+
+    const manager1 = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+    await manager1.allow(TOKEN_A);
+
+    // Simulate reload: new session storage, same persistent storage
+    const manager2 = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+    const extended = await manager2.allow(TOKEN_A, TOKEN_B);
+
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    // Original sign + old-address sign for decrypt + merged-address sign for extend
+    expect(signer.signTypedData).toHaveBeenCalledTimes(3);
+    const normalized = extended.contractAddresses.map((a) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
+  });
+
+  it("caches extended credentials — third call with same set does not re-sign", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    await credentialManager.allow(TOKEN_A);
+    await credentialManager.allow(TOKEN_A, TOKEN_B);
+    await credentialManager.allow(TOKEN_A, TOKEN_B);
+
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    // Only 2 signatures: initial + extend. Third call is cached.
+    expect(signer.signTypedData).toHaveBeenCalledTimes(2);
+  });
+
+  it("persists extended credentials across instances", async ({
+    relayer,
+    signer,
+    storage,
+    sessionStorage,
+    createCredentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    const manager1 = createCredentialManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage,
+      keypairTTL: 86400,
+    });
+    await manager1.allow(TOKEN_A);
+    await manager1.allow(TOKEN_A, TOKEN_B);
+
+    // New instance, same storage backends
+    const manager2 = createCredentialManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage,
+      keypairTTL: 86400,
+    });
+    await manager2.allow(TOKEN_A, TOKEN_B);
+
+    // No additional keypair or signature — all cached
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    expect(signer.signTypedData).toHaveBeenCalledTimes(2);
+  });
+
+  it("extends incrementally: A → A,B → A,B,C", async ({ relayer, signer, credentialManager }) => {
+    setupMocks(relayer, signer);
+
+    await credentialManager.allow(TOKEN_A);
+    await credentialManager.allow(TOKEN_A, TOKEN_B);
+    const final = await credentialManager.allow(TOKEN_A, TOKEN_B, TOKEN_C);
+
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    // 3 signatures: initial + extend to B + extend to C
+    expect(signer.signTypedData).toHaveBeenCalledTimes(3);
+    const normalized = final.contractAddresses.map((a) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
+    expect(normalized).toContain(TOKEN_C.toLowerCase());
+  });
+
+  it("subset of already-allowed contracts does not re-sign", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    await credentialManager.allow(TOKEN_A, TOKEN_B);
+    await credentialManager.allow(TOKEN_A); // subset
+
+    expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+    expect(signer.signTypedData).toHaveBeenCalledOnce();
+  });
+
+  it("fully regenerates when credentials are time-expired even with missing contracts", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+
+    const manager = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+    const storeKey = await CredentialsManager.computeStoreKey(
+      await signer.getAddress(),
+      await signer.getChainId(),
+    );
+
+    await manager.allow(TOKEN_A);
+
+    // Tamper stored data to simulate time expiration
+    const stored = await storage.get(storeKey);
+    const parsed = { ...(stored as Record<string, unknown>) };
+    parsed.startTimestamp = Math.floor(Date.now() / 1000) - 8 * 86400;
+    await storage.set(storeKey, parsed);
+
+    const manager2 = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+    await manager2.allow(TOKEN_A, TOKEN_B);
+
+    // Time-expired → full regeneration, not extension
+    expect(relayer.generateKeypair).toHaveBeenCalledTimes(2);
+  }, 30000);
+
+  it("EIP-712 is created with the merged contract set", async ({
+    relayer,
+    signer,
+    credentialManager,
+  }) => {
+    setupMocks(relayer, signer);
+
+    await credentialManager.allow(TOKEN_A);
+    await credentialManager.allow(TOKEN_A, TOKEN_B);
+
+    // Second createEIP712 call should include both tokens
+    const secondCall = vi.mocked(relayer.createEIP712).mock.calls[1]!;
+    const contractAddresses = secondCall[1] as Address[];
+    const normalized = contractAddresses.map((a) => a.toLowerCase());
+    expect(normalized).toContain(TOKEN_A.toLowerCase());
+    expect(normalized).toContain(TOKEN_B.toLowerCase());
   });
 });
 

--- a/packages/sdk/src/token/__tests__/credentials-manager.test.ts
+++ b/packages/sdk/src/token/__tests__/credentials-manager.test.ts
@@ -702,38 +702,38 @@ describe("contract address extension", () => {
     expect(signer.signTypedData).toHaveBeenCalledTimes(2);
   });
 
-  it("persists extended credentials across instances", async ({
+  it("persists extended credentials across instances (simulated reload)", async ({
     relayer,
     signer,
     storage,
-    sessionStorage,
-    createCredentialManager,
+    createMockStorage,
   }) => {
     setupMocks(relayer, signer);
 
-    const manager1 = createCredentialManager({
+    const sharedSessionStorage = createMockStorage();
+    const manager1 = new CredentialsManager({
       relayer,
       signer,
       storage,
-      sessionStorage,
+      sessionStorage: sharedSessionStorage,
       keypairTTL: 86400,
     });
     await manager1.allow(TOKEN_A);
     await manager1.allow(TOKEN_A, TOKEN_B);
 
-    // New instance, same storage backends
-    const manager2 = createCredentialManager({
+    // Simulate page reload: fresh session storage, same persistent storage
+    const manager2 = new CredentialsManager({
       relayer,
       signer,
       storage,
-      sessionStorage,
+      sessionStorage: createMockStorage(),
       keypairTTL: 86400,
     });
     await manager2.allow(TOKEN_A, TOKEN_B);
 
-    // No additional keypair or signature — all cached
+    // Keypair reused, but re-signed due to lost session
     expect(relayer.generateKeypair).toHaveBeenCalledOnce();
-    expect(signer.signTypedData).toHaveBeenCalledTimes(2);
+    expect(signer.signTypedData).toHaveBeenCalledTimes(3);
   });
 
   it("extends incrementally: A → A,B → A,B,C", async ({ relayer, signer, credentialManager }) => {
@@ -940,7 +940,7 @@ describe("storeKey caching", () => {
 });
 
 describe("deriveKey caching", () => {
-  it("caches the PBKDF2 derived key across decrypt operations", async ({
+  it("caches the PBKDF2 derived key across decrypt and encrypt operations", async ({
     relayer,
     signer,
     storage,
@@ -972,11 +972,9 @@ describe("deriveKey caching", () => {
 
     const firstDeriveCalls = deriveKeySpy.mock.calls.length;
 
-    // Third call on same manager2 — should use cached derived key
-    // Need to add TOKEN_B to force re-sign (otherwise in-memory cache returns)
-    // Instead, revoke to force re-sign path which re-decrypts
-    await manager2.revoke();
-    await manager2.allow(TOKEN_A);
+    // Extend to TOKEN_B — forces decrypt (to read existing) + encrypt (to persist extended).
+    // Both #deriveKey calls use the same signature+address, so the cache should hit.
+    await manager2.allow(TOKEN_A, TOKEN_B);
 
     const secondDeriveCalls = deriveKeySpy.mock.calls.length;
 

--- a/packages/sdk/src/token/__tests__/credentials-manager.test.ts
+++ b/packages/sdk/src/token/__tests__/credentials-manager.test.ts
@@ -840,6 +840,44 @@ describe("contract address extension", () => {
     expect(firstContracts).toContain(getAddress(TOKEN_A));
     expect(firstContracts).toContain(getAddress(TOKEN_B));
   });
+
+  it("persists ciphertext before session signature during extension", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+    const sessionStorage = createMockStorage();
+    const manager = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage,
+      keypairTTL: 86400,
+    });
+
+    await manager.allow(TOKEN_A);
+
+    // After the initial allow(), record the order of set() calls during
+    // the extension. storage.set = ciphertext write, sessionStorage.set = session write.
+    const writeOrder: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const storageMock = storage as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sessionMock = sessionStorage as any;
+    storageMock.set = vi.fn(async () => {
+      writeOrder.push("ciphertext");
+    });
+    sessionMock.set = vi.fn(async () => {
+      writeOrder.push("session");
+    });
+
+    await manager.allow(TOKEN_A, TOKEN_B);
+
+    // Extension should write ciphertext before updating the session signature
+    expect(writeOrder).toEqual(["ciphertext", "session"]);
+  });
 });
 
 describe("storeKey caching", () => {

--- a/packages/sdk/src/token/__tests__/credentials-manager.test.ts
+++ b/packages/sdk/src/token/__tests__/credentials-manager.test.ts
@@ -6,22 +6,11 @@ import { KeypairExpiredError } from "../errors";
 import type { RelayerSDK } from "../../relayer/relayer-sdk";
 import type { GenericSigner } from "../token.types";
 import { ZamaSDKEvents } from "../../events";
+import { getAddress } from "viem";
 import type { Address } from "viem";
 
 const TOKEN_A = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address;
 const TOKEN_B = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" as Address;
-
-/** Compute the truncated SHA-256 store key used by CredentialManager. */
-async function computeStoreKey(address: Address, chainId: number = 31337): Promise<string> {
-  const hash = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(`${address}:${chainId}`),
-  );
-  const hex = Array.from(new Uint8Array(hash))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  return hex.slice(0, 32);
-}
 
 /** Override fixture mock return values to match test expectations. */
 function setupMocks(relayer: RelayerSDK, signer: GenericSigner) {
@@ -74,9 +63,9 @@ describe("CredentialsManager", () => {
     // Re-signed with the extended address set
     expect(signer.signTypedData).toHaveBeenCalledTimes(2);
     // Merged contract addresses include both tokens (checksummed by getAddress)
-    const normalized = creds.contractAddresses.map((a: string) => a.toLowerCase());
-    expect(normalized).toContain(TOKEN_A.toLowerCase());
-    expect(normalized).toContain(TOKEN_B.toLowerCase());
+    const normalized = creds.contractAddresses.map((a: string) => getAddress(a));
+    expect(normalized).toContain(getAddress(TOKEN_A));
+    expect(normalized).toContain(getAddress(TOKEN_B));
   }, 30000);
 
   it("persists credentials to store with hashed key", async ({
@@ -86,7 +75,7 @@ describe("CredentialsManager", () => {
     credentialManager,
   }) => {
     setupMocks(relayer, signer);
-    const storeKey = await computeStoreKey(await signer.getAddress());
+    const storeKey = await CredentialsManager.computeStoreKey(await signer.getAddress(), 31337);
 
     await credentialManager.allow(TOKEN_A);
 
@@ -160,7 +149,7 @@ describe("CredentialsManager", () => {
       sessionStorage: createMockStorage(),
       keypairTTL: 86400,
     });
-    const storeKey = await computeStoreKey(await signer.getAddress());
+    const storeKey = await CredentialsManager.computeStoreKey(await signer.getAddress(), 31337);
 
     // Create credentials to get valid encrypted data
     await manager.allow(TOKEN_A);
@@ -197,7 +186,7 @@ describe("CredentialsManager", () => {
       sessionStorage: createMockStorage(),
       keypairTTL: 86400,
     });
-    const storeKey = await computeStoreKey(await signer.getAddress());
+    const storeKey = await CredentialsManager.computeStoreKey(await signer.getAddress(), 31337);
 
     // First call creates credentials — which get stored under the hashed key
     await manager.allow(TOKEN_A);
@@ -225,7 +214,7 @@ describe("CredentialsManager", () => {
 
   it("clears credentials", async ({ relayer, signer, storage, credentialManager }) => {
     setupMocks(relayer, signer);
-    const storeKey = await computeStoreKey(await signer.getAddress());
+    const storeKey = await CredentialsManager.computeStoreKey(await signer.getAddress(), 31337);
 
     await credentialManager.allow(TOKEN_A);
     await credentialManager.clear();
@@ -326,7 +315,7 @@ describe("CredentialsManager", () => {
     credentialManager,
   }) => {
     setupMocks(relayer, signer);
-    const storeKey = await computeStoreKey(await signer.getAddress());
+    const storeKey = await CredentialsManager.computeStoreKey(await signer.getAddress(), 31337);
 
     // Write garbage to the store
     await storage.set(storeKey, "not-valid-json{{{{");
@@ -349,7 +338,7 @@ describe("CredentialsManager", () => {
     credentialManager,
   }) => {
     setupMocks(relayer, signer);
-    const storeKey = await computeStoreKey(await signer.getAddress());
+    const storeKey = await CredentialsManager.computeStoreKey(await signer.getAddress(), 31337);
 
     // Write corrupted data to trigger the catch path
     await storage.set(storeKey, "corrupted");
@@ -381,7 +370,7 @@ describe("CredentialsManager", () => {
       sessionStorage: createMockStorage(),
       keypairTTL: 86400,
     });
-    const storeKey = await computeStoreKey(await signer.getAddress());
+    const storeKey = await CredentialsManager.computeStoreKey(await signer.getAddress(), 31337);
 
     await manager.allow(TOKEN_A);
     expect(relayer.generateKeypair).toHaveBeenCalledOnce();
@@ -439,7 +428,7 @@ describe("CredentialsManager", () => {
         sessionStorage: createMockStorage(),
         keypairTTL: 86400,
       });
-      const storeKey = await computeStoreKey(await signer.getAddress());
+      const storeKey = await CredentialsManager.computeStoreKey(await signer.getAddress(), 31337);
 
       await manager.allow(TOKEN_A);
 
@@ -493,7 +482,7 @@ describe("CredentialsManager", () => {
       credentialManager,
     }) => {
       setupMocks(relayer, signer);
-      const storeKey = await computeStoreKey(await signer.getAddress());
+      const storeKey = await CredentialsManager.computeStoreKey(await signer.getAddress(), 31337);
       await storage.set(storeKey, "corrupted-json{{{");
       expect(await credentialManager.isExpired()).toBe(false);
     });
@@ -519,7 +508,7 @@ describe("CredentialsManager", () => {
     credentialManager,
   }) => {
     setupMocks(relayer, signer);
-    const storeKey = await computeStoreKey(await signer.getAddress());
+    const storeKey = await CredentialsManager.computeStoreKey(await signer.getAddress(), 31337);
 
     await credentialManager.allow(TOKEN_A);
     expect(await credentialManager.isAllowed()).toBe(true);
@@ -626,9 +615,9 @@ describe("contract address extension", () => {
     expect(extended.publicKey).toBe(first.publicKey);
     expect(extended.privateKey).toBe(first.privateKey);
     // Merged addresses
-    const normalized = extended.contractAddresses.map((a) => a.toLowerCase());
-    expect(normalized).toContain(TOKEN_A.toLowerCase());
-    expect(normalized).toContain(TOKEN_B.toLowerCase());
+    const normalized = extended.contractAddresses.map((a) => getAddress(a));
+    expect(normalized).toContain(getAddress(TOKEN_A));
+    expect(normalized).toContain(getAddress(TOKEN_B));
   });
 
   it("extends contracts after revoke (no session path)", async ({
@@ -646,9 +635,9 @@ describe("contract address extension", () => {
     expect(relayer.generateKeypair).toHaveBeenCalledOnce();
     // Original sign + old-address sign for decrypt + merged-address sign for extend
     expect(signer.signTypedData).toHaveBeenCalledTimes(3);
-    const normalized = extended.contractAddresses.map((a) => a.toLowerCase());
-    expect(normalized).toContain(TOKEN_A.toLowerCase());
-    expect(normalized).toContain(TOKEN_B.toLowerCase());
+    const normalized = extended.contractAddresses.map((a) => getAddress(a));
+    expect(normalized).toContain(getAddress(TOKEN_A));
+    expect(normalized).toContain(getAddress(TOKEN_B));
   });
 
   it("extends contracts after page reload (new session storage, no session)", async ({
@@ -681,9 +670,9 @@ describe("contract address extension", () => {
     expect(relayer.generateKeypair).toHaveBeenCalledOnce();
     // Original sign + old-address sign for decrypt + merged-address sign for extend
     expect(signer.signTypedData).toHaveBeenCalledTimes(3);
-    const normalized = extended.contractAddresses.map((a) => a.toLowerCase());
-    expect(normalized).toContain(TOKEN_A.toLowerCase());
-    expect(normalized).toContain(TOKEN_B.toLowerCase());
+    const normalized = extended.contractAddresses.map((a) => getAddress(a));
+    expect(normalized).toContain(getAddress(TOKEN_A));
+    expect(normalized).toContain(getAddress(TOKEN_B));
   });
 
   it("caches extended credentials — third call with same set does not re-sign", async ({
@@ -746,10 +735,10 @@ describe("contract address extension", () => {
     expect(relayer.generateKeypair).toHaveBeenCalledOnce();
     // 3 signatures: initial + extend to B + extend to C
     expect(signer.signTypedData).toHaveBeenCalledTimes(3);
-    const normalized = final.contractAddresses.map((a) => a.toLowerCase());
-    expect(normalized).toContain(TOKEN_A.toLowerCase());
-    expect(normalized).toContain(TOKEN_B.toLowerCase());
-    expect(normalized).toContain(TOKEN_C.toLowerCase());
+    const normalized = final.contractAddresses.map((a) => getAddress(a));
+    expect(normalized).toContain(getAddress(TOKEN_A));
+    expect(normalized).toContain(getAddress(TOKEN_B));
+    expect(normalized).toContain(getAddress(TOKEN_C));
   });
 
   it("subset of already-allowed contracts does not re-sign", async ({
@@ -820,9 +809,9 @@ describe("contract address extension", () => {
     // Second createEIP712 call should include both tokens
     const secondCall = vi.mocked(relayer.createEIP712).mock.calls[1]!;
     const contractAddresses = secondCall[1] as Address[];
-    const normalized = contractAddresses.map((a) => a.toLowerCase());
-    expect(normalized).toContain(TOKEN_A.toLowerCase());
-    expect(normalized).toContain(TOKEN_B.toLowerCase());
+    const normalized = contractAddresses.map((a) => getAddress(a));
+    expect(normalized).toContain(getAddress(TOKEN_A));
+    expect(normalized).toContain(getAddress(TOKEN_B));
   });
 });
 
@@ -934,6 +923,37 @@ describe("storeKey caching", () => {
 
     const sha256Calls = digestSpy.mock.calls.filter(([algo]) => algo === "SHA-256").length;
     expect(sha256Calls).toBeGreaterThanOrEqual(1);
+
+    digestSpy.mockRestore();
+  });
+
+  it("reuses the same store key when signer address casing changes", async ({
+    relayer,
+    signer,
+    storage,
+    createMockStorage,
+  }) => {
+    setupMocks(relayer, signer);
+    const manager = new CredentialsManager({
+      relayer,
+      signer,
+      storage,
+      sessionStorage: createMockStorage(),
+      keypairTTL: 86400,
+    });
+
+    await manager.allow(TOKEN_A);
+
+    const digestSpy = vi.spyOn(crypto.subtle, "digest");
+
+    vi.mocked(signer.getAddress).mockResolvedValue(
+      "0x2222222222222222222222222222222222ABCDEF" as Address,
+    );
+
+    await manager.allow(TOKEN_A);
+
+    const sha256Calls = digestSpy.mock.calls.filter(([algo]) => algo === "SHA-256").length;
+    expect(sha256Calls).toBe(0);
 
     digestSpy.mockRestore();
   });
@@ -1072,7 +1092,7 @@ describe("unified #isValid", () => {
       sessionStorage: createMockStorage(),
       keypairTTL: 86400,
     });
-    const storeKey = await computeStoreKey(await signer.getAddress());
+    const storeKey = await CredentialsManager.computeStoreKey(await signer.getAddress(), 31337);
 
     await manager.allow(TOKEN_A);
 

--- a/packages/sdk/src/token/__tests__/readonly-token.test.ts
+++ b/packages/sdk/src/token/__tests__/readonly-token.test.ts
@@ -6,6 +6,7 @@ import type { GenericSigner, GenericStorage } from "../token.types";
 import type { RelayerSDK } from "../../relayer/relayer-sdk";
 
 import { DecryptionFailedError } from "../errors";
+import { saveCachedBalance } from "../balance-cache";
 import { getAddress, type Address } from "viem";
 
 const VALID_HANDLE2 = ("0x" + "cd".repeat(32)) as Address;
@@ -456,6 +457,118 @@ describe("ReadonlyToken", () => {
           handles: [handle as Address, VALID_HANDLE2 as Address],
         }),
       ).rejects.toThrow(/tokens\.length.*must equal.*handles\.length/);
+    });
+  });
+
+  describe("batchDecryptBalances (cache-aware allow)", () => {
+    const TOKEN2 = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address;
+
+    it("skips allow() entirely when all balances are cached", async ({
+      relayer,
+      signer,
+      storage,
+      sessionStorage,
+      tokenAddress,
+      handle,
+    }) => {
+      const token = createReadonlyToken({
+        relayer,
+        signer,
+        storage,
+        sessionStorage,
+        tokenAddress,
+        handle,
+      });
+      const token2 = new ReadonlyToken({
+        relayer,
+        signer,
+        storage,
+        sessionStorage,
+        address: TOKEN2,
+      });
+
+      const signerAddress = await signer.getAddress();
+
+      // Pre-populate cache for both tokens
+      await saveCachedBalance({
+        storage,
+        tokenAddress,
+        owner: signerAddress,
+        handle: handle as Address,
+        value: 1000n,
+      });
+      await saveCachedBalance({
+        storage,
+        tokenAddress: TOKEN2,
+        owner: signerAddress,
+        handle: VALID_HANDLE2,
+        value: 2000n,
+      });
+
+      const result = await ReadonlyToken.batchDecryptBalances([token, token2], {
+        handles: [handle as Address, VALID_HANDLE2],
+      });
+
+      expect(result.get(tokenAddress)).toBe(1000n);
+      expect(result.get(getAddress(TOKEN2))).toBe(2000n);
+      // No credentials needed — no keypair generation or signing
+      expect(relayer.generateKeypair).not.toHaveBeenCalled();
+      expect(signer.signTypedData).not.toHaveBeenCalled();
+    });
+
+    it("calls allow() only with uncached token addresses", async ({
+      relayer,
+      signer,
+      storage,
+      sessionStorage,
+      tokenAddress,
+      handle,
+    }) => {
+      const token = createReadonlyToken({
+        relayer,
+        signer,
+        storage,
+        sessionStorage,
+        tokenAddress,
+        handle,
+      });
+      const token2 = new ReadonlyToken({
+        relayer,
+        signer,
+        storage,
+        sessionStorage,
+        address: TOKEN2,
+      });
+
+      const signerAddress = await signer.getAddress();
+
+      // Pre-populate cache only for token1
+      await saveCachedBalance({
+        storage,
+        tokenAddress,
+        owner: signerAddress,
+        handle: handle as Address,
+        value: 1000n,
+      });
+
+      vi.mocked(relayer.userDecrypt).mockResolvedValueOnce({
+        [VALID_HANDLE2]: 2000n,
+      } as never);
+
+      const result = await ReadonlyToken.batchDecryptBalances([token, token2], {
+        handles: [handle as Address, VALID_HANDLE2],
+      });
+
+      expect(result.get(tokenAddress)).toBe(1000n);
+      expect(result.get(getAddress(TOKEN2))).toBe(2000n);
+      // Credentials generated only for the uncached token
+      expect(relayer.generateKeypair).toHaveBeenCalledOnce();
+      expect(signer.signTypedData).toHaveBeenCalledOnce();
+      // createEIP712 called with only token2's address
+      const eip712Call = vi.mocked(relayer.createEIP712).mock.calls[0]!;
+      const signedAddresses = eip712Call[1] as Address[];
+      expect(signedAddresses).toHaveLength(1);
+      expect(signedAddresses[0]!.toLowerCase()).toBe(TOKEN2.toLowerCase());
     });
   });
 

--- a/packages/sdk/src/token/credentials-manager.ts
+++ b/packages/sdk/src/token/credentials-manager.ts
@@ -70,6 +70,7 @@ export class CredentialsManager {
   #onEvent: ZamaSDKEventListener;
   #createPromise: Promise<StoredCredentials> | null = null;
   #createPromiseKey: string | null = null;
+  #extendPromise: Promise<StoredCredentials> | null = null;
   #cachedStoreKey: string | null = null;
   #cachedStoreKeyIdentity: string | null = null;
   #cachedDerivedKey: CryptoKey | null = null;
@@ -412,8 +413,44 @@ export class CredentialsManager {
   /**
    * Extend credentials with additional contract addresses: re-sign with the
    * merged set and persist, reusing the existing keypair.
+   *
+   * Serialized via `#extendPromise` so that concurrent `allow()` calls with
+   * different addresses don't race on read-modify-write of the contract list.
    */
   async #extendContracts({
+    storeKey,
+    credentials,
+    requiredContracts,
+  }: {
+    storeKey: string;
+    credentials: StoredCredentials;
+    requiredContracts: Address[];
+  }): Promise<StoredCredentials> {
+    // Serialize concurrent extensions to prevent last-write-wins races.
+    if (this.#extendPromise) {
+      const previous = await this.#extendPromise;
+      // Previous extension may already cover our required contracts.
+      if (this.#coversContracts(previous.contractAddresses, requiredContracts)) {
+        this.#emit({
+          type: ZamaSDKEvents.CredentialsAllowed,
+          contractAddresses: requiredContracts,
+        });
+        return previous;
+      }
+      // Use the latest state as our base so we don't drop its addresses.
+      credentials = previous;
+    }
+
+    const promise = this.#performExtend({ storeKey, credentials, requiredContracts });
+    this.#extendPromise = promise;
+    try {
+      return await promise;
+    } finally {
+      if (this.#extendPromise === promise) this.#extendPromise = null;
+    }
+  }
+
+  async #performExtend({
     storeKey,
     credentials,
     requiredContracts,

--- a/packages/sdk/src/token/credentials-manager.ts
+++ b/packages/sdk/src/token/credentials-manager.ts
@@ -6,7 +6,7 @@ import { SigningRejectedError, SigningFailedError } from "./errors";
 import { assertObject, assertString, assertArray, assertCondition, prefixHex } from "../utils";
 import { ZamaSDKEvents } from "../events/sdk-events";
 import type { ZamaSDKEventInput, ZamaSDKEventListener } from "../events/sdk-events";
-import { getAddress, type Address, type Hex } from "viem";
+import { getAddress, isAddress, type Address, type Hex } from "viem";
 
 /** Encrypted data format with IV for AES-GCM decryption. */
 interface EncryptedData {
@@ -253,6 +253,7 @@ export class CredentialsManager {
   async revoke(...contractAddresses: Address[]): Promise<void> {
     const storeKey = await this.#storeKey();
     await this.#sessionStorage.delete(storeKey);
+    this.#clearCryptoCache();
     this.#emit({
       type: ZamaSDKEvents.CredentialsRevoked,
       ...(contractAddresses.length > 0 && { contractAddresses }),
@@ -280,11 +281,20 @@ export class CredentialsManager {
   async clear(): Promise<void> {
     const storeKey = await this.#storeKey();
     await this.#sessionStorage.delete(storeKey);
+    this.#clearCryptoCache();
     try {
       await this.#storage.delete(storeKey);
     } catch {
       // Best effort
     }
+  }
+
+  /** Clear cached cryptographic material (store key, derived key). */
+  #clearCryptoCache(): void {
+    this.#cachedStoreKey = null;
+    this.#cachedStoreKeyIdentity = null;
+    this.#cachedDerivedKey = null;
+    this.#cachedDerivedKeyIdentity = null;
   }
 
   /** Returns a truncated SHA-256 hash of the address and chainId to avoid leaking it in storage. */
@@ -340,6 +350,12 @@ export class CredentialsManager {
     assertObject(data, "Stored credentials");
     assertString(data.publicKey, "credentials.publicKey");
     assertArray(data.contractAddresses, "credentials.contractAddresses");
+    for (const addr of data.contractAddresses) {
+      assertCondition(
+        typeof addr === "string" && isAddress(addr, { strict: false }),
+        `Expected each contractAddress to be a valid hex address`,
+      );
+    }
     assertObject(data.encryptedPrivateKey, "credentials.encryptedPrivateKey");
     assertString(data.encryptedPrivateKey.iv, "encryptedPrivateKey.iv");
     assertString(data.encryptedPrivateKey.ciphertext, "encryptedPrivateKey.ciphertext");
@@ -362,8 +378,8 @@ export class CredentialsManager {
 
   /** Check if the signed address set covers all required addresses. */
   #coversContracts(signedAddresses: Address[], requiredContracts: Address[]): boolean {
-    const signedSet = new Set(signedAddresses.map((a) => a.toLowerCase()));
-    return requiredContracts.every((addr) => signedSet.has(addr.toLowerCase()));
+    const signed = new Set(signedAddresses.map((a) => a.toLowerCase()));
+    return requiredContracts.every((addr) => signed.has(addr.toLowerCase()));
   }
 
   async #sign(encrypted: EncryptedCredentials): Promise<Hex> {
@@ -386,8 +402,11 @@ export class CredentialsManager {
 
   /** Merge two contract address lists into a deduplicated sorted array. */
   #mergeContracts(existing: Address[], incoming: Address[]): Address[] {
-    const set = new Set([...existing, ...incoming].map(getAddress));
-    return [...set].sort();
+    const seen = new Map<string, Address>();
+    for (const addr of [...existing, ...incoming]) {
+      seen.set(addr.toLowerCase(), addr);
+    }
+    return [...seen.values()].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
   }
 
   /**

--- a/packages/sdk/src/token/credentials-manager.ts
+++ b/packages/sdk/src/token/credentials-manager.ts
@@ -76,9 +76,10 @@ export class CredentialsManager {
   #cachedDerivedKeyIdentity: string | null = null;
 
   static async computeStoreKey(address: Address, chainId: number): Promise<string> {
+    const normalizedAddress = getAddress(address);
     const hash = await crypto.subtle.digest(
       "SHA-256",
-      new TextEncoder().encode(`${address}:${chainId}`),
+      new TextEncoder().encode(`${normalizedAddress}:${chainId}`),
     );
     const hex = Array.from(new Uint8Array(hash))
       .map((b) => b.toString(16).padStart(2, "0"))
@@ -124,6 +125,9 @@ export class CredentialsManager {
    * ```
    */
   async allow(...contractAddresses: Address[]): Promise<StoredCredentials> {
+    contractAddresses = [
+      ...new Set(contractAddresses.map((address) => getAddress(address))),
+    ].sort();
     const storeKey = await this.#storeKey();
     this.#emit({ type: ZamaSDKEvents.CredentialsLoading, contractAddresses });
     try {
@@ -185,7 +189,7 @@ export class CredentialsManager {
       }
     }
 
-    const key = contractAddresses.map(getAddress).sort().join(",");
+    const key = contractAddresses.join(",");
     if (!this.#createPromise || this.#createPromiseKey !== key) {
       this.#createPromiseKey = key;
       this.#createPromise = this.create(contractAddresses)
@@ -301,7 +305,7 @@ export class CredentialsManager {
   async #storeKey(): Promise<string> {
     const address = await this.#signer.getAddress();
     const chainId = await this.#signer.getChainId();
-    const identity = `${address}:${chainId}`;
+    const identity = `${getAddress(address)}:${chainId}`;
     if (this.#cachedStoreKey && this.#cachedStoreKeyIdentity === identity) {
       return this.#cachedStoreKey;
     }
@@ -378,8 +382,8 @@ export class CredentialsManager {
 
   /** Check if the signed address set covers all required addresses. */
   #coversContracts(signedAddresses: Address[], requiredContracts: Address[]): boolean {
-    const required = new Set(requiredContracts.map((a) => a.toLowerCase()));
-    return required.isSubsetOf(new Set(signedAddresses.map((a) => a.toLowerCase())));
+    const required = new Set(requiredContracts.map((address) => getAddress(address)));
+    return required.isSubsetOf(new Set(signedAddresses.map((address) => getAddress(address))));
   }
 
   async #sign(encrypted: EncryptedCredentials): Promise<Hex> {
@@ -402,7 +406,7 @@ export class CredentialsManager {
 
   /** Merge two contract address lists into a deduplicated sorted array. */
   #mergeContracts(existing: Address[], incoming: Address[]): Address[] {
-    return [...new Set([...existing, ...incoming].map((a) => a.toLowerCase() as Address))].sort();
+    return [...new Set([...existing, ...incoming].map((address) => getAddress(address)))].sort();
   }
 
   /**
@@ -454,6 +458,9 @@ export class CredentialsManager {
    * ```
    */
   async create(contractAddresses: Address[]): Promise<StoredCredentials> {
+    contractAddresses = [
+      ...new Set(contractAddresses.map((address) => getAddress(address))),
+    ].sort();
     this.#emit({ type: ZamaSDKEvents.CredentialsCreating, contractAddresses });
     try {
       const storeKey = await this.#storeKey();

--- a/packages/sdk/src/token/credentials-manager.ts
+++ b/packages/sdk/src/token/credentials-manager.ts
@@ -70,6 +70,10 @@ export class CredentialsManager {
   #onEvent: ZamaSDKEventListener;
   #createPromise: Promise<StoredCredentials> | null = null;
   #createPromiseKey: string | null = null;
+  #cachedStoreKey: string | null = null;
+  #cachedStoreKeyIdentity: string | null = null;
+  #cachedDerivedKey: CryptoKey | null = null;
+  #cachedDerivedKeyIdentity: string | null = null;
 
   static async computeStoreKey(address: Address, chainId: number): Promise<string> {
     const hash = await crypto.subtle.digest(
@@ -145,7 +149,7 @@ export class CredentialsManager {
           }
         }
         // No session signature or TTL expired — need to re-sign
-        if (this.#isValidWithoutDecrypt(encrypted, contractAddresses)) {
+        if (this.#isValid(encrypted, contractAddresses)) {
           const signature = await this.#sign(encrypted);
           await this.#setSessionEntry(storeKey, signature);
           const creds = await this.#decryptCredentials(encrypted, signature);
@@ -207,7 +211,7 @@ export class CredentialsManager {
       this.#assertEncryptedCredentials(encrypted);
 
       const requiredContracts = contractAddress ? [contractAddress] : [];
-      return !this.#isValidWithoutDecrypt(encrypted, requiredContracts);
+      return !this.#isValid(encrypted, requiredContracts);
     } catch {
       return false;
     }
@@ -269,7 +273,14 @@ export class CredentialsManager {
   async #storeKey(): Promise<string> {
     const address = await this.#signer.getAddress();
     const chainId = await this.#signer.getChainId();
-    return CredentialsManager.computeStoreKey(address, chainId);
+    const identity = `${address}:${chainId}`;
+    if (this.#cachedStoreKey && this.#cachedStoreKeyIdentity === identity) {
+      return this.#cachedStoreKey;
+    }
+    const key = await CredentialsManager.computeStoreKey(address, chainId);
+    this.#cachedStoreKeyIdentity = identity;
+    this.#cachedStoreKey = key;
+    return key;
   }
 
   /** Check if a session entry has expired based on its recorded TTL. */
@@ -316,20 +327,15 @@ export class CredentialsManager {
     assertString(data.encryptedPrivateKey.ciphertext, "encryptedPrivateKey.ciphertext");
   }
 
-  #isValid(creds: StoredCredentials, requiredContracts: Address[]): boolean {
+  #isValid(
+    creds: Pick<StoredCredentials, "startTimestamp" | "durationDays" | "contractAddresses">,
+    requiredContracts: Address[],
+  ): boolean {
     const nowSeconds = Math.floor(Date.now() / 1000);
     const expiresAt = creds.startTimestamp + creds.durationDays * 86400;
     if (nowSeconds >= expiresAt) return false;
 
     const signedSet = new Set(creds.contractAddresses.map(getAddress));
-    return requiredContracts.every((addr) => signedSet.has(getAddress(addr)));
-  }
-
-  #isValidWithoutDecrypt(encrypted: EncryptedCredentials, requiredContracts: Address[]): boolean {
-    const nowSeconds = Math.floor(Date.now() / 1000);
-    const expiresAt = encrypted.startTimestamp + encrypted.durationDays * 86400;
-    if (nowSeconds >= expiresAt) return false;
-    const signedSet = new Set(encrypted.contractAddresses.map(getAddress));
     return requiredContracts.every((addr) => signedSet.has(getAddress(addr)));
   }
 
@@ -435,6 +441,11 @@ export class CredentialsManager {
    * meaningful encryption protection for the stored private key.
    */
   async #deriveKey(signature: Hex, address: Address): Promise<CryptoKey> {
+    const identity = `${signature}:${address}`;
+    if (this.#cachedDerivedKey && this.#cachedDerivedKeyIdentity === identity) {
+      return this.#cachedDerivedKey;
+    }
+
     const encoder = new TextEncoder();
     const keyMaterial = await crypto.subtle.importKey(
       "raw",
@@ -444,7 +455,7 @@ export class CredentialsManager {
       ["deriveKey"],
     );
 
-    return crypto.subtle.deriveKey(
+    const key = await crypto.subtle.deriveKey(
       {
         name: "PBKDF2",
         salt: encoder.encode(address),
@@ -456,6 +467,10 @@ export class CredentialsManager {
       false,
       ["encrypt", "decrypt"],
     );
+
+    this.#cachedDerivedKeyIdentity = identity;
+    this.#cachedDerivedKey = key;
+    return key;
   }
 
   /** Encrypts a string using AES-GCM with a key derived from the wallet signature. */

--- a/packages/sdk/src/token/credentials-manager.ts
+++ b/packages/sdk/src/token/credentials-manager.ts
@@ -141,17 +141,35 @@ export class CredentialsManager {
               this.#emit({ type: ZamaSDKEvents.CredentialsAllowed, contractAddresses });
               return creds;
             }
+            // Keypair still time-valid but missing contracts — extend and re-sign
+            if (this.#isTimeValid(creds)) {
+              return this.#extendContracts({
+                storeKey,
+                credentials: creds,
+                requiredContracts: contractAddresses,
+              });
+            }
             this.#emit({ type: ZamaSDKEvents.CredentialsExpired, contractAddresses });
           }
         }
         // No session signature or TTL expired — need to re-sign
-        if (this.#isValidWithoutDecrypt(encrypted, contractAddresses)) {
-          const signature = await this.#sign(encrypted);
-          await this.#setSessionEntry(storeKey, signature);
-          const creds = await this.#decryptCredentials(encrypted, signature);
-          this.#emit({ type: ZamaSDKEvents.CredentialsCached, contractAddresses });
-          this.#emit({ type: ZamaSDKEvents.CredentialsAllowed, contractAddresses });
-          return creds;
+        if (this.#isTimeValid(encrypted)) {
+          if (this.#coversContracts(encrypted.contractAddresses, contractAddresses)) {
+            const signature = await this.#sign(encrypted);
+            await this.#setSessionEntry(storeKey, signature);
+            const creds = await this.#decryptCredentials(encrypted, signature);
+            this.#emit({ type: ZamaSDKEvents.CredentialsCached, contractAddresses });
+            this.#emit({ type: ZamaSDKEvents.CredentialsAllowed, contractAddresses });
+            return creds;
+          }
+          // Time-valid but missing contracts and no session — sign with old addresses to decrypt, then extend
+          const oldSignature = await this.#sign(encrypted);
+          const creds = await this.#decryptCredentials(encrypted, oldSignature);
+          return this.#extendContracts({
+            storeKey,
+            credentials: creds,
+            requiredContracts: contractAddresses,
+          });
         }
         this.#emit({ type: ZamaSDKEvents.CredentialsExpired, contractAddresses });
       }
@@ -207,7 +225,7 @@ export class CredentialsManager {
       this.#assertEncryptedCredentials(encrypted);
 
       const requiredContracts = contractAddress ? [contractAddress] : [];
-      return !this.#isValidWithoutDecrypt(encrypted, requiredContracts);
+      return !this.#isValid(encrypted, requiredContracts);
     } catch {
       return false;
     }
@@ -316,31 +334,90 @@ export class CredentialsManager {
     assertString(data.encryptedPrivateKey.ciphertext, "encryptedPrivateKey.ciphertext");
   }
 
-  #isValid(creds: StoredCredentials, requiredContracts: Address[]): boolean {
-    const nowSeconds = Math.floor(Date.now() / 1000);
-    const expiresAt = creds.startTimestamp + creds.durationDays * 86400;
-    if (nowSeconds >= expiresAt) return false;
-
-    const signedSet = new Set(creds.contractAddresses.map(getAddress));
-    return requiredContracts.every((addr) => signedSet.has(getAddress(addr)));
+  #isValid(
+    creds: { startTimestamp: number; durationDays: number; contractAddresses: Address[] },
+    requiredContracts: Address[],
+  ): boolean {
+    if (!this.#isTimeValid(creds)) return false;
+    return this.#coversContracts(creds.contractAddresses, requiredContracts);
   }
 
-  #isValidWithoutDecrypt(encrypted: EncryptedCredentials, requiredContracts: Address[]): boolean {
+  /** Check if credentials are still within their keypair TTL. */
+  #isTimeValid(creds: { startTimestamp: number; durationDays: number }): boolean {
     const nowSeconds = Math.floor(Date.now() / 1000);
-    const expiresAt = encrypted.startTimestamp + encrypted.durationDays * 86400;
-    if (nowSeconds >= expiresAt) return false;
-    const signedSet = new Set(encrypted.contractAddresses.map(getAddress));
-    return requiredContracts.every((addr) => signedSet.has(getAddress(addr)));
+    const expiresAt = creds.startTimestamp + creds.durationDays * 86400;
+    return nowSeconds < expiresAt;
+  }
+
+  /** Check if the signed address set covers all required addresses. */
+  #coversContracts(signedAddresses: Address[], requiredContracts: Address[]): boolean {
+    const signedSet = new Set(signedAddresses.map((a) => a.toLowerCase()));
+    return requiredContracts.every((addr) => signedSet.has(addr.toLowerCase()));
   }
 
   async #sign(encrypted: EncryptedCredentials): Promise<Hex> {
+    return this.#signWithContracts(encrypted, encrypted.contractAddresses);
+  }
+
+  /** Sign an EIP-712 authorization for the given contract addresses using the stored keypair metadata. */
+  async #signWithContracts(
+    keypairMeta: { publicKey: Hex; startTimestamp: number; durationDays: number },
+    contractAddresses: Address[],
+  ): Promise<Hex> {
     const eip712 = await this.#relayer.createEIP712(
-      encrypted.publicKey,
-      encrypted.contractAddresses,
-      encrypted.startTimestamp,
-      encrypted.durationDays,
+      keypairMeta.publicKey,
+      contractAddresses,
+      keypairMeta.startTimestamp,
+      keypairMeta.durationDays,
     );
     return this.#signer.signTypedData(eip712);
+  }
+
+  /** Merge two contract address lists into a deduplicated sorted array. */
+  #mergeContracts(existing: Address[], incoming: Address[]): Address[] {
+    const map = new Map<string, Address>();
+    for (const addr of [...existing, ...incoming]) {
+      const key = addr.toLowerCase();
+      if (!map.has(key)) map.set(key, getAddress(addr));
+    }
+    return [...map.values()].sort();
+  }
+
+  /**
+   * Extend credentials with additional contract addresses: re-sign with the
+   * merged set and persist, reusing the existing keypair.
+   */
+  async #extendContracts({
+    storeKey,
+    credentials,
+    requiredContracts,
+  }: {
+    storeKey: string;
+    credentials: StoredCredentials;
+    requiredContracts: Address[];
+  }): Promise<StoredCredentials> {
+    const merged = this.#mergeContracts(credentials.contractAddresses, requiredContracts);
+    const signature = await this.#signWithContracts(credentials, merged);
+    await this.#setSessionEntry(storeKey, signature);
+
+    const extended: StoredCredentials = {
+      ...credentials,
+      contractAddresses: merged,
+      signature,
+    };
+    await this.#persistExtended(storeKey, extended);
+    this.#emit({ type: ZamaSDKEvents.CredentialsAllowed, contractAddresses: requiredContracts });
+    return extended;
+  }
+
+  /** Re-encrypt and persist updated credentials. */
+  async #persistExtended(storeKey: string, creds: StoredCredentials): Promise<void> {
+    try {
+      const encrypted = await this.#encryptCredentials(creds);
+      await this.#storage.set(storeKey, encrypted);
+    } catch {
+      // Store write failed — credentials still usable in memory
+    }
   }
 
   // ── Credential generation ───────────────────────────────────

--- a/packages/sdk/src/token/credentials-manager.ts
+++ b/packages/sdk/src/token/credentials-manager.ts
@@ -461,14 +461,17 @@ export class CredentialsManager {
   }): Promise<StoredCredentials> {
     const merged = this.#mergeContracts(credentials.contractAddresses, requiredContracts);
     const signature = await this.#signWithContracts(credentials, merged);
-    await this.#setSessionEntry(storeKey, signature);
 
     const extended: StoredCredentials = {
       ...credentials,
       contractAddresses: merged,
       signature,
     };
+    // Persist ciphertext before updating the session signature to prevent a
+    // window where a concurrent reader sees the new signature but finds
+    // ciphertext encrypted with the old one, fails decrypt, and regenerates.
     await this.#persistCredentials(storeKey, extended);
+    await this.#setSessionEntry(storeKey, signature);
     this.#emit({ type: ZamaSDKEvents.CredentialsAllowed, contractAddresses: requiredContracts });
     return extended;
   }
@@ -517,7 +520,6 @@ export class CredentialsManager {
       );
 
       const signature = await this.#signer.signTypedData(eip712);
-      await this.#setSessionEntry(storeKey, signature);
 
       const creds: StoredCredentials = {
         publicKey,
@@ -528,7 +530,9 @@ export class CredentialsManager {
         durationDays,
       };
 
+      // Persist ciphertext before session signature (same rationale as #performExtend).
       await this.#persistCredentials(storeKey, creds);
+      await this.#setSessionEntry(storeKey, signature);
 
       this.#emit({ type: ZamaSDKEvents.CredentialsCreated, contractAddresses });
       return creds;

--- a/packages/sdk/src/token/credentials-manager.ts
+++ b/packages/sdk/src/token/credentials-manager.ts
@@ -386,12 +386,8 @@ export class CredentialsManager {
 
   /** Merge two contract address lists into a deduplicated sorted array. */
   #mergeContracts(existing: Address[], incoming: Address[]): Address[] {
-    const map = new Map<string, Address>();
-    for (const addr of [...existing, ...incoming]) {
-      const key = addr.toLowerCase();
-      if (!map.has(key)) map.set(key, getAddress(addr));
-    }
-    return [...map.values()].sort();
+    const set = new Set([...existing, ...incoming].map(getAddress));
+    return [...set].sort();
   }
 
   /**

--- a/packages/sdk/src/token/credentials-manager.ts
+++ b/packages/sdk/src/token/credentials-manager.ts
@@ -378,8 +378,8 @@ export class CredentialsManager {
 
   /** Check if the signed address set covers all required addresses. */
   #coversContracts(signedAddresses: Address[], requiredContracts: Address[]): boolean {
-    const signed = new Set(signedAddresses.map((a) => a.toLowerCase()));
-    return requiredContracts.every((addr) => signed.has(addr.toLowerCase()));
+    const required = new Set(requiredContracts.map((a) => a.toLowerCase()));
+    return required.isSubsetOf(new Set(signedAddresses.map((a) => a.toLowerCase())));
   }
 
   async #sign(encrypted: EncryptedCredentials): Promise<Hex> {
@@ -402,11 +402,7 @@ export class CredentialsManager {
 
   /** Merge two contract address lists into a deduplicated sorted array. */
   #mergeContracts(existing: Address[], incoming: Address[]): Address[] {
-    const seen = new Map<string, Address>();
-    for (const addr of [...existing, ...incoming]) {
-      seen.set(addr.toLowerCase(), addr);
-    }
-    return [...seen.values()].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+    return [...new Set([...existing, ...incoming].map((a) => a.toLowerCase() as Address))].sort();
   }
 
   /**

--- a/packages/sdk/src/token/credentials-manager.ts
+++ b/packages/sdk/src/token/credentials-manager.ts
@@ -405,13 +405,13 @@ export class CredentialsManager {
       contractAddresses: merged,
       signature,
     };
-    await this.#persistExtended(storeKey, extended);
+    await this.#persistCredentials(storeKey, extended);
     this.#emit({ type: ZamaSDKEvents.CredentialsAllowed, contractAddresses: requiredContracts });
     return extended;
   }
 
-  /** Re-encrypt and persist updated credentials. */
-  async #persistExtended(storeKey: string, creds: StoredCredentials): Promise<void> {
+  /** Re-encrypt and persist credentials (best-effort — failures are swallowed). */
+  async #persistCredentials(storeKey: string, creds: StoredCredentials): Promise<void> {
     try {
       const encrypted = await this.#encryptCredentials(creds);
       await this.#storage.set(storeKey, encrypted);
@@ -462,12 +462,7 @@ export class CredentialsManager {
         durationDays,
       };
 
-      try {
-        const encrypted = await this.#encryptCredentials(creds);
-        await this.#storage.set(storeKey, encrypted);
-      } catch {
-        // Store write failed — credentials still usable in memory
-      }
+      await this.#persistCredentials(storeKey, creds);
 
       this.#emit({ type: ZamaSDKEvents.CredentialsCreated, contractAddresses });
       return creds;

--- a/packages/sdk/src/token/indexeddb-storage.ts
+++ b/packages/sdk/src/token/indexeddb-storage.ts
@@ -60,52 +60,37 @@ export class IndexedDBStorage implements GenericStorage {
     return this.#dbPromise;
   }
 
-  async get<T = unknown>(key: string): Promise<T | null> {
+  async #withTransaction<T>(
+    mode: IDBTransactionMode,
+    fn: (store: IDBObjectStore) => IDBRequest,
+  ): Promise<T> {
     const db = await this.#getDB();
     return new Promise((resolve, reject) => {
-      const tx = db.transaction(this.#storeName, "readonly");
+      const tx = db.transaction(this.#storeName, mode);
       tx.onabort = () => reject(tx.error ?? new Error("Transaction aborted"));
-      const store = tx.objectStore(this.#storeName);
-      const request = store.get(key);
-      request.onsuccess = () => resolve(request.result?.value ?? null);
+      const request = fn(tx.objectStore(this.#storeName));
+      request.onsuccess = () => resolve(request.result);
       request.onerror = () => reject(request.error);
     });
+  }
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    const result = await this.#withTransaction<{ value: T } | undefined>("readonly", (store) =>
+      store.get(key),
+    );
+    return result?.value ?? null;
   }
 
   async set<T = unknown>(key: string, value: T): Promise<void> {
-    const db = await this.#getDB();
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(this.#storeName, "readwrite");
-      tx.onabort = () => reject(tx.error ?? new Error("Transaction aborted"));
-      const store = tx.objectStore(this.#storeName);
-      const request = store.put({ key, value });
-      request.onsuccess = () => resolve();
-      request.onerror = () => reject(request.error);
-    });
+    await this.#withTransaction<void>("readwrite", (store) => store.put({ key, value }));
   }
 
   async delete(key: string): Promise<void> {
-    const db = await this.#getDB();
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(this.#storeName, "readwrite");
-      tx.onabort = () => reject(tx.error ?? new Error("Transaction aborted"));
-      const store = tx.objectStore(this.#storeName);
-      const request = store.delete(key);
-      request.onsuccess = () => resolve();
-      request.onerror = () => reject(request.error);
-    });
+    await this.#withTransaction<void>("readwrite", (store) => store.delete(key));
   }
 
   async clear(): Promise<void> {
-    const db = await this.#getDB();
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(this.#storeName, "readwrite");
-      tx.onabort = () => reject(tx.error ?? new Error("Transaction aborted"));
-      const store = tx.objectStore(this.#storeName);
-      const request = store.clear();
-      request.onsuccess = () => resolve();
-      request.onerror = () => reject(request.error);
-    });
+    await this.#withTransaction<void>("readwrite", (store) => store.clear());
   }
 }
 

--- a/packages/sdk/src/token/indexeddb-storage.ts
+++ b/packages/sdk/src/token/indexeddb-storage.ts
@@ -69,7 +69,11 @@ export class IndexedDBStorage implements GenericStorage {
       const tx = db.transaction(this.#storeName, mode);
       tx.onabort = () => reject(tx.error ?? new Error("Transaction aborted"));
       const request = fn(tx.objectStore(this.#storeName));
-      request.onsuccess = () => resolve(request.result);
+      if (mode === "readonly") {
+        request.onsuccess = () => resolve(request.result);
+      } else {
+        tx.oncomplete = () => resolve(request.result);
+      }
       request.onerror = () => reject(request.error);
     });
   }

--- a/packages/sdk/src/token/readonly-token.ts
+++ b/packages/sdk/src/token/readonly-token.ts
@@ -281,14 +281,11 @@ export class ReadonlyToken {
       );
     }
 
-    const allAddresses = tokens.map((t) => t.address);
-    const creds = await tokens[0]!.credentials.allow(...allAddresses);
-
     const tokenStorage = tokens[0]!.storage;
     const results = new Map<Address, bigint>();
-    const errors: Array<{ address: Address; error: Error }> = [];
-    const decryptFns: Array<() => Promise<void>> = [];
 
+    // Determine which tokens actually need decryption (not zero, not cached).
+    const uncached: Array<{ token: ReadonlyToken; handle: Address }> = [];
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i]!;
       const handle = resolvedHandles[i]!;
@@ -298,18 +295,31 @@ export class ReadonlyToken {
         continue;
       }
 
-      // Check persistent cache — avoids re-decryption after page reload.
       const cached = await loadCachedBalance({
         storage: tokenStorage,
         tokenAddress: token.address,
         owner: signerAddress,
         handle,
       });
+
       if (cached !== null) {
         results.set(token.address, cached);
         continue;
       }
 
+      uncached.push({ token, handle });
+    }
+
+    // All balances resolved from cache — no credentials needed.
+    if (uncached.length === 0) return results;
+
+    const uncachedAddresses = uncached.map((entry) => entry.token.address);
+    const creds = await tokens[0]!.credentials.allow(...uncachedAddresses);
+
+    const errors: Array<{ address: Address; error: Error }> = [];
+    const decryptFns: Array<() => Promise<void>> = [];
+
+    for (const { token, handle } of uncached) {
       decryptFns.push(() =>
         sdk
           .userDecrypt({

--- a/packages/sdk/src/token/readonly-token.ts
+++ b/packages/sdk/src/token/readonly-token.ts
@@ -21,6 +21,7 @@ import { ZamaSDKEvents } from "../events/sdk-events";
 import type { ZamaSDKEventInput, ZamaSDKEventListener } from "../events/sdk-events";
 import { loadCachedBalance, saveCachedBalance } from "./balance-cache";
 import { getAddress, type Address } from "viem";
+import { toError } from "../utils";
 
 /** 32-byte zero handle, used to detect uninitialized encrypted balances. */
 export const ZERO_HANDLE =
@@ -129,53 +130,7 @@ export class ReadonlyToken {
   async balanceOf(owner?: Address): Promise<bigint> {
     const ownerAddress = owner ? getAddress(owner) : await this.signer.getAddress();
     const handle = await this.readConfidentialBalanceOf(ownerAddress);
-
-    if (this.isZeroHandle(handle)) return BigInt(0);
-
-    // Check persistent cache first.
-    const cached = await loadCachedBalance({
-      storage: this.#storage,
-      tokenAddress: this.address,
-      owner: ownerAddress,
-      handle,
-    });
-    if (cached !== null) return cached;
-
-    const creds = await this.credentials.allow(this.address);
-
-    const t0 = Date.now();
-    try {
-      this.emit({ type: ZamaSDKEvents.DecryptStart });
-      const result = await this.sdk.userDecrypt({
-        handles: [handle],
-        contractAddress: this.address,
-        signedContractAddresses: creds.contractAddresses,
-        privateKey: creds.privateKey,
-        publicKey: creds.publicKey,
-        signature: creds.signature,
-        signerAddress: ownerAddress,
-        startTimestamp: creds.startTimestamp,
-        durationDays: creds.durationDays,
-      });
-      this.emit({ type: ZamaSDKEvents.DecryptEnd, durationMs: Date.now() - t0 });
-
-      const value = (result[handle] as bigint | undefined) ?? BigInt(0);
-      await saveCachedBalance({
-        storage: this.#storage,
-        tokenAddress: this.address,
-        owner: ownerAddress,
-        handle,
-        value,
-      });
-      return value;
-    } catch (error) {
-      this.emit({
-        type: ZamaSDKEvents.DecryptError,
-        error: toError(error),
-        durationMs: Date.now() - t0,
-      });
-      throw wrapDecryptError(error, "Failed to decrypt balance");
-    }
+    return this.decryptBalance(handle, ownerAddress);
   }
 
   /**
@@ -289,23 +244,26 @@ export class ReadonlyToken {
     const errors: Array<{ address: Address; error: Error }> = [];
     const decryptFns: Array<() => Promise<void>> = [];
 
+    // Parallel cache lookups — avoids sequential IDB round-trips.
+    const cachedValues = await Promise.all(
+      tokens.map((token, i) => {
+        const handle = resolvedHandles[i]!;
+        if (token.isZeroHandle(handle)) return Promise.resolve(BigInt(0));
+        return loadCachedBalance({
+          storage: tokenStorage,
+          tokenAddress: token.address,
+          owner: signerAddress,
+          handle,
+        });
+      }),
+    );
+
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i]!;
       const handle = resolvedHandles[i]!;
+      const cached = cachedValues[i];
 
-      if (token.isZeroHandle(handle)) {
-        results.set(token.address, BigInt(0));
-        continue;
-      }
-
-      // Check persistent cache — avoids re-decryption after page reload.
-      const cached = await loadCachedBalance({
-        storage: tokenStorage,
-        tokenAddress: token.address,
-        owner: signerAddress,
-        handle,
-      });
-      if (cached !== null) {
+      if (cached !== null && cached !== undefined) {
         results.set(token.address, cached);
         continue;
       }
@@ -648,11 +606,6 @@ export class ReadonlyToken {
  * typed SDK error (NoCiphertextError for 400, RelayerRequestFailedError for
  * other HTTP errors, or the generic DecryptionFailedError as fallback).
  */
-/** Coerce an unknown caught value to an Error instance. */
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
-}
-
 function wrapDecryptError(error: unknown, fallbackMessage: string): Error {
   if (error instanceof NoCiphertextError || error instanceof RelayerRequestFailedError) {
     return error;

--- a/packages/sdk/src/token/readonly-token.ts
+++ b/packages/sdk/src/token/readonly-token.ts
@@ -77,7 +77,7 @@ export interface ReadonlyTokenConfig {
  */
 export class ReadonlyToken {
   protected readonly credentials: CredentialsManager;
-  protected readonly sdk: RelayerSDK;
+  protected readonly relayer: RelayerSDK;
   readonly signer: GenericSigner;
   readonly address: Address;
   readonly #storage: GenericStorage;
@@ -95,7 +95,7 @@ export class ReadonlyToken {
         keypairTTL: config.keypairTTL ?? 86400,
         onEvent: config.onEvent,
       });
-    this.sdk = config.relayer;
+    this.relayer = config.relayer;
     this.signer = config.signer;
     this.address = address;
     this.#storage = config.storage;
@@ -223,8 +223,9 @@ export class ReadonlyToken {
 
     const { handles, owner, onError, maxConcurrency } = options ?? {};
 
-    const sdk = tokens[0]!.sdk;
-    const signer = tokens[0]!.signer;
+    const firstToken = tokens[0]!;
+    const sdk = firstToken.relayer;
+    const signer = firstToken.signer;
     const signerAddress = owner ?? (await signer.getAddress());
 
     const resolvedHandles =
@@ -236,7 +237,7 @@ export class ReadonlyToken {
       );
     }
 
-    const tokenStorage = tokens[0]!.storage;
+    const tokenStorage = firstToken.storage;
     const results = new Map<Address, bigint>();
 
     // Parallel cache lookups — avoids sequential IDB round-trips.
@@ -271,7 +272,7 @@ export class ReadonlyToken {
     if (uncached.length === 0) return results;
 
     const uncachedAddresses = uncached.map((entry) => entry.token.address);
-    const creds = await tokens[0]!.credentials.allow(...uncachedAddresses);
+    const creds = await firstToken.credentials.allow(...uncachedAddresses);
 
     const errors: Array<{ address: Address; error: Error }> = [];
     const decryptFns: Array<() => Promise<void>> = [];
@@ -521,7 +522,7 @@ export class ReadonlyToken {
     const t0 = Date.now();
     try {
       this.emit({ type: ZamaSDKEvents.DecryptStart });
-      const result = await this.sdk.userDecrypt({
+      const result = await this.relayer.userDecrypt({
         handles: [handle],
         contractAddress: this.address,
         signedContractAddresses: creds.contractAddresses,
@@ -581,7 +582,7 @@ export class ReadonlyToken {
     const t0 = Date.now();
     try {
       this.emit({ type: ZamaSDKEvents.DecryptStart });
-      const decrypted = await this.sdk.userDecrypt({
+      const decrypted = await this.relayer.userDecrypt({
         handles: nonZeroHandles,
         contractAddress: this.address,
         signedContractAddresses: creds.contractAddresses,

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -104,7 +104,7 @@ export class Token extends ReadonlyToken {
     const t0 = Date.now();
     try {
       this.emit({ type: ZamaSDKEvents.EncryptStart });
-      ({ handles, inputProof } = await this.sdk.encrypt({
+      ({ handles, inputProof } = await this.relayer.encrypt({
         values: [{ value: amount, type: "euint64" }],
         contractAddress: this.address,
         userAddress: await this.signer.getAddress(),
@@ -178,7 +178,7 @@ export class Token extends ReadonlyToken {
     const t0 = Date.now();
     try {
       this.emit({ type: ZamaSDKEvents.EncryptStart });
-      ({ handles, inputProof } = await this.sdk.encrypt({
+      ({ handles, inputProof } = await this.relayer.encrypt({
         values: [{ value: amount, type: "euint64" }],
         contractAddress: this.address,
         userAddress: normalizedFrom,
@@ -405,7 +405,7 @@ export class Token extends ReadonlyToken {
     const t0 = Date.now();
     try {
       this.emit({ type: ZamaSDKEvents.EncryptStart });
-      ({ handles, inputProof } = await this.sdk.encrypt({
+      ({ handles, inputProof } = await this.relayer.encrypt({
         values: [{ value: amount, type: "euint64" }],
         contractAddress: this.wrapper,
         userAddress,
@@ -576,7 +576,7 @@ export class Token extends ReadonlyToken {
     const t0 = Date.now();
     try {
       this.emit({ type: ZamaSDKEvents.DecryptStart });
-      const result = await this.sdk.publicDecrypt([burnAmountHandle]);
+      const result = await this.relayer.publicDecrypt([burnAmountHandle]);
       this.emit({ type: ZamaSDKEvents.DecryptEnd, durationMs: Date.now() - t0 });
       decryptionProof = result.decryptionProof;
       try {

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -30,11 +30,7 @@ import type {
   ShieldCallbacks,
   TransferCallbacks,
 } from "./token.types";
-
-/** Coerce an unknown caught value to an Error instance. */
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
-}
+import { toError } from "../utils";
 
 /**
  * ERC-20-like interface for a single confidential token.

--- a/packages/sdk/src/token/zama-sdk.ts
+++ b/packages/sdk/src/token/zama-sdk.ts
@@ -8,10 +8,7 @@ import type { GenericSigner, GenericStorage } from "./token.types";
 import { ZamaSDKEvents } from "../events/sdk-events";
 import type { ZamaSDKEventListener } from "../events/sdk-events";
 import type { SignerLifecycleCallbacks } from "./token.types";
-
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
-}
+import { toError } from "../utils";
 
 /** Configuration for {@link ZamaSDK}. */
 export interface ZamaSDKConfig {

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -1,5 +1,10 @@
 import { type Hex } from "viem";
 
+/** Coerce an unknown caught value to an Error instance. */
+export function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
 /** Normalize a un-prefixed hex payload to a 0x-prefixed `Hex` value. */
 export function prefixHex(value: string): Hex {
   return (value.startsWith("0x") ? value : `0x${value}`) as Hex;


### PR DESCRIPTION
## Summary
- Extract shared `toError` helper to `utils.ts` (was duplicated in 3 files)
- Deduplicate IndexedDB transaction boilerplate via `#withTransaction` helper
- Simplify `balanceOf` to delegate to `decryptBalance`, eliminating ~40 lines of duplicated decrypt logic
- Parallelize cache lookups in `batchDecryptBalances` using `Promise.all` and skip `allow()` for cached balances
- Add SHA-256 store key and PBKDF2 derived key caching to `CredentialsManager` to avoid redundant crypto operations
- Unify `#isValid` / `#isValidWithoutDecrypt` into a single method with widened parameter type, then split into `#isTimeValid` + `#coversContracts` for finer-grained checks
- Extend contract address set instead of regenerating keypair when `allow()` is called with new contracts (integrates #97)
- Simplify `#mergeContracts` to use `Set` with `getAddress` canonical checksums

## Test plan
- [x] All 977 tests pass across 112 test files
- [x] 8 new caching tests (storeKey caching, deriveKey caching, unified #isValid)
- [x] 9 new contract extension tests (active session, revoke, page reload, caching, persistence, incremental, subset, time-expiry, EIP-712 verification)
- [x] 2 new batch decrypt tests (all cached skip allow, partial cached calls allow with uncached only)
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)