### PR TITLE
ci: use pnpm for npm 11 install — bundled npm is broken

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -48,7 +48,9 @@ jobs:
           npm_v="$(npm --version)"
           if [[ "${npm_v%%.*}" -lt 11 ]]; then
             echo "Bundled npm ${npm_v} is too old; installing npm 11"
-            npm i -g npm@^11
+            pnpm add -g npm@^11
+            echo "$(pnpm bin -g)" >> "$GITHUB_PATH"
+            export PATH="$(pnpm bin -g):$PATH"
           fi
           echo "npm $(npm --version)"
           [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -43,10 +43,17 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: Ensure npm 11
+      - name: Ensure npm >=11
         run: |
-          pnpm add -g npm@^11
-          npm --version
+          npm_v="$(npm --version)"
+          if [[ "${npm_v%%.*}" -lt 11 ]]; then
+            echo "Bundled npm ${npm_v} is too old; installing npm 11"
+            pnpm add -g npm@^11
+            echo "$(pnpm bin -g)" >> "$GITHUB_PATH"
+            export PATH="$(pnpm bin -g):$PATH"
+          fi
+          echo "npm $(npm --version)"
+          [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,9 @@ jobs:
           npm_v="$(npm --version)"
           if [[ "${npm_v%%.*}" -lt 11 ]]; then
             echo "Bundled npm ${npm_v} is too old; installing npm 11"
-            npm i -g npm@^11
+            pnpm add -g npm@^11
+            echo "$(pnpm bin -g)" >> "$GITHUB_PATH"
+            export PATH="$(pnpm bin -g):$PATH"
           fi
           echo "npm $(npm --version)"
           [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]


### PR DESCRIPTION
Closes SDK-88

## Summary

Follow-up to #240. The `npm i -g npm@^11` approach merged in #240 fails because Node 22.22.2's bundled npm 10.9.7 is still broken on GitHub Actions runners (missing `promise-retry` module) — it can't even self-upgrade.

Switches to `pnpm add -g npm@^11` (pnpm is already installed and doesn't depend on the broken bundled npm) and adds `$(pnpm bin -g)` to `$GITHUB_PATH` so subsequent steps resolve to the working npm 11. The version assertion at the end catches any regression.

## Test plan

- [ ] Release workflow passes the "Ensure npm >=11" step
- [ ] npm publish succeeds with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)