### PR TITLE
build: add exports ./package.json subpath and default condition

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -15,12 +15,15 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./wagmi": {
       "types": "./dist/wagmi/index.d.ts",
-      "import": "./dist/wagmi/index.js"
-    }
+      "import": "./dist/wagmi/index.js",
+      "default": "./dist/wagmi/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -23,7 +23,9 @@
       "import": "./dist/wagmi/index.js",
       "default": "./dist/wagmi/index.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": {
+      "default": "./package.json"
+    }
   },
   "files": [
     "dist",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -74,7 +74,8 @@
         "default": "./dist/esm/node/index.js"
       },
       "default": "./dist/esm/node/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -75,7 +75,9 @@
       },
       "default": "./dist/esm/node/index.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": {
+      "default": "./package.json"
+    }
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
Adding `"./package.json": "./package.json"` to the `exports` field of both packages. This is a standard practice for npm packages with strict exports — many tools in the ecosystem (bundlers, test frameworks, meta-frameworks) need to read a package's `package.json` at runtime via `require.resolve(pkg + '/package.json')`, which fails when the subpath isn't explicitly exported.

Also adds a `default` condition to `react-sdk` export entries. Without it, CJS resolution (`require.resolve`) can't find the main entry point since only `types` and `import` conditions were defined. The `sdk` package already had `import`/`require`/`default` on all entries.

**Concrete example:** Storybook 10's `sb.mock()` automocking system calls `require.resolve('@zama-fhe/react-sdk/package.json')` during test setup. Without these changes, the entire Storybook Vitest test runner crashes at startup with `Package subpath './package.json' is not defined by "exports"`.