### PR TITLE
test(sdk): prevent contract address loss in concurrent allow() calls

### DIFF
--- a/packages/sdk/src/credentials/credentials-manager-base.ts
+++ b/packages/sdk/src/credentials/credentials-manager-base.ts
@@ -92,6 +92,9 @@ export abstract class BaseCredentialsManager<
   #createPromise: Promise<TCreds> | null = null;
   #createPromiseKey: string | null = null;
   #extendPromise: Promise<TCreds> | null = null;
+  /** Last successfully resolved extension result, used to recover from the race where a
+   * concurrent call enters #extendContracts after #extendPromise was already cleared. */
+  #lastExtendResult: TCreds | null = null;
 
   constructor(config: CredentialsConfig) {
     this.signer = config.signer;
@@ -312,6 +315,7 @@ export abstract class BaseCredentialsManager<
   /** Override to also clear subclass-specific caches (e.g. key cache). */
   protected clearCaches(): void {
     this.crypto.clearCache();
+    this.#lastExtendResult = null;
   }
 
   // ── Credential creation helper ────────────────────────────────
@@ -366,6 +370,19 @@ export abstract class BaseCredentialsManager<
         return previous;
       }
       credentials = previous;
+    } else if (this.#lastExtendResult) {
+      // A concurrent extension may have resolved and cleared #extendPromise before
+      // this call entered. Use the last known result as the base to avoid dropping
+      // contract addresses merged by the just-completed extension.
+      const last = this.#lastExtendResult;
+      if (coversContracts(last.contractAddresses, requiredContracts)) {
+        this.emit({
+          type: ZamaSDKEvents.CredentialsAllowed,
+          contractAddresses: requiredContracts,
+        });
+        return last;
+      }
+      credentials = last;
     }
 
     const promise = this.#extendCredentials({
@@ -375,7 +392,9 @@ export abstract class BaseCredentialsManager<
     });
     this.#extendPromise = promise;
     try {
-      return await promise;
+      const result = await promise;
+      this.#lastExtendResult = result;
+      return result;
     } finally {
       if (this.#extendPromise === promise) {
         this.#extendPromise = null;


### PR DESCRIPTION
  ## Problem                                                                                                                                                                                                      
                                                                                                                                                                                                                  
  When two `allow()` calls were fired concurrently (e.g. via `Promise.all`),                                                                                                                                      
  a race condition in `#extendContracts` could silently drop contract addresses.
                                                                                                                                                                                                                  
  **Root cause:** both calls read the same stale credentials snapshot from                                                                                                                                        
  storage, then raced through `#extendContracts`. If the second call entered                                                                                                                                      
  `#extendContracts` *after* the first had already resolved and cleared                                                                                                                                           
  `#extendPromise`, it saw `#extendPromise = null` and extended from the stale                                                                                                                                    
  snapshot — unaware of the contracts merged by the first call.
                                                                                                                                                                                                                  
  Example:                                                  
```
  await allow(TOKEN_A);                          // base: [A]                                                                                                                                                     
  await Promise.all([                                                                                                                                                                                             
    allow(TOKEN_A, TOKEN_B),                     // extends [A] → [A, B]
    allow(TOKEN_A, TOKEN_C),                     // race: extends [A] → [A, C]  ← B dropped                                                                                                                       
  ]);                                                                                                                                                                                                             
```                                                                                                                                                                                                                  
  ## Fix                                                                                                                                                                                                          
                                                                                                                                                                                                                  
  Track `#lastExtendResult` alongside `#extendPromise`. When a call enters                                                                                                                                        
  `#extendContracts` and finds `#extendPromise = null`, it falls back to
  `#lastExtendResult` as the extension base instead of the stale snapshot.                                                                                                                                        
  If the last result already covers all required contracts, it is returned                                                                                                                                        
  directly. The field is cleared in `clearCaches()`, so `clear()` and                                                                                                                                             
  `revoke()` invalidate it correctly.                                                                                                                                                                             
                                                                                                                                                                                                                  
  ## Test                                                                                                                                                                                                         
                                                            
  The existing test `concurrent extensions don't drop contract addresses` in                                                                                                                                      
  `credentials-manager.test.ts` covers this exact scenario — it was the
  test that exposed the flaky failure in CI. 