### PR TITLE
fix: rename useAllowTokens/useRevokeTokens back to useAllow/useRevoke

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -33,13 +33,18 @@ jobs:
           path: |
             contracts/out
             contracts/cache
-          key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml') }}
+            contracts/lib/forge-fhevm/out
+          key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml', 'contracts/lib/forge-fhevm/src/**/*.sol') }}
 
       - name: Install Soldeer dependencies
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: |
           cd contracts/lib/forge-fhevm && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
           cd "$GITHUB_WORKSPACE/contracts" && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
+
+      - name: Build forge-fhevm contracts
+        if: steps.forge-build-cache.outputs.cache-hit != 'true'
+        run: cd contracts/lib/forge-fhevm && forge build
 
       - name: Build contracts
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
@@ -52,7 +57,8 @@ jobs:
           path: |
             contracts/out
             contracts/cache
-          key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml') }}
+            contracts/lib/forge-fhevm/out
+          key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml', 'contracts/lib/forge-fhevm/src/**/*.sol') }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 [![Unit tests](https://github.com/zama-ai/sdk/actions/workflows/vitest.yml/badge.svg)](https://github.com/zama-ai/sdk/actions/workflows/vitest.yml)
 [![E2E tests](https://github.com/zama-ai/sdk/actions/workflows/playwright.yml/badge.svg)](https://github.com/zama-ai/sdk/actions/workflows/playwright.yml)
 
-TypeScript SDKs for privacy-preserving ERC-20 token operations using [Fully Homomorphic Encryption on Zama Protocol](https://docs.zama.org/protocol/protocol/overview). Shield, transfer, and unshield tokens with encrypted balances — no one sees your amounts on-chain.
+TypeScript SDKs for privacy-preserving confidential contract operations using [Fully Homomorphic Encryption on Zama Protocol](https://docs.zama.org/protocol/protocol/overview). Shield, transfer, and unshield tokens with encrypted balances — no one sees your amounts on-chain.
 
 ## Packages
 
 | Package                                        | Description                                                                                                              |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| [`@zama-fhe/sdk`](./packages/sdk/)             | Core SDK — confidential token operations, FHE relayer, contract call builders, viem/ethers adapters, Node.js worker pool |
+| [`@zama-fhe/sdk`](./packages/sdk/)             | Core SDK — confidential contract operations, FHE relayer, contract call builders, viem/ethers adapters, Node.js worker pool |
 | [`@zama-fhe/react-sdk`](./packages/react-sdk/) | React hooks wrapping the core SDK via `@tanstack/react-query`, with viem/ethers/wagmi sub-paths                          |
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ TypeScript SDKs for privacy-preserving confidential contract operations using [F
 
 ## Packages
 
-| Package                                        | Description                                                                                                              |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Package                                        | Description                                                                                                                 |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | [`@zama-fhe/sdk`](./packages/sdk/)             | Core SDK — confidential contract operations, FHE relayer, contract call builders, viem/ethers adapters, Node.js worker pool |
-| [`@zama-fhe/react-sdk`](./packages/react-sdk/) | React hooks wrapping the core SDK via `@tanstack/react-query`, with viem/ethers/wagmi sub-paths                          |
+| [`@zama-fhe/react-sdk`](./packages/react-sdk/) | React hooks wrapping the core SDK via `@tanstack/react-query`, with viem/ethers/wagmi sub-paths                             |
 
 ## Install
 

--- a/docs/gitbook/src/README.md
+++ b/docs/gitbook/src/README.md
@@ -1,12 +1,12 @@
 ---
-description: TypeScript SDK for confidential ERC-20 tokens — shield, transfer, and unshield with Fully Homomorphic Encryption.
+description: TypeScript SDK for confidential smart contracts — shield, transfer, and unshield tokens with Fully Homomorphic Encryption.
 ---
 
 # Zama SDK
 
 Integrate the Zama fhEVM into your app
 
-TypeScript SDK for confidential ERC-20 tokens — shield, transfer, and unshield with Fully Homomorphic Encryption.
+TypeScript SDK for confidential smart contracts — shield, transfer, and unshield tokens with Fully Homomorphic Encryption.
 
 ## Features
 

--- a/docs/gitbook/src/concepts/architecture.md
+++ b/docs/gitbook/src/concepts/architecture.md
@@ -10,7 +10,7 @@ The SDK is organized into layers, each with a clear responsibility. Higher layer
 | ------------------------------ | --------------------------------------------------------------------------------------------------------- |
 | **React SDK**                  | `ZamaProvider` context + hooks wrapping `@tanstack/react-query`                                           |
 | **Query & Mutation Factories** | Framework-agnostic `queryOptions` / `mutationOptions` consumed by React Query (or directly)               |
-| **Token Abstraction**          | `ZamaSDK`, `Token`, `ReadonlyToken` — the main developer-facing API                                       |
+| **Contract Abstraction**       | `ZamaSDK`, `Token`, `ReadonlyToken` — the main developer-facing API                                       |
 | **Contract Call Builders**     | Pure functions returning `{ address, abi, functionName, args }` for any Web3 library                      |
 | **Signer Adapters**            | `ViemSigner`, `EthersSigner`, `WagmiSigner` — unified signing interface                                   |
 | **Relayer**                    | `RelayerWeb` (browser WASM), `RelayerNode` (server), `RelayerCleartext` (testing)                         |

--- a/docs/gitbook/src/concepts/security-model.md
+++ b/docs/gitbook/src/concepts/security-model.md
@@ -161,7 +161,7 @@ Two TTL controls are available:
 
 ### Address-scoped authorization
 
-The EIP-712 typed data includes the wallet address. A signature from address A cannot authorize decryption for address B. Combined with contract-scoped authorization (the signed message lists specific token contracts), each signature is tightly bound to a specific user and set of tokens.
+The EIP-712 typed data includes the wallet address. A signature from address A cannot authorize decryption for address B. Combined with contract-scoped authorization (the signed message lists specific contract addresses), each signature is tightly bound to a specific user and set of contracts.
 
 ### Revocation
 

--- a/docs/gitbook/src/concepts/session-model.md
+++ b/docs/gitbook/src/concepts/session-model.md
@@ -21,7 +21,7 @@ The keypair is generated once and encrypted before storage. It persists across p
 
 The session signature is an EIP-712 typed data signature from the user's wallet. It serves two purposes:
 
-1. **Authorization** — proves the user consents to decrypt balances for specific token contracts.
+1. **Authorization** — proves the user consents to decrypt balances for specific contract addresses.
 2. **Key derivation** — the signature's raw bytes are used as input to PBKDF2, producing the AES-GCM key that encrypts and decrypts the FHE private key.
 
 By default, the session signature lives in memory only. It is lost on page reload, tab close, or explicit revocation.
@@ -114,7 +114,7 @@ Call `allow()` early — ideally right after wallet connect — to prompt the si
 A single signature covers all contract addresses passed to `allow()`. The signed EIP-712 message includes the exact set of contracts. If you later call `allow()` with a contract not in the original set, the SDK generates a fresh keypair and requests a new wallet signature.
 
 {% hint style="warning" %}
-Batch all token addresses into a single `allow()` call. Each call with a new contract set triggers a new keypair and wallet popup. Plan your allow calls to minimize signing prompts.
+Batch all contract addresses into a single `allow()` call. Each call with a new contract set triggers a new keypair and wallet popup. Plan your allow calls to minimize signing prompts.
 {% endhint %}
 
 ### Revoke (clear session)

--- a/docs/gitbook/src/concepts/session-model.md
+++ b/docs/gitbook/src/concepts/session-model.md
@@ -153,17 +153,17 @@ The user switches networks (e.g., Sepolia to Mainnet) while keeping the same add
 
 Without wiring, cached signatures remain valid until TTL expiry. This is not a security vulnerability (signatures are time-bounded and address-scoped), but it creates confusing UX when switching accounts.
 
-## Multi-token batching
+## Multi-contract batching
 
-A single `allow()` call can cover multiple token contracts:
+A single `allow()` call can cover multiple contracts:
 
 ```ts
-await sdk.allow("0xTokenA", "0xTokenB", "0xTokenC");
+await sdk.allow("0xContractA", "0xContractB", "0xContractC");
 ```
 
-This produces one EIP-712 signature covering all three contracts. The signed message includes the full list of contract addresses, the start timestamp, and the duration. Any `balanceOf` call on TokenA, TokenB, or TokenC reuses the cached signature without additional popups.
+This produces one EIP-712 signature covering all three contracts. The signed message includes the full list of contract addresses, the start timestamp, and the duration. Any `balanceOf` call on ContractA, ContractB, or ContractC reuses the cached signature without additional popups.
 
-The tradeoff: if you later need to add TokenD, the SDK must generate a new keypair and request a fresh signature covering `[A, B, C, D]`. Plan your token set upfront when possible.
+The tradeoff: if you later need to add ContractD, the SDK must generate a new keypair and request a fresh signature covering `[A, B, C, D]`. Plan your contract set upfront when possible.
 
 ## Web extensions
 

--- a/docs/gitbook/src/reference/react/useAllow.md
+++ b/docs/gitbook/src/reference/react/useAllow.md
@@ -1,13 +1,13 @@
 ---
 title: useAllow
-description: Mutation hook that pre-authorizes an FHE keypair for multiple tokens with one wallet signature.
+description: Mutation hook that signs an EIP-712 message authorizing decryption of confidential handles for any contract.
 ---
 
 # useAllow
 
-Mutation hook that pre-authorizes an FHE keypair for multiple tokens with one wallet signature.
+Mutation hook that signs an EIP-712 message authorizing decryption of confidential handles for a list of contract addresses. This is **not token-specific** — any contract that uses FHE-encrypted values (confidential tokens, DeFi vaults, games, etc.) can be authorized in a single wallet signature.
 
-Call this early (e.g. after wallet connect) so that subsequent balance decrypts do not trigger individual wallet popups. Automatically invalidates [`useIsAllowed`](/reference/react/useIsAllowed) queries on success.
+Call this early (e.g. after wallet connect) so that subsequent decrypt operations do not trigger individual wallet popups. Automatically invalidates [`useIsAllowed`](/reference/react/useIsAllowed) queries on success.
 
 ## Import
 
@@ -23,17 +23,17 @@ import { useAllow } from "@zama-fhe/react-sdk";
 ```tsx
 import { useAllow } from "@zama-fhe/react-sdk";
 
-function AllowButton({ tokens }: { tokens: `0x${string}`[] }) {
+function AllowButton({ contracts }: { contracts: `0x${string}`[] }) {
   const { mutateAsync: allow, isPending } = useAllow();
 
   const handleAllow = async () => {
-    await allow(tokens);
-    // All subsequent balance reads reuse the cached credential
+    await allow(contracts);
+    // All subsequent decrypt operations reuse the cached credential
   };
 
   return (
     <button onClick={handleAllow} disabled={isPending}>
-      {isPending ? "Signing..." : "Authorize tokens"}
+      {isPending ? "Signing..." : "Authorize contracts"}
     </button>
   );
 }
@@ -46,12 +46,12 @@ function AllowButton({ tokens }: { tokens: `0x${string}`[] }) {
 import { useAllow } from "@zama-fhe/react-sdk";
 import { useEffect } from "react";
 
-function AuthOnConnect({ tokens }: { tokens: `0x${string}`[] }) {
+function AuthOnConnect({ contracts }: { contracts: `0x${string}`[] }) {
   const { mutateAsync: allow } = useAllow();
 
   useEffect(() => {
     // Pre-authorize on wallet connect
-    allow(tokens);
+    allow(contracts);
   }, []);
 
   return null;
@@ -71,10 +71,10 @@ function AuthOnConnect({ tokens }: { tokens: `0x${string}`[] }) {
 
 `Address[]`
 
-Array of confidential token wrapper addresses to authorize in a single wallet signature.
+Array of contract addresses to authorize decryption for in a single wallet signature. These can be any contracts that use FHE-encrypted values — not limited to tokens.
 
 ```tsx
-await allow(["0xTokenA", "0xTokenB", "0xTokenC"]);
+await allow(["0xContractA", "0xContractB", "0xContractC"]);
 ```
 
 ## Return Type
@@ -86,6 +86,6 @@ Returns a standard TanStack Query `UseMutationResult<void, Error, Address[]>`.
 ## Related
 
 - [`useIsAllowed`](/reference/react/useIsAllowed) -- check whether a session signature is cached
-- [`useRevoke`](/reference/react/useRevoke) -- revoke session credentials for specific tokens
+- [`useRevoke`](/reference/react/useRevoke) -- revoke decrypt authorization for specific contracts
 - [`useRevokeSession`](/reference/react/useRevokeSession) -- revoke the entire session
 - [Session Model](/concepts/session-model) -- security model and TTL configuration

--- a/docs/gitbook/src/reference/react/useAllow.md
+++ b/docs/gitbook/src/reference/react/useAllow.md
@@ -74,7 +74,8 @@ function AuthOnConnect({ contracts }: { contracts: `0x${string}`[] }) {
 Array of contract addresses to authorize decryption for in a single wallet signature. These can be any contracts that use FHE-encrypted values — not limited to tokens.
 
 ```tsx
-await allow(["0xContractA", "0xContractB", "0xContractC"]);
+// Authorize any contracts with encrypted state — tokens, auctions, governance, etc.
+await allow([confidentialTokenAddress, auctionAddress, governanceAddress]);
 ```
 
 ## Return Type

--- a/docs/gitbook/src/reference/react/useIsAllowed.md
+++ b/docs/gitbook/src/reference/react/useIsAllowed.md
@@ -1,6 +1,6 @@
 ---
 title: useIsAllowed
-description: Query hook that checks whether a session signature is cached and valid for a token.
+description: Query hook that checks whether a session signature is cached and valid.
 ---
 
 # useIsAllowed
@@ -63,6 +63,6 @@ const { data: allowed } = useIsAllowed();
 
 ## Related
 
-- [`useAllow`](/reference/react/useAllow) -- pre-authorize tokens with one wallet signature
+- [`useAllow`](/reference/react/useAllow) -- pre-authorize contracts with one wallet signature
 - [`useRevoke`](/reference/react/useRevoke) -- revoke session credentials
 - [Session Model](/concepts/session-model) -- security model and TTL configuration

--- a/docs/gitbook/src/reference/react/useRevoke.md
+++ b/docs/gitbook/src/reference/react/useRevoke.md
@@ -1,11 +1,11 @@
 ---
 title: useRevoke
-description: Revoke the session signature for specific token addresses.
+description: Revoke the EIP-712 decrypt authorization for specific contract addresses.
 ---
 
 # useRevoke
 
-Revoke the session signature for specific token addresses. Stored credentials remain intact — the next decrypt requires a fresh wallet signature.
+Revoke the EIP-712 decrypt authorization for specific contract addresses. This is **not token-specific** — it works for any contract that uses FHE-encrypted values. Stored credentials remain intact — the next decrypt requires a fresh wallet signature.
 
 ## Import
 
@@ -21,12 +21,12 @@ import { useRevoke } from "@zama-fhe/react-sdk";
 ```tsx
 import { useRevoke } from "@zama-fhe/react-sdk";
 
-function RevokeButton({ tokens }: { tokens: `0x${string}`[] }) {
+function RevokeButton({ contracts }: { contracts: `0x${string}`[] }) {
   const { mutate: revoke, isPending, isSuccess } = useRevoke();
 
   return (
-    <button onClick={() => revoke(tokens)} disabled={isPending}>
-      {isPending ? "Revoking..." : "Revoke tokens"}
+    <button onClick={() => revoke(contracts)} disabled={isPending}>
+      {isPending ? "Revoking..." : "Revoke authorization"}
     </button>
   );
 }
@@ -45,12 +45,12 @@ function RevokeButton({ tokens }: { tokens: `0x${string}`[] }) {
 
 `Address[]`
 
-Array of token addresses to revoke session signatures for.
+Array of contract addresses to revoke decrypt authorization for. These can be any contracts that use FHE-encrypted values — not limited to tokens.
 
 ```ts
 const { mutate: revoke } = useRevoke();
 
-revoke(["0xTokenA", "0xTokenB"]);
+revoke(["0xContractA", "0xContractB"]);
 ```
 
 ## Return Type
@@ -59,7 +59,7 @@ revoke(["0xTokenA", "0xTokenB"]);
 
 ## Behavior
 
-- Clears the cached session signature for each token in the array.
+- Clears the cached session signature for each contract in the array.
 - Auto-invalidates all [`useIsAllowed`](/reference/react/useIsAllowed) queries on success.
 - Does **not** delete stored FHE credentials — only the session-level signature is cleared.
 
@@ -69,7 +69,7 @@ If you use [`WagmiSigner`](/reference/sdk/WagmiSigner), the SDK auto-revokes on 
 
 ## Related
 
-- [`useRevokeSession`](/reference/react/useRevokeSession) — revoke the entire session instead of specific tokens
-- [`useAllow`](/reference/react/useAllow) — pre-authorize tokens with a single wallet signature
+- [`useRevokeSession`](/reference/react/useRevokeSession) — revoke the entire session instead of specific contracts
+- [`useAllow`](/reference/react/useAllow) — authorize decryption for contracts with a single wallet signature
 - [`useIsAllowed`](/reference/react/useIsAllowed) — check whether a session signature is valid
 - [`Token.revoke()`](/reference/sdk/Token#revoke) — imperative equivalent on the SDK class

--- a/docs/gitbook/src/reference/react/useRevokeSession.md
+++ b/docs/gitbook/src/reference/react/useRevokeSession.md
@@ -5,7 +5,7 @@ description: Revoke the entire session for the connected wallet.
 
 # useRevokeSession
 
-Revoke the entire session for the connected wallet. Unlike [`useRevoke`](/reference/react/useRevoke) which targets specific tokens, this clears the session-level signature.
+Revoke the entire session for the connected wallet. Unlike [`useRevoke`](/reference/react/useRevoke) which targets specific contract addresses, this clears the session-level signature.
 
 ## Import
 
@@ -65,6 +65,6 @@ If you use [`WagmiSigner`](/reference/sdk/WagmiSigner), the SDK auto-revokes on 
 
 ## Related
 
-- [`useRevoke`](/reference/react/useRevoke) — revoke specific token addresses instead of the full session
-- [`useAllow`](/reference/react/useAllow) — pre-authorize tokens with a single wallet signature
+- [`useRevoke`](/reference/react/useRevoke) — revoke specific contract addresses instead of the full session
+- [`useAllow`](/reference/react/useAllow) — pre-authorize contracts with a single wallet signature
 - [`useIsAllowed`](/reference/react/useIsAllowed) — check whether a session signature is valid

--- a/docs/gitbook/src/reference/sdk/ZamaSDK.md
+++ b/docs/gitbook/src/reference/sdk/ZamaSDK.md
@@ -1,11 +1,11 @@
 ---
 title: ZamaSDK
-description: Entry point for all confidential token operations.
+description: Entry point for all confidential contract operations.
 ---
 
 # ZamaSDK
 
-Entry point for all confidential token operations — creates tokens, manages sessions, and coordinates the relayer and signer.
+Entry point for all confidential contract operations — creates tokens, manages sessions, and coordinates the relayer and signer.
 
 ## Import
 

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -1,6 +1,6 @@
 # @zama-fhe/react-sdk
 
-React hooks for confidential token operations, built on [React Query](https://tanstack.com/query). Provides declarative, cache-aware hooks for balances, confidential transfers, shielding, unshielding, and decryption — so you never deal with raw FHE operations in your components.
+React hooks for confidential contract operations, built on [React Query](https://tanstack.com/query). Provides declarative, cache-aware hooks for session authorization, balances, confidential transfers, shielding, unshielding, and decryption — so you never deal with raw FHE operations in your components.
 
 ## Installation
 
@@ -275,53 +275,53 @@ const tokenABalance = balances?.get("0xTokenA");
 
 ### Authorization
 
-#### `useTokenAllow`
+#### `useAllow`
 
-Pre-authorize FHE decrypt credentials for a list of token addresses with a single wallet signature. Call this early (e.g. after loading the token list) so that subsequent individual decrypt operations reuse cached credentials without prompting the wallet again.
+Pre-authorize FHE decrypt credentials for a list of contract addresses with a single wallet signature. Call this early (e.g. after wallet connect) so that subsequent decrypt operations reuse cached credentials without prompting the wallet again.
 
 ```ts
-function useTokenAllow(): UseMutationResult<void, Error, Address[]>;
+function useAllow(): UseMutationResult<void, Error, Address[]>;
 ```
 
 ```tsx
-const { mutateAsync: tokenAllow, isPending } = useTokenAllow();
+const { mutateAsync: allow, isPending } = useAllow();
 
-// Pre-authorize all known tokens up front
-await tokenAllow(allTokenAddresses);
+// Pre-authorize all known contracts up front
+await allow(allContractAddresses);
 
 // Individual balance decrypts now reuse cached credentials
 const { data: balance } = useConfidentialBalance({ tokenAddress: "0xTokenA" });
 ```
 
-#### `useIsTokenAllowed`
+#### `useIsAllowed`
 
-Check whether a session signature is cached for a given token. Returns `true` if decrypt operations can proceed without a wallet prompt. Use this to conditionally enable UI elements (e.g. a "Reveal Balances" button).
+Check whether a session signature is cached and valid. Returns `true` if decrypt operations can proceed without a wallet prompt. Use this to conditionally enable UI elements (e.g. a "Reveal Balances" button).
 
 ```ts
-function useIsTokenAllowed(tokenAddress: Address): UseQueryResult<boolean, Error>;
+function useIsAllowed(): UseQueryResult<boolean, Error>;
 ```
 
 ```tsx
-const { data: allowed } = useIsTokenAllowed("0xTokenAddress");
+const { data: allowed } = useIsAllowed();
 
 <button disabled={!allowed}>Reveal Balance</button>;
 ```
 
-Automatically invalidated when `useTokenAllow` or `useTokenRevoke` succeed.
+Automatically invalidated when `useAllow` or `useRevoke` succeed.
 
-#### `useTokenRevoke`
+#### `useRevoke`
 
-Revoke the session signature for the connected wallet. Stored credentials remain intact, but the next decrypt operation will require a fresh wallet signature.
+Revoke decrypt authorization for specific contract addresses. Stored credentials remain intact, but the next decrypt operation will require a fresh wallet signature.
 
 ```ts
-function useTokenRevoke(): UseMutationResult<void, Error, Address[]>;
+function useRevoke(): UseMutationResult<void, Error, Address[]>;
 ```
 
 ```tsx
-const { mutate: tokenRevoke } = useTokenRevoke();
+const { mutate: revoke } = useRevoke();
 
-// Revoke session — addresses are included in the credentials:revoked event
-tokenRevoke(["0xTokenA", "0xTokenB"]);
+// Revoke — addresses are included in the credentials:revoked event
+revoke(["0xContractA", "0xContractB"]);
 ```
 
 ### Transfer Hooks
@@ -985,15 +985,15 @@ Place `ZamaProvider` inside your client-only layout. Do **not** create the relay
 
 ### FHE Credentials Lifecycle
 
-FHE decrypt credentials are generated once per wallet + token set and cached in the storage backend you provide (e.g. `IndexedDBStorage`). The wallet signature is kept **in memory only** — never persisted to disk. The lifecycle:
+FHE decrypt credentials are generated once per wallet + contract set and cached in the storage backend you provide (e.g. `IndexedDBStorage`). The wallet signature is kept **in memory only** — never persisted to disk. The lifecycle:
 
 1. **First decrypt** — SDK generates an FHE keypair, creates EIP-712 typed data, and prompts the wallet to sign. The encrypted credential is stored; the signature is cached in memory.
 2. **Same session** — Cached credentials and session signature are reused silently (no wallet prompt).
 3. **Page reload** — Encrypted credentials are loaded from storage; the wallet is prompted once to re-sign for the session.
 4. **Expiry** — Credentials expire based on `keypairTTL` (default: 86400s = 1 day). After expiry, the next decrypt regenerates and re-prompts.
-5. **Pre-authorization** — Call `useTokenAllow(tokenAddresses)` early to batch-authorize all tokens in one wallet prompt, avoiding repeated popups.
-6. **Check status** — Use `useIsTokenAllowed(tokenAddress)` to conditionally enable UI elements (e.g. disable "Reveal" until allowed).
-7. **Disconnect** — Call `useTokenRevoke(tokenAddresses)` or `await credentials.revoke()` to clear the session signature from memory.
+5. **Pre-authorization** — Call `useAllow(contractAddresses)` early to batch-authorize all contracts in one wallet prompt, avoiding repeated popups.
+6. **Check status** — Use `useIsAllowed()` to conditionally enable UI elements (e.g. disable "Reveal" until allowed).
+7. **Disconnect** — Call `useRevoke(contractAddresses)` or `await credentials.revoke()` to clear the session signature from memory.
 
 ### Web Extension Support
 

--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -1326,7 +1326,7 @@ export function useUserDecryptedValue(handle: Handle | undefined): _tanstack_rea
 // @public
 export function useUserDecryptedValues(handles: Handle[]): {
     data: Record<`0x${string}`, ClearValueType | undefined>;
-    results: (_tanstack_query_core0.QueryObserverRefetchErrorResult<unknown, unknown> | _tanstack_query_core0.QueryObserverSuccessResult<unknown, unknown> | _tanstack_query_core0.QueryObserverLoadingErrorResult<unknown, unknown> | _tanstack_query_core0.QueryObserverLoadingResult<unknown, unknown> | _tanstack_query_core0.QueryObserverPendingResult<unknown, unknown> | _tanstack_query_core0.QueryObserverPlaceholderResult<unknown, unknown> | _tanstack_query_core0.QueryObserverRefetchErrorResult<unknown, Error> | _tanstack_query_core0.QueryObserverSuccessResult<unknown, Error> | _tanstack_query_core0.QueryObserverLoadingErrorResult<unknown, Error> | _tanstack_query_core0.QueryObserverLoadingResult<unknown, Error> | _tanstack_query_core0.QueryObserverPendingResult<unknown, Error> | _tanstack_query_core0.QueryObserverPlaceholderResult<unknown, Error>)[];
+    results: _tanstack_react_query0.UseQueryResult<never, Error>[];
 };
 
 // @public

--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -743,7 +743,7 @@ export interface UseActivityFeedConfig {
 }
 
 // @public
-export function useAllowTokens(options?: UseMutationOptions<void, Error, Address[]>): _tanstack_react_query0.UseMutationResult<void, Error, `0x${string}`[], unknown>;
+export function useAllow(options?: UseMutationOptions<void, Error, Address[]>): _tanstack_react_query0.UseMutationResult<void, Error, `0x${string}`[], unknown>;
 
 // @public
 export function useApproveUnderlying(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, ApproveUnderlyingParams, Address>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, ApproveUnderlyingParams, `0x${string}`>;
@@ -1257,7 +1257,7 @@ export function useRevokeDelegation(config: UseZamaConfig, options?: UseMutation
 export function useRevokeSession(options?: UseMutationOptions<void>): _tanstack_react_query0.UseMutationResult<void, Error, void, unknown>;
 
 // @public
-export function useRevokeTokens(options?: UseMutationOptions<void, Error, Address[]>): _tanstack_react_query0.UseMutationResult<void, Error, `0x${string}`[], unknown>;
+export function useRevoke(options?: UseMutationOptions<void, Error, Address[]>): _tanstack_react_query0.UseMutationResult<void, Error, `0x${string}`[], unknown>;
 
 // @public
 export function useShield<TContext = unknown>(config: UseShieldConfig, options?: UseMutationOptions<TransactionResult, Error, ShieldParams, TContext>): UseMutationResult<TransactionResult, Error, ShieldParams, TContext>;

--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -1251,13 +1251,13 @@ export function useRequestZKProofVerification(): _tanstack_react_query0.UseMutat
 export function useResumeUnshield(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, ResumeUnshieldParams, Address>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, ResumeUnshieldParams, `0x${string}`>;
 
 // @public
+export function useRevoke(options?: UseMutationOptions<void, Error, Address[]>): _tanstack_react_query0.UseMutationResult<void, Error, `0x${string}`[], unknown>;
+
+// @public
 export function useRevokeDelegation(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, RevokeDelegationParams>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, RevokeDelegationParams, unknown>;
 
 // @public
 export function useRevokeSession(options?: UseMutationOptions<void>): _tanstack_react_query0.UseMutationResult<void, Error, void, unknown>;
-
-// @public
-export function useRevoke(options?: UseMutationOptions<void, Error, Address[]>): _tanstack_react_query0.UseMutationResult<void, Error, `0x${string}`[], unknown>;
 
 // @public
 export function useShield<TContext = unknown>(config: UseShieldConfig, options?: UseMutationOptions<TransactionResult, Error, ShieldParams, TContext>): UseMutationResult<TransactionResult, Error, ShieldParams, TContext>;

--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -1326,7 +1326,7 @@ export function useUserDecryptedValue(handle: Handle | undefined): _tanstack_rea
 // @public
 export function useUserDecryptedValues(handles: Handle[]): {
     data: Record<`0x${string}`, ClearValueType | undefined>;
-    results: (_tanstack_react_query0.UseQueryResult<unknown, unknown> | _tanstack_react_query0.UseQueryResult<unknown, Error>)[];
+    results: (_tanstack_query_core0.QueryObserverRefetchErrorResult<unknown, unknown> | _tanstack_query_core0.QueryObserverSuccessResult<unknown, unknown> | _tanstack_query_core0.QueryObserverLoadingErrorResult<unknown, unknown> | _tanstack_query_core0.QueryObserverLoadingResult<unknown, unknown> | _tanstack_query_core0.QueryObserverPendingResult<unknown, unknown> | _tanstack_query_core0.QueryObserverPlaceholderResult<unknown, unknown> | _tanstack_query_core0.QueryObserverRefetchErrorResult<unknown, Error> | _tanstack_query_core0.QueryObserverSuccessResult<unknown, Error> | _tanstack_query_core0.QueryObserverLoadingErrorResult<unknown, Error> | _tanstack_query_core0.QueryObserverLoadingResult<unknown, Error> | _tanstack_query_core0.QueryObserverPendingResult<unknown, Error> | _tanstack_query_core0.QueryObserverPlaceholderResult<unknown, Error>)[];
 };
 
 // @public

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -179,9 +179,9 @@ export {
   type UseConfidentialBalancesConfig,
   type UseConfidentialBalancesOptions,
 } from "./token/use-confidential-balances";
-export { useAllowTokens } from "./token/use-allow-tokens";
+export { useAllow } from "./token/use-allow";
 export { useIsAllowed } from "./token/use-is-allowed";
-export { useRevokeTokens } from "./token/use-revoke-tokens";
+export { useRevoke } from "./token/use-revoke";
 export { useRevokeSession } from "./token/use-revoke-session";
 export {
   useConfidentialTransfer,

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * React hooks for confidential token operations, built on React Query.
+ * React hooks for confidential contract operations, built on React Query.
  *
  * Requires {@link ZamaProvider} in the component tree. Re-exports all public
  * symbols from `@zama-fhe/sdk`.
@@ -166,7 +166,13 @@ export {
   getFeeRecipientContract,
 } from "@zama-fhe/sdk";
 
-// Token hooks
+// Authorization hooks (generic — any contract with encrypted state)
+export { useAllow } from "./token/use-allow";
+export { useIsAllowed } from "./token/use-is-allowed";
+export { useRevoke } from "./token/use-revoke";
+export { useRevokeSession } from "./token/use-revoke-session";
+
+// Token hooks (ERC-20 token operations)
 export { useToken, type UseZamaConfig } from "./token/use-token";
 export { useReadonlyToken } from "./token/use-readonly-token";
 export {
@@ -179,10 +185,6 @@ export {
   type UseConfidentialBalancesConfig,
   type UseConfidentialBalancesOptions,
 } from "./token/use-confidential-balances";
-export { useAllow } from "./token/use-allow";
-export { useIsAllowed } from "./token/use-is-allowed";
-export { useRevoke } from "./token/use-revoke";
-export { useRevokeSession } from "./token/use-revoke-session";
 export {
   useConfidentialTransfer,
   type UseConfidentialTransferConfig,
@@ -356,7 +358,7 @@ export {
   sortByBlockNumber,
 } from "@zama-fhe/sdk";
 
-// Re-export token types from core SDK
+// Re-export core types from SDK
 export type {
   Address,
   Hex,

--- a/packages/react-sdk/src/token/__tests__/use-allow.test.tsx
+++ b/packages/react-sdk/src/token/__tests__/use-allow.test.tsx
@@ -7,18 +7,18 @@ import {
   TOKEN,
   expectDefaultMutationState,
 } from "../../__tests__/mutation-test-helpers";
-import { useAllowTokens } from "../use-allow-tokens";
+import { useAllow } from "../use-allow";
 
-describe("useAllowTokens", () => {
+describe("useAllow", () => {
   test("default", ({ renderWithProviders }) => {
-    const { result } = renderWithProviders(() => useAllowTokens());
+    const { result } = renderWithProviders(() => useAllow());
     const { mutate: _mutate, mutateAsync: _mutateAsync, reset: _reset, ...state } = result.current;
 
     expectDefaultMutationState(state);
   });
 
   test("cache: invalidates isAllowed query after allow", async ({ renderWithProviders }) => {
-    const { result, queryClient } = renderWithProviders(() => useAllowTokens());
+    const { result, queryClient } = renderWithProviders(() => useAllow());
     queryClient.setQueryData(zamaQueryKeys.isAllowed.all, true);
 
     await act(() => result.current.mutateAsync([TOKEN, OTHER_TOKEN]));
@@ -34,7 +34,7 @@ describe("useAllowTokens", () => {
       expect(variables).toEqual([TOKEN, OTHER_TOKEN]);
     });
     const { result, queryClient } = renderWithProviders(() =>
-      useAllowTokens({
+      useAllow({
         onSuccess,
       }),
     );

--- a/packages/react-sdk/src/token/__tests__/use-revoke.test.tsx
+++ b/packages/react-sdk/src/token/__tests__/use-revoke.test.tsx
@@ -7,18 +7,18 @@ import {
   TOKEN,
   expectDefaultMutationState,
 } from "../../__tests__/mutation-test-helpers";
-import { useRevokeTokens } from "../use-revoke-tokens";
+import { useRevoke } from "../use-revoke";
 
-describe("useRevokeTokens", () => {
+describe("useRevoke", () => {
   test("default", ({ renderWithProviders }) => {
-    const { result } = renderWithProviders(() => useRevokeTokens());
+    const { result } = renderWithProviders(() => useRevoke());
     const { mutate: _mutate, mutateAsync: _mutateAsync, reset: _reset, ...state } = result.current;
 
     expectDefaultMutationState(state);
   });
 
   test("cache: invalidates isAllowed query after revoke", async ({ renderWithProviders }) => {
-    const { result, queryClient } = renderWithProviders(() => useRevokeTokens());
+    const { result, queryClient } = renderWithProviders(() => useRevoke());
     queryClient.setQueryData(zamaQueryKeys.isAllowed.all, true);
 
     await act(() => result.current.mutateAsync([TOKEN, OTHER_TOKEN]));
@@ -29,7 +29,7 @@ describe("useRevokeTokens", () => {
   test("behavior: forwards onSuccess callback", async ({ renderWithProviders }) => {
     const onSuccess = vi.fn();
 
-    const { result, queryClient } = renderWithProviders(() => useRevokeTokens({ onSuccess }));
+    const { result, queryClient } = renderWithProviders(() => useRevoke({ onSuccess }));
     queryClient.setQueryData(zamaQueryKeys.isAllowed.all, true);
 
     await act(() => result.current.mutateAsync([TOKEN, OTHER_TOKEN]));

--- a/packages/react-sdk/src/token/use-allow.ts
+++ b/packages/react-sdk/src/token/use-allow.ts
@@ -6,9 +6,11 @@ import { allowMutationOptions, zamaQueryKeys } from "@zama-fhe/sdk/query";
 import { useZamaSDK } from "../provider";
 
 /**
- * Pre-authorize FHE decrypt credentials for a list of token addresses.
- * A single wallet signature covers all addresses, so subsequent decrypt
- * operations on any of these tokens reuse cached credentials.
+ * Sign an EIP-712 message authorizing decryption of confidential handles
+ * for a list of contract addresses. This is not token-specific — any
+ * contract that uses FHE-encrypted values (tokens, DeFi vaults, games, etc.)
+ * can be authorized in a single wallet signature. Subsequent decrypt
+ * operations on any of these contracts reuse cached credentials.
  *
  * Errors are {@link ZamaError} subclasses — use `instanceof` to handle specific failures:
  * - {@link SigningRejectedError} — user rejected the wallet prompt
@@ -16,11 +18,11 @@ import { useZamaSDK } from "../provider";
  *
  * @example
  * ```tsx
- * const { mutateAsync: allowTokens, isPending } = useAllowTokens();
- * // Call allowTokens(allTokenAddresses) before any individual reveal
+ * const { mutateAsync: allow, isPending } = useAllow();
+ * // Call allow(contractAddresses) before any decrypt operation
  * ```
  */
-export function useAllowTokens(options?: UseMutationOptions<void, Error, Address[]>) {
+export function useAllow(options?: UseMutationOptions<void, Error, Address[]>) {
   const sdk = useZamaSDK();
 
   return useMutation<void, Error, Address[]>({

--- a/packages/react-sdk/src/token/use-allow.ts
+++ b/packages/react-sdk/src/token/use-allow.ts
@@ -19,7 +19,10 @@ import { useZamaSDK } from "../provider";
  * @example
  * ```tsx
  * const { mutateAsync: allow, isPending } = useAllow();
- * // Call allow(contractAddresses) before any decrypt operation
+ *
+ * // Authorize decryption for any contracts with encrypted state:
+ * // confidential tokens, auction contracts, governance contracts, etc.
+ * await allow([tokenAddress, auctionAddress, governanceAddress]);
  * ```
  */
 export function useAllow(options?: UseMutationOptions<void, Error, Address[]>) {

--- a/packages/react-sdk/src/token/use-revoke.ts
+++ b/packages/react-sdk/src/token/use-revoke.ts
@@ -6,16 +6,18 @@ import { revokeMutationOptions, zamaQueryKeys } from "@zama-fhe/sdk/query";
 import { useZamaSDK } from "../provider";
 
 /**
- * Revoke stored FHE credentials for a list of token addresses.
- * The next decrypt operation will require a fresh wallet signature.
+ * Revoke stored FHE decrypt credentials for a list of contract addresses.
+ * This is not token-specific — it revokes the EIP-712 authorization for
+ * any contract that uses FHE-encrypted values. The next decrypt operation
+ * on these contracts will require a fresh wallet signature.
  *
  * @example
  * ```tsx
- * const { mutate: revokeTokens } = useRevokeTokens();
- * revokeTokens(["0xTokenA", "0xTokenB"]);
+ * const { mutate: revoke } = useRevoke();
+ * revoke(["0xContractA", "0xContractB"]);
  * ```
  */
-export function useRevokeTokens(options?: UseMutationOptions<void, Error, Address[]>) {
+export function useRevoke(options?: UseMutationOptions<void, Error, Address[]>) {
   const sdk = useZamaSDK();
 
   return useMutation<void, Error, Address[]>({

--- a/packages/react-sdk/src/token/use-revoke.ts
+++ b/packages/react-sdk/src/token/use-revoke.ts
@@ -14,7 +14,9 @@ import { useZamaSDK } from "../provider";
  * @example
  * ```tsx
  * const { mutate: revoke } = useRevoke();
- * revoke(["0xContractA", "0xContractB"]);
+ *
+ * // Revoke for any contracts: tokens, auctions, governance, etc.
+ * revoke([tokenAddress, auctionAddress]);
  * ```
  */
 export function useRevoke(options?: UseMutationOptions<void, Error, Address[]>) {

--- a/packages/react-sdk/src/utils/query.ts
+++ b/packages/react-sdk/src/utils/query.ts
@@ -1,5 +1,7 @@
 import {
   type DefaultError,
+  type QueriesOptions,
+  type QueriesResults,
   useQueries as tanstack_useQueries,
   useQuery as tanstack_useQuery,
   useSuspenseQuery as tanstack_useSuspenseQuery,
@@ -47,15 +49,23 @@ export function useSuspenseQuery<TData = unknown, TError = DefaultError>(
  * Thin wrapper around TanStack's useQueries that injects our custom queryKeyHashFn
  * on every query in the array.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useQueries(options: { queries: any[]; combine?: any }) {
+export function useQueries<
+  // oxlint-disable-next-line typescript/no-explicit-any
+  T extends Array<any>,
+  TCombinedResult = QueriesResults<T>,
+>({
+  queries,
+  ...options
+}: {
+  queries: readonly [...QueriesOptions<T>];
+  combine?: (result: QueriesResults<T>) => TCombinedResult;
+  subscribed?: boolean;
+}): TCombinedResult {
   return tanstack_useQueries({
     ...options,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    queries: options.queries.map((q: any) => ({
+    queries: queries.map((q) => ({
       ...q,
       queryKeyHashFn: hashFn,
-    })),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any);
+    })) as [...QueriesOptions<T>],
+  });
 }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,6 @@
 # @zama-fhe/sdk
 
-A TypeScript SDK for building privacy-preserving token applications using Fully Homomorphic Encryption (FHE). It abstracts the complexity of encrypted ERC-20 operations — shielding, unshielding, confidential transfers, and balance decryption — behind a clean, high-level API. Works with any Web3 library (viem, ethers, or custom signers).
+A TypeScript SDK for building privacy-preserving applications on Zama's fhEVM using Fully Homomorphic Encryption (FHE). It abstracts the complexity of confidential contract operations — session management, encrypted state, shielding, unshielding, confidential transfers, and balance decryption — behind a clean, high-level API. Works with any Web3 library (viem, ethers, or custom signers).
 
 ## Installation
 
@@ -140,7 +140,7 @@ const balance = await token.balanceOf();
 
 ### ZamaSDK
 
-Entry point to the SDK. Composes a relayer backend with a signer and storage layer. Acts as a factory for token instances.
+Entry point to the SDK. Composes a relayer backend with a signer and storage layer. Manages sessions, credentials, and acts as a factory for contract instances.
 
 ```ts
 const sdk = new ZamaSDK({

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -1578,7 +1578,7 @@ export const ZERO_HANDLE: "0x000000000000000000000000000000000000000000000000000
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/activity-DRKVjKvL.d.ts:1520:3 - (ae-forgotten-export) The symbol "Handle" needs to be exported by the entry point index.d.ts
+// dist/esm/activity-B4coeVs1.d.ts:1520:3 - (ae-forgotten-export) The symbol "Handle" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zama-fhe/sdk",
   "version": "2.1.1-alpha.1",
-  "description": "TypeScript SDK for Zama confidential ERC-20 tokens (fhEVM)",
+  "description": "TypeScript SDK for Zama fhEVM confidential smart contracts",
   "license": "BSD-3-Clause-Clear",
   "author": "Zama",
   "repository": {

--- a/packages/sdk/src/query/allow.ts
+++ b/packages/sdk/src/query/allow.ts
@@ -7,6 +7,6 @@ export function allowMutationOptions(
 ): MutationFactoryOptions<readonly ["zama.allow"], Address[], void> {
   return {
     mutationKey: ["zama.allow"],
-    mutationFn: (tokenAddresses) => sdk.allow(...tokenAddresses),
+    mutationFn: (contractAddresses) => sdk.allow(...contractAddresses),
   };
 }

--- a/packages/sdk/src/query/revoke.ts
+++ b/packages/sdk/src/query/revoke.ts
@@ -7,6 +7,6 @@ export function revokeMutationOptions(
 ): MutationFactoryOptions<readonly ["zama.revoke"], Address[], void> {
   return {
     mutationKey: ["zama.revoke"],
-    mutationFn: (tokenAddresses) => sdk.revoke(...tokenAddresses),
+    mutationFn: (contractAddresses) => sdk.revoke(...contractAddresses),
   };
 }

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -45,8 +45,8 @@ export interface ZamaSDKConfig {
 }
 
 /**
- * ZamaSDK — composes a RelayerSDK with token abstraction.
- * Provides signer, storage, and high-level ERC-20-like token interface.
+ * ZamaSDK — composes a RelayerSDK with contract abstraction.
+ * Provides signer, storage, and high-level confidential contract interface.
  */
 export class ZamaSDK {
   readonly relayer: RelayerSDK;
@@ -204,13 +204,13 @@ export class ZamaSDK {
   /**
    * Pre-authorize FHE credentials for one or more contract addresses.
    * A single wallet signature covers all addresses, so subsequent decrypt
-   * operations on any of these tokens reuse cached credentials.
+   * operations on any of these contracts reuse cached credentials.
    *
-   * @param contractAddresses - Token contract addresses to authorize.
+   * @param contractAddresses - Contract addresses to authorize.
    *
    * @example
    * ```ts
-   * await sdk.allow("0xTokenA", "0xTokenB");
+   * await sdk.allow("0xContractA", "0xContractB");
    * ```
    */
   async allow(...contractAddresses: Address[]): Promise<void> {
@@ -227,7 +227,7 @@ export class ZamaSDK {
    * @example
    * ```ts
    * wallet.on("disconnect", () => sdk.revoke());
-   * await sdk.revoke("0xTokenA", "0xTokenB");
+   * await sdk.revoke("0xContractA", "0xContractB");
    * ```
    */
   async revoke(...contractAddresses: Address[]): Promise<void> {

--- a/test/playwright/start-anvil.sh
+++ b/test/playwright/start-anvil.sh
@@ -44,7 +44,11 @@ if ! nc -z 127.0.0.1 "$PORT" 2>/dev/null; then
 fi
 
 # Deploy fhevm host stack — independent per port, no lock needed.
-"$FORGE_FHEVM_DIR/deploy-local.sh" --anvil-port "$PORT"
+# In CI, artifacts are pre-built and cached; skip the internal forge build
+# to avoid failures when soldeer dependencies are absent (cache-hit path).
+DEPLOY_ARGS=(--anvil-port "$PORT")
+[ -n "${CI:-}" ] && DEPLOY_ARGS+=(--skip-build)
+"$FORGE_FHEVM_DIR/deploy-local.sh" "${DEPLOY_ARGS[@]}"
 
 # Acquire an exclusive lock for forge script only.
 # mkdir is atomic on all POSIX systems. Timeout after 120s.

--- a/test/test-components/src/allow-all-panel.tsx
+++ b/test/test-components/src/allow-all-panel.tsx
@@ -1,28 +1,28 @@
 "use client";
 
-import { useAllowTokens, type Address } from "@zama-fhe/react-sdk";
+import { useAllow, type Address } from "@zama-fhe/react-sdk";
 
 export function AllowAllPanel({ tokenAddresses }: { tokenAddresses: Address[] }) {
-  const allowTokens = useAllowTokens();
+  const allow = useAllow();
 
   return (
     <section className="space-y-2">
       <button
-        onClick={() => allowTokens.mutate(tokenAddresses)}
-        disabled={allowTokens.isPending}
+        onClick={() => allow.mutate(tokenAddresses)}
+        disabled={allow.isPending}
         className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
         data-testid="allow-all-button"
       >
-        {allowTokens.isPending ? "Allowing..." : "Allow All"}
+        {allow.isPending ? "Allowing..." : "Allow All"}
       </button>
-      {allowTokens.isSuccess && (
+      {allow.isSuccess && (
         <p className="text-green-600" data-testid="allow-all-success">
           Allowed successfully!
         </p>
       )}
-      {allowTokens.isError && (
+      {allow.isError && (
         <p className="text-red-600" data-testid="allow-all-error">
-          Error: {allowTokens.error.message}
+          Error: {allow.error.message}
         </p>
       )}
     </section>

--- a/test/test-components/src/token-table.tsx
+++ b/test/test-components/src/token-table.tsx
@@ -4,7 +4,7 @@ import {
   balanceOfContract,
   decimalsContract,
   symbolContract,
-  useAllowTokens,
+  useAllow,
   useConfidentialBalances,
   useMetadata,
   type Address,
@@ -107,7 +107,7 @@ export function TokenTable({
   LinkComponent: React.ComponentType<{ to: string; className?: string; children: React.ReactNode }>;
 }) {
   const [revealed, setRevealed] = useState(false);
-  const { mutate: allowTokens } = useAllowTokens();
+  const { mutate: allow } = useAllow();
   const {
     data: balances,
     isFetching,
@@ -120,7 +120,7 @@ export function TokenTable({
     <div className="space-y-4">
       <button
         onClick={() =>
-          allowTokens(tokenAddresses, {
+          allow(tokenAddresses, {
             onSuccess() {
               setRevealed(!revealed);
             },


### PR DESCRIPTION
Closes SDK-58

## Summary

- Renames `useAllowTokens` → `useAllow` and `useRevokeTokens` → `useRevoke`
- These hooks sign/revoke EIP-712 messages authorizing decryption of confidential handles for **any contract** — not just tokens. The `Tokens` suffix was misleading since the functionality applies to any contract using FHE-encrypted values (DeFi vaults, games, etc.)
- Updates JSDoc comments and gitbook documentation to clarify contract-scoped (not token-scoped) semantics
- Adds non-token examples (auction, governance contracts) to TSDoc and gitbook

## Test plan

- [x] All 297 react-sdk tests pass
- [x] API report regenerated
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.ai/code)