### PR TITLE
fix(sdk): colocate node worker with node entrypoint

### DIFF
--- a/packages/sdk/rolldown.config.ts
+++ b/packages/sdk/rolldown.config.ts
@@ -24,7 +24,7 @@ export default defineConfig([
     input: {
       ...entryPoints,
       "node/index": "src/node/index.ts",
-      "relayer-sdk.node-worker": "src/worker/relayer-sdk.node-worker.ts",
+      "node/relayer-sdk.node-worker": "src/worker/relayer-sdk.node-worker.ts",
     },
     output: {
       dir: "dist/esm",

--- a/packages/sdk/src/worker/__tests__/cjs.bundler.test.ts
+++ b/packages/sdk/src/worker/__tests__/cjs.bundler.test.ts
@@ -47,7 +47,7 @@ describe("CJS build smoke tests", () => {
   });
 
   it("node worker file exists in ESM output", () => {
-    expect(existsSync(resolve(DIST_ESM, "relayer-sdk.node-worker.js"))).toBe(true);
+    expect(existsSync(resolve(DIST_ESM, "node/relayer-sdk.node-worker.js"))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes [SDK-46](https://linear.app/zama/issue/SDK-46/bug-node-entrypoint-relative-import-is-broken)

- The node worker file was emitted to `dist/esm/` while `node/index.js` referenced it via `new URL("relayer-sdk.node-worker.js", import.meta.url)`, resolving to `dist/esm/node/` — a path that doesn't exist
- Moved the rolldown node-worker entry point into `node/` so the worker is colocated with the entrypoint that loads it

## Test plan

- [ ] `pnpm --filter @zama-fhe/sdk build` succeeds
- [ ] `pnpm vitest run packages/sdk/src/worker/__tests__/cjs.bundler.test.ts` passes
- [ ] `node -e "import('./packages/sdk/dist/esm/node/index.js').then(({ NodeWorkerClient }) => { ... })"` no longer throws `Cannot find module`

🤖 Generated with [Claude Code](https://claude.com/claude-code)