### PR TITLE
fix(sdk): improve error handling and observability

### DIFF
--- a/packages/sdk/src/credentials/credential-manager-base.ts
+++ b/packages/sdk/src/credentials/credential-manager-base.ts
@@ -10,6 +10,7 @@ import {
   normalizeAddresses,
 } from "./credential-validation";
 import { SigningFailedError, SigningRejectedError, wrapSigningError } from "../errors";
+import { toError } from "../utils/error";
 import { SessionSignatures } from "./session-signatures";
 import type { GenericSigner, GenericStorage, StoredCredentials } from "../types";
 
@@ -225,6 +226,10 @@ export abstract class BaseCredentialsManager<
       }
       // oxlint-disable-next-line no-console
       console.warn("[zama-sdk] Credential resolution failed, recreating:", error);
+      this.emit({
+        type: ZamaSDKEvents.CredentialsCorrupted,
+        error: toError(error),
+      });
       await this.#deleteCredentials(key);
     }
 
@@ -403,7 +408,10 @@ export abstract class BaseCredentialsManager<
     } catch (error) {
       // oxlint-disable-next-line no-console
       console.warn("[zama-sdk] Failed to encrypt credentials for persistence:", error);
-      return;
+      this.emit({
+        type: ZamaSDKEvents.CredentialsPersistFailed,
+        error: toError(error),
+      });
     }
   }
 
@@ -413,6 +421,10 @@ export abstract class BaseCredentialsManager<
     } catch (error) {
       // oxlint-disable-next-line no-console
       console.warn("[zama-sdk] Failed to delete credentials:", error);
+      this.emit({
+        type: ZamaSDKEvents.CredentialsPersistFailed,
+        error: toError(error),
+      });
     }
   }
 }

--- a/packages/sdk/src/errors/__tests__/errors.test.ts
+++ b/packages/sdk/src/errors/__tests__/errors.test.ts
@@ -147,6 +147,16 @@ describe("wrapSigningError", () => {
       }),
     );
   });
+
+  it("detects rejection from non-Error objects with code 4001", () => {
+    const walletError = { code: 4001, message: "User rejected" };
+    expect(() => wrapSigningError(walletError, "test")).toThrow(
+      expect.objectContaining({
+        code: "SIGNING_REJECTED",
+        cause: walletError,
+      }),
+    );
+  });
 });
 
 // --- Delegation errors ---

