### PR TITLE
feat(examples): update all examples with SDK 2.5.0-alpha.5 features

### DIFF
--- a/examples/example-hoodi/package.json
+++ b/examples/example-hoodi/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "2.2.0-alpha.4",
-    "@zama-fhe/sdk": "2.2.0-alpha.4",
+    "@zama-fhe/react-sdk": "2.5.0-alpha.5",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "ethers": "^6.13.0",
     "next": "^16.0.0",
     "react": "^19.2.0",

--- a/examples/example-hoodi/src/app/page.tsx
+++ b/examples/example-hoodi/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
   useAllow,
   useListPairs,
   useZamaSDK,
+  useTotalSupply,
   balanceOfContract,
 } from "@zama-fhe/react-sdk";
 import type { TokenWrapperPair, TokenWrapperPairWithMetadata } from "@zama-fhe/sdk";
@@ -291,11 +292,14 @@ export default function Home() {
   const refreshBalances = () => {
     queryClient.invalidateQueries({ queryKey: erc20BalanceKey });
     queryClient.invalidateQueries({ queryKey: ethBalanceKey });
-    // Invalidate the encrypted handle so useConfidentialBalance re-polls after
-    // any operation that changes the confidential balance (shield, unshield, transfer).
+    // Invalidate the confidential balance so useConfidentialBalance re-decrypts after
+    // any operation that changes the balance (shield, unshield, transfer).
     if (token) {
       queryClient.invalidateQueries({
-        queryKey: zamaQueryKeys.confidentialHandle.token(token.confidentialTokenAddress),
+        queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
+      });
+      queryClient.invalidateQueries({
+        queryKey: zamaQueryKeys.totalSupply.token(token.confidentialTokenAddress),
       });
     }
   };
@@ -335,6 +339,13 @@ export default function Home() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [address]);
 
+  // Fetch the inferred plaintext total supply for the selected confidential token.
+  // This is a public on-chain read — no credentials are required.
+  const { data: totalSupply } = useTotalSupply(
+    token?.confidentialTokenAddress ?? ZERO_ADDRESS,
+    { enabled: !!token },
+  );
+
   // Guard on token too: if balance resolves before the registry, decimals defaults to 0
   // and symbol to "" — the raw integer would be displayed without unit or decimal conversion.
   const formattedErc20 =
