### PR TITLE
docs: address review feedback on SDK-70 (aliases, JSDoc, example)

### DIFF
--- a/packages/react-sdk/src/unwrap/use-finalize-unwrap.ts
+++ b/packages/react-sdk/src/unwrap/use-finalize-unwrap.ts
@@ -25,7 +25,12 @@ import { useToken, type UseZamaConfig } from "../token/use-token";
  * @example
  * ```tsx
  * const finalize = useFinalizeUnwrap({ tokenAddress: "0x..." });
- * finalize.mutate({ unwrapRequestId: event.unwrapRequestId ?? event.encryptedAmount });
+ * const event = findUnwrapRequested(receipt.logs);
+ * // Pass unwrapRequestId from upgraded events, or fall back to encryptedAmount for legacy ones.
+ * finalize.mutate({
+ *   unwrapRequestId: event.unwrapRequestId,
+ *   burnAmountHandle: event.encryptedAmount,
+ * });
  * ```
  */
 export function useFinalizeUnwrap(

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -633,7 +633,7 @@ Individual topic hashes are accessible via the `Topics` object: `Topics.Confiden
 | `decodeWrapped(log)`              | `WrappedEvent \| null` — `{ to, amountIn }`                                                                 |
 | `decodeUnwrapRequested(log)`      | `UnwrapRequestedEvent \| null` — `{ receiver, encryptedAmount, unwrapRequestId? }`                          |
 | `decodeUnwrapFinalized(log)`      | `UnwrapFinalizedEvent \| null` — `{ receiver, encryptedAmount, cleartextAmount, unwrapRequestId? }`         |
-| `decodeUnwrappedFinalized(log)`   | Deprecated alias for `decodeUnwrapFinalized(log)`                                                           |
+| `decodeUnwrappedFinalized(log)`   | **Deprecated.** Like `decodeUnwrapFinalized(log)` but always returns `eventName: "UnwrappedFinalized"` — not a transparent alias. Update switch statements to use `decodeUnwrapFinalized` and `"UnwrapFinalized"` instead. |
 | `decodeUnwrappedStarted(log)`     | `UnwrappedStartedEvent \| null` — `{ returnVal, requestId, txId, to, refund, requestedAmount, burnAmount }` |
 | `decodeOnChainEvent(log)`         | `OnChainEvent \| null` — tries all decoders                                                                 |
 | `decodeOnChainEvents(logs)`       | `OnChainEvent[]` — batch decode, skips unrecognized logs                                                    |

--- a/packages/sdk/src/token/pending-unshield.ts
+++ b/packages/sdk/src/token/pending-unshield.ts
@@ -5,8 +5,19 @@ import type { Handle } from "../relayer/relayer-sdk.types";
 const STORAGE_PREFIX = "zama:pending-unshield:";
 const CURRENT_VERSION = 1;
 
+/**
+ * Persisted state for an in-progress unshield request.
+ * Used to resume an interrupted unshield after page reload.
+ */
 export interface PendingUnshieldRequest {
+  /** Transaction hash of the original unwrap call. */
   readonly unwrapTxHash: Hex;
+  /**
+   * Request identifier emitted by upgraded wrapper contracts.
+   * Present only for requests initiated after the protocol upgrade.
+   * When defined, pass this as `unwrapRequestId` to `finalizeUnwrap`.
+   * When absent (legacy request), pass the `encryptedAmount` from the `UnwrapRequested` event.
+   */
   readonly unwrapRequestId?: Handle;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #239. Addresses three documentation findings from the PR review.

- **`packages/sdk/README.md`** — `decodeUnwrappedFinalized` was listed as a "deprecated alias for `decodeUnwrapFinalized`", implying a transparent substitution. It is not: it always returns `eventName: "UnwrappedFinalized"` while the canonical decoder returns `"UnwrapFinalized"`. Clarified the description so switch-statement consumers know they cannot swap them blindly.

- **`packages/sdk/src/token/pending-unshield.ts`** — `PendingUnshieldRequest` was exported `@public (undocumented)` with no JSDoc on any field. Added interface-level and field-level JSDoc, including guidance on when `unwrapRequestId` is present and how to use it with `finalizeUnwrap`.

- **`packages/react-sdk/src/unwrap/use-finalize-unwrap.ts`** — The `@example` was passing `encryptedAmount` as `unwrapRequestId` for legacy events (`event.unwrapRequestId ?? event.encryptedAmount`), which is semantically wrong even though it works at runtime. Updated to pass each value in its correct field (`unwrapRequestId` / `burnAmountHandle`), matching the intent of `FinalizeUnwrapParams`.

## Test plan

- [ ] No behaviour changes — documentation only
- [ ] Confirm `decodeUnwrappedFinalized` description is accurate and actionable
- [ ] Confirm `PendingUnshieldRequest` JSDoc renders correctly in IDE hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)