### PR TITLE
ci: remove unnecessary npm 11 upgrade from release workflows

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -59,11 +59,6 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: Ensure npm 11
-        run: |
-          npm i -g npm@^11
-          npm --version
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -43,11 +43,6 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: Ensure npm 11
-        run: |
-          npm i -g npm@^11
-          npm --version
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,6 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: Ensure npm 11
-        run: |
-          npm i -g npm@^11
-          npm --version
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
## Summary

- Remove the "Ensure npm 11" step from `release.yml`, `release-preview.yml`, and `release-manual.yml`
- Node.js 22 ships with npm 10, which already supports provenance attestations and OIDC trusted publishing
- The npm 11 upgrade step broke when the GitHub Actions runner shipped Node.js 22.22.2 with a corrupt bundled npm (missing `promise-retry` module)

## Scope

- [x] CI/workflows

## Testing

- No code changes; CI workflows will validate on merge

## Breaking Changes

- [x] No breaking changes

## Linked Issues

Fixes https://github.com/zama-ai/sdk/actions/runs/24075380209/job/70223290254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>