@@ -344,6 +355,10 @@ export default function Home() {
   const formattedConfidential =
     balance.data !== undefined && token
       ? `${formatUnits(balance.data, decimals)} ${confidentialSymbol}`
+      : "—";
+  const formattedTotalSupply =
+    totalSupply !== undefined && token
+      ? `${formatUnits(totalSupply, decimals)} ${confidentialSymbol}`
       : "—";
 
   // Actions are disabled until the registry has loaded a valid token pair
@@ -452,6 +467,7 @@ export default function Home() {
       <BalancesCard
         formattedErc20={formattedErc20}
         formattedConfidential={formattedConfidential}
+        formattedTotalSupply={formattedTotalSupply}
         // handleQuery.isLoading: fetching the encrypted handle from chain (Phase 1).
         // balance.isLoading: decrypting it via RelayerCleartext (Phase 2).
         isLoadingConfidential={balance.handleQuery.isLoading || balance.isLoading}

--- a/examples/example-hoodi/src/components/BalancesCard.tsx
+++ b/examples/example-hoodi/src/components/BalancesCard.tsx
@@ -5,6 +5,7 @@ import { HOODI_EXPLORER_URL } from "@/lib/config";
 interface BalancesCardProps {
   formattedErc20: string;
   formattedConfidential: string;
+  formattedTotalSupply: string;
   isLoadingConfidential: boolean;
   erc20Symbol: string;
   onMint: () => void;
@@ -23,6 +24,7 @@ interface BalancesCardProps {
 export function BalancesCard({
   formattedErc20,
   formattedConfidential,
+  formattedTotalSupply,
   isLoadingConfidential,
   erc20Symbol,
   onMint,
@@ -69,6 +71,10 @@ export function BalancesCard({
             {isLoadingConfidential ? <i>Decrypting…</i> : formattedConfidential}
           </span>
         )}
+      </div>
+      <div className="balance-row">
+        <span className="balance-label">Total Supply (inferred)</span>
+        <span className="balance-value">{formattedTotalSupply}</span>
       </div>
       {decryptError && <div className="alert alert-error card-status">{decryptError}</div>}
       {mintError && <div className="alert alert-error card-status">{mintError}</div>}

--- a/examples/node-ethers/package.json
+++ b/examples/node-ethers/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@zama-fhe/sdk": "2.2.0-alpha.6",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "ethers": "^6.13.0"
   },
   "devDependencies": {

--- a/examples/node-ethers/src/index.ts
+++ b/examples/node-ethers/src/index.ts
@@ -1,8 +1,15 @@
 import { Contract, formatUnits, JsonRpcProvider, Wallet } from "ethers";
-import { DelegationNotPropagatedError, MemoryStorage, SepoliaConfig, ZamaSDK } from "@zama-fhe/sdk";
+import {
+  DelegationNotPropagatedError,
+  MemoryStorage,
+  SepoliaConfig,
+  ZamaSDK,
+  inferredTotalSupplyContract,
+  confidentialBalanceOfContract,
+} from "@zama-fhe/sdk";
 import { EthersSigner } from "@zama-fhe/sdk/ethers";
 import { RelayerNode } from "@zama-fhe/sdk/node";
-import type { Address } from "@zama-fhe/sdk";
+import type { Address, Handle } from "@zama-fhe/sdk";
 
 // ── Token amounts (USDT uses 6 decimals) ─────────────────────────────────────
 const DECIMALS = 6n;
@@ -230,6 +237,47 @@ async function main() {
     delegateAddress: walletB.address as Address,
   });
   console.log("Delegation active after revoke:", isDelegatedAfter);
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // SECTION 5 — Low-Level SDK Primitives
+  // The Token abstraction (used above) delegates to these lower-level methods
+  // internally. Use them directly when working with raw handles or when you
+  // need the decryption proof for on-chain finalization.
+  // ──────────────────────────────────────────────────────────────────────────
+  section("SECTION 5 — Low-Level SDK Primitives");
+
+  // 5a. Inferred total supply — reads the plaintext total supply from the wrapper.
+  // inferredTotalSupplyContract() is a contract call builder: it returns the
+  // { address, abi, functionName, args } config for signer.readContract().
+  console.log("── 5a. Inferred total supply ──");
+  const totalSupply = (await signerA.readContract(
+    inferredTotalSupplyContract(confidentialTokenAddress),
+  )) as bigint;
+  console.log("Inferred total supply:", fmt(totalSupply));
+
+  // 5b. sdk.userDecrypt() — decrypt raw FHE handles with user credentials.
+  // Token.balanceOf() calls this internally; here we show the explicit flow:
+  //   1. Read the encrypted handle from the contract
+  //   2. Decrypt it via the relayer using signed credentials
+  console.log("\n── 5b. sdk.userDecrypt() ──");
+  const handle = (await signerA.readContract(
+    confidentialBalanceOfContract(confidentialTokenAddress, walletA.address as Address),
+  )) as Handle;
+  console.log("Encrypted handle:", handle);
+
+  const decryptedValues = await sdkA.userDecrypt([
+    { handle, contractAddress: confidentialTokenAddress },
+  ]);
+  console.log("Decrypted balance:", fmt(decryptedValues[handle] as bigint));
+
+  // 5c. sdk.publicDecrypt() — decrypt without user credentials.
+  // Returns the decryption proof alongside clear values, which is needed for
+  // on-chain finalization (e.g. finalizeUnwrap in the unshield flow).
+  // No EIP-712 signature is required — any party can call this.
+  console.log("\n── 5c. sdk.publicDecrypt() ──");
+  const { clearValues, decryptionProof } = await sdkA.publicDecrypt([handle]);
+  console.log("Public-decrypted balance:", fmt(clearValues[handle] as bigint));
+  console.log("Decryption proof:", decryptionProof.slice(0, 20) + "…");
 }
 
 main().catch((err) => {

--- a/examples/node-viem/package.json
+++ b/examples/node-viem/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@zama-fhe/sdk": "2.2.0-alpha.6",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "viem": "^2.30.0"
   },
   "devDependencies": {

--- a/examples/node-viem/src/index.ts
+++ b/examples/node-viem/src/index.ts
@@ -1,10 +1,16 @@
 import { createPublicClient, createWalletClient, formatUnits, http, parseAbi } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
-import { DelegationNotPropagatedError, MemoryStorage, ZamaSDK } from "@zama-fhe/sdk";
+import {
+  DelegationNotPropagatedError,
+  MemoryStorage,
+  ZamaSDK,
+  inferredTotalSupplyContract,
+  confidentialBalanceOfContract,
+} from "@zama-fhe/sdk";
 import { ViemSigner } from "@zama-fhe/sdk/viem";
 import { RelayerNode } from "@zama-fhe/sdk/node";
-import type { Address } from "@zama-fhe/sdk";
+import type { Address, Handle } from "@zama-fhe/sdk";
 
 // ── Token amounts (USDT uses 6 decimals) ─────────────────────────────────────
 const DECIMALS = 6n;
@@ -256,6 +262,47 @@ async function main() {
     delegateAddress: accountB.address as Address,
   });
   console.log("Delegation active after revoke:", isDelegatedAfter);
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // SECTION 5 — Low-Level SDK Primitives
+  // The Token abstraction (used above) delegates to these lower-level methods
+  // internally. Use them directly when working with raw handles or when you
+  // need the decryption proof for on-chain finalization.
+  // ──────────────────────────────────────────────────────────────────────────
+  section("SECTION 5 — Low-Level SDK Primitives");
+
+  // 5a. Inferred total supply — reads the plaintext total supply from the wrapper.
+  // inferredTotalSupplyContract() is a contract call builder: it returns the
+  // { address, abi, functionName, args } config for signer.readContract().
+  console.log("── 5a. Inferred total supply ──");
+  const totalSupply = (await signerA.readContract(
+    inferredTotalSupplyContract(confidentialTokenAddress),
+  )) as bigint;
+  console.log("Inferred total supply:", fmt(totalSupply));
+
+  // 5b. sdk.userDecrypt() — decrypt raw FHE handles with user credentials.
+  // Token.balanceOf() calls this internally; here we show the explicit flow:
+  //   1. Read the encrypted handle from the contract
+  //   2. Decrypt it via the relayer using signed credentials
+  console.log("\n── 5b. sdk.userDecrypt() ──");
+  const handle = (await signerA.readContract(
+    confidentialBalanceOfContract(confidentialTokenAddress, accountA.address as Address),
+  )) as Handle;
+  console.log("Encrypted handle:", handle);
+
+  const decryptedValues = await sdkA.userDecrypt([
+    { handle, contractAddress: confidentialTokenAddress },
+  ]);
+  console.log("Decrypted balance:", fmt(decryptedValues[handle] as bigint));
+
+  // 5c. sdk.publicDecrypt() — decrypt without user credentials.
+  // Returns the decryption proof alongside clear values, which is needed for
+  // on-chain finalization (e.g. finalizeUnwrap in the unshield flow).
+  // No EIP-712 signature is required — any party can call this.
+  console.log("\n── 5c. sdk.publicDecrypt() ──");
+  const { clearValues, decryptionProof } = await sdkA.publicDecrypt([handle]);
+  console.log("Public-decrypted balance:", fmt(clearValues[handle] as bigint));
+  console.log("Decryption proof:", decryptionProof.slice(0, 20) + "…");
 }
 
 main().catch((err) => {

--- a/examples/react-ethers/package.json
+++ b/examples/react-ethers/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "2.2.0-alpha.2",
-    "@zama-fhe/sdk": "2.2.0-alpha.2",
+    "@zama-fhe/react-sdk": "2.5.0-alpha.5",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "ethers": "^6.13.0",
     "next": "^16.2.3",
     "react": "^19.2.0",

--- a/examples/react-ethers/src/app/page.tsx
+++ b/examples/react-ethers/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
   useAllow,
   useListPairs,
   useZamaSDK,
+  useTotalSupply,
   balanceOfContract,
 } from "@zama-fhe/react-sdk";
 import type { TokenWrapperPair, TokenWrapperPairWithMetadata } from "@zama-fhe/sdk";
@@ -284,11 +285,14 @@ export default function Home() {
   const refreshBalances = () => {
     queryClient.invalidateQueries({ queryKey: erc20BalanceKey });
     queryClient.invalidateQueries({ queryKey: ethBalanceKey });
-    // Invalidate the encrypted handle so useConfidentialBalance re-polls after
-    // any operation that changes the confidential balance (shield, unshield, transfer).
+    // Invalidate the confidential balance so useConfidentialBalance re-decrypts after
+    // any operation that changes the balance (shield, unshield, transfer).
     if (token) {
       queryClient.invalidateQueries({
-        queryKey: zamaQueryKeys.confidentialHandle.token(token.confidentialTokenAddress),
+        queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
+      });
+      queryClient.invalidateQueries({
+        queryKey: zamaQueryKeys.totalSupply.token(token.confidentialTokenAddress),
       });
     }
   };
@@ -328,6 +332,13 @@ export default function Home() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [address]);
 
+  // Fetch the inferred plaintext total supply for the selected confidential token.
+  // This is a public on-chain read — no credentials are required.
+  const { data: totalSupply } = useTotalSupply(
+    token?.confidentialTokenAddress ?? ZERO_ADDRESS,
+    { enabled: !!token },
+  );
+
   // Guard on token too: if balance resolves before the registry, decimals defaults to 0
   // and symbol to "" — the raw integer would be displayed without unit or decimal conversion.
   const formattedErc20 =
@@ -337,6 +348,10 @@ export default function Home() {
   const formattedConfidential =
     balance.data !== undefined && token
       ? `${formatUnits(balance.data, decimals)} ${confidentialSymbol}`
+      : "—";
+  const formattedTotalSupply =
+    totalSupply !== undefined && token
+      ? `${formatUnits(totalSupply, decimals)} ${confidentialSymbol}`
       : "—";
 
   // Actions are disabled until the registry has loaded a valid token pair
@@ -443,6 +458,7 @@ export default function Home() {
       <BalancesCard
         formattedErc20={formattedErc20}
         formattedConfidential={formattedConfidential}
+        formattedTotalSupply={formattedTotalSupply}
         // handleQuery.isLoading: fetching the encrypted handle from chain (Phase 1).
         // balance.isLoading: decrypting it via RelayerWeb (Phase 2).
         isLoadingConfidential={balance.handleQuery.isLoading || balance.isLoading}

--- a/examples/react-ethers/src/components/BalancesCard.tsx
+++ b/examples/react-ethers/src/components/BalancesCard.tsx
@@ -5,6 +5,7 @@ import { SEPOLIA_EXPLORER_URL } from "@/lib/config";
 interface BalancesCardProps {
   formattedErc20: string;
   formattedConfidential: string;
+  formattedTotalSupply: string;
   isLoadingConfidential: boolean;
   erc20Symbol: string;
   onMint: () => void;
@@ -21,6 +22,7 @@ interface BalancesCardProps {
 export function BalancesCard({
   formattedErc20,
   formattedConfidential,
+  formattedTotalSupply,
   isLoadingConfidential,
   erc20Symbol,
   onMint,
@@ -66,6 +68,10 @@ export function BalancesCard({
             {isLoadingConfidential ? <i>Decrypting…</i> : formattedConfidential}
           </span>
         )}
+      </div>
+      <div className="balance-row">
+        <span className="balance-label">Total Supply (inferred)</span>
+        <span className="balance-value">{formattedTotalSupply}</span>
       </div>
       {decryptError && <div className="alert alert-error card-status">{decryptError}</div>}
       {mintError && <div className="alert alert-error card-status">{mintError}</div>}

--- a/examples/react-viem/package.json
+++ b/examples/react-viem/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "2.2.0-alpha.3",
-    "@zama-fhe/sdk": "2.2.0-alpha.3",
+    "@zama-fhe/react-sdk": "2.5.0-alpha.5",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "next": "^16.1.7",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/examples/react-viem/src/app/page.tsx
+++ b/examples/react-viem/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
   useAllow,
   useListPairs,
   useZamaSDK,
+  useTotalSupply,
   balanceOfContract,
 } from "@zama-fhe/react-sdk";
 import type { TokenWrapperPairWithMetadata } from "@zama-fhe/sdk";
@@ -268,11 +269,14 @@ export default function Home() {
   const refreshBalances = () => {
     queryClient.invalidateQueries({ queryKey: erc20BalanceKey });
     queryClient.invalidateQueries({ queryKey: ethBalanceKey });
-    // Invalidate the encrypted handle so useConfidentialBalance re-polls after
-    // any operation that changes the confidential balance (shield, unshield, transfer).
+    // Invalidate the confidential balance so useConfidentialBalance re-decrypts after
+    // any operation that changes the balance (shield, unshield, transfer).
     if (token) {
       queryClient.invalidateQueries({
-        queryKey: zamaQueryKeys.confidentialHandle.token(token.confidentialTokenAddress),
+        queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
+      });
+      queryClient.invalidateQueries({
+        queryKey: zamaQueryKeys.totalSupply.token(token.confidentialTokenAddress),
       });
     }
   };
@@ -312,6 +316,13 @@ export default function Home() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [address]);
 
+  // Fetch the inferred plaintext total supply for the selected confidential token.
+  // This is a public on-chain read — no credentials are required.
+  const { data: totalSupply } = useTotalSupply(
+    token?.confidentialTokenAddress ?? ZERO_ADDRESS,
+    { enabled: !!token },
+  );
+
   // Guard on token too: if balance resolves before the registry, decimals defaults to 0
   // and symbol to "" — the raw integer would be displayed without unit or decimal conversion.
   const formattedErc20 =
@@ -321,6 +332,10 @@ export default function Home() {
   const formattedConfidential =
     balance.data !== undefined && token
       ? `${formatUnits(balance.data, decimals)} ${confidentialSymbol}`
+      : "—";
+  const formattedTotalSupply =
+    totalSupply !== undefined && token
+      ? `${formatUnits(totalSupply, decimals)} ${confidentialSymbol}`
       : "—";
 
   // Actions are disabled until the registry has loaded a valid token pair
@@ -428,6 +443,7 @@ export default function Home() {
       <BalancesCard
         formattedErc20={formattedErc20}
         formattedConfidential={formattedConfidential}
+        formattedTotalSupply={formattedTotalSupply}
         // handleQuery.isLoading: fetching the encrypted handle from chain (Phase 1).
         // balance.isLoading: decrypting it via RelayerWeb (Phase 2).
         isLoadingConfidential={balance.handleQuery.isLoading || balance.isLoading}

--- a/examples/react-viem/src/components/BalancesCard.tsx
+++ b/examples/react-viem/src/components/BalancesCard.tsx
@@ -5,6 +5,7 @@ import { SEPOLIA_EXPLORER_URL } from "@/lib/config";
 interface BalancesCardProps {
   formattedErc20: string;
   formattedConfidential: string;
+  formattedTotalSupply: string;
   isLoadingConfidential: boolean;
   erc20Symbol: string;
   onMint: () => void;
@@ -21,6 +22,7 @@ interface BalancesCardProps {
 export function BalancesCard({
   formattedErc20,
   formattedConfidential,
+  formattedTotalSupply,
   isLoadingConfidential,
   erc20Symbol,
   onMint,
@@ -66,6 +68,10 @@ export function BalancesCard({
             {isLoadingConfidential ? <i>Decrypting…</i> : formattedConfidential}
           </span>
         )}
+      </div>
+      <div className="balance-row">
+        <span className="balance-label">Total Supply (inferred)</span>
+        <span className="balance-value">{formattedTotalSupply}</span>
       </div>
       {decryptError && <div className="alert alert-error card-status">{decryptError}</div>}
       {mintError && <div className="alert alert-error card-status">{mintError}</div>}

--- a/examples/react-wagmi/WALKTHROUGH.md
+++ b/examples/react-wagmi/WALKTHROUGH.md
@@ -199,11 +199,11 @@ After any operation that changes balances, call `refreshBalances()`:
 const refreshBalances = () => {
   void refetchErc20();
   void refetchEth();
-  // Invalidate the encrypted handle so useConfidentialBalance re-polls after
-  // any operation that changes the confidential balance.
+  // Invalidate the confidential balance so useConfidentialBalance re-decrypts after
+  // any operation that changes the balance.
   if (token) {
     queryClient.invalidateQueries({
-      queryKey: zamaQueryKeys.confidentialHandle.token(token.confidentialTokenAddress),
+      queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
     });
   }
 };

--- a/examples/react-wagmi/package.json
+++ b/examples/react-wagmi/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "2.2.0-alpha.3",
-    "@zama-fhe/sdk": "2.2.0-alpha.3",
+    "@zama-fhe/react-sdk": "2.5.0-alpha.5",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "next": "^16.2.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/examples/react-wagmi/src/app/page.tsx
+++ b/examples/react-wagmi/src/app/page.tsx
@@ -19,6 +19,7 @@ import {
   useAllow,
   useListPairs,
   useZamaSDK,
+  useTotalSupply,
 } from "@zama-fhe/react-sdk";
 import type { TokenWrapperPairWithMetadata } from "@zama-fhe/sdk";
 import { zamaQueryKeys } from "@zama-fhe/sdk/query";
@@ -142,11 +143,14 @@ export default function Home() {
   const refreshBalances = () => {
     void refetchErc20();
     void refetchEth();
-    // Invalidate the encrypted handle so useConfidentialBalance re-polls after
-    // any operation that changes the confidential balance (shield, unshield, transfer).
+    // Invalidate the confidential balance so useConfidentialBalance re-decrypts after
+    // any operation that changes the balance (shield, unshield, transfer).
     if (token) {
       queryClient.invalidateQueries({
-        queryKey: zamaQueryKeys.confidentialHandle.token(token.confidentialTokenAddress),
+        queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
+      });
+      queryClient.invalidateQueries({
+        queryKey: zamaQueryKeys.totalSupply.token(token.confidentialTokenAddress),
       });
     }
   };
@@ -186,6 +190,13 @@ export default function Home() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [address]);
 
+  // Fetch the inferred plaintext total supply for the selected confidential token.
+  // This is a public on-chain read — no credentials are required.
+  const { data: totalSupply } = useTotalSupply(
+    token?.confidentialTokenAddress ?? ZERO_ADDRESS,
+    { enabled: !!token },
+  );
+
   // Guard on token too: if balance resolves before the registry, decimals defaults to 0
   // and symbol to "" — the raw integer would be displayed without unit or decimal conversion.
   const formattedErc20 =
@@ -195,6 +206,10 @@ export default function Home() {
   const formattedConfidential =
     balance.data !== undefined && token
       ? `${formatUnits(balance.data, decimals)} ${confidentialSymbol}`
+      : "—";
+  const formattedTotalSupply =
+    totalSupply !== undefined && token
+      ? `${formatUnits(totalSupply, decimals)} ${confidentialSymbol}`
       : "—";
 
   // Actions are disabled until the registry has loaded a valid token pair
@@ -310,6 +325,7 @@ export default function Home() {
       <BalancesCard
         formattedErc20={formattedErc20}
         formattedConfidential={formattedConfidential}
+        formattedTotalSupply={formattedTotalSupply}
         // handleQuery.isLoading: fetching the encrypted handle from chain (Phase 1).
         // balance.isLoading: decrypting it via RelayerWeb (Phase 2).
         isLoadingConfidential={balance.handleQuery.isLoading || balance.isLoading}

--- a/examples/react-wagmi/src/components/BalancesCard.tsx
+++ b/examples/react-wagmi/src/components/BalancesCard.tsx
@@ -5,6 +5,7 @@ import { SEPOLIA_EXPLORER_URL } from "@/lib/config";
 interface BalancesCardProps {
   formattedErc20: string;
   formattedConfidential: string;
+  formattedTotalSupply: string;
   isLoadingConfidential: boolean;
   erc20Symbol: string;
   onMint: () => void;
@@ -21,6 +22,7 @@ interface BalancesCardProps {
 export function BalancesCard({
   formattedErc20,
   formattedConfidential,
+  formattedTotalSupply,
   isLoadingConfidential,
   erc20Symbol,
   onMint,
@@ -66,6 +68,10 @@ export function BalancesCard({
             {isLoadingConfidential ? <i>Decrypting…</i> : formattedConfidential}
           </span>
         )}
+      </div>
+      <div className="balance-row">
+        <span className="balance-label">Total Supply (inferred)</span>
+        <span className="balance-value">{formattedTotalSupply}</span>
       </div>
       {decryptError && <div className="alert alert-error card-status">{decryptError}</div>}
       {mintError && <div className="alert alert-error card-status">{mintError}</div>}


### PR DESCRIPTION
## Summary

- **Node examples** (node-viem, node-ethers): Add Section 5 demonstrating low-level SDK primitives — `inferredTotalSupplyContract()`, `sdk.userDecrypt()`, and `sdk.publicDecrypt()`
- **React examples** (react-viem, react-ethers, react-wagmi, example-hoodi): Add `useTotalSupply` hook with inferred total supply row in BalancesCard
- **Bug fix**: Replace broken `zamaQueryKeys.confidentialHandle` references with `zamaQueryKeys.confidentialBalance` (the `confidentialHandle` key was removed in v2.5)
- **Version bump**: All example dependencies updated from 2.2.0-alpha.x → 2.5.0-alpha.5

## Test plan

- [ ] Verify node-viem example typechecks (`cd examples/node-viem && pnpm typecheck`)
- [ ] Verify node-ethers example typechecks (`cd examples/node-ethers && pnpm typecheck`)
- [ ] Verify react-viem builds (`cd examples/react-viem && pnpm build`)
- [ ] Verify react-ethers builds (`cd examples/react-ethers && pnpm build`)
- [ ] Verify react-wagmi builds (`cd examples/react-wagmi && pnpm build`)
- [ ] Verify example-hoodi builds (`cd examples/example-hoodi && pnpm build`)
- [ ] Confirm total supply row renders in BalancesCard for each React example
- [ ] Confirm balance invalidation works after shield/unshield/transfer operations

https://claude.ai/code/session_01GHW4aofhR11NkD4fDP1CS6