### PR TITLE
fix(sdk): cap keypairTTL at the fhevm 365-day maximum

### DIFF
--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -1723,7 +1723,7 @@ export const ZERO_HANDLE: "0x000000000000000000000000000000000000000000000000000
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/activity-DTBvolDB.d.ts:2034:3 - (ae-forgotten-export) The symbol "Handle" needs to be exported by the entry point index.d.ts
+// dist/esm/activity-Cxg_KvOg.d.ts:2036:3 - (ae-forgotten-export) The symbol "Handle" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/src/__tests__/zama-sdk.test.ts
+++ b/packages/sdk/src/__tests__/zama-sdk.test.ts
@@ -187,6 +187,58 @@ describe("ZamaSDK", () => {
     expect(clearCachesSpy).toHaveBeenCalledOnce();
   });
 
+  describe("keypairTTL validation", () => {
+    it("throws when keypairTTL is 0", ({ relayer, signer, storage }) => {
+      expect(() => new ZamaSDK({ relayer, signer, storage, keypairTTL: 0 })).toThrow(
+        "keypairTTL must be a positive number (seconds)",
+      );
+    });
+
+    it("throws when keypairTTL is negative", ({ relayer, signer, storage }) => {
+      expect(() => new ZamaSDK({ relayer, signer, storage, keypairTTL: -1 })).toThrow(
+        "keypairTTL must be a positive number (seconds)",
+      );
+    });
+
+    it("accepts keypairTTL exactly at the 365-day maximum without warning", ({
+      relayer,
+      signer,
+      storage,
+    }) => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const MAX = 365 * 86400;
+      const sdk = new ZamaSDK({ relayer, signer, storage, keypairTTL: MAX });
+      expect(sdk.credentials.keypairTTL).toBe(MAX);
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("caps keypairTTL above 365 days and emits a warning", ({ relayer, signer, storage }) => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const MAX = 365 * 86400;
+      const TOO_BIG = MAX + 1;
+      const sdk = new ZamaSDK({ relayer, signer, storage, keypairTTL: TOO_BIG });
+      expect(sdk.credentials.keypairTTL).toBe(MAX);
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0][0]).toContain("keypairTTL");
+      expect(warnSpy.mock.calls[0][0]).toContain("365 days");
+      warnSpy.mockRestore();
+    });
+
+    it("caps keypairTTL: Infinity to the 365-day maximum and emits a warning", ({
+      relayer,
+      signer,
+      storage,
+    }) => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const MAX = 365 * 86400;
+      const sdk = new ZamaSDK({ relayer, signer, storage, keypairTTL: Infinity });
+      expect(sdk.credentials.keypairTTL).toBe(MAX);
+      expect(warnSpy).toHaveBeenCalledOnce();
+      warnSpy.mockRestore();
+    });
+  });
+
   describe("lifecycle auto-revoke", () => {
     it("onDisconnect emits TransactionError when the composed lifecycle callback throws", async ({
       createMockRelayer,

--- a/packages/sdk/src/__tests__/zama-sdk.test.ts
+++ b/packages/sdk/src/__tests__/zama-sdk.test.ts
@@ -200,6 +200,12 @@ describe("ZamaSDK", () => {
       );
     });
 
+    it("throws when keypairTTL is NaN", ({ relayer, signer, storage }) => {
+      expect(() => new ZamaSDK({ relayer, signer, storage, keypairTTL: NaN })).toThrow(
+        "keypairTTL must be a positive number (seconds)",
+      );
+    });
+
     it("accepts keypairTTL exactly at the 365-day maximum without warning", ({
       relayer,
       signer,

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -110,7 +110,7 @@ export class ZamaSDK {
       sessionStorage: this.sessionStorage,
       keypairTTL: (() => {
         const ttl = config.keypairTTL ?? 2592000;
-        if (ttl <= 0) {
+        if (ttl <= 0 || isNaN(ttl)) {
           throw new Error("keypairTTL must be a positive number (seconds)");
         }
         if (ttl > MAX_KEYPAIR_TTL) {

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -11,6 +11,9 @@ import type { GenericSigner, GenericStorage, SignerLifecycleCallbacks } from "./
 import { toError } from "./utils";
 import { WrappersRegistry } from "./wrappers-registry";
 
+/** Maximum keypairTTL accepted by the fhevm ACL contract (365 days, in seconds). */
+const MAX_KEYPAIR_TTL = 365 * 86400; // 31_536_000 s
+
 /** Configuration for {@link ZamaSDK}. */
 export interface ZamaSDKConfig {
   /** FHE relayer backend (`RelayerWeb` for browser, `RelayerNode` for server). */
@@ -29,6 +32,8 @@ export interface ZamaSDKConfig {
    * How long the ML-KEM re-encryption keypair remains valid, in seconds.
    * Default: `2592000` (30 days). Must be a positive number — `0` is rejected
    * because the keypair is required to establish the relayer connection.
+   * Maximum: `31536000` (365 days) — the fhevm contract rejects `durationDays > 365`.
+   * Values above this maximum are automatically capped with a console warning.
    */
   keypairTTL?: number;
   /**
@@ -107,6 +112,13 @@ export class ZamaSDK {
         const ttl = config.keypairTTL ?? 2592000;
         if (ttl <= 0) {
           throw new Error("keypairTTL must be a positive number (seconds)");
+        }
+        if (ttl > MAX_KEYPAIR_TTL) {
+          // oxlint-disable-next-line no-console
+          console.warn(
+            `[zama-sdk] keypairTTL (${ttl}s) exceeds the fhevm maximum of 365 days (${MAX_KEYPAIR_TTL}s); capping to ${MAX_KEYPAIR_TTL}s.`,
+          );
+          return MAX_KEYPAIR_TTL;
         }
         return ttl;
       })(),


### PR DESCRIPTION
  ## Problem                                                                                                                                                                                                      
                                                            
  The fhevm ACL contract rejects any `durationDays > 365`. The SDK converts                                                                                                                                       
  `keypairTTL` to `durationDays = Math.ceil(keypairTTL / 86400)` before sending
  the EIP-712 request — but `keypairTTL` had no upper bound. Passing a value                                                                                                                                      
  above `365 * 86400 s` (or `Infinity`) would produce an invalid on-chain                                                                                                                                         
  request and result in a contract-level rejection with no actionable error                                                                                                                                       
  message for the developer.                                                                                                                                                                                      
                                                                                                                                                                                                                  
  > Note: the Linear ticket references `sessionTTL` as the culprit, but it is                                                                                                                                     
  > `keypairTTL` that maps to `durationDays`. `sessionTTL` only controls local                                                                                                                                    
  > signature caching and never reaches the contract.                                                                                                                                                             
                                                                                                                                                                                                                  
  ## Solution                                                                                                                                                                                                     
                                                                                                                                                                                                                  
  - Cap `keypairTTL` to `31_536_000 s` (365 days) in the `ZamaSDK` constructor,                                                                                                                                   
    silently clamping the value and emitting a `console.warn` — same pattern as
    the existing `sessionTTL > keypairTTL` clamping in `CredentialsManager`.                                                                                                                                      
  - Update the `keypairTTL` TSDoc to document the maximum.                                                                                                                                                        
                                                                                                                                                                                                                  
  ## Tests                                                                                                                                                                                                        
                                                                                                                                                                                                                  
  New `keypairTTL validation` suite in `zama-sdk.test.ts`:                                                                                                                                                        
  - rejects `0` and negative values (existing invariant, now explicitly tested)
  - accepts exactly `365 * 86400` without warning                                                                                                                                                                 
  - caps `> 365 days` to the maximum and emits a warning    
  - caps `Infinity` to the maximum and emits a warning  