### PR TITLE
ci(api): use base branch ref for API report diff

### DIFF
--- a/.github/workflows/api-report.yml
+++ b/.github/workflows/api-report.yml
@@ -40,12 +40,12 @@ jobs:
       - name: Extract base branch reports
         if: github.event_name == 'pull_request'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           mkdir -p /tmp/api-reports/base
-          git fetch --depth=1 origin "$BASE_SHA"
-          for f in $(git ls-tree -r --name-only "$BASE_SHA" -- packages/sdk/etc packages/react-sdk/etc 2>/dev/null | grep '\.api\.md$'); do
-            git show "$BASE_SHA:$f" > "/tmp/api-reports/base/$(basename "$f")" 2>/dev/null || true
+          git fetch --depth=1 origin "$BASE_REF"
+          for f in $(git ls-tree -r --name-only "origin/$BASE_REF" -- packages/sdk/etc packages/react-sdk/etc 2>/dev/null | grep '\.api\.md$'); do
+            git show "origin/$BASE_REF:$f" > "/tmp/api-reports/base/$(basename "$f")" 2>/dev/null || true
           done
 
       - name: Generate API diff


### PR DESCRIPTION
## Summary
- The API report diff comment compared against the wrong base when PRs target `prerelease`
- `github.event.pull_request.base.sha` resolves to the merge-base (often a `main` commit), not the target branch tip
- Switched to `base.ref` to fetch the actual target branch, producing an accurate diff
- Observed on PR #216 where the diff showed all of PR #191's Zaiffer removals as "new changes" despite targeting `prerelease` which already had them

## Test plan
- [ ] Open a PR targeting `prerelease` and verify the API report comment shows only the PR's own changes
- [ ] Open a PR targeting `main` and verify it still works correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)