### PR TITLE
refactor(sdk): extract PromiseLock utility from relayer classes

### DIFF
--- a/packages/sdk/src/relayer/relayer-node.ts
+++ b/packages/sdk/src/relayer/relayer-node.ts
@@ -9,6 +9,7 @@ import type { Address, Hex } from "viem";
 import { ConfigurationError, ZamaError } from "../errors";
 import { MemoryStorage } from "../storage/memory-storage";
 import type { GenericStorage } from "../types";
+import { PromiseLock } from "../utils/promise-lock";
 import { NodeWorkerPool, type NodeWorkerPoolConfig } from "../worker/worker.node-pool";
 import type { GenericLogger } from "../worker/worker.types";
 import { FheArtifactCache } from "./fhe-artifact-cache";
@@ -55,7 +56,7 @@ export class RelayerNode implements RelayerSDK, Disposable {
   readonly #config: RelayerNodeConfig;
   #pool: NodeWorkerPool | null = null;
   #initPromise: Promise<NodeWorkerPool> | null = null;
-  #ensureLock: Promise<NodeWorkerPool> | null = null;
+  #ensureLock = new PromiseLock<NodeWorkerPool>();
   #terminated = false;
   #resolvedChainId: number | null = null;
   #artifactCache: FheArtifactCache | null = null;
@@ -75,16 +76,62 @@ export class RelayerNode implements RelayerSDK, Disposable {
     };
   }
 
-  async #ensurePool(): Promise<NodeWorkerPool> {
-    if (this.#ensureLock) {
-      return this.#ensureLock;
-    }
-    this.#ensureLock = this.#ensurePoolInner();
-    try {
-      return await this.#ensureLock;
-    } finally {
-      this.#ensureLock = null;
-    }
+  #ensurePool(): Promise<NodeWorkerPool> {
+    return this.#ensureLock.run(async () => {
+      if (this.#terminated) {
+        throw new ConfigurationError("RelayerNode has been terminated");
+      }
+
+      const chainId = await this.#config.getChainId();
+
+      // Chain changed → tear down old pool, re-init
+      if (this.#resolvedChainId !== null && chainId !== this.#resolvedChainId) {
+        this.#tearDown();
+      }
+
+      this.#resolvedChainId = chainId;
+
+      // Create cache for current chain (when storage is provided)
+      if (!this.#artifactCache && this.#config.fheArtifactStorage) {
+        const config = Object.assign({}, DefaultConfigs[chainId], this.#config.transports[chainId]);
+        this.#artifactCache = new FheArtifactCache({
+          storage: this.#config.fheArtifactStorage,
+          chainId,
+          relayerUrl: config.relayerUrl,
+          ttl: this.#config.fheArtifactCacheTTL,
+          logger: this.#config.logger,
+        });
+      }
+
+      // Revalidate cached artifacts if due — never let revalidation block init
+      if (this.#artifactCache) {
+        let stale = false;
+        try {
+          stale = await this.#artifactCache.revalidateIfDue();
+        } catch (err) {
+          this.#config.logger?.warn(
+            "Artifact revalidation failed, proceeding with potentially stale cache",
+            { error: err instanceof Error ? err.message : String(err) },
+          );
+        }
+        if (stale) {
+          this.#config.logger?.info("Cached FHE artifacts are stale — reinitializing");
+          this.#tearDown();
+        }
+      }
+
+      if (!this.#initPromise) {
+        this.#initPromise = this.#initPool().catch((error) => {
+          this.#initPromise = null;
+          throw error instanceof ZamaError
+            ? error
+            : new ConfigurationError("Failed to initialize FHE worker pool", {
+                cause: error,
+              });
+        });
+      }
+      return this.#initPromise;
+    });
   }
 
   #tearDown(): void {
