### PR TITLE
fix: align keypairTTL default with sessionTTL (30 days)

### DIFF
--- a/docs/gitbook/src/concepts/security-model.md
+++ b/docs/gitbook/src/concepts/security-model.md
@@ -156,7 +156,7 @@ EIP-712 signatures include a start timestamp and duration. The relayer rejects s
 
 Two TTL controls are available:
 
-- `keypairTTL` — how long the FHE keypair remains valid (default: 1 day).
+- `keypairTTL` — how long the FHE keypair remains valid (default: 30 days).
 - `sessionTTL` — how long the cached wallet signature remains valid (default: 30 days).
 
 ### Address-scoped authorization

--- a/docs/gitbook/src/concepts/session-model.md
+++ b/docs/gitbook/src/concepts/session-model.md
@@ -76,7 +76,7 @@ The SDK has two separate time-to-live settings that control different aspects of
 
 ### `keypairTTL` — keypair regeneration
 
-Controls how long the FHE keypair remains valid. Default: 86,400 seconds (1 day).
+Controls how long the FHE keypair remains valid. Default: 2,592,000 seconds (30 days).
 
 When the keypair expires:
 

--- a/docs/gitbook/src/concepts/session-model.md
+++ b/docs/gitbook/src/concepts/session-model.md
@@ -101,6 +101,10 @@ When the session expires:
 For high-security contexts, set `sessionTTL: 0` to require a wallet signature on every operation. This provides maximum security at the cost of frequent wallet popups.
 {% endhint %}
 
+{% hint style="info" %}
+**`sessionTTL` is clamped to `keypairTTL`.** If you set `sessionTTL` greater than `keypairTTL`, the SDK automatically reduces it to match `keypairTTL` and emits a console warning. This prevents a state where `isAllowed()` returns `true` (session still valid) but the FHE keypair has expired, which would cause unexpected wallet prompts.
+{% endhint %}
+
 Each session entry records its TTL at creation time. If you change the `sessionTTL` configuration between sessions, existing sessions use their original TTL, not the new value.
 
 ## The allow / revoke flow

