### PR TITLE
feat(react-sdk): allow undefined tokenAddress in useConfidentialIsApproved

### DIFF
--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -1122,9 +1122,10 @@ export type UseConfidentialBalancesOptions = Omit<UseQueryOptions<ConfidentialBa
 export function useConfidentialIsApproved(config: UseConfidentialIsApprovedConfig, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<unknown, Error>;
 
 // @public
-export interface UseConfidentialIsApprovedConfig extends UseZamaConfig {
+export interface UseConfidentialIsApprovedConfig {
     holder?: Address;
     spender: Address | undefined;
+    tokenAddress: Address | undefined;
 }
 
 // @public

--- a/packages/react-sdk/src/token/__tests__/use-confidential-is-approved.test.tsx
+++ b/packages/react-sdk/src/token/__tests__/use-confidential-is-approved.test.tsx
@@ -8,6 +8,16 @@ import {
 import { TOKEN, SPENDER } from "../../__tests__/mutation-test-helpers";
 
 describe("useConfidentialIsApproved", () => {
+  test("behavior: disabled when tokenAddress is undefined", ({ renderWithProviders }) => {
+    const { result } = renderWithProviders(() =>
+      useConfidentialIsApproved({ tokenAddress: undefined, spender: SPENDER }),
+    );
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(result.current.data).toBeUndefined();
+  });
+
   test("behavior: disabled when spender is undefined", ({ renderWithProviders }) => {
     const { result } = renderWithProviders(() =>
       useConfidentialIsApproved({ tokenAddress: TOKEN, spender: undefined }),
@@ -16,6 +26,27 @@ describe("useConfidentialIsApproved", () => {
     expect(result.current.isPending).toBe(true);
     expect(result.current.fetchStatus).toBe("idle");
     expect(result.current.data).toBeUndefined();
+  });
+
+  test("behavior: tokenAddress undefined -> defined", async ({ createWrapper, signer }) => {
+    vi.mocked(signer.readContract).mockResolvedValue(true);
+
+    const ctx = createWrapper({ signer });
+    const { result, rerender } = renderHook(
+      ({ tokenAddress }) => useConfidentialIsApproved({ tokenAddress, spender: SPENDER }),
+      {
+        wrapper: ctx.Wrapper,
+        initialProps: { tokenAddress: undefined as Address | undefined },
+      },
+    );
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe("idle");
+
+    rerender({ tokenAddress: TOKEN });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(true);
   });
 
   test("behavior: spender undefined -> defined", async ({ createWrapper, signer }) => {

--- a/packages/react-sdk/src/token/use-confidential-is-approved.ts
+++ b/packages/react-sdk/src/token/use-confidential-is-approved.ts
@@ -8,12 +8,15 @@ import {
   signerAddressQueryOptions,
   zamaQueryKeys,
 } from "@zama-fhe/sdk/query";
+import { useZamaSDK } from "../provider";
 import { useToken, type UseZamaConfig } from "./use-token";
 
 export { confidentialIsApprovedQueryOptions };
 
 /** Configuration for {@link useConfidentialIsApproved}. */
-export interface UseConfidentialIsApprovedConfig extends UseZamaConfig {
+export interface UseConfidentialIsApprovedConfig {
+  /** Address of the confidential token contract. Pass `undefined` to disable the query. */
+  tokenAddress: Address | undefined;
   /** Address to check approval for. Pass `undefined` to disable the query. */
   spender: Address | undefined;
   /** Token holder address. Defaults to the connected wallet. */
@@ -48,23 +51,25 @@ export function useConfidentialIsApproved(
   config: UseConfidentialIsApprovedConfig,
   options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">,
 ) {
-  const { spender, holder, ...tokenConfig } = config;
+  const { tokenAddress, spender, holder } = config;
   const userEnabled = options?.enabled;
-  const token = useToken(tokenConfig);
+  const sdk = useZamaSDK();
   const holderQuery = useQuery<Address>({
-    ...signerAddressQueryOptions(token.signer),
+    ...signerAddressQueryOptions(sdk.signer),
     enabled: holder === undefined,
   });
   const resolvedHolder = holder ?? holderQuery.data;
 
   const baseOpts =
-    spender && resolvedHolder
-      ? confidentialIsApprovedQueryOptions(token.signer, token.address, {
+    tokenAddress && spender && resolvedHolder
+      ? confidentialIsApprovedQueryOptions(sdk.signer, tokenAddress, {
           holder: resolvedHolder,
           spender,
         })
       : {
-          queryKey: zamaQueryKeys.confidentialIsApproved.token(config.tokenAddress),
+          queryKey: tokenAddress
+            ? zamaQueryKeys.confidentialIsApproved.token(tokenAddress)
+            : zamaQueryKeys.confidentialIsApproved.all,
           queryFn: skipToken,
         };
   return useQuery({


### PR DESCRIPTION
## Summary
- `useConfidentialIsApproved` now accepts `tokenAddress: Address | undefined` — the query is automatically disabled (via `skipToken`) when tokenAddress is undefined, instead of throwing `"Address undefined is invalid"`.
- This supports use cases like swap UIs where the token is selected dynamically and may initially be `undefined`.
- Added tests for `tokenAddress: undefined` and the `undefined → defined` transition.

**Note on `until` data:** The issue also requested exposing the operator expiry timestamp. The on-chain `isOperator()` function only returns `bool` — there is no public getter for the raw `uint48 until` value stored in `_operators`. Exposing this would require a contract-level change (adding a view function like `operatorExpiration(holder, spender)`). This can be tracked separately.

Closes SDK-54

## Test plan
- [x] Existing tests pass (8/8 in `use-confidential-is-approved.test.tsx`)
- [x] New test: query disabled when `tokenAddress` is `undefined`
- [x] New test: query activates when `tokenAddress` transitions from `undefined` to a valid address
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)