@@ -92,62 +139,6 @@ export class RelayerNode implements RelayerSDK, Disposable {
     this.#pool = null;
     this.#initPromise = null;
     this.#artifactCache = null;
-  }
-
-  async #ensurePoolInner(): Promise<NodeWorkerPool> {
-    if (this.#terminated) {
-      throw new ConfigurationError("RelayerNode has been terminated");
-    }
-
-    const chainId = await this.#config.getChainId();
-
-    // Chain changed → tear down old pool, re-init
-    if (this.#resolvedChainId !== null && chainId !== this.#resolvedChainId) {
-      this.#tearDown();
-    }
-
-    this.#resolvedChainId = chainId;
-
-    // Create cache for current chain (when storage is provided)
-    if (!this.#artifactCache && this.#config.fheArtifactStorage) {
-      const config = Object.assign({}, DefaultConfigs[chainId], this.#config.transports[chainId]);
-      this.#artifactCache = new FheArtifactCache({
-        storage: this.#config.fheArtifactStorage,
-        chainId,
-        relayerUrl: config.relayerUrl,
-        ttl: this.#config.fheArtifactCacheTTL,
-        logger: this.#config.logger,
-      });
-    }
-
-    // Revalidate cached artifacts if due — never let revalidation block init
-    if (this.#artifactCache) {
-      let stale = false;
-      try {
-        stale = await this.#artifactCache.revalidateIfDue();
-      } catch (err) {
-        this.#config.logger?.warn(
-          "Artifact revalidation failed, proceeding with potentially stale cache",
-          { error: err instanceof Error ? err.message : String(err) },
-        );
-      }
-      if (stale) {
-        this.#config.logger?.info("Cached FHE artifacts are stale — reinitializing");
-        this.#tearDown();
-      }
-    }
-
-    if (!this.#initPromise) {
-      this.#initPromise = this.#initPool().catch((error) => {
-        this.#initPromise = null;
-        throw error instanceof ZamaError
-          ? error
-          : new ConfigurationError("Failed to initialize FHE worker pool", {
-              cause: error,
-            });
-      });
-    }
-    return this.#initPromise;
   }
 
   async #initPool(): Promise<NodeWorkerPool> {
@@ -169,7 +160,7 @@ export class RelayerNode implements RelayerSDK, Disposable {
       this.#pool = null;
     }
     this.#initPromise = null;
-    this.#ensureLock = null;
+    this.#ensureLock.clear();
   }
 
   /** Calls {@link terminate}, shutting down the worker thread pool. */

--- a/packages/sdk/src/relayer/relayer-web.ts
+++ b/packages/sdk/src/relayer/relayer-web.ts
@@ -8,6 +8,7 @@ import type { Address, Hex } from "viem";
 import { ConfigurationError, ZamaError } from "../errors";
 import { IndexedDBStorage } from "../storage/indexeddb-storage";
 import type { GenericStorage } from "../types";
+import { PromiseLock } from "../utils/promise-lock";
 import { RelayerWorkerClient, type WorkerClientConfig } from "../worker/worker.client";
 import { FheArtifactCache } from "./fhe-artifact-cache";
 import type { RelayerSDK } from "./relayer-sdk";
@@ -63,7 +64,7 @@ const CDN_INTEGRITY =
 export class RelayerWeb implements RelayerSDK, Disposable {
   #workerClient: RelayerWorkerClient | null = null;
   #initPromise: Promise<RelayerWorkerClient> | null = null;
-  #ensureLock: Promise<RelayerWorkerClient> | null = null;
+  #ensureLock = new PromiseLock<RelayerWorkerClient>();
   #terminated = false;
   #resolvedChainId: number | null = null;
   #artifactCache: FheArtifactCache | null = null;
@@ -123,16 +124,82 @@ export class RelayerWeb implements RelayerSDK, Disposable {
    * Uses a promise lock to prevent concurrent initialization.
    * Resets on failure to allow retries.
    */
-  async #ensureWorker(): Promise<RelayerWorkerClient> {
-    if (this.#ensureLock) {
-      return this.#ensureLock;
-    }
-    this.#ensureLock = this.#ensureWorkerInner();
-    try {
-      return await this.#ensureLock;
-    } finally {
-      this.#ensureLock = null;
-    }
+  #ensureWorker(): Promise<RelayerWorkerClient> {
+    return this.#ensureLock.run(async () => {
+      // Auto-restart after terminate() — supports React StrictMode's
+      // unmount→remount cycle and HMR without permanently killing the worker.
+      if (this.#terminated) {
+        this.#terminated = false;
+        this.#workerClient = null;
+        this.#initPromise = null;
+        this.#resolvedChainId = null;
+      }
+
+      const chainId = await this.#config.getChainId();
+
+      // Chain changed → tear down old worker, re-init
+      if (this.#resolvedChainId !== null && chainId !== this.#resolvedChainId) {
+        this.#tearDown();
+      }
+
+      this.#resolvedChainId = chainId;
+
+      // Create cache for current chain.
+      // Storage is chain-independent — reuse across chain switches.
+      if (!this.#artifactStorage) {
+        this.#artifactStorage =
+          this.#config.fheArtifactStorage ??
+          new IndexedDBStorage("FheArtifactCache", 1, "artifacts");
+      }
+      if (!this.#artifactCache) {
+        const config = Object.assign({}, DefaultConfigs[chainId], this.#config.transports[chainId]);
+        this.#artifactCache = new FheArtifactCache({
+          storage: this.#artifactStorage,
+          chainId,
+          relayerUrl: config.relayerUrl,
+          ttl: this.#config.fheArtifactCacheTTL,
+          logger: this.#config.logger,
+        });
+      }
+
+      // Revalidate cached artifacts if due — never let revalidation block init
+      if (this.#artifactCache) {
+        let stale = false;
+        try {
+          stale = await this.#artifactCache.revalidateIfDue();
+        } catch (err) {
+          this.#config.logger?.warn(
+            "Artifact revalidation failed, proceeding with potentially stale cache",
+            { error: err instanceof Error ? err.message : String(err) },
+          );
+        }
+        if (stale) {
+          this.#config.logger?.info("Cached FHE artifacts are stale — reinitializing");
+          this.#tearDown();
+        }
+      }
+
+      if (!this.#initPromise) {
+        this.#setStatus("initializing");
+        this.#initPromise = this.#initWorker()
+          .then((client) => {
+            this.#setStatus("ready");
+            return client;
+          })
+          .catch((error) => {
+            this.#initPromise = null;
+            const wrappedError =
+              error instanceof ZamaError
+                ? error
+                : new ConfigurationError("Failed to initialize FHE worker", {
+                    cause: error,
+                  });
+            this.#setStatus("error", wrappedError);
+            throw wrappedError;
+          });
+      }
+      return this.#initPromise;
+    });
   }
 
   #tearDown(): void {