--- a/docs/gitbook/src/guides/configuration.md
+++ b/docs/gitbook/src/guides/configuration.md
@@ -256,7 +256,7 @@ const sdk = new ZamaSDK({
   relayer,
   signer,
   storage,
-  keypairTTL: 604800, // 7 days (default: 86400 = 1 day)
+  keypairTTL: 604800, // 7 days (default: 2592000 = 30 days)
   sessionTTL: 3600, // 1 hour (default: 2592000 = 30 days)
   onEvent: ({ type, tokenAddress, ...rest }) => {
     console.debug(`[zama] ${type}`, rest);

--- a/docs/gitbook/src/guides/encrypt-decrypt.md
+++ b/docs/gitbook/src/guides/encrypt-decrypt.md
@@ -380,7 +380,7 @@ function DecryptWithProgress() {
 {% endcode %}
 
 {% hint style="info" %}
-**Decryption fails with "invalid keypair" or "expired credentials"?** The FHE keypair has a TTL (default: 1 day). If the keypair was generated more than `keypairTTL` seconds ago, the relayer rejects it. `useUserDecrypt` and `useConfidentialBalance` handle re-generation automatically.
+**Decryption fails with "invalid keypair" or "expired credentials"?** The FHE keypair has a TTL (default: 30 days). If the keypair was generated more than `keypairTTL` seconds ago, the relayer rejects it. `useUserDecrypt` and `useConfidentialBalance` handle re-generation automatically.
 {% endhint %}
 
 ### 4. Decrypt with usePublicDecrypt (advanced)

--- a/docs/gitbook/src/reference/react/useUserDecrypt.md
+++ b/docs/gitbook/src/reference/react/useUserDecrypt.md
@@ -168,7 +168,7 @@ On success, results are written to the decryption cache so that [`useUserDecrypt
 
 - **First call** — generates a new FHE keypair, creates EIP-712 typed data, and requests a wallet signature. The credentials are then cached.
 - **Subsequent calls** — reuses the cached credentials if they are still valid (not expired).
-- **Expiry** — credentials expire after `keypairTTL` seconds (default: 86400 = 1 day, configurable via SDK config). Once expired, the next call generates fresh credentials.
+- **Expiry** — credentials expire after `keypairTTL` seconds (default: 2592000 = 30 days, configurable via SDK config). Once expired, the next call generates fresh credentials.
 
 This means users only see a wallet signature prompt once per session (or per TTL window), even if they decrypt multiple times.
 

--- a/docs/gitbook/src/reference/sdk/ZamaSDK.md
+++ b/docs/gitbook/src/reference/sdk/ZamaSDK.md
@@ -129,7 +129,7 @@ const sdk = new ZamaSDK({
 
 `number | undefined`
 
-FHE keypair validity duration in seconds. Default: `86400` (1 day). After expiry, the next decrypt prompts a wallet signature to regenerate the keypair.
+FHE keypair validity duration in seconds. Default: `2592000` (30 days). After expiry, the next decrypt prompts a wallet signature to regenerate the keypair.
 
 ```ts
 const sdk = new ZamaSDK({
@@ -174,7 +174,7 @@ const sdk = new ZamaSDK({
 
 `number | undefined`
 
-How long cached registry results remain valid, in seconds. Default: `86400` (24 hours). Consistent with `keypairTTL`.
+How long cached registry results remain valid, in seconds. Default: `86400` (24 hours).
 
 ```ts
 const sdk = new ZamaSDK({

--- a/docs/gitbook/src/reference/sdk/errors.md
+++ b/docs/gitbook/src/reference/sdk/errors.md
@@ -205,7 +205,7 @@ matchZamaError(error, {
 });
 ```
 
-**How to handle:** Prompt the user to re-sign. Adjust `keypairTTL` in the SDK constructor if the default TTL is too short.
+**How to handle:** Prompt the user to re-sign. Adjust `keypairTTL` in the SDK constructor if the default TTL of 30 days is not appropriate.
 
 ### NoCiphertextError
 

--- a/examples/example-hoodi/src/providers.tsx
+++ b/examples/example-hoodi/src/providers.tsx
@@ -247,10 +247,6 @@ export function Providers({ children }: { children: ReactNode }) {
         storage={indexedDBStorage}
         sessionStorage={sessionDBStorage}
         signer={signer}
-        // Align keypairTTL with sessionTTL (both 30 days) to prevent a mismatch
-        // where a valid session prompts the SDK to decrypt, but the keypair has expired
-        // and must be regenerated mid-operation (causing an unexpected wallet prompt).
-        keypairTTL={30 * 24 * 60 * 60}
         onEvent={(event) => {
           // ZamaSDKEvents.UnshieldPhase1Submitted fires after Phase 1 is mined (the SDK
           // awaits the receipt before emitting). Saving here ensures the pending state

--- a/examples/react-ethers/src/providers.tsx
+++ b/examples/react-ethers/src/providers.tsx
@@ -165,12 +165,6 @@ export function Providers({ children }: { children: ReactNode }) {
         storage={indexedDBStorage}
         sessionStorage={sessionDBStorage}
         signer={signer}
-        // Align keypairTTL with sessionTTL (both 30 days) to prevent a mismatch
-        // where isAllowed() returns true (session valid) but the FHE keypair has
-        // already expired — causing an unexpected wallet prompt mid-operation.
-        // Root cause is in the SDK: checkAllowed() only checks session TTL, not
-        // keypair TTL. Setting them equal eliminates the desync window.
-        keypairTTL={30 * 24 * 60 * 60}
         onEvent={(event) => {
           // ZamaSDKEvents.UnshieldPhase1Submitted fires after Phase 1 is mined (the SDK awaits
           // the receipt before emitting). Saving here ensures the pending state survives a tab

--- a/examples/react-viem/src/providers.tsx
+++ b/examples/react-viem/src/providers.tsx
@@ -205,12 +205,6 @@ export function Providers({ children }: { children: ReactNode }) {
         storage={indexedDBStorage}
         sessionStorage={sessionDBStorage}
         signer={signer}
-        // Align keypairTTL with sessionTTL (both 30 days) to prevent a mismatch
-        // where isAllowed() returns true (session valid) but the FHE keypair has
-        // already expired — causing an unexpected wallet prompt mid-operation.
-        // Root cause is in the SDK: checkAllowed() only checks session TTL, not
-        // keypair TTL. Setting them equal eliminates the desync window.
-        keypairTTL={30 * 24 * 60 * 60}
         onEvent={(event) => {
           // ZamaSDKEvents.UnshieldPhase1Submitted fires after Phase 1 is mined (the SDK
           // awaits the receipt before emitting). Saving here ensures the pending state

--- a/examples/react-wagmi/src/providers.tsx
+++ b/examples/react-wagmi/src/providers.tsx
@@ -87,12 +87,6 @@ export function Providers({ children }: { children: ReactNode }) {
           storage={indexedDBStorage}
           sessionStorage={sessionDBStorage}
           signer={signer}
-          // Align keypairTTL with sessionTTL (both 30 days) to prevent a mismatch
-          // where isAllowed() returns true (session valid) but the FHE keypair has
-          // already expired — causing an unexpected wallet prompt mid-operation.
-          // Root cause is in the SDK: checkAllowed() only checks session TTL, not
-          // keypair TTL. Setting them equal eliminates the desync window.
-          keypairTTL={30 * 24 * 60 * 60}
           onEvent={(event) => {
             // ZamaSDKEvents.UnshieldPhase1Submitted fires after Phase 1 is mined (the SDK
             // awaits the receipt before emitting). Saving here ensures the pending state

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -154,7 +154,7 @@ import { ZamaProvider } from "@zama-fhe/react-sdk";
   signer={signer} // GenericSigner (WagmiSigner, ViemSigner, EthersSigner, or custom)
   storage={storage} // GenericStorage
   sessionStorage={sessionStorage} // Optional. Session storage for wallet signatures. Default: in-memory (lost on reload).
-  keypairTTL={86400} // Optional. Seconds the ML-KEM keypair remains valid. Default: 86400 (1 day).
+  keypairTTL={2592000} // Optional. Seconds the ML-KEM keypair remains valid. Default: 2592000 (30 days).
   sessionTTL={2592000} // Optional. Seconds the session signature remains valid. Default: 2592000 (30 days). 0 = re-sign every operation.
   onEvent={(event) => console.debug(event)} // Optional. Structured event listener for debugging.
 >
@@ -990,7 +990,7 @@ FHE decrypt credentials are generated once per wallet + contract set and cached 
 1. **First decrypt** — SDK generates an FHE keypair, creates EIP-712 typed data, and prompts the wallet to sign. The encrypted credential is stored; the signature is cached in memory.
 2. **Same session** — Cached credentials and session signature are reused silently (no wallet prompt).
 3. **Page reload** — Encrypted credentials are loaded from storage; the wallet is prompted once to re-sign for the session.
-4. **Expiry** — Credentials expire based on `keypairTTL` (default: 86400s = 1 day). After expiry, the next decrypt regenerates and re-prompts.
+4. **Expiry** — Credentials expire based on `keypairTTL` (default: 2592000s = 30 days). After expiry, the next decrypt regenerates and re-prompts.
 5. **Pre-authorization** — Call `useAllow(contractAddresses)` early to batch-authorize all contracts in one wallet prompt, avoiding repeated popups.
 6. **Check status** — Use `useIsAllowed()` to conditionally enable UI elements (e.g. disable "Reveal" until allowed).
 7. **Disconnect** — Call `useRevoke(contractAddresses)` or `await credentials.revoke()` to clear the session signature from memory.

--- a/packages/react-sdk/src/__tests__/use-user-decrypt.test.tsx
+++ b/packages/react-sdk/src/__tests__/use-user-decrypt.test.tsx
@@ -132,7 +132,7 @@ describe("useUserDecrypt", () => {
       "0xpub",
       [tokenAddress], // single address, not duplicated
       expect.any(Number),
-      1, // default durationDays
+      30, // default durationDays (keypairTTL = 2592000s = 30 days)
     );
   });
 
@@ -155,12 +155,12 @@ describe("useUserDecrypt", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    // durationDays is derived from keypairTTL (default 86400s = 1 day)
+    // durationDays is derived from keypairTTL (default 2592000s = 30 days)
     expect(relayer.createEIP712).toHaveBeenCalledWith(
       "0xpub",
       [tokenAddress],
       expect.any(Number),
-      1,
+      30,
     );
   });
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -338,7 +338,7 @@ const sdk = new ZamaSDK({
 | `signer`         | `GenericSigner`        | Wallet signer interface.                                                                                                               |
 | `storage`        | `GenericStorage`       | Credential storage backend.                                                                                                            |
 | `sessionStorage` | `GenericStorage`       | Optional. Session storage for wallet signatures. Default: in-memory (lost on reload). Use `chrome.storage.session` for web extensions. |
-| `keypairTTL`     | `number`               | Optional. Seconds the ML-KEM re-encryption keypair remains valid. Default: `86400` (1 day). Must be positive.                          |
+| `keypairTTL`     | `number`               | Optional. Seconds the ML-KEM re-encryption keypair remains valid. Default: `2592000` (30 days). Must be positive.                      |
 | `sessionTTL`     | `number`               | Optional. Seconds the session signature remains valid. Default: `2592000` (30 days). `0` = re-sign every operation.                    |
 | `onEvent`        | `ZamaSDKEventListener` | Optional. Structured event listener for debugging.                                                                                     |
 

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -1717,7 +1717,7 @@ export const ZERO_HANDLE: "0x000000000000000000000000000000000000000000000000000
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/activity-q99hCR8n.d.ts:1839:3 - (ae-forgotten-export) The symbol "Handle" needs to be exported by the entry point index.d.ts
+// dist/esm/activity-BeqE1jb7.d.ts:1839:3 - (ae-forgotten-export) The symbol "Handle" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/src/credentials/credentials-manager-base.ts
+++ b/packages/sdk/src/credentials/credentials-manager-base.ts
@@ -24,7 +24,7 @@ export interface CredentialsConfig {
   storage: GenericStorage;
   /** Storage for session signatures (shorter-lived than credentials). */
   sessionStorage: GenericStorage;
-  /** FHE keypair lifetime in seconds. Defaults to `86400` (1 day). */
+  /** FHE keypair lifetime in seconds. Defaults to `2592000` (30 days). */
   keypairTTL?: number;
   /** Session signature lifetime. `0` = always re-sign, `"infinite"` = never expire. Defaults to `2592000` (30 days). */
   sessionTTL?: number | "infinite";
@@ -97,7 +97,7 @@ export abstract class BaseCredentialsManager<
     this.storage = config.storage;
     this.sessionSignatures = new SessionSignatures(config.sessionStorage);
     this.crypto = new CredentialCrypto();
-    this.keypairTTL = config.keypairTTL ?? 86400;
+    this.keypairTTL = config.keypairTTL ?? 2592000;
     this.sessionTTL = config.sessionTTL ?? 2592000;
     this.#onEvent = config.onEvent ?? (() => {});
 

--- a/packages/sdk/src/credentials/credentials-manager-base.ts
+++ b/packages/sdk/src/credentials/credentials-manager-base.ts
@@ -107,6 +107,15 @@ export abstract class BaseCredentialsManager<
     if (typeof this.sessionTTL === "number" && this.sessionTTL < 0) {
       throw new Error("sessionTTL must be >= 0");
     }
+    if (typeof this.sessionTTL === "number" && this.sessionTTL > this.keypairTTL) {
+      this.sessionTTL = this.keypairTTL;
+      // oxlint-disable-next-line no-console
+      console.warn(
+        `[zama-sdk] sessionTTL was clamped to keypairTTL (${this.keypairTTL}s). ` +
+          "A session that outlives the keypair causes isAllowed() to return true " +
+          "after the keypair expires, leading to unexpected wallet prompts.",
+      );
+    }
   }
 
   /** Emit a credential lifecycle event, stamped with the current time. */

--- a/packages/sdk/src/test-fixtures.ts
+++ b/packages/sdk/src/test-fixtures.ts
@@ -252,7 +252,7 @@ export const test = base.extend<SdkFixtures>({
         signer: config.signer,
         storage: config.storage,
         sessionStorage: config.sessionStorage,
-        keypairTTL: config.keypairTTL ?? 86400,
+        keypairTTL: config.keypairTTL ?? 2592000,
         sessionTTL: config.sessionTTL ?? 2592000,
         onEvent: config.onEvent,
       });
@@ -266,7 +266,7 @@ export const test = base.extend<SdkFixtures>({
         signer: config.signer,
         storage: config.storage,
         sessionStorage: config.sessionStorage,
-        keypairTTL: config.keypairTTL ?? 86400,
+        keypairTTL: config.keypairTTL ?? 2592000,
         sessionTTL: config.sessionTTL ?? 2592000,
         onEvent: config.onEvent,
       });

--- a/packages/sdk/src/token/readonly-token.ts
+++ b/packages/sdk/src/token/readonly-token.ts
@@ -119,7 +119,7 @@ export class ReadonlyToken {
       signer: config.signer,
       storage: config.storage,
       sessionStorage: config.sessionStorage,
-      keypairTTL: config.keypairTTL ?? 86400,
+      keypairTTL: config.keypairTTL ?? 2592000,
       sessionTTL: config.sessionTTL ?? 2592000,
       onEvent: config.onEvent,
     };

--- a/packages/sdk/src/wrappers-registry.ts
+++ b/packages/sdk/src/wrappers-registry.ts
@@ -54,7 +54,7 @@ export interface WrappersRegistryConfig {
   registryAddresses?: Record<number, Address>;
   /**
    * How long cached registry results remain valid, in seconds.
-   * Default: `86400` (24 hours). Consistent with `keypairTTL`/`sessionTTL`.
+   * Default: `2592000` (30 days). Consistent with `keypairTTL`/`sessionTTL`.
    */
   registryTTL?: number;
 }

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -27,7 +27,7 @@ export interface ZamaSDKConfig {
   sessionStorage?: GenericStorage;
   /**
    * How long the ML-KEM re-encryption keypair remains valid, in seconds.
-   * Default: `86400` (1 day). Must be a positive number — `0` is rejected
+   * Default: `2592000` (30 days). Must be a positive number — `0` is rejected
    * because the keypair is required to establish the relayer connection.
    */
   keypairTTL?: number;
@@ -48,7 +48,7 @@ export interface ZamaSDKConfig {
   registryAddresses?: Record<number, Address>;
   /**
    * How long cached registry results remain valid, in seconds.
-   * Default: `86400` (24 hours). Consistent with `keypairTTL`/`sessionTTL`.
+   * Default: `2592000` (30 days). Consistent with `keypairTTL`/`sessionTTL`.
    */
   registryTTL?: number;
   /** Optional signer lifecycle callbacks composed with the SDK's internal session handling. */
@@ -104,7 +104,7 @@ export class ZamaSDK {
       storage: this.storage,
       sessionStorage: this.sessionStorage,
       keypairTTL: (() => {
-        const ttl = config.keypairTTL ?? 86400;
+        const ttl = config.keypairTTL ?? 2592000;
         if (ttl <= 0) {
           throw new Error("keypairTTL must be a positive number (seconds)");
         }


### PR DESCRIPTION
## Summary

- Change `keypairTTL` default from `86400` (1 day) to `2592000` (30 days), matching `sessionTTL`
- Clamp `sessionTTL` to `keypairTTL` at construction time to prevent the desync where `isAllowed()` returns `true` but the keypair has expired (causing unexpected wallet prompts)
- Remove the now-unnecessary `keypairTTL={30 * 24 * 60 * 60}` workaround from all 4 example apps
- Update all docs, READMEs, JSDoc, and gitbook references

Closes SDK-58

## Test plan

- [x] All 1089 SDK tests pass
- [x] All 307 react-sdk tests pass (updated 2 tests that asserted `durationDays: 1` → `30`)
- [ ] Verify no wallet prompt regressions on example-hoodi

🤖 Generated with [Claude Code](https://claude.ai/code)