### PR TITLE
build(deps): bump socket.io-parser to >=4.2.6 in examples/react-wagmi (Dependabot #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-* **example-hoodi:** add on-chain ACL delegation flows (SDK-41) ([#126](https://github.com/zama-ai/sdk/issues/126)) ([2ea2349](https://github.com/zama-ai/sdk/commit/2ea2349dbc868c16763e1e000f3d6057e7d0a14a))
+- **example-hoodi:** add on-chain ACL delegation flows (SDK-41) ([#126](https://github.com/zama-ai/sdk/issues/126)) ([2ea2349](https://github.com/zama-ai/sdk/commit/2ea2349dbc868c16763e1e000f3d6057e7d0a14a))
 
 ## [2.0.1-alpha.1](https://github.com/zama-ai/sdk/compare/v2.0.0...v2.0.1-alpha.1) (2026-03-20)
 

--- a/examples/react-wagmi/package-lock.json
+++ b/examples/react-wagmi/package-lock.json
@@ -1410,7 +1410,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1787,7 +1786,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2160,7 +2158,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2485,7 +2482,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2918,7 +2914,6 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
       "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/addresses": "5.5.1",
@@ -3633,7 +3628,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
       "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -3644,7 +3638,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
       "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -3698,7 +3691,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3759,7 +3751,6 @@
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.22.1.tgz",
       "integrity": "sha512-cG/xwQWsBEcKgRTkQVhH29cbpbs/TdcUJVFXCyri3ZknxhMyGv0YEjTcrNpRgt2SaswL1KrvslSNYKKo+5YEAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -4360,7 +4351,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4433,7 +4423,6 @@
       "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-1.0.0-alpha.16.tgz",
       "integrity": "sha512-QDX5nKMyI5wZJTHIHtL89AkqDulWVfZYOG4gcOlBlzDP4T1chH1WQ7CZSvRLTXZ8WZ/KFPrSn1icFY0ricnJ9A==",
       "license": "BSD-3-Clause-Clear",
-      "peer": true,
       "engines": {
         "node": ">=22"
       },
@@ -4572,7 +4561,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
       "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4707,7 +4695,6 @@
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -4939,7 +4926,6 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -5138,7 +5124,6 @@
       "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.18.tgz",
       "integrity": "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ecies/ciphers": "^0.2.5",
         "@noble/ciphers": "^1.3.0",
@@ -5466,8 +5451,7 @@
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
@@ -6811,7 +6795,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6821,7 +6804,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6834,7 +6816,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7097,7 +7078,6 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
       "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
@@ -7132,9 +7112,9 @@
       "license": "MIT"
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
-      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -7359,7 +7339,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7496,7 +7475,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -7507,7 +7485,6 @@
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -7548,7 +7525,6 @@
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
       "integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "derive-valtio": "0.1.0",
         "proxy-compare": "2.6.0",
@@ -7590,7 +7566,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -7615,7 +7590,6 @@
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.19.5.tgz",
       "integrity": "sha512-RQUfKMv6U+EcSNNGiPbdkDtJwtuFxZWLmvDiQmjjBgkuPulUwDJsKhi7gjynzJdsx2yDqhHCXkKsbbfbIsHfcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wagmi/connectors": "6.2.0",
         "@wagmi/core": "2.22.1",
@@ -7710,7 +7684,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7790,7 +7763,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/examples/react-wagmi/package.json
+++ b/examples/react-wagmi/package.json
@@ -22,6 +22,7 @@
     "typescript": "^5.8.0"
   },
   "overrides": {
-    "hono": ">=4.12.2"
+    "hono": ">=4.12.2",
+    "socket.io-parser": ">=4.2.6"
   }
 }


### PR DESCRIPTION
Adds an npm `overrides` entry for `socket.io-parser` (>=4.2.6) in examples/react-wagmi/package.json to fix CVE-2026-33151 (GHSA-677m-j7p3-52f9, CVSS 8.7 High): a crafted Socket.IO packet could cause unbounded memory buffering on the server.

The vulnerability was introduced transitively via wagmi → socket.io-parser 4.2.5. The override pins it to the patched 4.2.6 and regenerates package-lock.json.

Note: the same vulnerability also surfaces in the root pnpm-lock.yaml (Dependabot alert #40) because examples/react-wagmi is part of the pnpm workspace. That alert will be resolved automatically the next time a maintainer runs `pnpm install` at the monorepo root after this change is merged, as pnpm will pick up the constraint from this package's overrides. A root-level `pnpm.overrides` entry would be needed to fix the root lockfile independently — left for a separate pass to avoid touching core packages.

# Summary

<!-- What changed? Keep it short and concrete. -->

## Scope

- [ ] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-components`
- [ ] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [ ] CI/workflows
- [ ] Docs

## Validation

<!-- What did you run/check before opening this PR? -->
<!-- Example: pnpm typecheck, pnpm lint, pnpm test:coverage, pnpm e2e:test -->

## Related

<!-- Link issue(s) / related PR(s), if any. -->
<!-- Example: Closes issue-number> -->

## Demo (if possible)

<!-- Screenshot or short video/GIF for UI/UX changes. -->
