### PR TITLE
feat(sdk): add generic Batcher utility

### DIFF
--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -565,6 +565,12 @@ export interface BatchDecryptOptions {
 }
 
 // @public
+export class Batcher {
+    constructor(batchSize: number);
+    execute<TItem, TResult>(items: TItem[], fn: (accumulated: TItem[]) => Promise<TResult>): Promise<TResult>;
+}
+
+// @public
 export interface BatchTransferData {
     // (undocumented)
     encryptedAmount: Handle;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -94,6 +94,7 @@ export type {
   TransferCallbacks,
   TransferOptions,
 } from "./types";
+export { Batcher } from "./utils";
 export type { Address, Hex } from "viem";
 export { ZamaSDKEvents } from "./events";
 export type {

--- a/packages/sdk/src/utils/__tests__/batcher.test.ts
+++ b/packages/sdk/src/utils/__tests__/batcher.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from "../../test-fixtures";
+import { Batcher } from "../batcher";
+
+describe("Batcher", () => {
+  it("calls fn once when items fit in a single batch", async () => {
+    const batcher = new Batcher(10);
+    const fn = vi.fn().mockResolvedValue("result");
+
+    const result = await batcher.execute([1, 2, 3], fn);
+
+    expect(fn).toHaveBeenCalledOnce();
+    expect(fn).toHaveBeenCalledWith([1, 2, 3]);
+    expect(result).toBe("result");
+  });
+
+  it("calls fn once when items are exactly the batch size", async () => {
+    const batcher = new Batcher(3);
+    const fn = vi.fn().mockResolvedValue("result");
+
+    await batcher.execute([1, 2, 3], fn);
+
+    expect(fn).toHaveBeenCalledOnce();
+    expect(fn).toHaveBeenCalledWith([1, 2, 3]);
+  });
+
+  it("chunks into multiple batches with accumulated items", async () => {
+    const batcher = new Batcher(3);
+    const fn = vi.fn().mockResolvedValue("result");
+
+    await batcher.execute([1, 2, 3, 4, 5, 6, 7], fn);
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(fn.mock.calls[0]![0]).toEqual([1, 2, 3]);
+    expect(fn.mock.calls[1]![0]).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(fn.mock.calls[2]![0]).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it("calls batches sequentially", async () => {
+    const batcher = new Batcher(2);
+    const callOrder: number[] = [];
+    const fn = vi.fn().mockImplementation(async (items: number[]) => {
+      callOrder.push(items.length);
+    });
+
+    await batcher.execute([1, 2, 3, 4, 5], fn);
+
+    expect(callOrder).toEqual([2, 4, 5]);
+  });
+
+  it("throws when given an empty array", async () => {
+    const batcher = new Batcher(10);
+    const fn = vi.fn();
+
+    await expect(batcher.execute([], fn)).rejects.toThrow("At least one item is required");
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("throws when batchSize is less than 1", () => {
+    expect(() => new Batcher(0)).toThrow("batchSize must be at least 1");
+    expect(() => new Batcher(-1)).toThrow("batchSize must be at least 1");
+  });
+
+  it("propagates errors from the callback", async () => {
+    const batcher = new Batcher(10);
+    const fn = vi.fn().mockRejectedValue(new Error("boom"));
+
+    await expect(batcher.execute([1], fn)).rejects.toThrow("boom");
+  });
+
+  it("stops on first batch failure", async () => {
+    const batcher = new Batcher(2);
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce("ok")
+      .mockRejectedValueOnce(new Error("batch 2 failed"));
+
+    await expect(batcher.execute([1, 2, 3, 4, 5], fn)).rejects.toThrow("batch 2 failed");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the result of the final batch", async () => {
+    const batcher = new Batcher(2);
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce("first")
+      .mockResolvedValueOnce("second")
+      .mockResolvedValueOnce("final");
+
+    const result = await batcher.execute([1, 2, 3, 4, 5], fn);
+
+    expect(result).toBe("final");
+  });
+
+  it("does not mutate the accumulated array between calls", async () => {
+    const batcher = new Batcher(2);
+    const captured: number[][] = [];
+    const fn = vi.fn().mockImplementation(async (items: number[]) => {
+      captured.push(items);
+    });
+
+    await batcher.execute([1, 2, 3], fn);
+
+    // Each captured array should be independent
+    expect(captured[0]).toEqual([1, 2]);
+    expect(captured[1]).toEqual([1, 2, 3]);
+    captured[0]!.push(99);
+    expect(captured[1]).toEqual([1, 2, 3]); // not affected
+  });
+});

--- a/packages/sdk/src/utils/batcher.ts
+++ b/packages/sdk/src/utils/batcher.ts
@@ -1,0 +1,58 @@
+/**
+ * Batches items to work around per-call size limits (e.g. ACL contract's
+ * 10-address cap on `allow`).
+ *
+ * Calls the provided function sequentially with accumulated slices:
+ * batch 1 receives items 0..N, batch 2 receives items 0..2N, etc.
+ * This is necessary when each call must cover the full set processed so far
+ * (e.g. EIP-712 signatures that enumerate every authorized contract).
+ *
+ * @typeParam TItem - The item type being batched.
+ * @typeParam TResult - The return type of each batch call.
+ *
+ * @example
+ * ```ts
+ * const batcher = new Batcher(10);
+ *
+ * // With CredentialsManager
+ * const creds = await batcher.execute(addresses, (addrs) => credentials.allow(...addrs));
+ *
+ * // With DelegatedCredentialsManager
+ * const creds = await batcher.execute(addresses, (addrs) => delegated.allow(delegator, ...addrs));
+ * ```
+ */
+export class Batcher {
+  #batchSize: number;
+
+  constructor(batchSize: number) {
+    if (batchSize < 1) {
+      throw new Error("batchSize must be at least 1");
+    }
+    this.#batchSize = batchSize;
+  }
+
+  /**
+   * Process items in batches, passing accumulated items to the callback.
+   *
+   * @returns The result of the final callback invocation.
+   */
+  async execute<TItem, TResult>(
+    items: TItem[],
+    fn: (accumulated: TItem[]) => Promise<TResult>,
+  ): Promise<TResult> {
+    if (items.length === 0) {
+      throw new Error("At least one item is required");
+    }
+
+    let result!: TResult;
+    const accumulated: TItem[] = [];
+
+    for (let i = 0; i < items.length; i += this.#batchSize) {
+      const batch = items.slice(i, i + this.#batchSize);
+      accumulated.push(...batch);
+      result = await fn([...accumulated]);
+    }
+
+    return result;
+  }
+}

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { Batcher } from "./batcher";
 export { toError, isContractCallError } from "./error";
 export { prefixHex, unprefixHex } from "./hex";
 export {


### PR DESCRIPTION
## Summary
- Adds a generic `Batcher` class that chunks items into sequential batches with accumulated slices
- Handles per-call size limits (e.g. ACL contract's 10-address cap on `allow`)
- Exported from `@zama-fhe/sdk`

## Test plan
- [x] Unit tests cover single batch, multi-batch, sequential ordering, error propagation, and edge cases (10 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)