### PR TITLE
ci: use pnpm to install npm 11 in release workflows

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Ensure npm 11
         run: |
-          npm i -g npm@^11
+          pnpm add -g npm@^11
           npm --version
 
       - name: Install dependencies

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -59,6 +59,11 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Ensure npm 11
+        run: |
+          npm i -g npm@^11
+          npm --version
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -43,6 +43,11 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Ensure npm 11
+        run: |
+          npm i -g npm@^11
+          npm --version
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Ensure npm 11
         run: |
-          npm i -g npm@^11
+          pnpm add -g npm@^11
           npm --version
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Ensure npm 11
         run: |
-          npm i -g npm@^11
+          pnpm add -g npm@^11
           npm --version
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,11 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Ensure npm 11
+        run: |
+          npm i -g npm@^11
+          npm --version
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
## Summary

- Replace `npm i -g npm@^11` with `pnpm add -g npm@^11` in release workflows
- The GitHub Actions runner for Node.js 22.22.2 ships with a broken bundled npm (missing `promise-retry` module), causing the self-upgrade to fail
- pnpm is already installed in the workflow and can install npm independently

## Scope

- [x] CI/workflows

## Testing

- No code changes; the release workflow will validate on next push to `main`

## Breaking Changes

- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>