### PR TITLE
chore(deps-dev): bump rolldown-plugin-dts from 0.22.5 to 0.23.2

### DIFF
--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -4,6 +4,11 @@
 
 ```ts
 
+import * as _$_tanstack_query_core0 from '@tanstack/query-core';
+import * as _$_tanstack_react_query0 from '@tanstack/react-query';
+import * as _$_zama_fhe_relayer_sdk_web0 from '@zama-fhe/relayer-sdk/web';
+import * as _$_zama_fhe_sdk0 from '@zama-fhe/sdk';
+import * as _$react_jsx_runtime0 from 'react/jsx-runtime';
 import { ACL_TOPICS } from '@zama-fhe/sdk';
 import { AclEvent } from '@zama-fhe/sdk';
 import { AclPausedError } from '@zama-fhe/sdk';
@@ -184,7 +189,6 @@ import { publicParamsQueryOptions } from '@zama-fhe/sdk/query';
 import { QueryKey } from '@tanstack/react-query';
 import { rateContract } from '@zama-fhe/sdk';
 import { RawLog } from '@zama-fhe/sdk';
-import * as react_jsx_runtime0 from 'react/jsx-runtime';
 import { ReadContractArgs } from '@zama-fhe/sdk';
 import { ReadContractConfig } from '@zama-fhe/sdk';
 import { ReadContractReturnType } from '@zama-fhe/sdk';
@@ -225,8 +229,6 @@ import { sortByBlockNumber } from '@zama-fhe/sdk';
 import { StoredCredentials } from '@zama-fhe/sdk';
 import { supportsInterfaceContract } from '@zama-fhe/sdk';
 import { symbolContract } from '@zama-fhe/sdk';
-import * as _tanstack_query_core0 from '@tanstack/query-core';
-import * as _tanstack_react_query0 from '@tanstack/react-query';
 import { Token } from '@zama-fhe/sdk';
 import { TOKEN_TOPICS } from '@zama-fhe/sdk';
 import { TokenConfig } from '@zama-fhe/sdk';
@@ -281,8 +283,6 @@ import { WrappersRegistryConfig } from '@zama-fhe/sdk';
 import { WriteContractArgs } from '@zama-fhe/sdk';
 import { WriteContractConfig } from '@zama-fhe/sdk';
 import { WriteFunctionName } from '@zama-fhe/sdk';
-import * as _zama_fhe_relayer_sdk_web0 from '@zama-fhe/relayer-sdk/web';
-import * as _zama_fhe_sdk0 from '@zama-fhe/sdk';
 import { ZamaError } from '@zama-fhe/sdk';
 import { ZamaErrorCode } from '@zama-fhe/sdk';
 import { zamaQueryKeys } from '@zama-fhe/sdk/query';
@@ -830,7 +830,7 @@ export { UnwrapRequestedEvent }
 export { UnwrapSubmittedEvent }
 
 // @public
-export function useActivityFeed(config: UseActivityFeedConfig): _tanstack_react_query0.UseQueryResult<ActivityItem[], Error>;
+export function useActivityFeed(config: UseActivityFeedConfig): _$_tanstack_react_query0.UseQueryResult<ActivityItem[], Error>;
 
 // @public
 export interface UseActivityFeedConfig {
@@ -841,23 +841,23 @@ export interface UseActivityFeedConfig {
 }
 
 // @public
-export function useAllow(options?: UseMutationOptions<void, Error, Address[]>): _tanstack_react_query0.UseMutationResult<void, Error, `0x${string}`[], unknown>;
+export function useAllow(options?: UseMutationOptions<void, Error, Address[]>): _$_tanstack_react_query0.UseMutationResult<void, Error, `0x${string}`[], unknown>;
 
 // @public
-export function useApproveUnderlying(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, ApproveUnderlyingParams, Address>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, ApproveUnderlyingParams, `0x${string}`>;
+export function useApproveUnderlying(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, ApproveUnderlyingParams, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, ApproveUnderlyingParams, `0x${string}`>;
 
 // @public
-export function useBatchDecryptBalancesAs(tokens: ReadonlyToken[], options?: UseMutationOptions<Map<Address, bigint>, Error, BatchDecryptAsOptions>): _tanstack_react_query0.UseMutationResult<Map<`0x${string}`, bigint>, Error, BatchDecryptAsOptions, unknown>;
+export function useBatchDecryptBalancesAs(tokens: ReadonlyToken[], options?: UseMutationOptions<Map<Address, bigint>, Error, BatchDecryptAsOptions>): _$_tanstack_react_query0.UseMutationResult<Map<`0x${string}`, bigint>, Error, BatchDecryptAsOptions, unknown>;
 
 // @public
-export function useBatchTransferFee(feeManagerAddress: Address, options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<bigint, Error>;
+export function useBatchTransferFee(feeManagerAddress: Address, options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<bigint, Error>;
 
 // @public
-export function useConfidentialApprove(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, ConfidentialApproveParams, Address>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, ConfidentialApproveParams, `0x${string}`>;
+export function useConfidentialApprove(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, ConfidentialApproveParams, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, ConfidentialApproveParams, `0x${string}`>;
 
 // @public
 export function useConfidentialBalance(config: UseConfidentialBalanceConfig, options?: UseConfidentialBalanceOptions): {
-    handleQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
+    handleQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
     data: bigint;
     error: Error;
     isError: true;
@@ -881,11 +881,11 @@ export function useConfidentialBalance(config: UseConfidentialBalanceConfig, opt
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<bigint>;
 } | {
-    handleQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
+    handleQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
     data: bigint;
     error: null;
     isError: false;
@@ -909,11 +909,11 @@ export function useConfidentialBalance(config: UseConfidentialBalanceConfig, opt
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<bigint>;
 } | {
-    handleQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
+    handleQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
     data: undefined;
     error: Error;
     isError: true;
@@ -937,11 +937,11 @@ export function useConfidentialBalance(config: UseConfidentialBalanceConfig, opt
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<bigint>;
 } | {
-    handleQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
+    handleQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
     data: undefined;
     error: null;
     isError: false;
@@ -965,11 +965,11 @@ export function useConfidentialBalance(config: UseConfidentialBalanceConfig, opt
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<bigint>;
 } | {
-    handleQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
+    handleQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
     data: undefined;
     error: null;
     isError: false;
@@ -993,11 +993,11 @@ export function useConfidentialBalance(config: UseConfidentialBalanceConfig, opt
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<bigint>;
 } | {
-    handleQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
+    handleQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
     data: bigint;
     isError: false;
     error: null;
@@ -1021,8 +1021,8 @@ export function useConfidentialBalance(config: UseConfidentialBalanceConfig, opt
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<bigint, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<bigint>;
 };
 
@@ -1039,7 +1039,7 @@ export interface UseConfidentialBalanceOptions extends Omit<UseQueryOptions<bigi
 
 // @public
 export function useConfidentialBalances(config: UseConfidentialBalancesConfig, options?: UseConfidentialBalancesOptions): {
-    handlesQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
+    handlesQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
     data: ConfidentialBalancesData;
     error: Error;
     isError: true;
@@ -1063,11 +1063,11 @@ export function useConfidentialBalances(config: UseConfidentialBalancesConfig, o
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<ConfidentialBalancesData>;
 } | {
-    handlesQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
+    handlesQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
     data: ConfidentialBalancesData;
     error: null;
     isError: false;
@@ -1091,11 +1091,11 @@ export function useConfidentialBalances(config: UseConfidentialBalancesConfig, o
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<ConfidentialBalancesData>;
 } | {
-    handlesQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
+    handlesQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
     data: undefined;
     error: Error;
     isError: true;
@@ -1119,11 +1119,11 @@ export function useConfidentialBalances(config: UseConfidentialBalancesConfig, o
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<ConfidentialBalancesData>;
 } | {
-    handlesQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
+    handlesQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
     data: undefined;
     error: null;
     isError: false;
@@ -1147,11 +1147,11 @@ export function useConfidentialBalances(config: UseConfidentialBalancesConfig, o
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<ConfidentialBalancesData>;
 } | {
-    handlesQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
+    handlesQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
     data: undefined;
     error: null;
     isError: false;
@@ -1175,11 +1175,11 @@ export function useConfidentialBalances(config: UseConfidentialBalancesConfig, o
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<ConfidentialBalancesData>;
 } | {
-    handlesQuery: _tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
+    handlesQuery: _$_tanstack_react_query0.UseQueryResult<`0x${string}`[], Error>;
     data: ConfidentialBalancesData;
     isError: false;
     error: null;
@@ -1203,8 +1203,8 @@ export function useConfidentialBalances(config: UseConfidentialBalancesConfig, o
     isRefetching: boolean;
     isStale: boolean;
     isEnabled: boolean;
-    refetch: (options?: _tanstack_query_core0.RefetchOptions) => Promise<_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
-    fetchStatus: _tanstack_query_core0.FetchStatus;
+    refetch: (options?: _$_tanstack_query_core0.RefetchOptions) => Promise<_$_tanstack_query_core0.QueryObserverResult<ConfidentialBalancesData, Error>>;
+    fetchStatus: _$_tanstack_query_core0.FetchStatus;
     promise: Promise<ConfidentialBalancesData>;
 };
 
@@ -1221,7 +1221,7 @@ export interface UseConfidentialBalancesOptions extends Omit<UseQueryOptions<Con
 }
 
 // @public
-export function useConfidentialIsApproved(config: UseConfidentialIsApprovedConfig, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<boolean, Error>;
+export function useConfidentialIsApproved(config: UseConfidentialIsApprovedConfig, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<boolean, Error>;
 
 // @public
 export interface UseConfidentialIsApprovedConfig {
@@ -1231,7 +1231,7 @@ export interface UseConfidentialIsApprovedConfig {
 }
 
 // @public
-export function useConfidentialIsApprovedSuspense(config: UseConfidentialIsApprovedSuspenseConfig): _tanstack_react_query0.UseSuspenseQueryResult<boolean, Error>;
+export function useConfidentialIsApprovedSuspense(config: UseConfidentialIsApprovedSuspenseConfig): _$_tanstack_react_query0.UseSuspenseQueryResult<boolean, Error>;
 
 // @public
 export interface UseConfidentialIsApprovedSuspenseConfig extends UseZamaConfig {
@@ -1242,7 +1242,7 @@ export interface UseConfidentialIsApprovedSuspenseConfig extends UseZamaConfig {
 // @public
 export function useConfidentialTokenAddress(input: {
     tokenAddress: Address | undefined;
-}): _tanstack_react_query0.UseQueryResult<readonly [boolean, `0x${string}`], Error>;
+}): _$_tanstack_react_query0.UseQueryResult<readonly [boolean, `0x${string}`], Error>;
 
 // @public
 export function useConfidentialTransfer<TContext = unknown>(config: UseConfidentialTransferConfig, options?: UseMutationOptions<TransactionResult, Error, ConfidentialTransferParams, TContext>): UseMutationResult<TransactionResult, Error, ConfidentialTransferParams, TContext>;
@@ -1253,30 +1253,30 @@ export interface UseConfidentialTransferConfig extends UseZamaConfig {
 }
 
 // @public
-export function useConfidentialTransferFrom(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, ConfidentialTransferFromParams, Address>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, ConfidentialTransferFromParams, `0x${string}`>;
+export function useConfidentialTransferFrom(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, ConfidentialTransferFromParams, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, ConfidentialTransferFromParams, `0x${string}`>;
 
 // @public
-export function useCreateDelegatedUserDecryptEIP712(): _tanstack_react_query0.UseMutationResult<Readonly<{
-    types: _zama_fhe_relayer_sdk_web0.KmsDelegatedUserDecryptEIP712TypesType;
+export function useCreateDelegatedUserDecryptEIP712(): _$_tanstack_react_query0.UseMutationResult<Readonly<{
+    types: _$_zama_fhe_relayer_sdk_web0.KmsDelegatedUserDecryptEIP712TypesType;
     primaryType: "DelegatedUserDecryptRequestVerification";
-    domain: _zama_fhe_relayer_sdk_web0.KmsEIP712DomainType;
-    message: _zama_fhe_relayer_sdk_web0.KmsDelegatedUserDecryptEIP712MessageType;
+    domain: _$_zama_fhe_relayer_sdk_web0.KmsEIP712DomainType;
+    message: _$_zama_fhe_relayer_sdk_web0.KmsDelegatedUserDecryptEIP712MessageType;
 }>, Error, CreateDelegatedUserDecryptEIP712Params, unknown>;
 
 // @public
-export function useCreateEIP712(): _tanstack_react_query0.UseMutationResult<EIP712TypedData, Error, CreateEIP712Params, unknown>;
+export function useCreateEIP712(): _$_tanstack_react_query0.UseMutationResult<EIP712TypedData, Error, CreateEIP712Params, unknown>;
 
 // @public
-export function useDecryptBalanceAs(tokenAddress: Address, options?: UseMutationOptions<bigint, Error, DecryptBalanceAsParams>): _tanstack_react_query0.UseMutationResult<bigint, Error, DecryptBalanceAsParams, unknown>;
+export function useDecryptBalanceAs(tokenAddress: Address, options?: UseMutationOptions<bigint, Error, DecryptBalanceAsParams>): _$_tanstack_react_query0.UseMutationResult<bigint, Error, DecryptBalanceAsParams, unknown>;
 
 // @public
-export function useDelegateDecryption(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, DelegateDecryptionParams>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, DelegateDecryptionParams, unknown>;
+export function useDelegateDecryption(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, DelegateDecryptionParams>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, DelegateDecryptionParams, unknown>;
 
 // @public
-export function useDelegatedUserDecrypt(): _tanstack_react_query0.UseMutationResult<Record<`0x${string}`, ClearValueType>, Error, DelegatedUserDecryptParams, unknown>;
+export function useDelegatedUserDecrypt(): _$_tanstack_react_query0.UseMutationResult<Record<`0x${string}`, ClearValueType>, Error, DelegatedUserDecryptParams, unknown>;
 
 // @public
-export function useDelegationStatus(config: UseDelegationStatusConfig, options?: Omit<UseQueryOptions<DelegationStatusData>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<DelegationStatusData, Error>;
+export function useDelegationStatus(config: UseDelegationStatusConfig, options?: Omit<UseQueryOptions<DelegationStatusData>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<DelegationStatusData, Error>;
 
 // @public (undocumented)
 export interface UseDelegationStatusConfig {
@@ -1286,7 +1286,7 @@ export interface UseDelegationStatusConfig {
 }
 
 // @public
-export function useEncrypt(): _tanstack_react_query0.UseMutationResult<EncryptResult, Error, EncryptParams, unknown>;
+export function useEncrypt(): _$_tanstack_react_query0.UseMutationResult<EncryptResult, Error, EncryptParams, unknown>;
 
 // @public
 export interface UseFeeConfig {
@@ -1297,55 +1297,55 @@ export interface UseFeeConfig {
 }
 
 // @public
-export function useFeeRecipient(feeManagerAddress: Address, options?: Omit<UseQueryOptions<Address>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
+export function useFeeRecipient(feeManagerAddress: Address, options?: Omit<UseQueryOptions<Address>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<`0x${string}`, Error>;
 
 // @public
-export function useFinalizeUnwrap(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, FinalizeUnwrapParams, Address>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, FinalizeUnwrapParams, `0x${string}`>;
+export function useFinalizeUnwrap(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, FinalizeUnwrapParams, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, FinalizeUnwrapParams, `0x${string}`>;
 
 // @public
-export function useGenerateKeypair(): _tanstack_react_query0.UseMutationResult<_zama_fhe_sdk0.KeypairType<`0x${string}`>, Error, void, unknown>;
+export function useGenerateKeypair(): _$_tanstack_react_query0.UseMutationResult<_$_zama_fhe_sdk0.KeypairType<`0x${string}`>, Error, void, unknown>;
 
 // @public
-export function useIsAllowed(): _tanstack_react_query0.UseQueryResult<boolean, Error>;
+export function useIsAllowed(): _$_tanstack_react_query0.UseQueryResult<boolean, Error>;
 
 // @public
-export function useIsConfidential(tokenAddress: Address, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<boolean, Error>;
+export function useIsConfidential(tokenAddress: Address, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<boolean, Error>;
 
 // @public
-export function useIsConfidentialSuspense(tokenAddress: Address): _tanstack_react_query0.UseSuspenseQueryResult<boolean, Error>;
+export function useIsConfidentialSuspense(tokenAddress: Address): _$_tanstack_react_query0.UseSuspenseQueryResult<boolean, Error>;
 
 // @public
 export function useIsConfidentialTokenValid(input: {
     confidentialTokenAddress: Address | undefined;
-}): _tanstack_react_query0.UseQueryResult<boolean, Error>;
+}): _$_tanstack_react_query0.UseQueryResult<boolean, Error>;
 
 // @public
-export function useIsWrapper(tokenAddress: Address, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<boolean, Error>;
+export function useIsWrapper(tokenAddress: Address, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<boolean, Error>;
 
 // @public
-export function useIsWrapperSuspense(tokenAddress: Address): _tanstack_react_query0.UseSuspenseQueryResult<boolean, Error>;
+export function useIsWrapperSuspense(tokenAddress: Address): _$_tanstack_react_query0.UseSuspenseQueryResult<boolean, Error>;
 
 // @public
 export function useListPairs(input?: {
     page?: number;
     pageSize?: number;
     metadata?: boolean;
-}): _tanstack_react_query0.UseQueryResult<PaginatedResult<TokenWrapperPair | TokenWrapperPairWithMetadata>, Error>;
+}): _$_tanstack_react_query0.UseQueryResult<PaginatedResult<TokenWrapperPair | TokenWrapperPairWithMetadata>, Error>;
 
 // @public
-export function useMetadata(tokenAddress: Address, options?: Omit<UseQueryOptions<TokenMetadata>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<TokenMetadata, Error>;
+export function useMetadata(tokenAddress: Address, options?: Omit<UseQueryOptions<TokenMetadata>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<TokenMetadata, Error>;
 
 // @public
-export function useMetadataSuspense(tokenAddress: Address): _tanstack_react_query0.UseSuspenseQueryResult<TokenMetadata, Error>;
+export function useMetadataSuspense(tokenAddress: Address): _$_tanstack_react_query0.UseSuspenseQueryResult<TokenMetadata, Error>;
 
 // @public
-export function usePublicDecrypt(): _tanstack_react_query0.UseMutationResult<PublicDecryptResult, Error, `0x${string}`[], unknown>;
+export function usePublicDecrypt(): _$_tanstack_react_query0.UseMutationResult<PublicDecryptResult, Error, `0x${string}`[], unknown>;
 
 // @public
-export function usePublicKey(): _tanstack_react_query0.UseQueryResult<PublicKeyData | null, Error>;
+export function usePublicKey(): _$_tanstack_react_query0.UseQueryResult<PublicKeyData | null, Error>;
 
 // @public
-export function usePublicParams(bits: number): _tanstack_react_query0.UseQueryResult<PublicParamsData | null, Error>;
+export function usePublicParams(bits: number): _$_tanstack_react_query0.UseQueryResult<PublicParamsData | null, Error>;
 
 export { UserDecryptCallbacks as DecryptCallbacks }
 export { UserDecryptCallbacks }
@@ -1358,25 +1358,25 @@ export { UserDecryptMutationParams }
 export { UserDecryptParams }
 
 // @public
-export function useReadonlyToken(address: Address): _zama_fhe_sdk0.ReadonlyToken;
+export function useReadonlyToken(address: Address): _$_zama_fhe_sdk0.ReadonlyToken;
 
 // @public
-export function useRequestZKProofVerification(): _tanstack_react_query0.UseMutationResult<Readonly<{
+export function useRequestZKProofVerification(): _$_tanstack_react_query0.UseMutationResult<Readonly<{
     handles: Uint8Array[];
     inputProof: Uint8Array;
 }>, Error, ZKProofLike, unknown>;
 
 // @public
-export function useResumeUnshield(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, ResumeUnshieldParams, Address>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, ResumeUnshieldParams, `0x${string}`>;
+export function useResumeUnshield(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, ResumeUnshieldParams, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, ResumeUnshieldParams, `0x${string}`>;
 
 // @public
-export function useRevoke(options?: UseMutationOptions<void, Error, Address[]>): _tanstack_react_query0.UseMutationResult<void, Error, `0x${string}`[], unknown>;
+export function useRevoke(options?: UseMutationOptions<void, Error, Address[]>): _$_tanstack_react_query0.UseMutationResult<void, Error, `0x${string}`[], unknown>;
 
 // @public
-export function useRevokeDelegation(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, RevokeDelegationParams>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, RevokeDelegationParams, unknown>;
+export function useRevokeDelegation(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, RevokeDelegationParams>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, RevokeDelegationParams, unknown>;
 
 // @public
-export function useRevokeSession(options?: UseMutationOptions<void>): _tanstack_react_query0.UseMutationResult<void, Error, void, unknown>;
+export function useRevokeSession(options?: UseMutationOptions<void>): _$_tanstack_react_query0.UseMutationResult<void, Error, void, unknown>;
 
 // @public
 export function useShield<TContext = unknown>(config: UseShieldConfig, options?: UseMutationOptions<TransactionResult, Error, ShieldParams, TContext>): UseMutationResult<TransactionResult, Error, ShieldParams, TContext>;
@@ -1395,41 +1395,41 @@ export interface UseShieldETHConfig extends UseZamaConfig {
 }
 
 // @public
-export function useShieldFee(config: UseFeeConfig, options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<bigint, Error>;
+export function useShieldFee(config: UseFeeConfig, options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<bigint, Error>;
 
 // @public
-export function useToken(config: UseZamaConfig): _zama_fhe_sdk0.Token;
+export function useToken(config: UseZamaConfig): _$_zama_fhe_sdk0.Token;
 
 // @public
 export function useTokenAddress(input: {
     confidentialTokenAddress: Address | undefined;
-}): _tanstack_react_query0.UseQueryResult<readonly [boolean, `0x${string}`], Error>;
+}): _$_tanstack_react_query0.UseQueryResult<readonly [boolean, `0x${string}`], Error>;
 
 // @public
 export function useTokenPair(input: {
     index: bigint | undefined;
-}): _tanstack_react_query0.UseQueryResult<TokenWrapperPair, Error>;
+}): _$_tanstack_react_query0.UseQueryResult<TokenWrapperPair, Error>;
 
 // @public
-export function useTokenPairsLength(): _tanstack_react_query0.UseQueryResult<bigint, Error>;
+export function useTokenPairsLength(): _$_tanstack_react_query0.UseQueryResult<bigint, Error>;
 
 // @public
-export function useTokenPairsRegistry(): _tanstack_react_query0.UseQueryResult<readonly TokenWrapperPair[], Error>;
+export function useTokenPairsRegistry(): _$_tanstack_react_query0.UseQueryResult<readonly TokenWrapperPair[], Error>;
 
 // @public
 export function useTokenPairsSlice(input: {
     fromIndex: bigint | undefined;
     toIndex: bigint | undefined;
-}): _tanstack_react_query0.UseQueryResult<readonly TokenWrapperPair[], Error>;
+}): _$_tanstack_react_query0.UseQueryResult<readonly TokenWrapperPair[], Error>;
 
 // @public
-export function useTotalSupply(tokenAddress: Address, options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<bigint, Error>;
+export function useTotalSupply(tokenAddress: Address, options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<bigint, Error>;
 
 // @public
-export function useTotalSupplySuspense(tokenAddress: Address): _tanstack_react_query0.UseSuspenseQueryResult<bigint, Error>;
+export function useTotalSupplySuspense(tokenAddress: Address): _$_tanstack_react_query0.UseSuspenseQueryResult<bigint, Error>;
 
 // @public
-export function useUnderlyingAllowance(config: UseUnderlyingAllowanceConfig, options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<bigint, Error>;
+export function useUnderlyingAllowance(config: UseUnderlyingAllowanceConfig, options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<bigint, Error>;
 
 // @public
 export interface UseUnderlyingAllowanceConfig {
@@ -1438,40 +1438,40 @@ export interface UseUnderlyingAllowanceConfig {
 }
 
 // @public
-export function useUnderlyingAllowanceSuspense(config: UseUnderlyingAllowanceConfig): _tanstack_react_query0.UseSuspenseQueryResult<bigint, Error>;
+export function useUnderlyingAllowanceSuspense(config: UseUnderlyingAllowanceConfig): _$_tanstack_react_query0.UseSuspenseQueryResult<bigint, Error>;
 
 // @public
-export function useUnshield(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, UnshieldParams, Address>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, UnshieldParams, `0x${string}`>;
+export function useUnshield(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, UnshieldParams, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, UnshieldParams, `0x${string}`>;
 
 // @public
-export function useUnshieldAll(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, UnshieldAllParams | void, Address>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, void | UnshieldAllParams, `0x${string}`>;
+export function useUnshieldAll(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, UnshieldAllParams | void, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, void | UnshieldAllParams, `0x${string}`>;
 
 // @public
-export function useUnshieldFee(config: UseFeeConfig, options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<bigint, Error>;
+export function useUnshieldFee(config: UseFeeConfig, options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<bigint, Error>;
 
 // @public
-export function useUnwrap(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, UnwrapParams, Address>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, UnwrapParams, `0x${string}`>;
+export function useUnwrap(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, UnwrapParams, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, UnwrapParams, `0x${string}`>;
 
 // @public
-export function useUnwrapAll(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, void, Address>): _tanstack_react_query0.UseMutationResult<TransactionResult, Error, void, `0x${string}`>;
+export function useUnwrapAll(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, void, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, void, `0x${string}`>;
 
 // @public
-export function useUserDecrypt(config?: UseUserDecryptConfig): _tanstack_react_query0.UseMutationResult<Record<`0x${string}`, ClearValueType>, Error, UserDecryptMutationParams, unknown>;
+export function useUserDecrypt(config?: UseUserDecryptConfig): _$_tanstack_react_query0.UseMutationResult<Record<`0x${string}`, ClearValueType>, Error, UserDecryptMutationParams, unknown>;
 
 // @public
 export type UseUserDecryptConfig = UserDecryptCallbacks;
 
 // @public
-export function useUserDecryptedValue(handle: Handle | undefined): _tanstack_react_query0.UseQueryResult<ClearValueType, Error>;
+export function useUserDecryptedValue(handle: Handle | undefined): _$_tanstack_react_query0.UseQueryResult<ClearValueType, Error>;
 
 // @public
 export function useUserDecryptedValues(handles: Handle[]): {
     data: Record<`0x${string}`, ClearValueType | undefined>;
-    results: _tanstack_react_query0.UseQueryResult<never, Error>[];
+    results: _$_tanstack_react_query0.UseQueryResult<never, Error>[];
 };
 
 // @public
-export function useWrapperDiscovery(config: UseWrapperDiscoveryConfig, options?: Omit<UseQueryOptions<Address | null>, "queryKey" | "queryFn">): _tanstack_react_query0.UseQueryResult<`0x${string}` | null, Error>;
+export function useWrapperDiscovery(config: UseWrapperDiscoveryConfig, options?: Omit<UseQueryOptions<Address | null>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<`0x${string}` | null, Error>;
 
 // @public
 export interface UseWrapperDiscoveryConfig {
@@ -1480,7 +1480,7 @@ export interface UseWrapperDiscoveryConfig {
 }
 
 // @public
-export function useWrapperDiscoverySuspense(config: UseWrapperDiscoverySuspenseConfig): _tanstack_react_query0.UseSuspenseQueryResult<`0x${string}` | null, Error>;
+export function useWrapperDiscoverySuspense(config: UseWrapperDiscoverySuspenseConfig): _$_tanstack_react_query0.UseSuspenseQueryResult<`0x${string}` | null, Error>;
 
 // @public
 export interface UseWrapperDiscoverySuspenseConfig {
@@ -1525,7 +1525,7 @@ export { ZamaError }
 export { ZamaErrorCode }
 
 // @public
-export function ZamaProvider(input: ZamaProviderProps): react_jsx_runtime0.JSX.Element;
+export function ZamaProvider(input: ZamaProviderProps): _$react_jsx_runtime0.JSX.Element;
 
 // @public
 export interface ZamaProviderProps extends PropsWithChildren {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@zama-fhe/sdk": "workspace:*",
     "rolldown": "1.0.0-rc.7",
-    "rolldown-plugin-dts": "^0.22.5",
+    "rolldown-plugin-dts": "^0.23.2",
     "viem": "^2.47.6"
   },
   "peerDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -134,7 +134,7 @@
   "devDependencies": {
     "@tanstack/query-core": "^5.95.2",
     "rolldown": "1.0.0-rc.7",
-    "rolldown-plugin-dts": "^0.22.5"
+    "rolldown-plugin-dts": "^0.23.2"
   },
   "peerDependencies": {
     "@tanstack/query-core": ">=5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,8 +158,8 @@ importers:
         specifier: 1.0.0-rc.7
         version: 1.0.0-rc.7
       rolldown-plugin-dts:
-        specifier: ^0.22.5
-        version: 0.22.5(rolldown@1.0.0-rc.7)(typescript@6.0.2)
+        specifier: ^0.23.2
+        version: 0.23.2(rolldown@1.0.0-rc.7)(typescript@6.0.2)
       viem:
         specifier: ^2.47.6
         version: 2.47.6(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -183,8 +183,8 @@ importers:
         specifier: 1.0.0-rc.7
         version: 1.0.0-rc.7
       rolldown-plugin-dts:
-        specifier: ^0.22.5
-        version: 0.22.5(rolldown@1.0.0-rc.7)(typescript@6.0.2)
+        specifier: ^0.23.2
+        version: 0.23.2(rolldown@1.0.0-rc.7)(typescript@6.0.2)
 
   test/playwright:
     dependencies:
@@ -420,6 +420,10 @@ packages:
     resolution: {integrity: sha512-oCQ1IKPwkzCeJzAPb7Fv8rQ9k5+1sG8mf2uoHiMInPYvkRfrDJxbTIbH51U+jstlkghus0vAi3EBvkfvEsYNLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  '@babel/generator@8.0.0-rc.3':
+    resolution: {integrity: sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -436,6 +440,10 @@ packages:
     resolution: {integrity: sha512-xExUBkuXWJjVuIbO7z6q7/BA9bgfJDEhVL0ggrggLMbg0IzCUWGT1hZGE8qUH7Il7/RD/a6cZ3AAFrrlp1LF/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  '@babel/helper-validator-identifier@8.0.0-rc.3':
+    resolution: {integrity: sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
@@ -443,6 +451,11 @@ packages:
 
   '@babel/parser@8.0.0-rc.2':
     resolution: {integrity: sha512-29AhEtcq4x8Dp3T72qvUMZHx0OMXCj4Jy/TEReQa+KWLln524Cj1fWb3QFi0l/xSpptQBR6y9RNEXuxpFvwiUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  '@babel/parser@8.0.0-rc.3':
+    resolution: {integrity: sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -456,6 +469,10 @@ packages:
 
   '@babel/types@8.0.0-rc.2':
     resolution: {integrity: sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/types@8.0.0-rc.3':
+    resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -3719,6 +3736,25 @@ packages:
       vue-tsc:
         optional: true
 
+  rolldown-plugin-dts@0.23.2:
+    resolution: {integrity: sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@ts-macro/tsc': ^0.3.6
+      '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
+      rolldown: ^1.0.0-rc.12
+      typescript: ^5.0.0 || ^6.0.0
+      vue-tsc: ~3.2.0
+    peerDependenciesMeta:
+      '@ts-macro/tsc':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
   rolldown-vite@7.3.1:
     resolution: {integrity: sha512-LYzdNAjRHhF2yA4JUQm/QyARyi216N2rpJ0lJZb8E9FU2y5v6Vk+xq/U4XBOxMefpWixT5H3TslmAHm1rqIq2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4599,6 +4635,15 @@ snapshots:
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
+  '@babel/generator@8.0.0-rc.3':
+    dependencies:
+      '@babel/parser': 8.0.0-rc.3
+      '@babel/types': 8.0.0-rc.3
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-string-parser@8.0.0-rc.3': {}
@@ -4607,6 +4652,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@8.0.0-rc.2': {}
 
+  '@babel/helper-validator-identifier@8.0.0-rc.3': {}
+
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
@@ -4614,6 +4661,10 @@ snapshots:
   '@babel/parser@8.0.0-rc.2':
     dependencies:
       '@babel/types': 8.0.0-rc.2
+
+  '@babel/parser@8.0.0-rc.3':
+    dependencies:
+      '@babel/types': 8.0.0-rc.3
 
   '@babel/runtime@7.29.2': {}
 
@@ -4626,6 +4677,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.2
+
+  '@babel/types@8.0.0-rc.3':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0-rc.3
+      '@babel/helper-validator-identifier': 8.0.0-rc.3
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -7389,23 +7445,6 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.7)(typescript@6.0.2):
-    dependencies:
-      '@babel/generator': 8.0.0-rc.2
-      '@babel/helper-validator-identifier': 8.0.0-rc.2
-      '@babel/parser': 8.0.0-rc.2
-      '@babel/types': 8.0.0-rc.2
-      ast-kit: 3.0.0-beta.1
-      birpc: 4.0.0
-      dts-resolver: 2.1.3
-      get-tsconfig: 4.13.7
-      obug: 2.1.1
-      rolldown: 1.0.0-rc.7
-    optionalDependencies:
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - oxc-resolver
-
   rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.9)(typescript@6.0.2):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
@@ -7418,6 +7457,24 @@ snapshots:
       get-tsconfig: 4.13.7
       obug: 2.1.1
       rolldown: 1.0.0-rc.9
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - oxc-resolver
+
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.7)(typescript@6.0.2):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.3
+      '@babel/helper-validator-identifier': 8.0.0-rc.3
+      '@babel/parser': 8.0.0-rc.3
+      '@babel/types': 8.0.0-rc.3
+      ast-kit: 3.0.0-beta.1
+      birpc: 4.0.0
+      dts-resolver: 2.1.3
+      get-tsconfig: 4.13.7
+      obug: 2.1.1
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.7
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Bumps `rolldown-plugin-dts` from 0.22.5 to 0.23.2 in both `packages/sdk` and `packages/react-sdk`
- Combines dependabot PRs #186 and #187

## Test plan
- [ ] CI passes (build, tests, api-report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)