@@ -140,81 +207,6 @@ export class RelayerWeb implements RelayerSDK, Disposable {
     this.#workerClient = null;
     this.#initPromise = null;
     this.#artifactCache = null;
-  }
-
-  async #ensureWorkerInner(): Promise<RelayerWorkerClient> {
-    // Auto-restart after terminate() — supports React StrictMode's
-    // unmount→remount cycle and HMR without permanently killing the worker.
-    if (this.#terminated) {
-      this.#terminated = false;
-      this.#workerClient = null;
-      this.#initPromise = null;
-      this.#resolvedChainId = null;
-    }
-
-    const chainId = await this.#config.getChainId();
-
-    // Chain changed → tear down old worker, re-init
-    if (this.#resolvedChainId !== null && chainId !== this.#resolvedChainId) {
-      this.#tearDown();
-    }
-
-    this.#resolvedChainId = chainId;
-
-    // Create cache for current chain.
-    // Storage is chain-independent — reuse across chain switches.
-    if (!this.#artifactStorage) {
-      this.#artifactStorage =
-        this.#config.fheArtifactStorage ?? new IndexedDBStorage("FheArtifactCache", 1, "artifacts");
-    }
-    if (!this.#artifactCache) {
-      const config = Object.assign({}, DefaultConfigs[chainId], this.#config.transports[chainId]);
-      this.#artifactCache = new FheArtifactCache({
-        storage: this.#artifactStorage,
-        chainId,
-        relayerUrl: config.relayerUrl,
-        ttl: this.#config.fheArtifactCacheTTL,
-        logger: this.#config.logger,
-      });
-    }
-
-    // Revalidate cached artifacts if due — never let revalidation block init
-    if (this.#artifactCache) {
-      let stale = false;
-      try {
-        stale = await this.#artifactCache.revalidateIfDue();
-      } catch (err) {
-        this.#config.logger?.warn(
-          "Artifact revalidation failed, proceeding with potentially stale cache",
-          { error: err instanceof Error ? err.message : String(err) },
-        );
-      }
-      if (stale) {
-        this.#config.logger?.info("Cached FHE artifacts are stale — reinitializing");
-        this.#tearDown();
-      }
-    }
-
-    if (!this.#initPromise) {
-      this.#setStatus("initializing");
-      this.#initPromise = this.#initWorker()
-        .then((client) => {
-          this.#setStatus("ready");
-          return client;
-        })
-        .catch((error) => {
-          this.#initPromise = null;
-          const wrappedError =
-            error instanceof ZamaError
-              ? error
-              : new ConfigurationError("Failed to initialize FHE worker", {
-                  cause: error,
-                });
-          this.#setStatus("error", wrappedError);
-          throw wrappedError;
-        });
-    }
-    return this.#initPromise;
   }
 
   /**
@@ -244,7 +236,7 @@ export class RelayerWeb implements RelayerSDK, Disposable {
       this.#workerClient = null;
     }
     this.#initPromise = null;
-    this.#ensureLock = null;
+    this.#ensureLock.clear();
   }
 
   /** Calls {@link terminate}, shutting down the Web Worker. */

