### PR TITLE
feat(react-sdk): improve query wrappers types

### DIFF
--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -1119,7 +1119,7 @@ export interface UseConfidentialBalancesConfig {
 export type UseConfidentialBalancesOptions = Omit<UseQueryOptions<ConfidentialBalancesData>, "queryKey" | "queryFn">;
 
 // @public
-export function useConfidentialIsApproved(config: UseConfidentialIsApprovedConfig, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<unknown, Error>;
+export function useConfidentialIsApproved(config: UseConfidentialIsApprovedConfig, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<boolean, Error>;
 
 // @public
 export interface UseConfidentialIsApprovedConfig {
@@ -1199,7 +1199,7 @@ export function useFinalizeUnwrap(config: UseZamaConfig, options?: UseMutationOp
 export function useGenerateKeypair(): _tanstack_react_query0.UseMutationResult<_zama_fhe_sdk0.KeypairType<`0x${string}`>, Error, void, unknown>;
 
 // @public
-export function useIsAllowed(): _tanstack_react_query0.UseQueryResult<unknown, Error>;
+export function useIsAllowed(): _tanstack_react_query0.UseQueryResult<boolean, Error>;
 
 // @public
 export function useIsConfidential(tokenAddress: Address, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<boolean, Error>;

--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -935,7 +935,9 @@ export interface UseConfidentialBalanceConfig {
 }
 
 // @public
-export type UseConfidentialBalanceOptions = Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">;
+export interface UseConfidentialBalanceOptions extends Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn" | "enabled"> {
+    enabled?: boolean;
+}
 
 // @public
 export function useConfidentialBalances(config: UseConfidentialBalancesConfig, options?: UseConfidentialBalancesOptions): {
@@ -1116,10 +1118,12 @@ export interface UseConfidentialBalancesConfig {
 }
 
 // @public
-export type UseConfidentialBalancesOptions = Omit<UseQueryOptions<ConfidentialBalancesData>, "queryKey" | "queryFn">;
+export interface UseConfidentialBalancesOptions extends Omit<UseQueryOptions<ConfidentialBalancesData>, "queryKey" | "queryFn" | "enabled"> {
+    enabled?: boolean;
+}
 
 // @public
-export function useConfidentialIsApproved(config: UseConfidentialIsApprovedConfig, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<unknown, Error>;
+export function useConfidentialIsApproved(config: UseConfidentialIsApprovedConfig, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<boolean, Error>;
 
 // @public
 export interface UseConfidentialIsApprovedConfig {
@@ -1199,7 +1203,7 @@ export function useFinalizeUnwrap(config: UseZamaConfig, options?: UseMutationOp
 export function useGenerateKeypair(): _tanstack_react_query0.UseMutationResult<_zama_fhe_sdk0.KeypairType<`0x${string}`>, Error, void, unknown>;
 
 // @public
-export function useIsAllowed(): _tanstack_react_query0.UseQueryResult<unknown, Error>;
+export function useIsAllowed(): _tanstack_react_query0.UseQueryResult<boolean, Error>;
 
 // @public
 export function useIsConfidential(tokenAddress: Address, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<boolean, Error>;

--- a/packages/react-sdk/src/token/use-confidential-balance.ts
+++ b/packages/react-sdk/src/token/use-confidential-balance.ts
@@ -42,7 +42,7 @@ export function useConfidentialBalance(
   options?: UseConfidentialBalanceOptions,
 ) {
   const { tokenAddress, handleRefetchInterval } = config;
-  const userEnabled = options?.enabled;
+  const userEnabled = typeof options?.enabled === "function" ? undefined : options?.enabled;
   const token = useReadonlyToken(tokenAddress);
 
   const addressQuery = useQuery<Address>({
@@ -58,7 +58,7 @@ export function useConfidentialBalance(
   });
   const handleQuery = useQuery<Handle>({
     ...baseHandleQueryOptions,
-    enabled: (baseHandleQueryOptions.enabled ?? true) && (userEnabled ?? true),
+    enabled: Boolean(baseHandleQueryOptions.enabled ?? true) && (userEnabled ?? true),
   });
 
   // Phase 2: Decrypt only when handle changes (expensive relayer roundtrip)
@@ -70,7 +70,7 @@ export function useConfidentialBalance(
   const balanceQuery = useQuery<bigint>({
     ...baseBalanceQueryOptions,
     ...options,
-    enabled: (baseBalanceQueryOptions.enabled ?? true) && (userEnabled ?? true),
+    enabled: Boolean(baseBalanceQueryOptions.enabled ?? true) && (userEnabled ?? true),
   });
 
   return { ...balanceQuery, handleQuery };

--- a/packages/react-sdk/src/token/use-confidential-balance.ts
+++ b/packages/react-sdk/src/token/use-confidential-balance.ts
@@ -19,7 +19,13 @@ export interface UseConfidentialBalanceConfig {
 }
 
 /** Query options for the decrypt phase of {@link useConfidentialBalance}. */
-export type UseConfidentialBalanceOptions = Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">;
+export interface UseConfidentialBalanceOptions extends Omit<
+  UseQueryOptions<bigint>,
+  "queryKey" | "queryFn" | "enabled"
+> {
+  /** Whether the query is enabled. Callback form is not supported in composite hooks. */
+  enabled?: boolean;
+}
 
 /**
  * Declarative hook to read the connected wallet's confidential token balance.
@@ -42,7 +48,7 @@ export function useConfidentialBalance(
   options?: UseConfidentialBalanceOptions,
 ) {
   const { tokenAddress, handleRefetchInterval } = config;
-  const userEnabled = options?.enabled;
+  const { enabled = true } = options ?? {};
   const token = useReadonlyToken(tokenAddress);
 
   const addressQuery = useQuery<Address>({
@@ -58,7 +64,7 @@ export function useConfidentialBalance(
   });
   const handleQuery = useQuery<Handle>({
     ...baseHandleQueryOptions,
-    enabled: (baseHandleQueryOptions.enabled ?? true) && (userEnabled ?? true),
+    enabled: baseHandleQueryOptions.enabled && enabled,
   });
 
   // Phase 2: Decrypt only when handle changes (expensive relayer roundtrip)
@@ -70,7 +76,7 @@ export function useConfidentialBalance(
   const balanceQuery = useQuery<bigint>({
     ...baseBalanceQueryOptions,
     ...options,
-    enabled: (baseBalanceQueryOptions.enabled ?? true) && (userEnabled ?? true),
+    enabled: baseBalanceQueryOptions.enabled && enabled,
   });
 
   return { ...balanceQuery, handleQuery };

--- a/packages/react-sdk/src/token/use-confidential-balances.ts
+++ b/packages/react-sdk/src/token/use-confidential-balances.ts
@@ -25,10 +25,13 @@ export interface UseConfidentialBalancesConfig {
 export type { ConfidentialBalancesData };
 
 /** Query options for the decrypt phase of {@link useConfidentialBalances}. */
-export type UseConfidentialBalancesOptions = Omit<
+export interface UseConfidentialBalancesOptions extends Omit<
   UseQueryOptions<ConfidentialBalancesData>,
-  "queryKey" | "queryFn"
->;
+  "queryKey" | "queryFn" | "enabled"
+> {
+  /** Whether the query is enabled. Callback form is not supported in composite hooks. */
+  enabled?: boolean;
+}
 
 /**
  * Declarative hook to read multiple confidential token balances in batch.
@@ -58,7 +61,7 @@ export function useConfidentialBalances(
   options?: UseConfidentialBalancesOptions,
 ) {
   const { tokenAddresses, handleRefetchInterval, maxConcurrency } = config;
-  const userEnabled = options?.enabled;
+  const { enabled = true } = options ?? {};
   const sdk = useZamaSDK();
 
   const addressQuery = useQuery<Address>({
@@ -79,7 +82,7 @@ export function useConfidentialBalances(
   });
   const handlesQuery = useQuery<Handle[]>({
     ...baseHandlesQueryOptions,
-    enabled: (baseHandlesQueryOptions.enabled ?? true) && (userEnabled ?? true),
+    enabled: baseHandlesQueryOptions.enabled && enabled,
   });
 
   // Phase 2: Batch decrypt only when any handle changes
@@ -96,7 +99,7 @@ export function useConfidentialBalances(
   const balancesQuery = useQuery<ConfidentialBalancesData>({
     ...baseBalancesQueryOptions,
     ...options,
-    enabled: factoryEnabled && handlesReady && (userEnabled ?? true),
+    enabled: factoryEnabled && handlesReady && enabled,
   });
 
   return { ...balancesQuery, handlesQuery };

--- a/packages/react-sdk/src/token/use-confidential-balances.ts
+++ b/packages/react-sdk/src/token/use-confidential-balances.ts
@@ -58,7 +58,7 @@ export function useConfidentialBalances(
   options?: UseConfidentialBalancesOptions,
 ) {
   const { tokenAddresses, handleRefetchInterval, maxConcurrency } = config;
-  const userEnabled = options?.enabled;
+  const userEnabled = typeof options?.enabled === "function" ? undefined : options?.enabled;
   const sdk = useZamaSDK();
 
   const addressQuery = useQuery<Address>({

--- a/packages/react-sdk/src/token/use-is-allowed.ts
+++ b/packages/react-sdk/src/token/use-is-allowed.ts
@@ -25,16 +25,17 @@ export function useIsAllowed() {
     ...signerAddressQueryOptions(sdk.signer),
   });
   const account = addressQuery.data;
-  const baseOpts = account
-    ? isAllowedQueryOptions(sdk, { account })
-    : {
-        queryKey: zamaQueryKeys.isAllowed.all,
-        queryFn: skipToken,
-      };
-  const factoryEnabled = "enabled" in baseOpts ? (baseOpts.enabled ?? true) : true;
+  if (!account) {
+    return useQuery<boolean>({
+      queryKey: zamaQueryKeys.isAllowed.all,
+      queryFn: skipToken,
+      enabled: false,
+    });
+  }
 
-  return useQuery({
+  const baseOpts = isAllowedQueryOptions(sdk, { account });
+  return useQuery<boolean>({
     ...baseOpts,
-    enabled: factoryEnabled,
+    enabled: baseOpts.enabled ?? true,
   });
 }

--- a/packages/react-sdk/src/token/use-is-allowed.ts
+++ b/packages/react-sdk/src/token/use-is-allowed.ts
@@ -32,10 +32,6 @@ export function useIsAllowed() {
         queryFn: skipToken,
         enabled: false,
       } as const);
-  const { enabled = true } = baseOpts;
 
-  return useQuery<boolean>({
-    ...baseOpts,
-    enabled,
-  });
+  return useQuery<boolean>(baseOpts);
 }

--- a/packages/react-sdk/src/utils/query.ts
+++ b/packages/react-sdk/src/utils/query.ts
@@ -5,7 +5,9 @@ import {
   useQueries as tanstack_useQueries,
   useQuery as tanstack_useQuery,
   useSuspenseQuery as tanstack_useSuspenseQuery,
+  type UseQueryOptions,
   type UseQueryResult,
+  type UseSuspenseQueryOptions,
   type UseSuspenseQueryResult,
 } from "@tanstack/react-query";
 import { hashFn } from "@zama-fhe/sdk/query";
@@ -14,35 +16,42 @@ import { hashFn } from "@zama-fhe/sdk/query";
  * Thin wrapper around TanStack's useQuery that injects our custom queryKeyHashFn.
  * Mirrors the wagmi pattern — the type safety boundary is at the factory and hook levels.
  *
- * The `options` parameter is typed as `any` because TanStack Query v5 has:
- * 1. Discriminated overloads around `initialData` (Defined vs Undefined)
- * 2. Function-typed fields (`staleTime`, `enabled`, `gcTime`) that are generic over `TQueryKey`
- *
- * Our factories produce options with specific tuple keys (e.g. `readonly ["zama.totalSupply", {...}]`)
- * whose function-typed fields are contravariant with `QueryKey` (`readonly unknown[]`).
- * Typing the parameter as `UseQueryOptions<TData, TError, TData, any>` still fails because
- * the query-key variance leaks through `staleTime`, `enabled`, etc.
- *
- * Hooks must pass explicit generics: `useQuery<DataType>({...})`.
+ * Callers typically specify only `<TData>` (e.g. `useQuery<PublicKeyData>(...)`) while
+ * factory options carry specific tuple keys (e.g. `readonly ["zama.publicKey"]`).
+ * We erase the QueryKey param via `AnyKeyQueryOptions` so callers don't need to
+ * spell out the key type — any QueryKey subtype is accepted.
  */
+type AnyKeyQueryOptions<TData, TError> = UseQueryOptions<
+  TData,
+  TError,
+  TData,
+  // oxlint-disable-next-line typescript/no-explicit-any
+  any
+>;
+type AnyKeySuspenseOptions<TData, TError> = UseSuspenseQueryOptions<
+  TData,
+  TError,
+  TData,
+  // oxlint-disable-next-line typescript/no-explicit-any
+  any
+>;
+
 export function useQuery<TData = unknown, TError = DefaultError>(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  options: any,
+  options: AnyKeyQueryOptions<TData, TError>,
 ): UseQueryResult<TData, TError> {
   return tanstack_useQuery({
     ...options,
     queryKeyHashFn: hashFn,
-  }) as UseQueryResult<TData, TError>;
+  });
 }
 
 export function useSuspenseQuery<TData = unknown, TError = DefaultError>(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  options: any,
+  options: AnyKeySuspenseOptions<TData, TError>,
 ): UseSuspenseQueryResult<TData, TError> {
   return tanstack_useSuspenseQuery({
     ...options,
     queryKeyHashFn: hashFn,
-  }) as UseSuspenseQueryResult<TData, TError>;
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace `any`-typed `options` parameter in `useQuery`/`useSuspenseQuery` wrappers with `AnyKeyQueryOptions<TData, TError>` — erases the QueryKey param via `any` in the type alias so callers don't need to spell out specific tuple keys, while keeping full type safety on `TData` and `TError`
- Type `useQueries` wrapper with `QueriesOptions<T>` / `QueriesResults<T>` for deterministic API reports (the untyped return previously caused non-deterministic union ordering in api-extractor)
- Fix `Enabled<bigint>` leaking into `Enabled<Address>` queries in `useConfidentialBalance`/`useConfidentialBalances` by extracting `userEnabled` as `boolean | undefined`
- Split `useIsAllowed` into early-return branches to avoid union type between `skipToken` and factory options
- Add explicit `<boolean>` type param to `useConfidentialIsApproved` and `useIsAllowed` for correct `UseQueryResult` inference

## Test plan
- [x] `pnpm typecheck` passes (0 errors in SDK packages)
- [x] `pnpm test:run` passes (1370 tests, 145 files)
- [x] `pnpm build && pnpm api-report:check` passes (7/7 checks, deterministic)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)