### PR TITLE
fix: gate queries on undefined tokenAddress

### DIFF
--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -1122,9 +1122,10 @@ export type UseConfidentialBalancesOptions = Omit<UseQueryOptions<ConfidentialBa
 export function useConfidentialIsApproved(config: UseConfidentialIsApprovedConfig, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<unknown, Error>;
 
 // @public
-export interface UseConfidentialIsApprovedConfig extends UseZamaConfig {
+export interface UseConfidentialIsApprovedConfig {
     holder?: Address;
     spender: Address | undefined;
+    tokenAddress: Address | undefined;
 }
 
 // @public
@@ -1174,7 +1175,7 @@ export function useDelegationStatus(config: UseDelegationStatusConfig, options?:
 export interface UseDelegationStatusConfig {
     delegateAddress?: Address;
     delegatorAddress?: Address;
-    tokenAddress: Address;
+    tokenAddress: Address | undefined;
 }
 
 // @public
@@ -1334,7 +1335,7 @@ export function useWrapperDiscovery(config: UseWrapperDiscoveryConfig, options?:
 // @public
 export interface UseWrapperDiscoveryConfig {
     coordinatorAddress: Address | undefined;
-    tokenAddress: Address;
+    tokenAddress: Address | undefined;
 }
 
 // @public

--- a/packages/react-sdk/src/token/__tests__/use-confidential-is-approved.test.tsx
+++ b/packages/react-sdk/src/token/__tests__/use-confidential-is-approved.test.tsx
@@ -8,6 +8,16 @@ import {
 import { TOKEN, SPENDER } from "../../__tests__/mutation-test-helpers";
 
 describe("useConfidentialIsApproved", () => {
+  test("behavior: disabled when tokenAddress is undefined", ({ renderWithProviders }) => {
+    const { result } = renderWithProviders(() =>
+      useConfidentialIsApproved({ tokenAddress: undefined, spender: SPENDER }),
+    );
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(result.current.data).toBeUndefined();
+  });
+
   test("behavior: disabled when spender is undefined", ({ renderWithProviders }) => {
     const { result } = renderWithProviders(() =>
       useConfidentialIsApproved({ tokenAddress: TOKEN, spender: undefined }),
@@ -34,6 +44,27 @@ describe("useConfidentialIsApproved", () => {
     expect(result.current.fetchStatus).toBe("idle");
 
     rerender({ spender: SPENDER });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(true);
+  });
+
+  test("behavior: tokenAddress undefined -> defined", async ({ createWrapper, signer }) => {
+    vi.mocked(signer.readContract).mockResolvedValue(true);
+
+    const ctx = createWrapper({ signer });
+    const { result, rerender } = renderHook(
+      ({ tokenAddress }) => useConfidentialIsApproved({ tokenAddress, spender: SPENDER }),
+      {
+        wrapper: ctx.Wrapper,
+        initialProps: { tokenAddress: undefined as Address | undefined },
+      },
+    );
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe("idle");
+
+    rerender({ tokenAddress: TOKEN });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBe(true);

--- a/packages/react-sdk/src/token/__tests__/use-delegation-status.test.tsx
+++ b/packages/react-sdk/src/token/__tests__/use-delegation-status.test.tsx
@@ -11,6 +11,24 @@ vi.mock("@tanstack/react-query", async () => {
 });
 
 describe("useDelegationStatus", () => {
+  test("disables query when tokenAddress is missing", ({ renderWithProviders }) => {
+    vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+
+    renderWithProviders(() =>
+      useDelegationStatus({
+        tokenAddress: undefined,
+        delegatorAddress: USER,
+        delegateAddress: RECIPIENT,
+      }),
+    );
+
+    expect(vi.mocked(useQuery)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+      }),
+    );
+  });
+
   test("passes the shared queryKeyHashFn when addresses are provided", ({
     renderWithProviders,
   }) => {

--- a/packages/react-sdk/src/token/__tests__/use-wrapper-discovery.test.tsx
+++ b/packages/react-sdk/src/token/__tests__/use-wrapper-discovery.test.tsx
@@ -5,6 +5,16 @@ import { useWrapperDiscovery } from "../use-wrapper-discovery";
 import { TOKEN, COORDINATOR } from "../../__tests__/mutation-test-helpers";
 
 describe("useWrapperDiscovery", () => {
+  test("behavior: disabled when tokenAddress is undefined", ({ renderWithProviders }) => {
+    const { result } = renderWithProviders(() =>
+      useWrapperDiscovery({ tokenAddress: undefined, coordinatorAddress: COORDINATOR }),
+    );
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(result.current.data).toBeUndefined();
+  });
+
   test("behavior: disabled when coordinatorAddress is undefined", ({ renderWithProviders }) => {
     const { result } = renderWithProviders(() =>
       useWrapperDiscovery({ tokenAddress: TOKEN, coordinatorAddress: undefined }),
@@ -44,6 +54,28 @@ describe("useWrapperDiscovery", () => {
     expect(result.current.fetchStatus).toBe("idle");
 
     rerender({ coordinatorAddress: COORDINATOR });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(wrapperAddress);
+  });
+
+  test("behavior: tokenAddress: undefined -> defined", async ({ createWrapper, signer }) => {
+    const wrapperAddress = "0x7A7a7A7a7a7a7a7A7a7a7a7A7a7A7A7A7A7A7a7A" as Address;
+    vi.mocked(signer.readContract).mockResolvedValue(wrapperAddress);
+
+    const ctx = createWrapper({ signer });
+    const { result, rerender } = renderHook(
+      ({ tokenAddress }) => useWrapperDiscovery({ tokenAddress, coordinatorAddress: COORDINATOR }),
+      {
+        wrapper: ctx.Wrapper,
+        initialProps: { tokenAddress: undefined as Address | undefined },
+      },
+    );
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe("idle");
+
+    rerender({ tokenAddress: TOKEN });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBe(wrapperAddress);

--- a/packages/react-sdk/src/token/use-confidential-is-approved.ts
+++ b/packages/react-sdk/src/token/use-confidential-is-approved.ts
@@ -10,7 +10,7 @@ import { useToken, type UseZamaConfig } from "./use-token";
 export { confidentialIsApprovedQueryOptions };
 
 /** Configuration for {@link useConfidentialIsApproved}. */
-export interface UseConfidentialIsApprovedConfig extends Omit<UseZamaConfig, "tokenAddress"> {
+export interface UseConfidentialIsApprovedConfig {
   /** Address of the confidential token contract. Pass `undefined` to disable the query. */
   tokenAddress: Address | undefined;
   /** Address to check approval for. Pass `undefined` to disable the query. */
@@ -51,7 +51,7 @@ export function useConfidentialIsApproved(
   const sdk = useZamaSDK();
   const holderQuery = useQuery<Address>({
     ...signerAddressQueryOptions(sdk.signer),
-    enabled: tokenAddress !== undefined && holder === undefined,
+    enabled: tokenAddress !== undefined && spender !== undefined && holder === undefined,
   });
   const resolvedHolder = holder ?? holderQuery.data;
   const baseOpts = confidentialIsApprovedQueryOptions(sdk.signer, tokenAddress, {

--- a/packages/react-sdk/src/token/use-confidential-is-approved.ts
+++ b/packages/react-sdk/src/token/use-confidential-is-approved.ts
@@ -1,19 +1,18 @@
 "use client";
 
 import { useQuery, useSuspenseQuery } from "../utils/query";
-import { skipToken, type UseQueryOptions } from "@tanstack/react-query";
+import type { UseQueryOptions } from "@tanstack/react-query";
 import type { Address } from "@zama-fhe/sdk";
-import {
-  confidentialIsApprovedQueryOptions,
-  signerAddressQueryOptions,
-  zamaQueryKeys,
-} from "@zama-fhe/sdk/query";
+import { confidentialIsApprovedQueryOptions, signerAddressQueryOptions } from "@zama-fhe/sdk/query";
+import { useZamaSDK } from "../provider";
 import { useToken, type UseZamaConfig } from "./use-token";
 
 export { confidentialIsApprovedQueryOptions };
 
 /** Configuration for {@link useConfidentialIsApproved}. */
-export interface UseConfidentialIsApprovedConfig extends UseZamaConfig {
+export interface UseConfidentialIsApprovedConfig extends Omit<UseZamaConfig, "tokenAddress"> {
+  /** Address of the confidential token contract. Pass `undefined` to disable the query. */
+  tokenAddress: Address | undefined;
   /** Address to check approval for. Pass `undefined` to disable the query. */
   spender: Address | undefined;
   /** Token holder address. Defaults to the connected wallet. */
@@ -48,29 +47,21 @@ export function useConfidentialIsApproved(
   config: UseConfidentialIsApprovedConfig,
   options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">,
 ) {
-  const { spender, holder, ...tokenConfig } = config;
-  const userEnabled = options?.enabled;
-  const token = useToken(tokenConfig);
+  const { tokenAddress, spender, holder } = config;
+  const sdk = useZamaSDK();
   const holderQuery = useQuery<Address>({
-    ...signerAddressQueryOptions(token.signer),
-    enabled: holder === undefined,
+    ...signerAddressQueryOptions(sdk.signer),
+    enabled: tokenAddress !== undefined && holder === undefined,
   });
   const resolvedHolder = holder ?? holderQuery.data;
-
-  const baseOpts =
-    spender && resolvedHolder
-      ? confidentialIsApprovedQueryOptions(token.signer, token.address, {
-          holder: resolvedHolder,
-          spender,
-        })
-      : {
-          queryKey: zamaQueryKeys.confidentialIsApproved.token(config.tokenAddress),
-          queryFn: skipToken,
-        };
+  const baseOpts = confidentialIsApprovedQueryOptions(sdk.signer, tokenAddress, {
+    holder: resolvedHolder,
+    spender,
+  });
   return useQuery({
     ...baseOpts,
     ...options,
-    enabled: ("enabled" in baseOpts ? (baseOpts.enabled ?? true) : true) && (userEnabled ?? true),
+    enabled: (baseOpts.enabled ?? true) && (options?.enabled ?? true),
   });
 }
 

--- a/packages/react-sdk/src/token/use-delegation-status.ts
+++ b/packages/react-sdk/src/token/use-delegation-status.ts
@@ -1,18 +1,14 @@
 "use client";
 
-import { skipToken, type UseQueryOptions } from "@tanstack/react-query";
+import type { UseQueryOptions } from "@tanstack/react-query";
 import type { Address } from "@zama-fhe/sdk";
-import {
-  delegationStatusQueryOptions,
-  zamaQueryKeys,
-  type DelegationStatusData,
-} from "@zama-fhe/sdk/query";
+import { delegationStatusQueryOptions, type DelegationStatusData } from "@zama-fhe/sdk/query";
 import { useQuery } from "../utils/query";
-import { useReadonlyToken } from "./use-readonly-token";
+import { useZamaSDK } from "../provider";
 
 export interface UseDelegationStatusConfig {
-  /** Address of the confidential token contract. */
-  tokenAddress: Address;
+  /** Address of the confidential token contract. Pass `undefined` to disable the query. */
+  tokenAddress: Address | undefined;
   /** The address that granted the delegation. */
   delegatorAddress?: Address;
   /** The address that received delegation rights. */
@@ -40,23 +36,15 @@ export function useDelegationStatus(
   config: UseDelegationStatusConfig,
   options?: Omit<UseQueryOptions<DelegationStatusData, Error>, "queryKey" | "queryFn">,
 ) {
-  const readonlyToken = useReadonlyToken(config.tokenAddress);
-
-  const enabled = Boolean(config.delegatorAddress && config.delegateAddress);
-  const baseOpts =
-    config.delegatorAddress && config.delegateAddress
-      ? delegationStatusQueryOptions(readonlyToken, {
-          delegatorAddress: config.delegatorAddress,
-          delegateAddress: config.delegateAddress,
-        })
-      : {
-          queryKey: zamaQueryKeys.delegationStatus.all,
-          queryFn: skipToken as unknown as () => Promise<DelegationStatusData>,
-        };
+  const sdk = useZamaSDK();
+  const baseOpts = delegationStatusQueryOptions(sdk.signer, sdk.relayer, config.tokenAddress, {
+    delegatorAddress: config.delegatorAddress,
+    delegateAddress: config.delegateAddress,
+  });
 
   return useQuery<DelegationStatusData>({
     ...baseOpts,
-    enabled,
     ...options,
+    enabled: (baseOpts.enabled ?? true) && (options?.enabled ?? true),
   });
 }

--- a/packages/react-sdk/src/token/use-wrapper-discovery.ts
+++ b/packages/react-sdk/src/token/use-wrapper-discovery.ts
@@ -1,17 +1,18 @@
 "use client";
 
 import { useQuery, useSuspenseQuery } from "../utils/query";
-import { skipToken, type UseQueryOptions } from "@tanstack/react-query";
+import type { UseQueryOptions } from "@tanstack/react-query";
 import type { Address } from "@zama-fhe/sdk";
-import { wrapperDiscoveryQueryOptions, zamaQueryKeys } from "@zama-fhe/sdk/query";
+import { wrapperDiscoveryQueryOptions } from "@zama-fhe/sdk/query";
+import { useZamaSDK } from "../provider";
 import { useReadonlyToken } from "./use-readonly-token";
 
 export { wrapperDiscoveryQueryOptions };
 
 /** Configuration for {@link useWrapperDiscovery}. */
 export interface UseWrapperDiscoveryConfig {
-  /** Address of the underlying ERC-20 token. */
-  tokenAddress: Address;
+  /** Address of the underlying ERC-20 token. Pass `undefined` to disable the query. */
+  tokenAddress: Address | undefined;
   /** Address of the wrapper coordinator. Pass `undefined` to disable the query. */
   coordinatorAddress: Address | undefined;
 }
@@ -46,16 +47,13 @@ export function useWrapperDiscovery(
   options?: Omit<UseQueryOptions<Address | null>, "queryKey" | "queryFn">,
 ) {
   const { tokenAddress, coordinatorAddress } = config;
-  const token = useReadonlyToken(tokenAddress);
+  const sdk = useZamaSDK();
+  const baseOpts = wrapperDiscoveryQueryOptions(sdk.signer, tokenAddress, { coordinatorAddress });
 
   return useQuery<Address | null>({
-    ...(coordinatorAddress
-      ? wrapperDiscoveryQueryOptions(token.signer, tokenAddress, { coordinatorAddress })
-      : {
-          queryKey: zamaQueryKeys.wrapperDiscovery.all,
-          queryFn: skipToken,
-        }),
+    ...baseOpts,
     ...options,
+    enabled: (baseOpts.enabled ?? true) && (options?.enabled ?? true),
   });
 }
 

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -226,7 +226,7 @@ export interface ConfidentialIsApprovedQueryConfig {
 }
 
 // @public (undocumented)
-export function confidentialIsApprovedQueryOptions(signer: GenericSigner, tokenAddress: Address, config: ConfidentialIsApprovedQueryConfig): QueryFactoryOptions<boolean, Error, boolean, ReturnType<typeof zamaQueryKeys.confidentialIsApproved.scope>>;
+export function confidentialIsApprovedQueryOptions(signer: GenericSigner, tokenAddress: Address | undefined, config: ConfidentialIsApprovedQueryConfig): QueryFactoryOptions<boolean, Error, boolean, ReturnType<typeof zamaQueryKeys.confidentialIsApproved.scope>>;
 
 // @public
 export interface ConfidentialTransferEvent {
@@ -471,15 +471,15 @@ export interface DelegationStatusData {
 // @public (undocumented)
 export interface DelegationStatusQueryConfig {
     // (undocumented)
-    delegateAddress: Address;
+    delegateAddress?: Address;
     // (undocumented)
-    delegatorAddress: Address;
+    delegatorAddress?: Address;
     // (undocumented)
     query?: Record<string, unknown>;
 }
 
 // @public (undocumented)
-export function delegationStatusQueryOptions(readonlyToken: ReadonlyToken, config: DelegationStatusQueryConfig): QueryFactoryOptions<DelegationStatusData, Error, DelegationStatusData, ReturnType<typeof zamaQueryKeys.delegationStatus.scope>>;
+export function delegationStatusQueryOptions(signer: GenericSigner, relayer: RelayerSDK, tokenAddress: Address | undefined, config: DelegationStatusQueryConfig): QueryFactoryOptions<DelegationStatusData, Error, DelegationStatusData, ReturnType<typeof zamaQueryKeys.delegationStatus.scope>>;
 
 // @public
 export function deriveActivityFeedLogsKey(logs?: readonly (RawLog & Partial<ActivityLogMetadata>)[]): string | undefined;
@@ -1276,13 +1276,13 @@ export interface WrappedEvent {
 // @public (undocumented)
 export interface WrapperDiscoveryQueryConfig {
     // (undocumented)
-    coordinatorAddress: Address;
+    coordinatorAddress?: Address;
     // (undocumented)
     query?: Record<string, unknown>;
 }
 
 // @public (undocumented)
-export function wrapperDiscoveryQueryOptions(signer: GenericSigner, tokenAddress: Address, config: WrapperDiscoveryQueryConfig): QueryFactoryOptions<Address | null, Error, Address | null, ReturnType<typeof zamaQueryKeys.wrapperDiscovery.token>>;
+export function wrapperDiscoveryQueryOptions(signer: GenericSigner, tokenAddress: Address | undefined, config: WrapperDiscoveryQueryConfig): QueryFactoryOptions<Address | null, Error, Address | null, ReturnType<typeof zamaQueryKeys.wrapperDiscovery.token>>;
 
 // @public
 export const zamaQueryKeys: {
@@ -1351,9 +1351,9 @@ export const zamaQueryKeys: {
     };
     readonly wrapperDiscovery: {
         readonly all: readonly ["zama.wrapperDiscovery"];
-        readonly token: (tokenAddress: Address, coordinatorAddress: Address) => readonly ["zama.wrapperDiscovery", {
-            readonly tokenAddress: `0x${string}`;
-            readonly coordinatorAddress: `0x${string}`;
+        readonly token: (tokenAddress?: Address, coordinatorAddress?: Address) => readonly ["zama.wrapperDiscovery", {
+            readonly coordinatorAddress?: `0x${string}` | undefined;
+            readonly tokenAddress?: `0x${string}` | undefined;
         }];
     };
     readonly underlyingAllowance: {
@@ -1369,13 +1369,15 @@ export const zamaQueryKeys: {
     };
     readonly confidentialIsApproved: {
         readonly all: readonly ["zama.confidentialIsApproved"];
-        readonly token: (tokenAddress: Address) => readonly ["zama.confidentialIsApproved", {
-            readonly tokenAddress: `0x${string}`;
+        readonly token: (tokenAddress?: Address) => readonly ["zama.confidentialIsApproved", {
+            tokenAddress: `0x${string}`;
+        } | {
+            tokenAddress?: undefined;
         }];
-        readonly scope: (tokenAddress: Address, holder?: Address, spender?: Address) => readonly ["zama.confidentialIsApproved", {
+        readonly scope: (tokenAddress?: Address, holder?: Address, spender?: Address) => readonly ["zama.confidentialIsApproved", {
             readonly spender?: `0x${string}` | undefined;
             readonly holder?: `0x${string}` | undefined;
-            readonly tokenAddress: `0x${string}`;
+            readonly tokenAddress?: `0x${string}` | undefined;
         }];
     };
     readonly totalSupply: {
@@ -1438,13 +1440,15 @@ export const zamaQueryKeys: {
     };
     readonly delegationStatus: {
         readonly all: readonly ["zama.delegationStatus"];
-        readonly token: (tokenAddress: string) => readonly ["zama.delegationStatus", {
-            readonly tokenAddress: `0x${string}`;
+        readonly token: (tokenAddress?: Address) => readonly ["zama.delegationStatus", {
+            tokenAddress: `0x${string}`;
+        } | {
+            tokenAddress?: undefined;
         }];
-        readonly scope: (tokenAddress: string, delegator: string, delegate: string) => readonly ["zama.delegationStatus", {
-            readonly tokenAddress: `0x${string}`;
-            readonly delegatorAddress: `0x${string}`;
-            readonly delegateAddress: `0x${string}`;
+        readonly scope: (tokenAddress?: Address, delegator?: Address, delegate?: Address) => readonly ["zama.delegationStatus", {
+            readonly delegateAddress?: `0x${string}` | undefined;
+            readonly delegatorAddress?: `0x${string}` | undefined;
+            readonly tokenAddress?: `0x${string}` | undefined;
         }];
     };
     readonly decryption: {

--- a/packages/sdk/src/query/__tests__/confidential-is-approved.test.ts
+++ b/packages/sdk/src/query/__tests__/confidential-is-approved.test.ts
@@ -37,6 +37,22 @@ describe("confidentialIsApprovedQueryOptions", () => {
     expect(missingSpender.enabled).toBe(false);
   });
 
+  test("is disabled when tokenAddress is missing", ({ signer }) => {
+    const options = confidentialIsApprovedQueryOptions(signer, undefined, {
+      holder: "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B",
+      spender: "0x3C3C3C3C3c3C3c3C3C3C3C3C3c3c3c3c3c3c3c3C",
+    });
+
+    expect(options.enabled).toBe(false);
+    expect(options.queryKey).toEqual([
+      "zama.confidentialIsApproved",
+      {
+        holder: "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B",
+        spender: "0x3C3C3C3C3c3C3c3C3C3C3C3C3c3c3c3c3c3c3c3C",
+      },
+    ]);
+  });
+
   test("checks operator approval", async ({ signer }) => {
     vi.mocked(signer.readContract).mockResolvedValue(true);
 
@@ -178,5 +194,16 @@ describe("confidentialIsApprovedQueryOptions", () => {
         ),
       ),
     ).rejects.toThrow("holder is required");
+  });
+
+  test("queryFn throws when tokenAddress is missing from context.queryKey", async ({ signer }) => {
+    const options = confidentialIsApprovedQueryOptions(signer, undefined, {
+      holder: "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B",
+      spender: "0x3C3C3C3C3c3C3c3C3C3C3C3C3c3c3c3c3c3c3c3C",
+    });
+
+    await expect(options.queryFn(mockQueryContext(options.queryKey))).rejects.toThrow(
+      "tokenAddress is required",
+    );
   });
 });

--- a/packages/sdk/src/query/__tests__/delegation-status.test.ts
+++ b/packages/sdk/src/query/__tests__/delegation-status.test.ts
@@ -6,13 +6,37 @@ const DELEGATOR = "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC" as const;
 const DELEGATE = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" as const;
 
 describe("delegationStatusQueryOptions", () => {
-  test("returns isDelegated: false when expiryTimestamp is 0n", async ({
-    createMockReadonlyToken,
+  test("is disabled when required params are missing", async ({
+    signer,
+    relayer,
+    tokenAddress,
   }) => {
-    const readonlyToken = createMockReadonlyToken();
-    vi.mocked(readonlyToken.getDelegationExpiry).mockResolvedValue(0n);
+    const missingToken = delegationStatusQueryOptions(signer, relayer, undefined, {
+      delegatorAddress: DELEGATOR,
+      delegateAddress: DELEGATE,
+    });
+    const missingDelegator = delegationStatusQueryOptions(signer, relayer, tokenAddress, {
+      delegateAddress: DELEGATE,
+    });
+    const missingDelegate = delegationStatusQueryOptions(signer, relayer, tokenAddress, {
+      delegatorAddress: DELEGATOR,
+    });
 
-    const options = delegationStatusQueryOptions(readonlyToken, {
+    expect(missingToken.enabled).toBe(false);
+    expect(missingDelegator.enabled).toBe(false);
+    expect(missingDelegate.enabled).toBe(false);
+  });
+
+  test("returns isDelegated: false when expiryTimestamp is 0n", async ({
+    signer,
+    relayer,
+    tokenAddress,
+    aclAddress,
+  }) => {
+    vi.mocked(relayer.getAclAddress).mockResolvedValue(aclAddress);
+    vi.mocked(signer.readContract).mockResolvedValue(0n);
+
+    const options = delegationStatusQueryOptions(signer, relayer, tokenAddress, {
       delegatorAddress: DELEGATOR,
       delegateAddress: DELEGATE,
     });
@@ -21,16 +45,19 @@ describe("delegationStatusQueryOptions", () => {
     const result = await options.queryFn!(context);
 
     expect(result).toEqual({ isDelegated: false, expiryTimestamp: 0n });
-    expect(readonlyToken.signer.getBlockTimestamp).not.toHaveBeenCalled();
+    expect(signer.getBlockTimestamp).not.toHaveBeenCalled();
   });
 
   test("returns isDelegated: true when expiryTimestamp is MAX_UINT64 (skips getBlockTimestamp)", async ({
-    createMockReadonlyToken,
+    signer,
+    relayer,
+    tokenAddress,
+    aclAddress,
   }) => {
-    const readonlyToken = createMockReadonlyToken();
-    vi.mocked(readonlyToken.getDelegationExpiry).mockResolvedValue(MAX_UINT64);
+    vi.mocked(relayer.getAclAddress).mockResolvedValue(aclAddress);
+    vi.mocked(signer.readContract).mockResolvedValue(MAX_UINT64);
 
-    const options = delegationStatusQueryOptions(readonlyToken, {
+    const options = delegationStatusQueryOptions(signer, relayer, tokenAddress, {
       delegatorAddress: DELEGATOR,
       delegateAddress: DELEGATE,
     });
@@ -39,20 +66,21 @@ describe("delegationStatusQueryOptions", () => {
     const result = await options.queryFn!(context);
 
     expect(result).toEqual({ isDelegated: true, expiryTimestamp: MAX_UINT64 });
-    expect(readonlyToken.signer.getBlockTimestamp).not.toHaveBeenCalled();
+    expect(signer.getBlockTimestamp).not.toHaveBeenCalled();
   });
 
   test("returns isDelegated: true when expiryTimestamp is in the future", async ({
-    createMockReadonlyToken,
+    signer,
+    relayer,
+    tokenAddress,
+    aclAddress,
   }) => {
-    const readonlyToken = createMockReadonlyToken();
     const futureTimestamp = BigInt(Math.floor(Date.now() / 1000) + 3600);
-    vi.mocked(readonlyToken.getDelegationExpiry).mockResolvedValue(futureTimestamp);
-    vi.mocked(readonlyToken.signer.getBlockTimestamp).mockResolvedValue(
-      BigInt(Math.floor(Date.now() / 1000)),
-    );
+    vi.mocked(relayer.getAclAddress).mockResolvedValue(aclAddress);
+    vi.mocked(signer.readContract).mockResolvedValue(futureTimestamp);
+    vi.mocked(signer.getBlockTimestamp).mockResolvedValue(BigInt(Math.floor(Date.now() / 1000)));
 
-    const options = delegationStatusQueryOptions(readonlyToken, {
+    const options = delegationStatusQueryOptions(signer, relayer, tokenAddress, {
       delegatorAddress: DELEGATOR,
       delegateAddress: DELEGATE,
     });
@@ -61,18 +89,21 @@ describe("delegationStatusQueryOptions", () => {
     const result = await options.queryFn!(context);
 
     expect(result).toEqual({ isDelegated: true, expiryTimestamp: futureTimestamp });
-    expect(readonlyToken.signer.getBlockTimestamp).toHaveBeenCalled();
+    expect(signer.getBlockTimestamp).toHaveBeenCalled();
   });
 
   test("returns isDelegated: false when expiryTimestamp is in the past", async ({
-    createMockReadonlyToken,
+    signer,
+    relayer,
+    tokenAddress,
+    aclAddress,
   }) => {
-    const readonlyToken = createMockReadonlyToken();
     const pastTimestamp = 1000n;
-    vi.mocked(readonlyToken.getDelegationExpiry).mockResolvedValue(pastTimestamp);
-    vi.mocked(readonlyToken.signer.getBlockTimestamp).mockResolvedValue(2000n);
+    vi.mocked(relayer.getAclAddress).mockResolvedValue(aclAddress);
+    vi.mocked(signer.readContract).mockResolvedValue(pastTimestamp);
+    vi.mocked(signer.getBlockTimestamp).mockResolvedValue(2000n);
 
-    const options = delegationStatusQueryOptions(readonlyToken, {
+    const options = delegationStatusQueryOptions(signer, relayer, tokenAddress, {
       delegatorAddress: DELEGATOR,
       delegateAddress: DELEGATE,
     });
@@ -81,6 +112,17 @@ describe("delegationStatusQueryOptions", () => {
     const result = await options.queryFn!(context);
 
     expect(result).toEqual({ isDelegated: false, expiryTimestamp: pastTimestamp });
-    expect(readonlyToken.signer.getBlockTimestamp).toHaveBeenCalled();
+    expect(signer.getBlockTimestamp).toHaveBeenCalled();
+  });
+
+  test("queryFn throws when required params are missing from context.queryKey", async ({
+    signer,
+    relayer,
+  }) => {
+    const options = delegationStatusQueryOptions(signer, relayer, undefined, {});
+
+    await expect(options.queryFn!(mockQueryContext(options.queryKey))).rejects.toThrow(
+      "tokenAddress is required",
+    );
   });
 });

--- a/packages/sdk/src/query/__tests__/wrapper-discovery.test.ts
+++ b/packages/sdk/src/query/__tests__/wrapper-discovery.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, test, vi, mockQueryContext } from "../../test-fixture
 import { wrapperDiscoveryQueryOptions } from "../wrapper-discovery";
 
 describe("wrapperDiscoveryQueryOptions", () => {
+  test("is disabled when tokenAddress or coordinatorAddress is missing", ({ signer }) => {
+    const missingToken = wrapperDiscoveryQueryOptions(signer, undefined, {
+      coordinatorAddress: "0x3C3C3C3C3c3C3c3C3C3C3C3C3c3c3c3c3c3c3c3C",
+    });
+    const missingCoordinator = wrapperDiscoveryQueryOptions(
+      signer,
+      "0x1a1A1A1A1a1A1A1a1A1a1a1a1a1a1a1A1A1a1a1a",
+      {},
+    );
+
+    expect(missingToken.enabled).toBe(false);
+    expect(missingCoordinator.enabled).toBe(false);
+  });
+
   test("includes coordinatorAddress in query key", ({ signer }) => {
     const options = wrapperDiscoveryQueryOptions(
       signer,
@@ -77,5 +91,15 @@ describe("wrapperDiscoveryQueryOptions", () => {
       address: "0x5e5E5e5e5E5e5E5E5e5E5E5e5e5E5E5E5e5E5E5e",
       args: ["0x1a1A1A1A1a1A1A1a1A1a1a1a1a1a1a1A1A1a1a1a"],
     });
+  });
+
+  test("queryFn throws when required params are missing from context.queryKey", async ({
+    signer,
+  }) => {
+    const options = wrapperDiscoveryQueryOptions(signer, undefined, {});
+
+    await expect(options.queryFn(mockQueryContext(options.queryKey))).rejects.toThrow(
+      "tokenAddress is required",
+    );
   });
 });

--- a/packages/sdk/src/query/confidential-is-approved.ts
+++ b/packages/sdk/src/query/confidential-is-approved.ts
@@ -13,7 +13,7 @@ export interface ConfidentialIsApprovedQueryConfig {
 
 export function confidentialIsApprovedQueryOptions(
   signer: GenericSigner,
-  tokenAddress: Address,
+  tokenAddress: Address | undefined,
   config: ConfidentialIsApprovedQueryConfig,
 ): QueryFactoryOptions<
   boolean,
@@ -32,6 +32,9 @@ export function confidentialIsApprovedQueryOptions(
     queryFn: async (context) => {
       const [, { tokenAddress: keyTokenAddress, holder: keyHolder, spender: keySpender }] =
         context.queryKey;
+      if (!keyTokenAddress) {
+        throw new Error("tokenAddress is required");
+      }
       if (!keyHolder) {
         throw new Error("holder is required");
       }
@@ -41,6 +44,6 @@ export function confidentialIsApprovedQueryOptions(
       return signer.readContract(isOperatorContract(keyTokenAddress, keyHolder, keySpender));
     },
     staleTime: 30_000,
-    enabled: Boolean(holderKey && spenderKey) && queryEnabled,
+    enabled: Boolean(tokenAddress && holderKey && spenderKey) && queryEnabled,
   };
 }

--- a/packages/sdk/src/query/delegation-status.ts
+++ b/packages/sdk/src/query/delegation-status.ts
@@ -1,5 +1,4 @@
 import type { Address } from "viem";
-import { getAddress } from "viem";
 import { MAX_UINT64 } from "../contracts";
 import { getDelegationExpiryContract } from "../contracts/acl";
 import type { RelayerSDK } from "../relayer/relayer-sdk";
@@ -51,12 +50,7 @@ export function delegationStatusQueryOptions(
       }
       const acl = await relayer.getAclAddress();
       const expiryTimestamp = await signer.readContract(
-        getDelegationExpiryContract(
-          acl,
-          getAddress(delegatorAddress),
-          getAddress(delegateAddress),
-          getAddress(keyTokenAddress),
-        ),
+        getDelegationExpiryContract(acl, delegatorAddress, delegateAddress, keyTokenAddress),
       );
       // Derive isDelegated from expiry + chain time to stay consistent
       // with ReadonlyToken.isDelegated() (avoids client-clock skew).

--- a/packages/sdk/src/query/delegation-status.ts
+++ b/packages/sdk/src/query/delegation-status.ts
@@ -1,6 +1,9 @@
-import type { ReadonlyToken } from "../token/readonly-token";
 import type { Address } from "viem";
+import { getAddress } from "viem";
 import { MAX_UINT64 } from "../contracts";
+import { getDelegationExpiryContract } from "../contracts/acl";
+import type { RelayerSDK } from "../relayer/relayer-sdk";
+import type { GenericSigner } from "../token/token.types";
 import type { QueryFactoryOptions } from "./factory-types";
 import { filterQueryOptions } from "./utils";
 import { zamaQueryKeys } from "./query-keys";
@@ -11,13 +14,15 @@ export interface DelegationStatusData {
 }
 
 export interface DelegationStatusQueryConfig {
-  delegatorAddress: Address;
-  delegateAddress: Address;
+  delegatorAddress?: Address;
+  delegateAddress?: Address;
   query?: Record<string, unknown>;
 }
 
 export function delegationStatusQueryOptions(
-  readonlyToken: ReadonlyToken,
+  signer: GenericSigner,
+  relayer: RelayerSDK,
+  tokenAddress: Address | undefined,
   config: DelegationStatusQueryConfig,
 ): QueryFactoryOptions<
   DelegationStatusData,
@@ -28,16 +33,31 @@ export function delegationStatusQueryOptions(
   return {
     ...filterQueryOptions(config.query ?? {}),
     queryKey: zamaQueryKeys.delegationStatus.scope(
-      readonlyToken.address,
+      tokenAddress,
       config.delegatorAddress,
       config.delegateAddress,
     ),
     queryFn: async (context) => {
-      const [, { delegatorAddress, delegateAddress }] = context.queryKey;
-      const expiryTimestamp = await readonlyToken.getDelegationExpiry({
-        delegatorAddress,
-        delegateAddress,
-      });
+      const [, { tokenAddress: keyTokenAddress, delegatorAddress, delegateAddress }] =
+        context.queryKey;
+      if (!keyTokenAddress) {
+        throw new Error("tokenAddress is required");
+      }
+      if (!delegatorAddress) {
+        throw new Error("delegatorAddress is required");
+      }
+      if (!delegateAddress) {
+        throw new Error("delegateAddress is required");
+      }
+      const acl = await relayer.getAclAddress();
+      const expiryTimestamp = await signer.readContract(
+        getDelegationExpiryContract(
+          acl,
+          getAddress(delegatorAddress),
+          getAddress(delegateAddress),
+          getAddress(keyTokenAddress),
+        ),
+      );
       // Derive isDelegated from expiry + chain time to stay consistent
       // with ReadonlyToken.isDelegated() (avoids client-clock skew).
       let isDelegated: boolean;
@@ -46,11 +66,13 @@ export function delegationStatusQueryOptions(
       } else if (expiryTimestamp === MAX_UINT64) {
         isDelegated = true;
       } else {
-        const now = await readonlyToken.signer.getBlockTimestamp();
+        const now = await signer.getBlockTimestamp();
         isDelegated = expiryTimestamp > now;
       }
       return { isDelegated, expiryTimestamp };
     },
-    enabled: config.query?.enabled !== false,
+    enabled:
+      Boolean(tokenAddress && config.delegatorAddress && config.delegateAddress) &&
+      config.query?.enabled !== false,
   } as const;
 }

--- a/packages/sdk/src/query/query-keys.ts
+++ b/packages/sdk/src/query/query-keys.ts
@@ -99,18 +99,17 @@ export const zamaQueryKeys = {
 
   wrapperDiscovery: {
     all: ["zama.wrapperDiscovery"] as const,
-    token: (tokenAddress?: Address, coordinatorAddress?: Address) =>
-      [
+    token: (tokenAddress?: Address, coordinatorAddress?: Address) => {
+      const t = normalizeAddress(tokenAddress);
+      const c = normalizeAddress(coordinatorAddress);
+      return [
         "zama.wrapperDiscovery",
         {
-          ...(normalizeAddress(tokenAddress)
-            ? { tokenAddress: normalizeAddress(tokenAddress) }
-            : {}),
-          ...(normalizeAddress(coordinatorAddress)
-            ? { coordinatorAddress: normalizeAddress(coordinatorAddress) }
-            : {}),
+          ...(t ? { tokenAddress: t } : {}),
+          ...(c ? { coordinatorAddress: c } : {}),
         },
-      ] as const,
+      ] as const;
+    },
   },
 
   underlyingAllowance: {
@@ -130,24 +129,23 @@ export const zamaQueryKeys = {
 
   confidentialIsApproved: {
     all: ["zama.confidentialIsApproved"] as const,
-    token: (tokenAddress?: Address) =>
-      [
-        "zama.confidentialIsApproved",
-        (normalizeAddress(tokenAddress)
-            ? { tokenAddress: normalizeAddress(tokenAddress) }
-            : {}),
-      ] as const,
-    scope: (tokenAddress?: Address, holder?: Address, spender?: Address) =>
-      [
+    token: (tokenAddress?: Address) => {
+      const t = normalizeAddress(tokenAddress);
+      return ["zama.confidentialIsApproved", t ? { tokenAddress: t } : {}] as const;
+    },
+    scope: (tokenAddress?: Address, holder?: Address, spender?: Address) => {
+      const t = normalizeAddress(tokenAddress);
+      const h = normalizeAddress(holder);
+      const s = normalizeAddress(spender);
+      return [
         "zama.confidentialIsApproved",
         {
-          ...(normalizeAddress(tokenAddress)
-            ? { tokenAddress: normalizeAddress(tokenAddress) }
-            : {}),
-          ...(normalizeAddress(holder) ? { holder: normalizeAddress(holder) } : {}),
-          ...(normalizeAddress(spender) ? { spender: normalizeAddress(spender) } : {}),
+          ...(t ? { tokenAddress: t } : {}),
+          ...(h ? { holder: h } : {}),
+          ...(s ? { spender: s } : {}),
         },
-      ] as const,
+      ] as const;
+    },
   },
 
   totalSupply: {
@@ -230,20 +228,23 @@ export const zamaQueryKeys = {
 
   delegationStatus: {
     all: ["zama.delegationStatus"] as const,
-    token: (tokenAddress?: string) =>
-      [
-        "zama.delegationStatus",
-        (tokenAddress ? { tokenAddress: getAddress(tokenAddress) } : {}),
-      ] as const,
-    scope: (tokenAddress?: string, delegator?: string, delegate?: string) =>
-      [
+    token: (tokenAddress?: Address) => {
+      const t = normalizeAddress(tokenAddress);
+      return ["zama.delegationStatus", t ? { tokenAddress: t } : {}] as const;
+    },
+    scope: (tokenAddress?: Address, delegator?: Address, delegate?: Address) => {
+      const t = normalizeAddress(tokenAddress);
+      const dr = normalizeAddress(delegator);
+      const de = normalizeAddress(delegate);
+      return [
         "zama.delegationStatus",
         {
-          ...(tokenAddress ? { tokenAddress: getAddress(tokenAddress) } : {}),
-          ...(delegator ? { delegatorAddress: getAddress(delegator) } : {}),
-          ...(delegate ? { delegateAddress: getAddress(delegate) } : {}),
+          ...(t ? { tokenAddress: t } : {}),
+          ...(dr ? { delegatorAddress: dr } : {}),
+          ...(de ? { delegateAddress: de } : {}),
         },
-      ] as const,
+      ] as const;
+    },
   },
 
   decryption: {

--- a/packages/sdk/src/query/query-keys.ts
+++ b/packages/sdk/src/query/query-keys.ts
@@ -4,6 +4,8 @@ import type { Handle } from "../relayer/relayer-sdk.types";
 
 const normalizeAddresses = (addresses: Address[]): Address[] =>
   addresses.map((address) => getAddress(address));
+const normalizeAddress = (address?: Address): Address | undefined =>
+  address === undefined ? undefined : getAddress(address);
 
 /**
  * Canonical query-key namespace for `@zama-fhe/sdk/query`.
@@ -97,12 +99,16 @@ export const zamaQueryKeys = {
 
   wrapperDiscovery: {
     all: ["zama.wrapperDiscovery"] as const,
-    token: (tokenAddress: Address, coordinatorAddress: Address) =>
+    token: (tokenAddress?: Address, coordinatorAddress?: Address) =>
       [
         "zama.wrapperDiscovery",
         {
-          tokenAddress: getAddress(tokenAddress),
-          coordinatorAddress: getAddress(coordinatorAddress),
+          ...(normalizeAddress(tokenAddress)
+            ? { tokenAddress: normalizeAddress(tokenAddress) }
+            : {}),
+          ...(normalizeAddress(coordinatorAddress)
+            ? { coordinatorAddress: normalizeAddress(coordinatorAddress) }
+            : {}),
         },
       ] as const,
   },
@@ -124,15 +130,22 @@ export const zamaQueryKeys = {
 
   confidentialIsApproved: {
     all: ["zama.confidentialIsApproved"] as const,
-    token: (tokenAddress: Address) =>
-      ["zama.confidentialIsApproved", { tokenAddress: getAddress(tokenAddress) }] as const,
-    scope: (tokenAddress: Address, holder?: Address, spender?: Address) =>
+    token: (tokenAddress?: Address) =>
+      [
+        "zama.confidentialIsApproved",
+        (normalizeAddress(tokenAddress)
+            ? { tokenAddress: normalizeAddress(tokenAddress) }
+            : {}),
+      ] as const,
+    scope: (tokenAddress?: Address, holder?: Address, spender?: Address) =>
       [
         "zama.confidentialIsApproved",
         {
-          tokenAddress: getAddress(tokenAddress),
-          ...(holder ? { holder: getAddress(holder) } : {}),
-          ...(spender ? { spender: getAddress(spender) } : {}),
+          ...(normalizeAddress(tokenAddress)
+            ? { tokenAddress: normalizeAddress(tokenAddress) }
+            : {}),
+          ...(normalizeAddress(holder) ? { holder: normalizeAddress(holder) } : {}),
+          ...(normalizeAddress(spender) ? { spender: normalizeAddress(spender) } : {}),
         },
       ] as const,
   },
@@ -217,15 +230,18 @@ export const zamaQueryKeys = {
 
   delegationStatus: {
     all: ["zama.delegationStatus"] as const,
-    token: (tokenAddress: string) =>
-      ["zama.delegationStatus", { tokenAddress: getAddress(tokenAddress) }] as const,
-    scope: (tokenAddress: string, delegator: string, delegate: string) =>
+    token: (tokenAddress?: string) =>
+      [
+        "zama.delegationStatus",
+        (tokenAddress ? { tokenAddress: getAddress(tokenAddress) } : {}),
+      ] as const,
+    scope: (tokenAddress?: string, delegator?: string, delegate?: string) =>
       [
         "zama.delegationStatus",
         {
-          tokenAddress: getAddress(tokenAddress),
-          delegatorAddress: getAddress(delegator),
-          delegateAddress: getAddress(delegate),
+          ...(tokenAddress ? { tokenAddress: getAddress(tokenAddress) } : {}),
+          ...(delegator ? { delegatorAddress: getAddress(delegator) } : {}),
+          ...(delegate ? { delegateAddress: getAddress(delegate) } : {}),
         },
       ] as const,
   },

--- a/packages/sdk/src/query/wrapper-discovery.ts
+++ b/packages/sdk/src/query/wrapper-discovery.ts
@@ -6,13 +6,13 @@ import { zamaQueryKeys } from "./query-keys";
 import { filterQueryOptions } from "./utils";
 
 export interface WrapperDiscoveryQueryConfig {
-  coordinatorAddress: Address;
+  coordinatorAddress?: Address;
   query?: Record<string, unknown>;
 }
 
 export function wrapperDiscoveryQueryOptions(
   signer: GenericSigner,
-  tokenAddress: Address,
+  tokenAddress: Address | undefined,
   config: WrapperDiscoveryQueryConfig,
 ): QueryFactoryOptions<
   Address | null,
@@ -28,6 +28,12 @@ export function wrapperDiscoveryQueryOptions(
     queryFn: async (context) => {
       const [, { tokenAddress: keyTokenAddress, coordinatorAddress: keyCoordinatorAddress }] =
         context.queryKey;
+      if (!keyTokenAddress) {
+        throw new Error("tokenAddress is required");
+      }
+      if (!keyCoordinatorAddress) {
+        throw new Error("coordinatorAddress is required");
+      }
       const exists = await signer.readContract(
         wrapperExistsContract(keyCoordinatorAddress, keyTokenAddress),
       );
@@ -37,6 +43,6 @@ export function wrapperDiscoveryQueryOptions(
       return signer.readContract(getWrapperContract(keyCoordinatorAddress, keyTokenAddress));
     },
     staleTime: Infinity,
-    enabled: Boolean(tokenAddress) && config.query?.enabled !== false,
+    enabled: Boolean(tokenAddress && config.coordinatorAddress) && config.query?.enabled !== false,
   };
 }


### PR DESCRIPTION
## Summary
- Query options factories (`confidentialIsApproved`, `delegationStatus`, `wrapperDiscovery`) now accept `tokenAddress: Address | undefined` and auto-disable via `enabled: false` when it's missing — instead of crashing with `Address "undefined" is invalid`.
- React hooks simplified: removed `skipToken` branching in favor of letting the factory handle gating, following the TanStack Query auto-gating pattern.
- `delegationStatus` factory decoupled from `ReadonlyToken` — now takes `(signer, relayer, tokenAddress)` primitives, since it only does plain contract reads (no FHE decryption).

Closes SDK-54

## Motivation
In dynamic UIs (e.g. swap token selector), `tokenAddress` starts as `undefined`. Previously this crashed because `getAddress(undefined)` throws. The fix pushes the `undefined` handling into the Layer 2 query options factories, so any consumer gets correct auto-gating behavior without manual guards.