### PR TITLE
fix(sdk): detect session expiry with 30s staleTime on isAllowed query

### DIFF
--- a/packages/sdk/src/query/__tests__/allow-revoke.test.ts
+++ b/packages/sdk/src/query/__tests__/allow-revoke.test.ts
@@ -74,14 +74,14 @@ describe("isAllowedQueryOptions", () => {
     expect(isAllowedSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("sets staleTime to Infinity", ({ signer, relayer, storage }) => {
+  test("staleTime should be 30 seconds", ({ signer, relayer, storage }) => {
     const sdk = new ZamaSDK({ relayer, signer, storage });
 
     const options = isAllowedQueryOptions(sdk, {
       account: "0x1a1A1A1A1a1A1A1a1A1a1a1a1a1a1a1A1A1a1a1a",
     });
 
-    expect(options.staleTime).toBe(Infinity);
+    expect(options.staleTime).toBe(30_000);
   });
 
   test("enabled is false when query.enabled is false", ({ signer, relayer, storage }) => {

--- a/packages/sdk/src/query/is-allowed.ts
+++ b/packages/sdk/src/query/is-allowed.ts
@@ -18,7 +18,7 @@ export function isAllowedQueryOptions(
     ...filterQueryOptions(config.query ?? {}),
     queryKey: zamaQueryKeys.isAllowed.scope(config.account),
     queryFn: () => sdk.isAllowed(),
-    staleTime: Infinity,
+    staleTime: 30_000,
     enabled: config.query?.enabled !== false,
   } as const;
 }


### PR DESCRIPTION
## Summary

- Replace `staleTime: Infinity` with `staleTime: 30_000` on the `isAllowed` query so session TTL expiry is detected automatically — `isAllowed()` is a local timestamp check with zero network cost, so 30s re-fetches are negligible.

This avoids a scenario where the allowance is revoked, but the query doesnt refecth.

## Test plan

- [ ] Verify `useIsAllowed()` returns `false` within ~30s of session TTL expiring (no manual invalidation needed)
- [ ] Confirm `useAllow` / `useRevokeSession` still invalidate the cache immediately on success