--- a/packages/sdk/src/utils/__tests__/promise-lock.test.ts
+++ b/packages/sdk/src/utils/__tests__/promise-lock.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "../../test-fixtures";
+import { PromiseLock } from "../promise-lock";
+
+describe("PromiseLock", () => {
+  it("runs the function and returns the result", async () => {
+    const lock = new PromiseLock<number>();
+    const result = await lock.run(async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("deduplicates concurrent calls — fn is invoked once", async () => {
+    const lock = new PromiseLock<string>();
+    let resolve!: (v: string) => void;
+    const fn = vi.fn(
+      () =>
+        new Promise<string>((r) => {
+          resolve = r;
+        }),
+    );
+
+    const p1 = lock.run(fn);
+    const p2 = lock.run(fn);
+    const p3 = lock.run(fn);
+
+    resolve("done");
+
+    const results = await Promise.all([p1, p2, p3]);
+    expect(results).toEqual(["done", "done", "done"]);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the lock after the promise resolves", async () => {
+    const lock = new PromiseLock<number>();
+    const fn = vi.fn(async () => 1);
+
+    await lock.run(fn);
+    await lock.run(fn);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the lock after the promise rejects", async () => {
+    const lock = new PromiseLock<number>();
+    const fail = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const succeed = vi.fn(async () => 99);
+
+    await expect(lock.run(fail)).rejects.toThrow("boom");
+
+    const result = await lock.run(succeed);
+    expect(result).toBe(99);
+    expect(succeed).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates the same rejection to all concurrent callers", async () => {
+    const lock = new PromiseLock<void>();
+    let reject!: (e: Error) => void;
+    const fn = vi.fn(
+      () =>
+        new Promise<void>((_, r) => {
+          reject = r;
+        }),
+    );
+
+    const p1 = lock.run(fn);
+    const p2 = lock.run(fn);
+
+    reject(new Error("fail"));
+
+    await expect(p1).rejects.toThrow("fail");
+    await expect(p2).rejects.toThrow("fail");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("clear() drops the in-flight promise", async () => {
+    const lock = new PromiseLock<string>();
+    const fn = vi.fn(
+      () =>
+        new Promise<string>(() => {
+          /* never resolves */
+        }),
+    );
+
+    // Start a call that will hang
+    lock.run(fn);
+    lock.clear();
+
+    // After clear, a new call should invoke fn again
+    lock.run(fn);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("Symbol.dispose calls clear", async () => {
+    const lock = new PromiseLock<string>();
+    const fn = vi.fn(
+      () =>
+        new Promise<string>(() => {
+          /* never resolves */
+        }),
+    );
+
+    lock.run(fn);
+    lock[Symbol.dispose]();
+
+    // After dispose, a new call should invoke fn again
+    lock.run(fn);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -8,3 +8,4 @@ export {
   assertCondition,
   assertNonNullable,
 } from "./assertions";
+export { PromiseLock } from "./promise-lock";

--- a/packages/sdk/src/utils/promise-lock.ts
+++ b/packages/sdk/src/utils/promise-lock.ts
@@ -1,0 +1,39 @@
+/**
+ * Serializes concurrent calls to an async function.
+ * While one call is in-flight, all subsequent callers await
+ * the same promise instead of starting new work.
+ */
+export class PromiseLock<T> {
+  #lock: Promise<T> | null = null;
+
+  /**
+   * Run `fn` if no call is in-flight; otherwise return the existing promise.
+   * The lock is released (success or failure) once the promise settles.
+   */
+  run(fn: () => Promise<T>): Promise<T> {
+    if (this.#lock) {
+      return this.#lock;
+    }
+    this.#lock = fn();
+    return this.#lock.then(
+      (value) => {
+        this.#lock = null;
+        return value;
+      },
+      (error) => {
+        this.#lock = null;
+        throw error;
+      },
+    );
+  }
+
+  /** Force-clear the in-flight promise (e.g. on teardown). */
+  clear(): void {
+    this.#lock = null;
+  }
+
+  /** Calls {@link clear}, enabling `using lock = new PromiseLock()`. */
+  [Symbol.dispose](): void {
+    this.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- Extract the duplicated promise-lock pattern from `RelayerWeb` and `RelayerNode` into a reusable `PromiseLock<T>` utility class
- Implements `Disposable` (`Symbol.dispose`) for use with `using` declarations
- Includes 7 unit tests covering concurrency deduplication, error propagation, cleanup, and dispose

## Test plan
- [x] All 1533 existing unit tests pass
- [x] New `promise-lock.test.ts` tests pass (concurrent dedup, error release, clear, dispose)
- [x] Build succeeds with no type errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)