### PR TITLE
feat(example-hoodi): add on-chain ACL delegation flows (SDK-41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* **sdk:** colocate node worker with node entrypoint ([#138](https://github.com/zama-ai/sdk/issues/138)) ([294d76e](https://github.com/zama-ai/sdk/commit/294d76eb9a753b663857e29dd7d4267dca7c3801))
+- **sdk:** colocate node worker with node entrypoint ([#138](https://github.com/zama-ai/sdk/issues/138)) ([294d76e](https://github.com/zama-ai/sdk/commit/294d76eb9a753b663857e29dd7d4267dca7c3801))
 
 ## [2.0.0](https://github.com/zama-ai/sdk/compare/v1.1.0...v2.0.0) (2026-03-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-* **sdk:** persist FHE public key and params with artifact-level revalidation ([#110](https://github.com/zama-ai/sdk/issues/110)) ([e2dd6ae](https://github.com/zama-ai/sdk/commit/e2dd6aef7af39975981fc511a4d6f649b2adf93b))
+- **sdk:** persist FHE public key and params with artifact-level revalidation ([#110](https://github.com/zama-ai/sdk/issues/110)) ([e2dd6ae](https://github.com/zama-ai/sdk/commit/e2dd6aef7af39975981fc511a4d6f649b2adf93b))
 
 ## [2.0.0-alpha.3](https://github.com/zama-ai/sdk/compare/v2.0.0-alpha.2...v2.0.0-alpha.3) (2026-03-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,17 @@
 
 ### ⚠ BREAKING CHANGES
 
-* useUserDecryptFlow removed, useUserDecrypt now has the
-flow hook's signature. Old low-level useUserDecrypt accepting
-UserDecryptParams is removed.
+- useUserDecryptFlow removed, useUserDecrypt now has the
+  flow hook's signature. Old low-level useUserDecrypt accepting
+  UserDecryptParams is removed.
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 
-* docs(react-sdk): fix stale JSDoc example in useEncrypt
+- docs(react-sdk): fix stale JSDoc example in useEncrypt
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 
-* refactor(sdk,react-sdk): extract userDecryptMutationOptions and remove decryptionKeys wrapper
+- refactor(sdk,react-sdk): extract userDecryptMutationOptions and remove decryptionKeys wrapper
 
 Move the user-decrypt orchestration logic (credential resolution, handle
 grouping, relayer calls) into `userDecryptMutationOptions` in the SDK query
@@ -26,13 +26,14 @@ Also remove the `decryptionKeys` indirection — all code now uses
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 
-* refactor(sdk,react-sdk): extract all relayer mutation options into SDK query module
+- refactor(sdk,react-sdk): extract all relayer mutation options into SDK query module
 
 Move all remaining inline relayer mutation logic from react-sdk hooks into
 shared mutation option factories in `@zama-fhe/sdk/query`. Hooks now delegate
 to these options instead of calling `sdk.relayer.*` directly.
 
 New SDK mutation options:
+
 - generateKeypairMutationOptions
 - createEIP712MutationOptions
 - createDelegatedUserDecryptEIP712MutationOptions
@@ -47,36 +48,36 @@ hooks to manage cache population.
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 
-* chore: regenerate API reports after mutation options refactor
+- chore: regenerate API reports after mutation options refactor
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 
 ### Features
 
-* add delegated decryption support [SDK-12] ([#72](https://github.com/zama-ai/sdk/issues/72)) ([7bcaeb6](https://github.com/zama-ai/sdk/commit/7bcaeb612b3268a3b94fa71217c09b8763391735)), closes [#batchDelegationOp](https://github.com/zama-ai/sdk/issues/batchDelegationOp) [#storage](https://github.com/zama-ai/sdk/issues/storage) [#batchDecryptCore](https://github.com/zama-ai/sdk/issues/batchDecryptCore)
-* **examples:** add example-hoodi — ERC-7984 demo on Hoodi testnet ([#111](https://github.com/zama-ai/sdk/issues/111)) ([438f90a](https://github.com/zama-ai/sdk/commit/438f90aff0d16056ba03d78dd20731a3ac5cb8d8))
-* **sdk:** persist FHE public key and params with artifact-level revalidation ([#110](https://github.com/zama-ai/sdk/issues/110)) ([e2dd6ae](https://github.com/zama-ai/sdk/commit/e2dd6aef7af39975981fc511a4d6f649b2adf93b))
+- add delegated decryption support [SDK-12] ([#72](https://github.com/zama-ai/sdk/issues/72)) ([7bcaeb6](https://github.com/zama-ai/sdk/commit/7bcaeb612b3268a3b94fa71217c09b8763391735)), closes [#batchDelegationOp](https://github.com/zama-ai/sdk/issues/batchDelegationOp) [#storage](https://github.com/zama-ai/sdk/issues/storage) [#batchDecryptCore](https://github.com/zama-ai/sdk/issues/batchDecryptCore)
+- **examples:** add example-hoodi — ERC-7984 demo on Hoodi testnet ([#111](https://github.com/zama-ai/sdk/issues/111)) ([438f90a](https://github.com/zama-ai/sdk/commit/438f90aff0d16056ba03d78dd20731a3ac5cb8d8))
+- **sdk:** persist FHE public key and params with artifact-level revalidation ([#110](https://github.com/zama-ai/sdk/issues/110)) ([e2dd6ae](https://github.com/zama-ai/sdk/commit/e2dd6aef7af39975981fc511a4d6f649b2adf93b))
 
 ### Bug Fixes
 
-* remove ABI re-exports from react-sdk that are no longer in sdk public API ([ad24185](https://github.com/zama-ai/sdk/commit/ad24185280469a363e293ed65249667e5333d8ff))
-* **sdk:** auto-detect browser extensions and fall back to file-based worker URL ([292bd3b](https://github.com/zama-ai/sdk/commit/292bd3bacd18bdadbf04985f053c43e873b6378a))
-* **sdk:** detect session expiry with 30s staleTime on isAllowed query ([#124](https://github.com/zama-ai/sdk/issues/124)) ([532fb92](https://github.com/zama-ai/sdk/commit/532fb9298a5e2ff333b7bf72cd4256b3a9db05ba))
-* **sdk:** fix extension runtime fallback and revoke blob URL after worker creation ([e7c6d07](https://github.com/zama-ai/sdk/commit/e7c6d074bcbe8c0bed3565db3243fab0b52b3218))
-* **sdk:** inline worker code via blob URL to eliminate Vite optimizeDeps workaround ([60f09b1](https://github.com/zama-ai/sdk/commit/60f09b1a833e98852c0abd5982ff14019dd26c04))
-* **sdk:** make worker blob URL creation lazy to avoid SSR crashes ([9a9311a](https://github.com/zama-ai/sdk/commit/9a9311a6ef03420d311b4092d4fbc3d9c9a8986c))
-* **sdk:** support browser extensions and lazy worker creation ([c0fcd44](https://github.com/zama-ai/sdk/commit/c0fcd44f7d8884dc4f580066f83ef5e6cd18eea4))
-* **sdk:** use proper TypeScript assertion type narrowing in utility guards ([632bb80](https://github.com/zama-ai/sdk/commit/632bb80d27e6390c4effd795b0fcb29e6b4d0277))
-* **test:** use forks pool for react-sdk in CI instead of default ([4eca9aa](https://github.com/zama-ai/sdk/commit/4eca9aa3df6ad8285e8d096421aa75dcf5678149))
+- remove ABI re-exports from react-sdk that are no longer in sdk public API ([ad24185](https://github.com/zama-ai/sdk/commit/ad24185280469a363e293ed65249667e5333d8ff))
+- **sdk:** auto-detect browser extensions and fall back to file-based worker URL ([292bd3b](https://github.com/zama-ai/sdk/commit/292bd3bacd18bdadbf04985f053c43e873b6378a))
+- **sdk:** detect session expiry with 30s staleTime on isAllowed query ([#124](https://github.com/zama-ai/sdk/issues/124)) ([532fb92](https://github.com/zama-ai/sdk/commit/532fb9298a5e2ff333b7bf72cd4256b3a9db05ba))
+- **sdk:** fix extension runtime fallback and revoke blob URL after worker creation ([e7c6d07](https://github.com/zama-ai/sdk/commit/e7c6d074bcbe8c0bed3565db3243fab0b52b3218))
+- **sdk:** inline worker code via blob URL to eliminate Vite optimizeDeps workaround ([60f09b1](https://github.com/zama-ai/sdk/commit/60f09b1a833e98852c0abd5982ff14019dd26c04))
+- **sdk:** make worker blob URL creation lazy to avoid SSR crashes ([9a9311a](https://github.com/zama-ai/sdk/commit/9a9311a6ef03420d311b4092d4fbc3d9c9a8986c))
+- **sdk:** support browser extensions and lazy worker creation ([c0fcd44](https://github.com/zama-ai/sdk/commit/c0fcd44f7d8884dc4f580066f83ef5e6cd18eea4))
+- **sdk:** use proper TypeScript assertion type narrowing in utility guards ([632bb80](https://github.com/zama-ai/sdk/commit/632bb80d27e6390c4effd795b0fcb29e6b4d0277))
+- **test:** use forks pool for react-sdk in CI instead of default ([4eca9aa](https://github.com/zama-ai/sdk/commit/4eca9aa3df6ad8285e8d096421aa75dcf5678149))
 
 ### Performance Improvements
 
-* reduce bundle size by inlining slim ABI fragments ([613321c](https://github.com/zama-ai/sdk/commit/613321c09eb73d560a2aeb36cf77956870e584d9))
-* **test:** use vmForks locally, vmThreads in CI for both test projects ([d6f9de9](https://github.com/zama-ai/sdk/commit/d6f9de9e5d03ca4e2dab982afcd2460a0dd01f19))
+- reduce bundle size by inlining slim ABI fragments ([613321c](https://github.com/zama-ai/sdk/commit/613321c09eb73d560a2aeb36cf77956870e584d9))
+- **test:** use vmForks locally, vmThreads in CI for both test projects ([d6f9de9](https://github.com/zama-ai/sdk/commit/d6f9de9e5d03ca4e2dab982afcd2460a0dd01f19))
 
 ### Documentation
 
-* improve documentation for useEncrypt and useUserDecrypt ([#81](https://github.com/zama-ai/sdk/issues/81)) ([5ce5f2e](https://github.com/zama-ai/sdk/commit/5ce5f2ede175f14813b9c1c663ab7696d754d787)), closes [#114](https://github.com/zama-ai/sdk/issues/114)
+- improve documentation for useEncrypt and useUserDecrypt ([#81](https://github.com/zama-ai/sdk/issues/81)) ([5ce5f2e](https://github.com/zama-ai/sdk/commit/5ce5f2ede175f14813b9c1c663ab7696d754d787)), closes [#114](https://github.com/zama-ai/sdk/issues/114)
 
 ## [2.0.0-alpha.4](https://github.com/zama-ai/sdk/compare/v2.0.0-alpha.3...v2.0.0-alpha.4) (2026-03-19)
 

--- a/examples/example-hoodi/README.md
+++ b/examples/example-hoodi/README.md
@@ -1,6 +1,6 @@
 # Hoodi + Cleartext Example
 
-Next.js app demonstrating the four core ERC-7984 operations on the **Hoodi** testnet using the **cleartext stack** and **ethers**.
+Next.js app demonstrating ERC-7984 confidential token operations on the **Hoodi** testnet using the **cleartext stack** and **ethers** — including on-chain ACL delegation.
 
 ## Stack
 
@@ -13,12 +13,15 @@ Next.js app demonstrating the four core ERC-7984 operations on the **Hoodi** tes
 
 ## Operations demonstrated
 
-| Operation                    | SDK API                      |
-| ---------------------------- | ---------------------------- |
-| Decrypt confidential balance | `useConfidentialBalance`     |
-| Shield (ERC-20 → cToken)     | `sdk.createToken().shield()` |
-| Confidential transfer        | `useConfidentialTransfer`    |
-| Unshield (cToken → ERC-20)   | `useUnshield`                |
+| Operation                    | SDK API                                       |
+| ---------------------------- | --------------------------------------------- |
+| Decrypt confidential balance | `useConfidentialBalance`                      |
+| Shield (ERC-20 → cToken)     | `sdk.createToken().shield()`                  |
+| Confidential transfer        | `useConfidentialTransfer`                     |
+| Unshield (cToken → ERC-20)   | `useUnshield`                                 |
+| Grant decryption access      | `useDelegateDecryption`                       |
+| Revoke decryption access     | `useRevokeDelegation`                         |
+| Decrypt balance as delegate  | `useDecryptBalanceAs` + `useDelegationStatus` |
 
 > **Shield** uses `token.shield()` directly (via `sdk.createToken()`) rather than the `useShield` hook, with a manual approval step. The spend cap is set to the user's full ERC-20 balance (not the exact shield amount), so subsequent shields within the remaining allowance require only the wrap transaction — no re-approval. USDT-style detection uses an optimistic approach: `writeContract` is tried directly (gas estimation uses `from = userAddress`, so USDT reverts fail pre-wallet), with a silent fallback to reset + approve only for tokens that actually need it.
 
@@ -69,7 +72,7 @@ npm run test:e2e          # run all tests (starts dev server automatically)
 npx playwright test --ui  # interactive mode — watch tests run in the browser
 ```
 
-18 Playwright e2e tests covering the connect flow, wrong-network screen, and main UI (no real wallet or transactions required — uses a mocked EIP-1193 provider).
+19 Playwright e2e tests covering the connect flow, wrong-network screen, and main UI (no real wallet or transactions required — uses a mocked EIP-1193 provider).
 
 ## Environment variables
 

--- a/examples/example-hoodi/README.md
+++ b/examples/example-hoodi/README.md
@@ -1,6 +1,16 @@
-# Hoodi + Cleartext Example
+# Example Hoodi app with cleartext Zama Protocol support
 
-Next.js app demonstrating ERC-7984 confidential token operations on the **Hoodi** testnet using the **cleartext stack** and **ethers** — including on-chain ACL delegation.
+Next.js app demonstrating ERC-7984 confidential token operations on the **Hoodi** testnet and **ethers** — including on-chain ACL delegation.
+
+## Cleartext Zama Protocol
+
+[Zama Protocol](https://docs.zama.org/protocol) is currently supported officially on Ethereum mainnet and Sepolia testnet. This setup uses a co-processor model to offload FHE computation from the host chain to a decentralised network.
+
+To provide support for yet-unsupported testnets, such as Hoodi, this example app simulates Zama Protocol using a **cleartext stack**. Essentially, it uses mocked FHE contracts to provide an API-compatible surface to write the values to the host chain, without needing an actual co-processor or relayer support to be added by Zama Protocol.
+
+This mode allows developers to test **smart contracts** and **app/backend integrations** with Hoodi chain in an API-compatible fashion with the real Zama Protocol.
+
+**WARNING**: Support for testnets such as Hoodi via this cleartext Zama Protocol method is only intended for **testing** purposes. A **the "encrypted" values are stored in cleartext** on Hoodi testnet.
 
 ## Stack
 
@@ -74,7 +84,7 @@ npm run test:e2e          # run all tests (starts dev server automatically)
 npx playwright test --ui  # interactive mode — watch tests run in the browser
 ```
 
-22 Playwright e2e tests covering the connect flow, wrong-network screen, main UI, and delegation section (no real wallet or transactions required — uses a mocked EIP-1193 provider).
+Playwright e2e tests covering the connect flow, wrong-network screen, main UI, and delegation section (no real wallet or transactions required — uses a mocked EIP-1193 provider).
 
 ## Environment variables
 

--- a/examples/example-hoodi/README.md
+++ b/examples/example-hoodi/README.md
@@ -29,6 +29,8 @@ Next.js app demonstrating ERC-7984 confidential token operations on the **Hoodi*
 
 > **Separate IndexedDB instances** for `storage` and `sessionStorage` in `ZamaProvider`: both use the same key internally, so sharing a single `IndexedDBStorage` instance causes the session entry to overwrite the encrypted keypair, forcing a re-sign on every balance decryption.
 
+> **Delegation revocation cache:** `useDecryptBalanceAs` caches decrypted values in IndexedDB keyed by `(token, owner, handle)`. When delegation is revoked, the cached plaintext is still served until the owner's balance changes (via shield, transfer, or unshield), which produces a new on-chain handle and invalidates the cache entry. No TTL is applied — the handle itself is the cache key.
+
 ## How it differs from `react-ethers`
 
 |           | `react-ethers`                   | `example-hoodi`                      |
@@ -72,7 +74,7 @@ npm run test:e2e          # run all tests (starts dev server automatically)
 npx playwright test --ui  # interactive mode — watch tests run in the browser
 ```
 
-19 Playwright e2e tests covering the connect flow, wrong-network screen, and main UI (no real wallet or transactions required — uses a mocked EIP-1193 provider).
+22 Playwright e2e tests covering the connect flow, wrong-network screen, main UI, and delegation section (no real wallet or transactions required — uses a mocked EIP-1193 provider).
 
 ## Environment variables
 

--- a/examples/example-hoodi/WALKTHROUGH.md
+++ b/examples/example-hoodi/WALKTHROUGH.md
@@ -32,12 +32,15 @@ Specifically:
 
 ## Supported operations
 
-| Operation                    | SDK API                      | Source file                       | Transactions          |
-| ---------------------------- | ---------------------------- | --------------------------------- | --------------------- |
-| Decrypt confidential balance | `useConfidentialBalance`     | `src/app/page.tsx`                | 0 (read)              |
-| Shield (ERC-20 → cToken)     | `sdk.createToken().shield()` | `src/components/ShieldCard.tsx`   | 1–3 (wrap, ± approve) |
-| Confidential transfer        | `useConfidentialTransfer`    | `src/components/TransferCard.tsx` | 1                     |
-| Unshield (cToken → ERC-20)   | `useUnshield`                | `src/components/UnshieldCard.tsx` | 2 (unwrap + finalize) |
+| Operation                    | SDK API                                       | Source file                                 | Transactions          |
+| ---------------------------- | --------------------------------------------- | ------------------------------------------- | --------------------- |
+| Decrypt confidential balance | `useConfidentialBalance`                      | `src/app/page.tsx`                          | 0 (read)              |
+| Shield (ERC-20 → cToken)     | `sdk.createToken().shield()`                  | `src/components/ShieldCard.tsx`             | 1–3 (wrap, ± approve) |
+| Confidential transfer        | `useConfidentialTransfer`                     | `src/components/TransferCard.tsx`           | 1                     |
+| Unshield (cToken → ERC-20)   | `useUnshield`                                 | `src/components/UnshieldCard.tsx`           | 2 (unwrap + finalize) |
+| Grant decryption access      | `useDelegateDecryption`                       | `src/components/DelegateDecryptionCard.tsx` | 1                     |
+| Revoke decryption access     | `useRevokeDelegation`                         | `src/components/RevokeDelegationCard.tsx`   | 1                     |
+| Decrypt balance as delegate  | `useDecryptBalanceAs` + `useDelegationStatus` | `src/components/DecryptAsCard.tsx`          | 0 (read)              |
 
 ---
 
@@ -265,6 +268,38 @@ After each operation, balances refresh automatically. All three operations (shie
 
 ---
 
+## Delegation walkthrough
+
+The three delegation cards are located below the core operation cards. They require **two separate wallets** — one acting as the token owner (delegator) and one as the delegate.
+
+### Step 9 — Grant decryption access (owner wallet)
+
+In the **Grant Decryption Access** card, enter the delegate's wallet address. By default, access is permanent (the **No expiration** checkbox is checked). To set a time limit, uncheck it and pick a date — the SDK sends `MAX_UINT64` on-chain for permanent delegations, or the expiry timestamp otherwise.
+
+Click **Grant Access** and confirm the transaction in your wallet. One transaction is submitted to the on-chain ACL contract.
+
+### Step 10 — Decrypt balance as delegate (delegate wallet)
+
+Switch to the delegate wallet (or open a second browser profile with the delegate account). In the **Decrypt Balance On Behalf Of** card, enter the owner's wallet address.
+
+As soon as a valid address is entered, a live **delegation status** indicator appears:
+
+- **✓ Delegated · Permanent** — delegation is active and has no expiry.
+- **✓ Delegated · \<date\>** — delegation is active until the shown date.
+- **No active delegation for this token** — no delegation exists; go back to Step 9.
+
+Click **Decrypt Balance** to decrypt the owner's confidential balance. The result is displayed in token units.
+
+> **Cache behaviour:** decrypted values are cached locally in IndexedDB, keyed by the on-chain encrypted handle. If the owner's balance does not change between two decrypt calls, the second call returns the cached value without re-checking the ACL — this is intentional. See [Troubleshooting](#troubleshooting) for details.
+
+### Step 11 — Revoke decryption access (owner wallet)
+
+Switch back to the owner wallet. In the **Revoke Decryption Access** card, enter the delegate's address and click **Revoke Access**. One transaction is submitted. After confirmation, the delegation is removed from the on-chain ACL.
+
+> **Revocation and caching:** if the delegate calls Decrypt Balance again immediately after revocation and the owner's balance has not changed, the cached plaintext is returned — no new ACL check occurs. Revocation takes full effect for the delegate as soon as the owner's balance changes (any shield, transfer, or unshield), which produces a new on-chain handle and invalidates the cache entry.
+
+---
+
 ## SDK integration details
 
 ### Providers setup
@@ -414,6 +449,53 @@ unshield.mutate({
 });
 ```
 
+### Delegation hooks
+
+```tsx
+import {
+  useDelegateDecryption,
+  useRevokeDelegation,
+  useDelegationStatus,
+  useDecryptBalanceAs,
+} from "@zama-fhe/react-sdk";
+import { DelegationNotFoundError, DelegationExpiredError } from "@zama-fhe/sdk";
+
+// Grant decryption access — 1 transaction.
+// expirationDate: undefined → SDK sends MAX_UINT64 on-chain (permanent delegation).
+const delegate = useDelegateDecryption({ tokenAddress: cTokenAddress });
+delegate.mutate({ delegateAddress: "0xDelegate" });
+delegate.mutate({ delegateAddress: "0xDelegate", expirationDate: new Date("2027-01-01") });
+
+// Revoke decryption access — 1 transaction.
+const revoke = useRevokeDelegation({ tokenAddress: cTokenAddress });
+revoke.mutate({ delegateAddress: "0xDelegate" });
+
+// Query delegation status — fires automatically when both addresses are valid.
+// Pass undefined for either address to disable the query (useful before the user
+// has entered an address).
+const { data: status } = useDelegationStatus({
+  tokenAddress: cTokenAddress,
+  delegatorAddress: "0xOwner", // the wallet that granted the delegation
+  delegateAddress: "0xDelegate", // the wallet that received it (usually the connected wallet)
+});
+// status?.isDelegated       → boolean
+// status?.expiryTimestamp   → bigint (MAX_UINT64 for permanent delegations)
+
+// Decrypt owner's balance as a delegate — 0 transactions (read + local cache).
+// Throws DelegationNotFoundError / DelegationExpiredError if the ACL check fails.
+const decryptAs = useDecryptBalanceAs(cTokenAddress);
+decryptAs.mutate({ delegatorAddress: "0xOwner" });
+// decryptAs.data → bigint (raw balance)
+
+// Typed error handling:
+if (decryptAs.error instanceof DelegationNotFoundError) {
+  /* no delegation */
+}
+if (decryptAs.error instanceof DelegationExpiredError) {
+  /* expired */
+}
+```
+
 ---
 
 ## Environment variables
@@ -428,27 +510,28 @@ Copy `.env.example` to `.env.local` and fill in `NEXT_PUBLIC_HOODI_RPC_URL` if y
 
 ## Troubleshooting
 
-| Symptom                                                   | Likely cause                                                                            | Fix                                                                                                                                                                                                                                                                                                                                    |
-| --------------------------------------------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "No wallet found" on connect                              | No EIP-1193 wallet extension installed                                                  | Install an EIP-1193 browser wallet ([Rabby](https://rabby.io) recommended; MetaMask or Phantom also work)                                                                                                                                                                                                                              |
-| Phantom shows a multi-chain connect dialog                | Phantom's generic picker — app auto-selects Phantom's Ethereum provider                 | Proceed normally; only Ethereum accounts are used. For a cleaner experience use [Rabby](https://rabby.io)                                                                                                                                                                                                                              |
-| Stuck on "Connect Wallet" after clicking                  | Wallet popup was dismissed or blocked                                                   | Open your wallet manually and approve the connection request                                                                                                                                                                                                                                                                           |
-| Network switch fails with error                           | Wallet cannot reach the Hoodi RPC                                                       | Check `NEXT_PUBLIC_HOODI_RPC_URL`; try the default `https://rpc.hoodi.ethpandaops.io`                                                                                                                                                                                                                                                  |
-| Wrong network screen appears                              | Wallet switched away from Hoodi                                                         | Click **Switch to Hoodi** to switch back to Hoodi                                                                                                                                                                                                                                                                                      |
-| ERC-20 balance shows `—`                                  | Not yet connected or query pending                                                      | Wait for the connection to complete                                                                                                                                                                                                                                                                                                    |
-| ERC-20 balance shows `0`                                  | Tokens not yet minted                                                                   | Click the **Mint** button or use one of the methods in [Minting test tokens](#minting-test-tokens)                                                                                                                                                                                                                                     |
-| Confidential balance shows `—` immediately after connect  | No shielded balance yet — no encrypted handle to read                                   | Shield some tokens first; the balance will display once there is something to decrypt                                                                                                                                                                                                                                                  |
-| "Decrypting…" stays indefinitely                          | Wallet EIP-712 signature request was missed (small notification badge)                  | Open your wallet and approve the pending signature request; balance will update immediately                                                                                                                                                                                                                                            |
-| Asked to sign an EIP-712 message after each action        | Session not yet cached (first use — expected)                                           | Approve once — subsequent decryptions reuse the IndexedDB-persisted session credential (30-day TTL). If the prompt recurs every time, make sure `storage` and `sessionStorage` in `ZamaProvider` point to **different** `IndexedDBStorage` instances — sharing the same instance corrupts the stored credentials (see Providers setup) |
-| Shield fails immediately after approving spend cap        | Approval transaction not yet confirmed on Hoodi when wrap was attempted                 | Wait for the approval confirmation and retry — the app detects this and shows a hint                                                                                                                                                                                                                                                   |
-| Shield fails after a recent transfer or other operation   | Pending transaction in the mempool caused a nonce conflict                              | Wait for all pending transactions to confirm, then retry                                                                                                                                                                                                                                                                               |
-| Shield stuck on "Shielding… (1/2)"                        | Ran out of Hoodi ETH after the approval transaction                                     | Top up your wallet with Hoodi ETH and try again                                                                                                                                                                                                                                                                                        |
-| Shield completes but balances unchanged                   | Decimal mismatch — wrong number of decimals used to parse the amount                    | Ensure the amount input uses the ERC-20 contract's decimals (not the ERC-7984 token's); call `useMetadata` on both contracts                                                                                                                                                                                                           |
-| "nonce too low: next nonce X, tx nonce Y"                 | The Hoodi public RPC returned a stale nonce; ethers built the tx with an outdated value | This is fixed by routing `eth_getTransactionCount` through the wallet in the hybrid provider. If you see this in your own integration, ensure `eth_getTransactionCount` is NOT routed to a load-balanced RPC — it must go through the same node that will receive your `eth_sendTransaction`                                           |
-| "Transaction reverted" on any operation                   | Insufficient token balance, or wrong network                                            | Verify you are on Hoodi (chainId 560048) and have sufficient tokens                                                                                                                                                                                                                                                                    |
-| Unshield shows "Unshielding… (2/2)" for longer than usual | Finalize phase waiting for the Phase 2 receipt                                          | Normal on Hoodi — the public RPC can be slow; the app polls receipt via the wallet's node for consistency                                                                                                                                                                                                                              |
-| Pending unshield card appears on reload                   | Tab was closed between Phase 1 and Phase 2 of an unshield                               | Click **Finalize** in the Pending Unshield card to complete the operation and receive your ERC-20 tokens                                                                                                                                                                                                                               |
-| Amounts displayed as very large or very small numbers     | Raw units displayed without decimal conversion                                          | Always use `formatUnits(balance, decimals)` for display and `parseUnits(input, decimals)` for input; fetch decimals via `useMetadata`                                                                                                                                                                                                  |
+| Symptom                                                   | Likely cause                                                                                                                                             | Fix                                                                                                                                                                                                                                                                                                                                                              |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "No wallet found" on connect                              | No EIP-1193 wallet extension installed                                                                                                                   | Install an EIP-1193 browser wallet ([Rabby](https://rabby.io) recommended; MetaMask or Phantom also work)                                                                                                                                                                                                                                                        |
+| Phantom shows a multi-chain connect dialog                | Phantom's generic picker — app auto-selects Phantom's Ethereum provider                                                                                  | Proceed normally; only Ethereum accounts are used. For a cleaner experience use [Rabby](https://rabby.io)                                                                                                                                                                                                                                                        |
+| Stuck on "Connect Wallet" after clicking                  | Wallet popup was dismissed or blocked                                                                                                                    | Open your wallet manually and approve the connection request                                                                                                                                                                                                                                                                                                     |
+| Network switch fails with error                           | Wallet cannot reach the Hoodi RPC                                                                                                                        | Check `NEXT_PUBLIC_HOODI_RPC_URL`; try the default `https://rpc.hoodi.ethpandaops.io`                                                                                                                                                                                                                                                                            |
+| Wrong network screen appears                              | Wallet switched away from Hoodi                                                                                                                          | Click **Switch to Hoodi** to switch back to Hoodi                                                                                                                                                                                                                                                                                                                |
+| ERC-20 balance shows `—`                                  | Not yet connected or query pending                                                                                                                       | Wait for the connection to complete                                                                                                                                                                                                                                                                                                                              |
+| ERC-20 balance shows `0`                                  | Tokens not yet minted                                                                                                                                    | Click the **Mint** button or use one of the methods in [Minting test tokens](#minting-test-tokens)                                                                                                                                                                                                                                                               |
+| Confidential balance shows `—` immediately after connect  | No shielded balance yet — no encrypted handle to read                                                                                                    | Shield some tokens first; the balance will display once there is something to decrypt                                                                                                                                                                                                                                                                            |
+| "Decrypting…" stays indefinitely                          | Wallet EIP-712 signature request was missed (small notification badge)                                                                                   | Open your wallet and approve the pending signature request; balance will update immediately                                                                                                                                                                                                                                                                      |
+| Asked to sign an EIP-712 message after each action        | Session not yet cached (first use — expected)                                                                                                            | Approve once — subsequent decryptions reuse the IndexedDB-persisted session credential (30-day TTL). If the prompt recurs every time, make sure `storage` and `sessionStorage` in `ZamaProvider` point to **different** `IndexedDBStorage` instances — sharing the same instance corrupts the stored credentials (see Providers setup)                           |
+| Shield fails immediately after approving spend cap        | Approval transaction not yet confirmed on Hoodi when wrap was attempted                                                                                  | Wait for the approval confirmation and retry — the app detects this and shows a hint                                                                                                                                                                                                                                                                             |
+| Shield fails after a recent transfer or other operation   | Pending transaction in the mempool caused a nonce conflict                                                                                               | Wait for all pending transactions to confirm, then retry                                                                                                                                                                                                                                                                                                         |
+| Shield stuck on "Shielding… (1/2)"                        | Ran out of Hoodi ETH after the approval transaction                                                                                                      | Top up your wallet with Hoodi ETH and try again                                                                                                                                                                                                                                                                                                                  |
+| Shield completes but balances unchanged                   | Decimal mismatch — wrong number of decimals used to parse the amount                                                                                     | Ensure the amount input uses the ERC-20 contract's decimals (not the ERC-7984 token's); call `useMetadata` on both contracts                                                                                                                                                                                                                                     |
+| "nonce too low: next nonce X, tx nonce Y"                 | The Hoodi public RPC returned a stale nonce; ethers built the tx with an outdated value                                                                  | This is fixed by routing `eth_getTransactionCount` through the wallet in the hybrid provider. If you see this in your own integration, ensure `eth_getTransactionCount` is NOT routed to a load-balanced RPC — it must go through the same node that will receive your `eth_sendTransaction`                                                                     |
+| "Transaction reverted" on any operation                   | Insufficient token balance, or wrong network                                                                                                             | Verify you are on Hoodi (chainId 560048) and have sufficient tokens                                                                                                                                                                                                                                                                                              |
+| Unshield shows "Unshielding… (2/2)" for longer than usual | Finalize phase waiting for the Phase 2 receipt                                                                                                           | Normal on Hoodi — the public RPC can be slow; the app polls receipt via the wallet's node for consistency                                                                                                                                                                                                                                                        |
+| Pending unshield card appears on reload                   | Tab was closed between Phase 1 and Phase 2 of an unshield                                                                                                | Click **Finalize** in the Pending Unshield card to complete the operation and receive your ERC-20 tokens                                                                                                                                                                                                                                                         |
+| Amounts displayed as very large or very small numbers     | Raw units displayed without decimal conversion                                                                                                           | Always use `formatUnits(balance, decimals)` for display and `parseUnits(input, decimals)` for input; fetch decimals via `useMetadata`                                                                                                                                                                                                                            |
+| Delegate can still decrypt after revocation               | Expected behavior — decrypted values are cached in IndexedDB keyed by `(token, owner, handle)`; the cache is served without re-checking the on-chain ACL | This is by design: the SDK uses the on-chain encrypted handle as the cache key (no TTL). Revocation takes effect for the delegate as soon as the owner's balance changes (via shield, transfer, or unshield), which produces a new handle and automatically invalidates the cache entry. Until then, the previously decrypted value is still accessible locally. |
 
 ---
 
@@ -460,7 +543,7 @@ This example ships with a Playwright e2e test suite. Tests run against the real 
 # Install deps (first time only)
 npm install
 
-# Run all 18 tests — starts the dev server automatically
+# Run all 19 tests — starts the dev server automatically
 npm run test:e2e
 
 # Interactive mode — watch each test run step-by-step in the browser
@@ -470,7 +553,7 @@ npx playwright test --ui
 npx playwright test e2e/connect.spec.ts
 ```
 
-Covered flows: connect screen (no wallet, install error, auto-detect, click-to-connect), wrong-network screen (display, chain ID, switch button), main UI (cards, token selector, buttons disabled before metadata loads, balance display, loading hint, token switching, pending unshield absence, mint button state).
+Covered flows: connect screen (no wallet, install error, auto-detect, click-to-connect), wrong-network screen (display, chain ID, switch button), main UI (cards, token selector, buttons disabled before metadata loads, balance display, loading hint, token switching, pending unshield absence, mint button state, delegation buttons disabled when no address entered).
 
 Tests run automatically on CI for every pull request that touches `examples/example-hoodi/`.
 
@@ -482,17 +565,17 @@ Tests run automatically on CI for every pull request that touches `examples/exam
 - **Production use** — replace `RelayerCleartext` with `RelayerWeb` (browser) or `RelayerNode` (server) when targeting a chain with the full FHE co-processor (Sepolia, Mainnet).
 - **Batch balance decryption** — for multiple tokens, use `useConfidentialBalances` (batch hook) to decrypt all balances in a single relayer call.
 - **Optimistic balance updates** — for `useConfidentialTransfer`, pass `optimistic: true` to immediately update the cached confidential balance while the transaction confirms, then roll back automatically on error. Improves perceived responsiveness in production UIs.
-- **On-chain ACL delegation** — grant another wallet the right to decrypt your confidential balance via `useDelegateDecryption`, revoke it with `useRevokeDelegation`, and let delegates decrypt on your behalf with `useDecryptBalanceAs`.
+- **On-chain ACL delegation** — grant another wallet the right to decrypt your confidential balance via `useDelegateDecryption`, revoke it with `useRevokeDelegation`, and let delegates decrypt on your behalf with `useDecryptBalanceAs`. Note: revocation takes effect for the delegate only after the owner's balance changes (shield, transfer, or unshield). Until then, the SDK serves the previously decrypted value from its local IndexedDB cache — keyed by the on-chain encrypted handle — without re-checking the ACL. This is intentional: the handle changes whenever the balance changes, which automatically invalidates the cache entry.
 
 ---
 
 ## Tech stack
 
-| Package                 | Version       | Role                                                                                            |
-| ----------------------- | ------------- | ----------------------------------------------------------------------------------------------- |
-| `@zama-fhe/sdk`         | 1.2.0-alpha.5 | FHE core — `RelayerCleartext`, `EthersSigner`, contract builders                                |
-| `@zama-fhe/react-sdk`   | 1.2.0-alpha.5 | React hooks — `useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`, `useMetadata` |
-| `ethers`                | ^6.13.0       | Ethereum client (via `EthersSigner`)                                                            |
-| `@tanstack/react-query` | ^5.90.0       | Async state management                                                                          |
-| `next`                  | ^16.0.0       | React framework (App Router)                                                                    |
-| **Chain**               | Hoodi testnet | chainId 560048                                                                                  |
+| Package                 | Version       | Role                                                                                                                                                                                          |
+| ----------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@zama-fhe/sdk`         | 1.2.0-alpha.5 | FHE core — `RelayerCleartext`, `EthersSigner`, contract builders                                                                                                                              |
+| `@zama-fhe/react-sdk`   | 1.2.0-alpha.5 | React hooks — `useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`, `useMetadata`, `useDelegateDecryption`, `useRevokeDelegation`, `useDelegationStatus`, `useDecryptBalanceAs` |
+| `ethers`                | ^6.13.0       | Ethereum client (via `EthersSigner`)                                                                                                                                                          |
+| `@tanstack/react-query` | ^5.90.0       | Async state management                                                                                                                                                                        |
+| `next`                  | ^16.0.0       | React framework (App Router)                                                                                                                                                                  |
+| **Chain**               | Hoodi testnet | chainId 560048                                                                                                                                                                                |

--- a/examples/example-hoodi/WALKTHROUGH.md
+++ b/examples/example-hoodi/WALKTHROUGH.md
@@ -362,9 +362,10 @@ import {
 const cTokenAddress = "0x..."; // ERC-7984 wrapper contract address
 const erc20Address = "0x..."; // Underlying ERC-20 contract address (from your config)
 
-// Fetch decimal precision for each contract — they may differ.
+// useMetadata reads name/symbol/decimals from any contract exposing the ERC-20
+// metadata interface — works on both plain ERC-20s and ERC-7984 wrappers.
 // Use erc20Decimals for shield (amounts are in ERC-20 units).
-// Use cTokenDecimals for transfer and unshield (amounts are in confidential token units).
+// Use cTokenDecimals for transfer and unshield (amounts are in cToken units).
 const { data: cTokenMetadata } = useMetadata(cTokenAddress);
 const { data: erc20Metadata } = useMetadata(erc20Address);
 const cTokenDecimals = cTokenMetadata?.decimals ?? 0;
@@ -569,7 +570,6 @@ Tests run automatically on CI for every pull request that touches `examples/exam
 - **Production use** — replace `RelayerCleartext` with `RelayerWeb` (browser) or `RelayerNode` (server) when targeting a chain with the full FHE co-processor (Sepolia, Mainnet).
 - **Batch balance decryption** — for multiple tokens, use `useConfidentialBalances` (batch hook) to decrypt all balances in a single relayer call.
 - **Optimistic balance updates** — for `useConfidentialTransfer`, pass `optimistic: true` to immediately update the cached confidential balance while the transaction confirms, then roll back automatically on error. Improves perceived responsiveness in production UIs.
-- **On-chain ACL delegation** — grant another wallet the right to decrypt your confidential balance via `useDelegateDecryption`, revoke it with `useRevokeDelegation`, and let delegates decrypt on your behalf with `useDecryptBalanceAs`. Note: revocation takes effect for the delegate only after the owner's balance changes (shield, transfer, or unshield). Until then, the SDK serves the previously decrypted value from its local IndexedDB cache — keyed by the on-chain encrypted handle — without re-checking the ACL. This is intentional: the handle changes whenever the balance changes, which automatically invalidates the cache entry.
 
 ---
 
@@ -577,8 +577,8 @@ Tests run automatically on CI for every pull request that touches `examples/exam
 
 | Package                 | Version       | Role                                                                                                                                                                                          |
 | ----------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@zama-fhe/sdk`         | 1.2.0-alpha.5 | FHE core — `RelayerCleartext`, `EthersSigner`, contract builders                                                                                                                              |
-| `@zama-fhe/react-sdk`   | 1.2.0-alpha.5 | React hooks — `useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`, `useMetadata`, `useDelegateDecryption`, `useRevokeDelegation`, `useDelegationStatus`, `useDecryptBalanceAs` |
+| `@zama-fhe/sdk`         | 2.0.0-alpha.2 | FHE core — `RelayerCleartext`, `EthersSigner`, contract builders                                                                                                                              |
+| `@zama-fhe/react-sdk`   | 2.0.0-alpha.2 | React hooks — `useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`, `useMetadata`, `useDelegateDecryption`, `useRevokeDelegation`, `useDelegationStatus`, `useDecryptBalanceAs` |
 | `ethers`                | ^6.13.0       | Ethereum client (via `EthersSigner`)                                                                                                                                                          |
 | `@tanstack/react-query` | ^5.90.0       | Async state management                                                                                                                                                                        |
 | `next`                  | ^16.0.0       | React framework (App Router)                                                                                                                                                                  |

--- a/examples/example-hoodi/WALKTHROUGH.md
+++ b/examples/example-hoodi/WALKTHROUGH.md
@@ -276,7 +276,7 @@ The three delegation cards are located below the core operation cards. They requ
 
 ### Step 9 — Grant decryption access (owner wallet)
 
-In the **Grant Decryption Access** card, enter the delegate's wallet address. By default, access is permanent (the **No expiration** checkbox is checked). To set a time limit, uncheck it and pick a date — the SDK sends `MAX_UINT64` on-chain for permanent delegations, or the expiry timestamp otherwise.
+In the **Grant Decryption Access** card, enter the delegate's wallet address. By default, access is permanent (the **No expiration** checkbox is checked). To set a time limit, uncheck it and pick a date and time — the SDK sends `MAX_UINT64` on-chain for permanent delegations, or the expiry timestamp otherwise. **The ACL contract requires the expiry to be at least 1 hour in the future** (`expirationDate >= block.timestamp + 1 hours`); shorter values will revert on-chain.
 
 Click **Grant Access** and confirm the transaction in your wallet. One transaction is submitted to the on-chain ACL contract.
 
@@ -558,7 +558,7 @@ npx playwright test --ui
 npx playwright test e2e/connect.spec.ts
 ```
 
-Covered flows: connect screen (no wallet, install error, auto-detect, click-to-connect), wrong-network screen (display, chain ID, switch button), main UI (cards, token selector, buttons disabled before metadata loads, balance display, loading hint, token switching, pending unshield absence, mint button state), delegation section (section labels, buttons disabled before address entry, Grant Access and Revoke Access enabled after valid address entry).
+Covered flows: connect screen (no wallet, install error, page title, auto-detect, click-to-connect), wrong-network screen (display, chain ID, switch button), main UI (all cards rendered, connected address, ETH balance, token selector, buttons disabled before metadata loads, balance display, loading hint, token switching, pending unshield absence, mint button state), delegation section (section labels, buttons disabled before address entry, Grant Access and Revoke Access enabled after valid address entry).
 
 Tests run automatically on CI for every pull request that touches `examples/example-hoodi/`.
 

--- a/examples/example-hoodi/WALKTHROUGH.md
+++ b/examples/example-hoodi/WALKTHROUGH.md
@@ -156,6 +156,8 @@ Registry (DeploymentCoordinator): `0x1807aE2f693F8530DFB126D0eF98F2F2518F292f`
 
 All contracts verified on [hoodi.etherscan.io](https://hoodi.etherscan.io).
 
+> These addresses are also defined in `src/lib/config.ts` and `src/app/page.tsx` (`TOKENS` constant). If contracts are redeployed, update all three locations.
+
 ---
 
 ## Minting test tokens
@@ -466,7 +468,9 @@ import { DelegationNotFoundError, DelegationExpiredError } from "@zama-fhe/sdk";
 // Grant decryption access — 1 transaction.
 // expirationDate: undefined → SDK sends MAX_UINT64 on-chain (permanent delegation).
 const delegate = useDelegateDecryption({ tokenAddress: cTokenAddress });
+// Permanent delegation (no expiry):
 delegate.mutate({ delegateAddress: "0xDelegate" });
+// With expiry (must be at least 1 hour in the future):
 delegate.mutate({ delegateAddress: "0xDelegate", expirationDate: new Date("2027-01-01") });
 
 // Revoke decryption access — 1 transaction.
@@ -537,6 +541,9 @@ Copy `.env.example` to `.env.local` and fill in `NEXT_PUBLIC_HOODI_RPC_URL` if y
 | Pending unshield card appears on reload                   | Tab was closed between Phase 1 and Phase 2 of an unshield                                                                                                | Click **Finalize** in the Pending Unshield card to complete the operation and receive your ERC-20 tokens                                                                                                                                                                                                                                                         |
 | Amounts displayed as very large or very small numbers     | Raw units displayed without decimal conversion                                                                                                           | Always use `formatUnits(balance, decimals)` for display and `parseUnits(input, decimals)` for input; fetch decimals via `useMetadata`                                                                                                                                                                                                                            |
 | Delegate can still decrypt after revocation               | Expected behavior — decrypted values are cached in IndexedDB keyed by `(token, owner, handle)`; the cache is served without re-checking the on-chain ACL | This is by design: the SDK uses the on-chain encrypted handle as the cache key (no TTL). Revocation takes effect for the delegate as soon as the owner's balance changes (via shield, transfer, or unshield), which produces a new handle and automatically invalidates the cache entry. Until then, the previously decrypted value is still accessible locally. |
+| Grant Access reverts with `ExpirationDateBeforeOneHour`   | Expiration date is less than 1 hour in the future (ACL contract requirement)                                                                             | Set the expiry to at least 1 hour from now. The contract compares against `block.timestamp` (UTC), not your local clock — account for any clock skew. A future SDK release will validate this client-side before submitting the transaction.                                                                                                                     |
+| Grant Access reverts with `SenderCannotBeDelegate`        | Attempted to delegate decryption access to your own address                                                                                              | Enter a different wallet address. The ACL contract does not allow self-delegation. A future SDK release will validate this client-side before submitting the transaction.                                                                                                                                                                                        |
+| Revoke Access reverts with `NotDelegatedYet`              | No active delegation exists for the entered address and token                                                                                            | Verify the delegate address is correct and that a grant was previously confirmed on-chain for the selected token. A future SDK release will validate this client-side before submitting the transaction.                                                                                                                                                         |
 
 ---
 
@@ -548,7 +555,7 @@ This example ships with a Playwright e2e test suite. Tests run against the real 
 # Install deps (first time only)
 npm install
 
-# Run all 22 tests — starts the dev server automatically
+# Run all tests — starts the dev server automatically
 npm run test:e2e
 
 # Interactive mode — watch each test run step-by-step in the browser
@@ -575,11 +582,11 @@ Tests run automatically on CI for every pull request that touches `examples/exam
 
 ## Tech stack
 
-| Package                 | Version       | Role                                                                                                                                                                                          |
-| ----------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@zama-fhe/sdk`         | 2.0.0-alpha.2 | FHE core — `RelayerCleartext`, `EthersSigner`, contract builders                                                                                                                              |
-| `@zama-fhe/react-sdk`   | 2.0.0-alpha.2 | React hooks — `useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`, `useMetadata`, `useDelegateDecryption`, `useRevokeDelegation`, `useDelegationStatus`, `useDecryptBalanceAs` |
-| `ethers`                | ^6.13.0       | Ethereum client (via `EthersSigner`)                                                                                                                                                          |
-| `@tanstack/react-query` | ^5.90.0       | Async state management                                                                                                                                                                        |
-| `next`                  | ^16.0.0       | React framework (App Router)                                                                                                                                                                  |
-| **Chain**               | Hoodi testnet | chainId 560048                                                                                                                                                                                |
+| Package                 | Version            | Role                                                                                                                                                                                          |
+| ----------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@zama-fhe/sdk`         | see `package.json` | FHE core — `RelayerCleartext`, `EthersSigner`, contract builders                                                                                                                              |
+| `@zama-fhe/react-sdk`   | see `package.json` | React hooks — `useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`, `useMetadata`, `useDelegateDecryption`, `useRevokeDelegation`, `useDelegationStatus`, `useDecryptBalanceAs` |
+| `ethers`                | ^6.13.0            | Ethereum client (via `EthersSigner`)                                                                                                                                                          |
+| `@tanstack/react-query` | ^5.90.0            | Async state management                                                                                                                                                                        |
+| `next`                  | ^16.0.0            | React framework (App Router)                                                                                                                                                                  |
+| **Chain**               | Hoodi testnet      | chainId 560048                                                                                                                                                                                |

--- a/examples/example-hoodi/WALKTHROUGH.md
+++ b/examples/example-hoodi/WALKTHROUGH.md
@@ -1,6 +1,6 @@
 # Integrating Zama Confidential Tokens (ERC-7984) on Hoodi
 
-**Audience:** Partners integrating Zama confidential tokens on the Hoodi testnet (ethers-based stack).
+**Audience:** Partners integrating Zama confidential tokens on the Hoodi testnet (ethers-based stack), including on-chain ACL delegation.
 
 **What this document covers:** context and motivation, how the cleartext stack works, prerequisites, step-by-step operation walkthrough, minting instructions, environment variable reference, and troubleshooting.
 
@@ -26,7 +26,7 @@ Specifically:
 
 1. A user connects any injected EIP-1193 wallet.
 2. They can select between two tokens (USDT Mock / Test Token).
-3. All four ERC-7984 protocol operations work end-to-end.
+3. All ERC-7984 protocol operations work end-to-end: shield, transfer, unshield, balance decryption, and on-chain ACL delegation (grant, revoke, decrypt-as).
 
 ---
 
@@ -100,6 +100,8 @@ page.tsx — sdk.createToken().shield() / useConfidentialTransfer / useUnshield 
        └─ reads plaintexts from CleartextFHEVMExecutor (on-chain, Hoodi)
        └─ produces mock KMS signatures locally (no external call)
 ```
+
+**`getActiveUnshieldToken` bridge** (`src/lib/activeUnshield.ts`): module-level variable that stores the token address of an in-flight unshield. `ZamaSDKEvents.UnshieldPhase1Submitted` does not carry the token address, so `UnshieldCard` sets this variable just before calling `mutate()`. The `onEvent` handler in `providers.tsx` reads it to call `savePendingUnshield` with the correct wrapper address. A module-level variable is safe here — only one unshield can be in flight per browser tab.
 
 **Hybrid EIP-1193 provider:** contract read calls (`eth_call`, `eth_estimateGas`) are routed to a direct `JsonRpcProvider` for fast, wallet-independent reads. The following calls are routed to the injected wallet's node instead, because `rpc.hoodi.ethpandaops.io` is a load balancer whose backends can be at different chain heights:
 
@@ -483,6 +485,8 @@ const { data: status } = useDelegationStatus({
 
 // Decrypt owner's balance as a delegate — 0 transactions (read + local cache).
 // Throws DelegationNotFoundError / DelegationExpiredError if the ACL check fails.
+// Note: useDecryptBalanceAs takes a positional tokenAddress argument (unlike
+// useDelegateDecryption / useRevokeDelegation which use a config object { tokenAddress }).
 const decryptAs = useDecryptBalanceAs(cTokenAddress);
 decryptAs.mutate({ delegatorAddress: "0xOwner" });
 // decryptAs.data → bigint (raw balance)
@@ -543,7 +547,7 @@ This example ships with a Playwright e2e test suite. Tests run against the real 
 # Install deps (first time only)
 npm install
 
-# Run all 19 tests — starts the dev server automatically
+# Run all 22 tests — starts the dev server automatically
 npm run test:e2e
 
 # Interactive mode — watch each test run step-by-step in the browser
@@ -553,7 +557,7 @@ npx playwright test --ui
 npx playwright test e2e/connect.spec.ts
 ```
 
-Covered flows: connect screen (no wallet, install error, auto-detect, click-to-connect), wrong-network screen (display, chain ID, switch button), main UI (cards, token selector, buttons disabled before metadata loads, balance display, loading hint, token switching, pending unshield absence, mint button state, delegation buttons disabled when no address entered).
+Covered flows: connect screen (no wallet, install error, auto-detect, click-to-connect), wrong-network screen (display, chain ID, switch button), main UI (cards, token selector, buttons disabled before metadata loads, balance display, loading hint, token switching, pending unshield absence, mint button state), delegation section (section labels, buttons disabled before address entry, Grant Access and Revoke Access enabled after valid address entry).
 
 Tests run automatically on CI for every pull request that touches `examples/example-hoodi/`.
 

--- a/examples/example-hoodi/e2e/delegation.spec.ts
+++ b/examples/example-hoodi/e2e/delegation.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect, mockWallet, mockRpc, HOODI_CHAIN_ID_HEX, TEST_ADDRESS } from "./fixtures";
+
+// A valid Ethereum address different from TEST_ADDRESS — used to fill delegate inputs.
+const VALID_DELEGATE = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+
+// All tests start with the wallet already connected on Hoodi.
+test.describe("delegation section", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockRpc(page);
+    await mockWallet(page, { accounts: [TEST_ADDRESS], chainId: HOODI_CHAIN_ID_HEX });
+    await page.goto("/");
+  });
+
+  test("shows section labels for owner and delegate perspectives", async ({ page }) => {
+    await expect(page.getByText("Delegation — as owner")).toBeVisible();
+    await expect(page.getByText("Delegation — as delegate")).toBeVisible();
+  });
+
+  test("delegation buttons are disabled when no address is entered", async ({ page }) => {
+    // Grant Access and Revoke Access require a valid delegate address — disabled when input is empty.
+    await expect(page.getByRole("button", { name: "Grant Access", exact: true })).toBeDisabled();
+    await expect(page.getByRole("button", { name: "Revoke Access", exact: true })).toBeDisabled();
+  });
+
+  test("Grant Access is enabled when a valid address is entered", async ({ page }) => {
+    const grantCard = page.locator(".card", { hasText: "Grant Decryption Access" });
+    await grantCard.getByPlaceholder("Delegate address (0x…)").fill(VALID_DELEGATE);
+    await expect(page.getByRole("button", { name: "Grant Access", exact: true })).toBeEnabled();
+  });
+
+  test("Revoke Access is enabled when a valid address is entered", async ({ page }) => {
+    const revokeCard = page.locator(".card", { hasText: "Revoke Decryption Access" });
+    await revokeCard.getByPlaceholder("Delegate address (0x…)").fill(VALID_DELEGATE);
+    await expect(page.getByRole("button", { name: "Revoke Access", exact: true })).toBeEnabled();
+  });
+});

--- a/examples/example-hoodi/e2e/main.spec.ts
+++ b/examples/example-hoodi/e2e/main.spec.ts
@@ -13,6 +13,9 @@ test.describe("main screen", () => {
     await expect(page.getByText("Shield — ERC-20 → Confidential")).toBeVisible();
     await expect(page.getByText("Confidential Transfer")).toBeVisible();
     await expect(page.getByText("Unshield — Confidential → ERC-20")).toBeVisible();
+    await expect(page.getByText("Grant Decryption Access")).toBeVisible();
+    await expect(page.getByText("Revoke Decryption Access")).toBeVisible();
+    await expect(page.getByText("Decrypt Balance On Behalf Of")).toBeVisible();
   });
 
   test("shows connected address in header", async ({ page }) => {
@@ -35,6 +38,14 @@ test.describe("main screen", () => {
     await expect(page.getByRole("button", { name: "Shield", exact: true })).toBeDisabled();
     await expect(page.getByRole("button", { name: "Transfer", exact: true })).toBeDisabled();
     await expect(page.getByRole("button", { name: "Unshield", exact: true })).toBeDisabled();
+    // Decrypt Balance requires cTokenMetadata (for decimals/symbol) — disabled until metadata loads.
+    await expect(page.getByRole("button", { name: "Decrypt Balance", exact: true })).toBeDisabled();
+  });
+
+  test("delegation buttons are disabled when no address is entered", async ({ page }) => {
+    // Grant Access and Revoke Access require a valid delegate address — disabled when input is empty.
+    await expect(page.getByRole("button", { name: "Grant Access", exact: true })).toBeDisabled();
+    await expect(page.getByRole("button", { name: "Revoke Access", exact: true })).toBeDisabled();
   });
 
   test("shows dash for ERC-20 and confidential balances when data unavailable", async ({

--- a/examples/example-hoodi/e2e/main.spec.ts
+++ b/examples/example-hoodi/e2e/main.spec.ts
@@ -42,12 +42,6 @@ test.describe("main screen", () => {
     await expect(page.getByRole("button", { name: "Decrypt Balance", exact: true })).toBeDisabled();
   });
 
-  test("delegation buttons are disabled when no address is entered", async ({ page }) => {
-    // Grant Access and Revoke Access require a valid delegate address — disabled when input is empty.
-    await expect(page.getByRole("button", { name: "Grant Access", exact: true })).toBeDisabled();
-    await expect(page.getByRole("button", { name: "Revoke Access", exact: true })).toBeDisabled();
-  });
-
   test("shows dash for ERC-20 and confidential balances when data unavailable", async ({
     page,
   }) => {

--- a/examples/example-hoodi/src/app/globals.css
+++ b/examples/example-hoodi/src/app/globals.css
@@ -237,9 +237,21 @@ body {
   color: #94a3b8;
 }
 
-/* Divider */
-.divider {
-  border: none;
+/* Section label — centered text with a line on each side */
+.section-label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+  margin: 16px 0 12px;
+}
+.section-label::before,
+.section-label::after {
+  content: "";
+  flex: 1;
   border-top: 1px solid #e2e8f0;
-  margin: 4px 0 12px;
 }

--- a/examples/example-hoodi/src/app/globals.css
+++ b/examples/example-hoodi/src/app/globals.css
@@ -174,6 +174,9 @@ body {
   color: #94a3b8;
   margin-top: 8px;
 }
+.token-meta-error {
+  color: #991b1b;
+}
 
 /* Select */
 .select {

--- a/examples/example-hoodi/src/app/globals.css
+++ b/examples/example-hoodi/src/app/globals.css
@@ -215,6 +215,28 @@ body {
   margin-top: 10px;
 }
 
+/* Checkbox label */
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+/* Delegation status indicator (DecryptAsCard) */
+.delegation-status {
+  font-size: 13px;
+}
+.delegation-status-active {
+  color: #166534;
+}
+.delegation-status-none,
+.delegation-status-checking {
+  color: #94a3b8;
+}
+
 /* Divider */
 .divider {
   border: none;

--- a/examples/example-hoodi/src/app/page.tsx
+++ b/examples/example-hoodi/src/app/page.tsx
@@ -334,6 +334,8 @@ export default function Home() {
       <BalancesCard
         formattedErc20={formattedErc20}
         formattedConfidential={formattedConfidential}
+        // handleQuery.isLoading: fetching the encrypted handle from chain (Phase 1).
+        // balance.isLoading: decrypting it via RelayerCleartext (Phase 2).
         isLoadingConfidential={balance.handleQuery.isLoading || balance.isLoading}
         erc20Symbol={erc20Symbol}
         onMint={() => mint.mutate()}
@@ -352,7 +354,7 @@ export default function Home() {
         />
       ))}
 
-      <hr className="divider" />
+      <div className="section-label">Operations</div>
 
       {/* key includes address and selectedToken so cards remount (inputs + state reset) on wallet or token change */}
       <ShieldCard
@@ -386,7 +388,7 @@ export default function Home() {
       {/* ── Delegation — token owner perspective ──────────────────────────────
           These cards are used by the wallet that OWNS the token.
           Grant or revoke another wallet's right to decrypt your balance. */}
-      <hr className="divider" />
+      <div className="section-label">Delegation — as owner</div>
 
       <DelegateDecryptionCard
         key={`grant-delegation-${address}-${selectedToken}`}
@@ -403,7 +405,7 @@ export default function Home() {
       {/* ── Delegation — delegate perspective ────────────────────────────────
           This card is used by the wallet that RECEIVED a delegation.
           Decrypt another wallet's confidential balance on their behalf. */}
-      <hr className="divider" />
+      <div className="section-label">Delegation — as delegate</div>
 
       <DecryptAsCard
         key={`decrypt-as-${address}-${selectedToken}`}

--- a/examples/example-hoodi/src/app/page.tsx
+++ b/examples/example-hoodi/src/app/page.tsx
@@ -16,6 +16,9 @@ import { ShieldCard } from "@/components/ShieldCard";
 import { TransferCard } from "@/components/TransferCard";
 import { UnshieldCard } from "@/components/UnshieldCard";
 import { PendingUnshieldCard } from "@/components/PendingUnshieldCard";
+import { DelegateDecryptionCard } from "@/components/DelegateDecryptionCard";
+import { RevokeDelegationCard } from "@/components/RevokeDelegationCard";
+import { DecryptAsCard } from "@/components/DecryptAsCard";
 import {
   HOODI_CHAIN_ID,
   HOODI_CHAIN_ID_HEX,
@@ -378,6 +381,37 @@ export default function Home() {
         symbol={confidentialSymbol}
         disabled={actionsDisabled}
         onSuccess={refreshBalances}
+      />
+
+      {/* ── Delegation — token owner perspective ──────────────────────────────
+          These cards are used by the wallet that OWNS the token.
+          Grant or revoke another wallet's right to decrypt your balance. */}
+      <hr className="divider" />
+
+      <DelegateDecryptionCard
+        key={`grant-delegation-${address}-${selectedToken}`}
+        tokenAddress={token.confidential}
+        disabled={!isHoodi}
+      />
+
+      <RevokeDelegationCard
+        key={`revoke-delegation-${address}-${selectedToken}`}
+        tokenAddress={token.confidential}
+        disabled={!isHoodi}
+      />
+
+      {/* ── Delegation — delegate perspective ────────────────────────────────
+          This card is used by the wallet that RECEIVED a delegation.
+          Decrypt another wallet's confidential balance on their behalf. */}
+      <hr className="divider" />
+
+      <DecryptAsCard
+        key={`decrypt-as-${address}-${selectedToken}`}
+        tokenAddress={token.confidential}
+        decimals={decimals}
+        symbol={confidentialSymbol}
+        disabled={!isHoodi || !cTokenMetadata.data}
+        connectedAddress={address as Address}
       />
     </div>
   );

--- a/examples/example-hoodi/src/app/page.tsx
+++ b/examples/example-hoodi/src/app/page.tsx
@@ -174,10 +174,12 @@ export default function Home() {
       const accounts = (await ethereum.request({
         method: "eth_requestAccounts",
       })) as string[];
-      setAddress(accounts[0] ?? null);
 
-      // Switch to Hoodi — updates chainId based on actual result, never throws.
+      // Switch before setting address: both chainId and address are then known
+      // when the first non-connect-screen render fires, avoiding a brief flash
+      // of the wrong-network screen between the two state updates.
       await handleSwitchToHoodi();
+      setAddress(accounts[0] ?? null);
     } catch (err) {
       console.error("Failed to connect wallet:", err);
       setConnectError(err instanceof Error ? err.message : "Failed to connect wallet");
@@ -186,9 +188,10 @@ export default function Home() {
     }
   }
 
-  // useMetadata fetches name/symbol/decimals for each contract.
-  // erc20Metadata is used for the shield amount and ERC-20 balance display;
-  // cTokenMetadata (ERC-7984) is used for transfer/unshield amounts and confidential balance display.
+  // useMetadata reads name/symbol/decimals from any contract that exposes the standard
+  // ERC-20 metadata interface — it works equally on plain ERC-20s and ERC-7984 wrappers.
+  // erc20Metadata drives shield amounts and ERC-20 balance display.
+  // cTokenMetadata drives transfer/unshield amounts and confidential balance display.
   const cTokenMetadata = useMetadata(token.confidential);
   const erc20Metadata = useMetadata(token.erc20);
 

--- a/examples/example-hoodi/src/components/DecryptAsCard.tsx
+++ b/examples/example-hoodi/src/components/DecryptAsCard.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import { isAddress, formatUnits } from "ethers";
+import { useDelegationStatus, useDecryptBalanceAs } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/react-sdk";
+import { DelegationNotFoundError, DelegationExpiredError } from "@zama-fhe/sdk";
+
+// Matches the SDK's internal sentinel value for permanent (no-expiry) delegations.
+const MAX_UINT64 = 2n ** 64n - 1n;
+
+interface DecryptAsCardProps {
+  tokenAddress: Address;
+  decimals: number;
+  symbol: string;
+  disabled: boolean;
+  connectedAddress: Address;
+}
+
+function formatExpiry(expiryTimestamp: bigint): string {
+  if (expiryTimestamp === MAX_UINT64) return "Permanent";
+  return new Date(Number(expiryTimestamp) * 1000).toLocaleString();
+}
+
+function delegationErrorMessage(error: Error): string {
+  if (error instanceof DelegationNotFoundError)
+    return "No delegation found — ask the owner to grant you access first.";
+  if (error instanceof DelegationExpiredError)
+    return "Delegation has expired — ask the owner to renew it.";
+  return error.message;
+}
+
+export function DecryptAsCard({
+  tokenAddress,
+  decimals,
+  symbol,
+  disabled,
+  connectedAddress,
+}: DecryptAsCardProps) {
+  const [ownerAddress, setOwnerAddress] = useState("");
+
+  const ownerIsValid = isAddress(ownerAddress);
+
+  // Live delegation status query — only fires when a valid owner address is entered.
+  // delegatorAddress = the owner who granted the delegation.
+  // delegateAddress  = the connected wallet (us).
+  const delegationStatus = useDelegationStatus({
+    tokenAddress,
+    delegatorAddress: ownerIsValid ? (ownerAddress as Address) : undefined,
+    delegateAddress: connectedAddress,
+  });
+
+  const decryptAs = useDecryptBalanceAs(tokenAddress);
+
+  function handleDecrypt() {
+    decryptAs.mutate({ delegatorAddress: ownerAddress as Address });
+  }
+
+  return (
+    <div className="card">
+      <div className="card-title">Decrypt Balance On Behalf Of</div>
+      <input
+        className="input card-gap"
+        type="text"
+        value={ownerAddress}
+        onChange={(e) => {
+          setOwnerAddress(e.target.value);
+          decryptAs.reset();
+        }}
+        placeholder="Owner address (0x…)"
+      />
+
+      {/* Live delegation status — shown as soon as a valid address is entered */}
+      {ownerIsValid && (
+        <div className="delegation-status card-gap">
+          {delegationStatus.isPending && (
+            <span className="delegation-status-checking">Checking delegation status…</span>
+          )}
+          {delegationStatus.isError && (
+            <span className="delegation-status-none">Unable to check delegation status</span>
+          )}
+          {delegationStatus.data?.isDelegated && (
+            <span className="delegation-status-active">
+              ✓ Delegated · {formatExpiry(delegationStatus.data.expiryTimestamp)}
+            </span>
+          )}
+          {delegationStatus.data && !delegationStatus.data.isDelegated && (
+            <span className="delegation-status-none">No active delegation for this token</span>
+          )}
+        </div>
+      )}
+
+      <button
+        className="btn btn-primary btn-full"
+        onClick={handleDecrypt}
+        disabled={disabled || !ownerIsValid || decryptAs.isPending}
+      >
+        {decryptAs.isPending ? "Decrypting…" : "Decrypt Balance"}
+      </button>
+      {decryptAs.isError && (
+        <div className="alert alert-error card-status">
+          {delegationErrorMessage(decryptAs.error)}
+        </div>
+      )}
+      {decryptAs.isSuccess && decryptAs.data !== undefined && (
+        <div className="alert alert-success card-status">
+          {formatUnits(decryptAs.data, decimals)} {symbol}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-hoodi/src/components/DecryptAsCard.tsx
+++ b/examples/example-hoodi/src/components/DecryptAsCard.tsx
@@ -50,6 +50,9 @@ export function DecryptAsCard({
     delegateAddress: connectedAddress,
   });
 
+  // Note: useDecryptBalanceAs takes a positional tokenAddress argument, unlike
+  // useDelegateDecryption / useRevokeDelegation which use a config object { tokenAddress }.
+  // This asymmetry is a current SDK API design decision.
   const decryptAs = useDecryptBalanceAs(tokenAddress);
 
   function handleDecrypt() {

--- a/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
+++ b/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
@@ -67,9 +67,11 @@ export function DelegateDecryptionCard({ tokenAddress, disabled }: DelegateDecry
         </label>
       </div>
       {!noExpiry && !expirationInput && (
-        <p className="token-meta card-gap">Select an expiration date.</p>
+        <p className="token-meta card-gap">
+          Select an expiration date and time (ACL contract requires at least 1 hour from now).
+        </p>
       )}
-      {!noExpiry && expirationInput && new Date(expirationInput) <= new Date() && (
+      {!noExpiry && expirationInput && !isExpiryValid && (
         <p className="token-meta token-meta-error card-gap">Date must be in the future.</p>
       )}
       <button

--- a/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
+++ b/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
@@ -70,9 +70,7 @@ export function DelegateDecryptionCard({ tokenAddress, disabled }: DelegateDecry
         <p className="token-meta card-gap">Select an expiration date.</p>
       )}
       {!noExpiry && expirationInput && new Date(expirationInput) <= new Date() && (
-        <p className="token-meta card-gap" style={{ color: "#991b1b" }}>
-          Date must be in the future.
-        </p>
+        <p className="token-meta token-meta-error card-gap">Date must be in the future.</p>
       )}
       <button
         className="btn btn-primary btn-full"

--- a/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
+++ b/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
@@ -66,6 +66,14 @@ export function DelegateDecryptionCard({ tokenAddress, disabled }: DelegateDecry
           No expiration
         </label>
       </div>
+      {!noExpiry && !expirationInput && (
+        <p className="token-meta card-gap">Select an expiration date.</p>
+      )}
+      {!noExpiry && expirationInput && new Date(expirationInput) <= new Date() && (
+        <p className="token-meta card-gap" style={{ color: "#991b1b" }}>
+          Date must be in the future.
+        </p>
+      )}
       <button
         className="btn btn-primary btn-full"
         onClick={handleGrant}

--- a/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
+++ b/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { isAddress } from "ethers";
+import { useDelegateDecryption } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/react-sdk";
+import { HOODI_EXPLORER_URL } from "@/lib/config";
+
+interface DelegateDecryptionCardProps {
+  tokenAddress: Address;
+  disabled: boolean;
+}
+
+export function DelegateDecryptionCard({ tokenAddress, disabled }: DelegateDecryptionCardProps) {
+  const [delegateAddress, setDelegateAddress] = useState("");
+  // Checked by default so a developer can grant access in one click during testing.
+  const [noExpiry, setNoExpiry] = useState(true);
+  const [expirationInput, setExpirationInput] = useState("");
+
+  const delegate = useDelegateDecryption(
+    { tokenAddress },
+    {
+      onSuccess: () => {
+        setDelegateAddress("");
+        setNoExpiry(true);
+        setExpirationInput("");
+      },
+    },
+  );
+
+  const isExpiryValid = noExpiry || (!!expirationInput && new Date(expirationInput) > new Date());
+  const canSubmit = isAddress(delegateAddress) && isExpiryValid;
+
+  function handleGrant() {
+    delegate.mutate({
+      delegateAddress: delegateAddress as Address,
+      // undefined → SDK sends MAX_UINT64 on-chain (permanent delegation).
+      expirationDate: noExpiry ? undefined : new Date(expirationInput),
+    });
+  }
+
+  return (
+    <div className="card">
+      <div className="card-title">Grant Decryption Access</div>
+      <input
+        className="input card-gap"
+        type="text"
+        value={delegateAddress}
+        onChange={(e) => setDelegateAddress(e.target.value)}
+        placeholder="Delegate address (0x…)"
+      />
+      <div className="input-row card-gap">
+        <input
+          className="input"
+          type="datetime-local"
+          value={expirationInput}
+          onChange={(e) => setExpirationInput(e.target.value)}
+          disabled={noExpiry}
+        />
+        <label className="checkbox-label">
+          <input
+            type="checkbox"
+            checked={noExpiry}
+            onChange={(e) => setNoExpiry(e.target.checked)}
+          />
+          No expiration
+        </label>
+      </div>
+      <button
+        className="btn btn-primary btn-full"
+        onClick={handleGrant}
+        disabled={disabled || !canSubmit || delegate.isPending}
+      >
+        {delegate.isPending ? "Granting…" : "Grant Access"}
+      </button>
+      {delegate.isError && (
+        <div className="alert alert-error card-status">{delegate.error?.message}</div>
+      )}
+      {delegate.isSuccess && delegate.data?.txHash && (
+        <div className="alert alert-success card-status">
+          Access granted!{" "}
+          <a
+            href={`${HOODI_EXPLORER_URL}/tx/${delegate.data.txHash}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {delegate.data.txHash.slice(0, 10)}…
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-hoodi/src/components/PendingUnshieldCard.tsx
+++ b/examples/example-hoodi/src/components/PendingUnshieldCard.tsx
@@ -27,7 +27,7 @@ export function PendingUnshieldCard({ tokenAddress, label, onSuccess }: PendingU
   }, [storage, tokenAddress]);
 
   const resume = useResumeUnshield(
-    // For ERC-7984 tokens, the wrapper contract and the cToken share the same address.
+    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
     { tokenAddress, wrapperAddress: tokenAddress },
     {
       onSuccess: () => {

--- a/examples/example-hoodi/src/components/RevokeDelegationCard.tsx
+++ b/examples/example-hoodi/src/components/RevokeDelegationCard.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { isAddress } from "ethers";
+import { useRevokeDelegation } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/react-sdk";
+import { HOODI_EXPLORER_URL } from "@/lib/config";
+
+interface RevokeDelegationCardProps {
+  tokenAddress: Address;
+  disabled: boolean;
+}
+
+export function RevokeDelegationCard({ tokenAddress, disabled }: RevokeDelegationCardProps) {
+  const [delegateAddress, setDelegateAddress] = useState("");
+
+  const revoke = useRevokeDelegation(
+    { tokenAddress },
+    {
+      onSuccess: () => setDelegateAddress(""),
+    },
+  );
+
+  function handleRevoke() {
+    revoke.mutate({ delegateAddress: delegateAddress as Address });
+  }
+
+  return (
+    <div className="card">
+      <div className="card-title">Revoke Decryption Access</div>
+      <input
+        className="input card-gap"
+        type="text"
+        value={delegateAddress}
+        onChange={(e) => setDelegateAddress(e.target.value)}
+        placeholder="Delegate address (0x…)"
+      />
+      <button
+        className="btn btn-primary btn-full"
+        onClick={handleRevoke}
+        disabled={disabled || !isAddress(delegateAddress) || revoke.isPending}
+      >
+        {revoke.isPending ? "Revoking…" : "Revoke Access"}
+      </button>
+      {revoke.isError && (
+        <div className="alert alert-error card-status">{revoke.error?.message}</div>
+      )}
+      {revoke.isSuccess && revoke.data?.txHash && (
+        <div className="alert alert-success card-status">
+          Access revoked!{" "}
+          <a
+            href={`${HOODI_EXPLORER_URL}/tx/${revoke.data.txHash}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {revoke.data.txHash.slice(0, 10)}…
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-hoodi/src/components/UnshieldCard.tsx
+++ b/examples/example-hoodi/src/components/UnshieldCard.tsx
@@ -28,7 +28,7 @@ export function UnshieldCard({
   const { storage } = useZamaSDK();
 
   const unshield = useUnshield(
-    // For ERC-7984 tokens, the wrapper contract and the cToken share the same address.
+    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
     { tokenAddress, wrapperAddress: tokenAddress },
     {
       onSuccess: () => {

--- a/examples/example-hoodi/src/lib/config.ts
+++ b/examples/example-hoodi/src/lib/config.ts
@@ -2,7 +2,7 @@
 // Edit these values to target a different network.
 
 export const HOODI_CHAIN_ID = 560048;
-export const HOODI_CHAIN_ID_HEX = "0x88bb0";
+export const HOODI_CHAIN_ID_HEX = `0x${HOODI_CHAIN_ID.toString(16)}`;
 export const HOODI_EXPLORER_URL = "https://hoodi.etherscan.io";
 const HOODI_RPC_DEFAULT = "https://rpc.hoodi.ethpandaops.io";
 export const HOODI_RPC_URL = process.env.NEXT_PUBLIC_HOODI_RPC_URL || HOODI_RPC_DEFAULT;

--- a/examples/example-hoodi/src/providers.tsx
+++ b/examples/example-hoodi/src/providers.tsx
@@ -53,7 +53,7 @@ const sessionDBStorage = new IndexedDBStorage("SessionStore");
 /**
  * Methods routed to the injected wallet rather than the direct Hoodi RPC.
  *
- * Three categories:
+ * Four categories:
  *
  * 1. Chain management — must go through the wallet. Note: eth_requestAccounts /
  *    eth_accounts are NOT in this set; they are intercepted before routing and always


### PR DESCRIPTION
  ## Summary

  Extends the `example-hoodi` quickstart app with the three SDK delegation
  operations, demonstrating the full on-chain ACL delegation lifecycle using
  `@zama-fhe/react-sdk` hooks.

  ### New components

  - **`DelegateDecryptionCard`** — grants decryption access to a delegate
    address via `useDelegateDecryption`. Supports permanent delegation
    (default) or a datetime-bound expiry via a datetime picker. Form resets
    on success.
  - **`RevokeDelegationCard`** — revokes a previously granted delegation via
    `useRevokeDelegation`. Address validated before enabling the button.
  - **`DecryptAsCard`** — decrypts another wallet's confidential balance as a
    delegate via `useDecryptBalanceAs`, with a live `useDelegationStatus`
    indicator (fires as soon as a valid owner address is entered) and typed
    error handling for `DelegationNotFoundError` / `DelegationExpiredError`.

  ### Wiring (page.tsx)

  Cards are split across two visual sections with `<hr>` separators and JSX
  comments:
  - **Owner perspective** — Grant Decryption Access + Revoke Decryption Access
  - **Delegate perspective** — Decrypt Balance On Behalf Of

  All `key` props include `address` and `selectedToken` so cards remount
  (inputs + state reset) on wallet or token change, consistent with the
  existing core operation cards.

  ### Tests

  `e2e/main.spec.ts`: 18 → 19 tests
  - "renders all operation cards" extended to include the 3 delegation card titles
  - "action buttons are disabled before metadata loads" extended to include
    "Decrypt Balance" (disabled until `cTokenMetadata` resolves)
  - New: "delegation buttons are disabled when no address is entered"

  ### Documentation

  - `README.md`: operations table 4 → 7 rows, test count 18 → 19
  - `WALKTHROUGH.md`:
    - Supported operations table: 4 → 7 rows (with Source file column)
    - New **Delegation walkthrough** section (Steps 9–11): grant, decrypt-as,
      revoke — including a note on the revocation cache behaviour
    - New **Delegation hooks** code block in SDK integration details
    - Troubleshooting: entry documenting why a delegate can still decrypt
      after revocation (handle-keyed IndexedDB cache, by design)
    - Tech stack: delegation hooks added to `@zama-fhe/react-sdk` row

  ## Base branch

  Built on top of `feature/sdk-33-create-example-hoodi-example-app-using-ethers`
  (pending review). Should be merged after SDK-33.

  ## Test plan

  - [ ] `npm run typecheck` — 0 errors
  - [ ] `npm run test:e2e` — 19/19 passing
  - [ ] Manual: connect wallet on Hoodi, grant access to a second wallet,
        decrypt balance as delegate, verify delegation status indicator,
        revoke access and verify `DelegationNotFoundError` on next decrypt
        (after a balance change)