--- a/packages/sdk/src/errors/base.ts
+++ b/packages/sdk/src/errors/base.ts
@@ -60,6 +60,7 @@ export class ZamaError extends Error {
 
   constructor(code: ZamaErrorCode, message: string, options?: ErrorOptions) {
     super(message, options);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = "ZamaError";
     this.code = code;
   }

--- a/packages/sdk/src/errors/signing.ts
+++ b/packages/sdk/src/errors/signing.ts
@@ -21,11 +21,15 @@ export class SigningFailedError extends ZamaError {
  * Detects user rejection via EIP-1193 code 4001 or message heuristics.
  */
 export function wrapSigningError(error: unknown, context: string): never {
-  const isRejected =
-    (error instanceof Error && "code" in error && error.code === 4001) ||
-    (error instanceof Error &&
-      (error.message.includes("rejected") || error.message.includes("denied")));
-  if (isRejected) {
+  const hasCode4001 =
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code: unknown }).code === 4001;
+  const hasRejectionMessage =
+    error instanceof Error &&
+    (error.message.includes("rejected") || error.message.includes("denied"));
+  if (hasCode4001 || hasRejectionMessage) {
     throw new SigningRejectedError(context, { cause: error });
   }
   throw new SigningFailedError(context, {

--- a/packages/sdk/src/events/sdk-events.ts
+++ b/packages/sdk/src/events/sdk-events.ts
@@ -12,6 +12,8 @@ export const ZamaSDKEvents = {
   CredentialsCreated: "credentials:created",
   CredentialsRevoked: "credentials:revoked",
   CredentialsAllowed: "credentials:allowed",
+  CredentialsPersistFailed: "credentials:persist_failed",
+  CredentialsCorrupted: "credentials:corrupted",
   SessionExpired: "session:expired",
   // FHE operations
   EncryptStart: "encrypt:start",
@@ -91,6 +93,18 @@ export interface CredentialsAllowedEvent extends BaseEvent {
   type: typeof ZamaSDKEvents.CredentialsAllowed;
   /** Contract addresses covered by the authorized credentials. */
   contractAddresses?: Address[];
+}
+
+export interface CredentialsPersistFailedEvent extends BaseEvent {
+  type: typeof ZamaSDKEvents.CredentialsPersistFailed;
+  /** The error that caused persistence to fail. */
+  error: Error;
+}
+
+export interface CredentialsCorruptedEvent extends BaseEvent {
+  type: typeof ZamaSDKEvents.CredentialsCorrupted;
+  /** The error that revealed storage corruption. */
+  error: Error;
 }
 
 export interface SessionExpiredEvent extends BaseEvent {
@@ -207,6 +221,8 @@ export type ZamaSDKEvent =
   | CredentialsCreatedEvent
   | CredentialsRevokedEvent
   | CredentialsAllowedEvent
+  | CredentialsPersistFailedEvent
+  | CredentialsCorruptedEvent
   | SessionExpiredEvent
   | EncryptStartEvent
   | EncryptEndEvent

--- a/packages/sdk/src/token/__tests__/events.test.ts
+++ b/packages/sdk/src/token/__tests__/events.test.ts
@@ -46,8 +46,8 @@ describe("ZamaSDKEvents constants", () => {
     expect(ZamaSDKEvents.RevokeDelegationSubmitted).toBe("revokeDelegation:submitted");
   });
 
-  it("has exactly 27 event types", () => {
-    expect(Object.keys(ZamaSDKEvents)).toHaveLength(27);
+  it("has exactly 29 event types", () => {
+    expect(Object.keys(ZamaSDKEvents)).toHaveLength(29);
   });
 
   it("has unique event values", () => {

--- a/packages/sdk/src/utils/__tests__/error.test.ts
+++ b/packages/sdk/src/utils/__tests__/error.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "../../test-fixtures";
+import { toError } from "../error";
+
+describe("toError", () => {
+  it("returns the same Error instance", () => {
+    const err = new Error("original");
+    expect(toError(err)).toBe(err);
+  });
+
+  it("wraps a string as an Error", () => {
+    const result = toError("string error");
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe("string error");
+  });
+
+  it("extracts message from object with message property", () => {
+    const result = toError({ message: "User rejected", code: 4001 });
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe("User rejected");
+  });
+
+  it("handles undefined", () => {
+    const result = toError(undefined);
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe("undefined");
+  });
+
+  it("handles null", () => {
+    const result = toError(null);
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe("null");
+  });
+
+  it("handles a number", () => {
+    const result = toError(42);
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe("42");
+  });
+});

--- a/packages/sdk/src/utils/error.ts
+++ b/packages/sdk/src/utils/error.ts
@@ -1,4 +1,10 @@
 /** Coerce an unknown caught value to an Error instance. */
 export function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
+  if (error instanceof Error) {
+    return error;
+  }
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return new Error(String(error.message));
+  }
+  return new Error(String(error));
 }


### PR DESCRIPTION
## Summary

- **Fix `ZamaError` prototype chain** — `Object.setPrototypeOf(this, new.target.prototype)` ensures `instanceof` works in transpiled (ES5) environments
- **Fix `wrapSigningError` non-Error detection** — detects `code: 4001` on plain objects (not just `Error` instances), fixing rejection detection for mobile wallets that throw non-Error values
- **Improve `toError` utility** — extracts `.message` from objects instead of producing `[object Object]`
- **Add `CredentialsPersistFailed` and `CredentialsCorrupted` SDK events** — integrators can now observe credential storage failures via the event system instead of relying on `console.warn`
- **Emit events from `persistCredentials`, `resolveCredentials`, and `deleteCredentials`** catch blocks
- **Add `toError()` runtime tests** and non-Error rejection test for `wrapSigningError`

## Test plan

- [x] All 1308 unit tests pass
- [x] TypeScript compilation passes
- [x] API extractor passes
- [ ] Verify `instanceof ZamaError` works in a bundled ES5 target
- [ ] Verify wallet rejection detection with a mobile wallet that throws `{ code: 4001 }`


🤖 Generated with [Claude Code](https://claude.com/claude-code)