### PR TITLE
ci: Enable npm provenance in release workflows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
 - [ ] `@zama-fhe/test-components`
 - [ ] `@zama-fhe/test-nextjs`
 - [ ] `@zama-fhe/test-vite`
+- [ ] Examples (`examples/`)
 - [ ] CI/workflows
 - [ ] Docs
 

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -96,7 +96,7 @@ jobs:
           cd ../react-sdk
           npm publish --access public --tag "${npm_tag}"
         env:
-          NPM_CONFIG_PROVENANCE: false # Re-enable once repo is public
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Verify release was published
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           cd ../react-sdk
           npm publish --access public --tag "${npm_tag}"
         env:
-          NPM_CONFIG_PROVENANCE: false # Re-enable once repo is public
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Verify release was published
         if: github.event_name == 'workflow_dispatch'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,6 @@ Maintainer requirements:
 - Configure branch protection on `main` to require both `Vitest` and `Playwright` checks before merge.
 - Configure branch protection on `prerelease` with the same required checks.
 - Configure npm trusted publishers for `@zama-fhe/sdk` and `@zama-fhe/react-sdk` pointing to this repository's `release.yml` and `release-manual.yml` workflows.
-- npm provenance is intentionally disabled while the repository is private (`NPM_CONFIG_PROVENANCE=false`). Re-enable provenance when the repository is public.
 
 ## Architecture Guidelines
 


### PR DESCRIPTION
Set NPM_CONFIG_PROVENANCE=true in both release.yml and release-manual.yml so published packages include provenance metadata. Also remove the CONTRIBUTING.md note that provenance is intentionally disabled while the repo is private, reflecting the change in publishing behavior.

# Summary

<!-- What changed? Keep it short and concrete. -->

## Scope

- [ ] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-components`
- [ ] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [x] CI/workflows
- [ ] Docs

## Validation

<!-- What did you run/check before opening this PR? -->
<!-- Example: pnpm typecheck, pnpm lint, pnpm test:coverage, pnpm e2e:test -->

## Related

<!-- Link issue(s) / related PR(s), if any. -->
<!-- Example: Closes issue-number> -->

## Demo (if possible)

<!-- Screenshot or short video/GIF for UI/UX changes. -->
