### PR TITLE
ci: Remove need for submodule

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -35,8 +35,6 @@ jobs:
   playwright:
     needs: [validate-branch]
     uses: ./.github/workflows/playwright.yml
-    secrets:
-      SUBMODULE_TOKEN: ${{ secrets.SUBMODULE_TOKEN }}
 
   release:
     needs: [vitest, playwright]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,6 @@ jobs:
     needs: [validate-branch]
     if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/playwright.yml
-    secrets:
-      SUBMODULE_TOKEN: ${{ secrets.SUBMODULE_TOKEN }}
 
   api-report:
     needs: [validate-branch]


### PR DESCRIPTION
# Summary
Remove unneeded variable in CI workflows which is causing failure. It was the removed submodule in #109 

## Scope

- [ ] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-components`
- [ ] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [x] CI/workflows
- [ ] Docs

## Validation

<!-- What did you run/check before opening this PR? -->
<!-- Example: pnpm typecheck, pnpm lint, pnpm test:coverage, pnpm e2e:test -->

## Related

<!-- Link issue(s) / related PR(s), if any. -->
<!-- Example: Closes issue-number> -->

## Demo (if possible)

<!-- Screenshot or short video/GIF for UI/UX changes. -->
