### PR TITLE
test: make test apps compatible with injected providers

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -123,8 +123,6 @@ jobs:
 
       - name: Build Next.js test-nextjs
         run: pnpm build:test-nextjs
-        env:
-          NEXT_PUBLIC_NETWORK: hardhat
 
       - name: Save Next.js build cache
         if: steps.nextjs-build-cache.outputs.cache-hit != 'true'
@@ -135,14 +133,9 @@ jobs:
 
       - name: Build Vite test-vite
         run: pnpm build:test-vite
-        env:
-          VITE_NETWORK: hardhat
 
       - name: Run Playwright tests
         run: pnpm e2e:test
-        env:
-          NEXT_PUBLIC_NETWORK: hardhat
-          VITE_NETWORK: hardhat
 
       - name: Upload test results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/packages/playwright/playwright.config.ts
+++ b/packages/playwright/playwright.config.ts
@@ -48,14 +48,14 @@ export default defineConfig({
     {
       command: CI
         ? "pnpm --filter @zama-fhe/test-nextjs start"
-        : "pnpm --filter @zama-fhe/test-nextjs dev:e2e",
+        : "pnpm --filter @zama-fhe/test-nextjs dev",
       port: NEXTJS_PORT,
       reuseExistingServer: !CI,
     },
     {
       command: CI
         ? "pnpm --filter @zama-fhe/test-vite preview"
-        : "pnpm --filter @zama-fhe/test-vite dev:e2e",
+        : "pnpm --filter @zama-fhe/test-vite dev",
       port: VITE_PORT,
       reuseExistingServer: !CI,
     },

--- a/packages/test-components/src/connect-wallet.tsx
+++ b/packages/test-components/src/connect-wallet.tsx
@@ -2,6 +2,22 @@
 
 import { useAccount, useConnect, useDisconnect, useConnectors } from "wagmi";
 
+const BURNER_PK_KEY = "burnerWallet.pk";
+
+/**
+ * Picks the right connector based on environment:
+ * - If a burner private key is in localStorage, use the burner connector (Playwright / E2E)
+ * - Otherwise, use the injected connector (MetaMask / browser wallet)
+ */
+function pickConnector(connectors: readonly { id: string; name: string }[]) {
+  const hasBurnerPk = typeof window !== "undefined" && !!localStorage.getItem(BURNER_PK_KEY);
+
+  if (hasBurnerPk) {
+    return connectors.find((c) => c.id === "burnerWallet") ?? connectors[0];
+  }
+  return connectors.find((c) => c.id === "injected") ?? connectors[0];
+}
+
 export function ConnectWallet() {
   const { address, isConnected } = useAccount();
   const { connect } = useConnect();
@@ -26,7 +42,11 @@ export function ConnectWallet() {
 
   return (
     <button
-      onClick={() => connect({ connector: connectors[0]! })}
+      onClick={() => {
+        const connector = pickConnector(connectors);
+        if (connector)
+          connect({ connector: connector as Parameters<typeof connect>[0]["connector"] });
+      }}
       className="px-2.5 py-1 text-xs font-medium bg-zama-yellow text-zama-black rounded hover:bg-zama-yellow-hover transition-colors"
     >
       Connect Wallet

--- a/packages/test-nextjs/package.json
+++ b/packages/test-nextjs/package.json
@@ -7,7 +7,6 @@
   "author": "Zama",
   "scripts": {
     "dev": "next dev --port 3100",
-    "dev:e2e": "next dev --port 3100",
     "build": "next build",
     "start": "next start --port 3100"
   },

--- a/packages/test-nextjs/package.json
+++ b/packages/test-nextjs/package.json
@@ -7,7 +7,7 @@
   "author": "Zama",
   "scripts": {
     "dev": "next dev --port 3100",
-    "dev:e2e": "NEXT_PUBLIC_NETWORK=hardhat next dev --port 3100",
+    "dev:e2e": "next dev --port 3100",
     "build": "next build",
     "start": "next start --port 3100"
   },

--- a/packages/test-nextjs/src/providers.tsx
+++ b/packages/test-nextjs/src/providers.tsx
@@ -10,19 +10,16 @@ import { injected } from "wagmi/connectors";
 import { burner } from "@zama-fhe/test-components";
 import { RelayerCleartext, hardhatCleartextConfig } from "@zama-fhe/sdk/cleartext";
 
-const isHardhat = process.env.NEXT_PUBLIC_NETWORK === "hardhat";
-
 const wagmiConfig = createConfig({
   chains: [hardhat],
-  connectors: isHardhat
-    ? [
-        burner({
-          rpcUrls: {
-            [hardhat.id]: hardhat.rpcUrls.default.http[0],
-          },
-        }),
-      ]
-    : [injected()],
+  connectors: [
+    burner({
+      rpcUrls: {
+        [hardhat.id]: hardhat.rpcUrls.default.http[0],
+      },
+    }),
+    injected(),
+  ],
   transports: {
     [hardhat.id]: http(),
   },

--- a/packages/test-vite/package.json
+++ b/packages/test-vite/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 3200",
-    "dev:e2e": "VITE_NETWORK=hardhat vite --port 3200",
+    "dev:e2e": "vite --port 3200",
     "build": "vite build",
     "preview": "vite preview --port 3200"
   },

--- a/packages/test-vite/package.json
+++ b/packages/test-vite/package.json
@@ -4,7 +4,6 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 3200",
-    "dev:e2e": "vite --port 3200",
     "build": "vite build",
     "preview": "vite preview --port 3200"
   },

--- a/packages/test-vite/src/providers.tsx
+++ b/packages/test-vite/src/providers.tsx
@@ -8,19 +8,16 @@ import { injected } from "wagmi/connectors";
 import { burner } from "@zama-fhe/test-components";
 import { RelayerCleartext, hardhatCleartextConfig } from "@zama-fhe/sdk/cleartext";
 
-const isHardhat = import.meta.env.VITE_NETWORK === "hardhat";
-
 const wagmiConfig = createConfig({
   chains: [hardhat],
-  connectors: isHardhat
-    ? [
-        burner({
-          rpcUrls: {
-            [hardhat.id]: hardhat.rpcUrls.default.http[0],
-          },
-        }),
-      ]
-    : [injected()],
+  connectors: [
+    burner({
+      rpcUrls: {
+        [hardhat.id]: hardhat.rpcUrls.default.http[0],
+      },
+    }),
+    injected(),
+  ],
   transports: {
     [hardhat.id]: http(),
   },


### PR DESCRIPTION
Current way of handling injected providers would cause some issues on connection via injected provider (MM window not opening); so I propose instead using the burnWallet.pk from localstorage as discriminator to know whether to use the injected provider or the burner wallet.