### PR TITLE
feat(examples): upgrade all examples to SDK 2.5.0-alpha.5

### DIFF
--- a/examples/example-hoodi/package.json
+++ b/examples/example-hoodi/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "2.2.0-alpha.4",
-    "@zama-fhe/sdk": "2.2.0-alpha.4",
+    "@zama-fhe/react-sdk": "2.5.0-alpha.5",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "ethers": "^6.13.0",
     "next": "^16.0.0",
     "react": "^19.2.0",

--- a/examples/example-hoodi/src/app/page.tsx
+++ b/examples/example-hoodi/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
   useAllow,
   useListPairs,
   useZamaSDK,
+  useTotalSupply,
   balanceOfContract,
 } from "@zama-fhe/react-sdk";
 import type { TokenWrapperPair, TokenWrapperPairWithMetadata } from "@zama-fhe/sdk";
@@ -149,9 +150,10 @@ export default function Home() {
   const token = validPairs.find((p) => p.confidentialTokenAddress === selectedTokenAddress);
 
   // Check whether cached credentials cover the currently selected confidential token.
+  // ZERO_ADDRESS is used as a non-empty placeholder when no token is selected —
+  // credentials will never match it, so isAllowed stays false until a real token loads.
   const { data: isAllowed } = useIsAllowed({
-    contractAddresses: token ? [token.confidentialTokenAddress] : [],
-    query: { enabled: Boolean(token) },
+    contractAddresses: token ? [token.confidentialTokenAddress] : [ZERO_ADDRESS],
   });
 
   // Metadata for the selected token pair — sourced directly from the registry response
@@ -160,6 +162,12 @@ export default function Home() {
   const erc20Decimals = token?.underlying.decimals ?? 0;
   const confidentialSymbol = token?.confidential.symbol ?? "";
   const erc20Symbol = token?.underlying.symbol ?? "";
+
+  // Read the wrapper's inferred total supply — a plaintext on-chain value that
+  // does not require FHE decryption or credentials. Stale after 30 s (SDK default).
+  const { data: totalSupply } = useTotalSupply(token?.confidentialTokenAddress ?? ZERO_ADDRESS, {
+    enabled: !!token && isHoodi,
+  });
 
   // Triggers the EIP-712 wallet signature to create FHE decrypt credentials.
   // All registry pairs are passed at once — a single signature covers all tokens,
@@ -295,7 +303,7 @@ export default function Home() {
     // any operation that changes the confidential balance (shield, unshield, transfer).
     if (token) {
       queryClient.invalidateQueries({
-        queryKey: zamaQueryKeys.confidentialHandle.token(token.confidentialTokenAddress),
+        queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
       });
     }
   };
@@ -447,14 +455,17 @@ export default function Home() {
         {!isRegistryPending && !isRegistryError && validPairs.length === 0 && (
           <p className="token-meta">No tokens available.</p>
         )}
+        {token && totalSupply !== undefined && (
+          <p className="token-meta">
+            Total supply: {formatUnits(totalSupply, decimals)} {confidentialSymbol}
+          </p>
+        )}
       </div>
 
       <BalancesCard
         formattedErc20={formattedErc20}
         formattedConfidential={formattedConfidential}
-        // handleQuery.isLoading: fetching the encrypted handle from chain (Phase 1).
-        // balance.isLoading: decrypting it via RelayerCleartext (Phase 2).
-        isLoadingConfidential={balance.handleQuery.isLoading || balance.isLoading}
+        isLoadingConfidential={balance.isLoading}
         erc20Symbol={erc20Symbol}
         onMint={() => mint.mutate()}
         isMinting={mint.isPending}

--- a/examples/example-hoodi/src/components/TransferCard.tsx
+++ b/examples/example-hoodi/src/components/TransferCard.tsx
@@ -38,7 +38,7 @@ export function TransferCard({
     transfer.mutate({
       to: recipient as Address,
       amount: parsedAmount,
-      callbacks: { onEncryptComplete: () => setStep(2) },
+      onEncryptComplete: () => setStep(2),
     });
   }
 

--- a/examples/example-hoodi/src/components/UnshieldCard.tsx
+++ b/examples/example-hoodi/src/components/UnshieldCard.tsx
@@ -57,10 +57,8 @@ export function UnshieldCard({
     setActiveUnshieldToken(tokenAddress);
     unshield.mutate({
       amount: parsedAmount,
-      callbacks: {
-        // onFinalizing fires between the two on-chain transactions, marking step 2.
-        onFinalizing: () => setStep(2),
-      },
+      // onFinalizing fires between the two on-chain transactions, marking step 2.
+      onFinalizing: () => setStep(2),
     });
   }
 

--- a/examples/node-ethers/package.json
+++ b/examples/node-ethers/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@zama-fhe/sdk": "2.2.0-alpha.6",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "ethers": "^6.13.0"
   },
   "devDependencies": {

--- a/examples/node-ethers/src/index.ts
+++ b/examples/node-ethers/src/index.ts
@@ -1,5 +1,12 @@
 import { Contract, formatUnits, JsonRpcProvider, Wallet } from "ethers";
-import { DelegationNotPropagatedError, MemoryStorage, SepoliaConfig, ZamaSDK } from "@zama-fhe/sdk";
+import {
+  DelegationNotPropagatedError,
+  MemoryStorage,
+  SepoliaConfig,
+  ZamaSDK,
+  inferredTotalSupplyContract,
+  confidentialTotalSupplyContract,
+} from "@zama-fhe/sdk";
 import { EthersSigner } from "@zama-fhe/sdk/ethers";
 import { RelayerNode } from "@zama-fhe/sdk/node";
 import type { Address } from "@zama-fhe/sdk";
@@ -230,6 +237,38 @@ async function main() {
     delegateAddress: walletB.address as Address,
   });
   console.log("Delegation active after revoke:", isDelegatedAfter);
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // SECTION 5 — Public Decryption & Inferred Total Supply
+  // Public decryption uses the network public key — no credentials (allow())
+  // are needed. This is useful for reading on-chain encrypted values that
+  // should be visible to everyone, like confidential total supply.
+  // ──────────────────────────────────────────────────────────────────────────
+  section("SECTION 5 — Public Decryption & Inferred Total Supply");
+
+  // 5a. inferredTotalSupplyContract — reads the plaintext total supply that the
+  // wrapper infers from wrap/unwrap activity. No decryption required.
+  console.log("── 5a. Inferred total supply (plaintext) ──");
+  const inferredSupply = await sdkA.signer.readContract(
+    inferredTotalSupplyContract(confidentialTokenAddress),
+  );
+  console.log("Inferred total supply:", fmt(inferredSupply as bigint));
+
+  // 5b. confidentialTotalSupplyContract — reads the encrypted total supply handle.
+  // The handle is an FHE ciphertext reference stored on-chain.
+  console.log("\n── 5b. Confidential total supply (encrypted handle) ──");
+  const totalSupplyHandle = await sdkA.signer.readContract(
+    confidentialTotalSupplyContract(confidentialTokenAddress),
+  );
+  console.log("Total supply handle:", totalSupplyHandle);
+
+  // 5c. publicDecrypt — decrypt the handle without user credentials.
+  // Unlike userDecrypt (which requires an EIP-712 session signature), publicDecrypt
+  // uses the network public key and is open to everyone.
+  console.log("\n── 5c. Public decrypt ──");
+  const { clearValues } = await sdkA.publicDecrypt([totalSupplyHandle as `0x${string}`]);
+  const decryptedSupply = clearValues[totalSupplyHandle as `0x${string}`];
+  console.log("Public-decrypted total supply:", fmt(decryptedSupply as bigint));
 }
 
 main().catch((err) => {

--- a/examples/node-viem/package.json
+++ b/examples/node-viem/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@zama-fhe/sdk": "2.2.0-alpha.6",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "viem": "^2.30.0"
   },
   "devDependencies": {

--- a/examples/node-viem/src/index.ts
+++ b/examples/node-viem/src/index.ts
@@ -1,7 +1,13 @@
 import { createPublicClient, createWalletClient, formatUnits, http, parseAbi } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
-import { DelegationNotPropagatedError, MemoryStorage, ZamaSDK } from "@zama-fhe/sdk";
+import {
+  DelegationNotPropagatedError,
+  MemoryStorage,
+  ZamaSDK,
+  inferredTotalSupplyContract,
+  confidentialTotalSupplyContract,
+} from "@zama-fhe/sdk";
 import { ViemSigner } from "@zama-fhe/sdk/viem";
 import { RelayerNode } from "@zama-fhe/sdk/node";
 import type { Address } from "@zama-fhe/sdk";
@@ -256,6 +262,38 @@ async function main() {
     delegateAddress: accountB.address as Address,
   });
   console.log("Delegation active after revoke:", isDelegatedAfter);
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // SECTION 5 — Public Decryption & Inferred Total Supply
+  // Public decryption uses the network public key — no credentials (allow())
+  // are needed. This is useful for reading on-chain encrypted values that
+  // should be visible to everyone, like confidential total supply.
+  // ──────────────────────────────────────────────────────────────────────────
+  section("SECTION 5 — Public Decryption & Inferred Total Supply");
+
+  // 5a. inferredTotalSupplyContract — reads the plaintext total supply that the
+  // wrapper infers from wrap/unwrap activity. No decryption required.
+  console.log("── 5a. Inferred total supply (plaintext) ──");
+  const inferredSupply = await sdkA.signer.readContract(
+    inferredTotalSupplyContract(confidentialTokenAddress),
+  );
+  console.log("Inferred total supply:", fmt(inferredSupply as bigint));
+
+  // 5b. confidentialTotalSupplyContract — reads the encrypted total supply handle.
+  // The handle is an FHE ciphertext reference stored on-chain.
+  console.log("\n── 5b. Confidential total supply (encrypted handle) ──");
+  const totalSupplyHandle = await sdkA.signer.readContract(
+    confidentialTotalSupplyContract(confidentialTokenAddress),
+  );
+  console.log("Total supply handle:", totalSupplyHandle);
+
+  // 5c. publicDecrypt — decrypt the handle without user credentials.
+  // Unlike userDecrypt (which requires an EIP-712 session signature), publicDecrypt
+  // uses the network public key and is open to everyone.
+  console.log("\n── 5c. Public decrypt ──");
+  const { clearValues } = await sdkA.publicDecrypt([totalSupplyHandle as `0x${string}`]);
+  const decryptedSupply = clearValues[totalSupplyHandle as `0x${string}`];
+  console.log("Public-decrypted total supply:", fmt(decryptedSupply as bigint));
 }
 
 main().catch((err) => {

--- a/examples/react-ethers/package.json
+++ b/examples/react-ethers/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "2.2.0-alpha.2",
-    "@zama-fhe/sdk": "2.2.0-alpha.2",
+    "@zama-fhe/react-sdk": "2.5.0-alpha.5",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "ethers": "^6.13.0",
     "next": "^16.2.3",
     "react": "^19.2.0",

--- a/examples/react-ethers/src/app/page.tsx
+++ b/examples/react-ethers/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
   useAllow,
   useListPairs,
   useZamaSDK,
+  useTotalSupply,
   balanceOfContract,
 } from "@zama-fhe/react-sdk";
 import type { TokenWrapperPair, TokenWrapperPairWithMetadata } from "@zama-fhe/sdk";
@@ -149,9 +150,10 @@ export default function Home() {
   const token = validPairs.find((p) => p.confidentialTokenAddress === selectedTokenAddress);
 
   // Check whether cached credentials cover the currently selected confidential token.
+  // ZERO_ADDRESS is used as a non-empty placeholder when no token is selected —
+  // credentials will never match it, so isAllowed stays false until a real token loads.
   const { data: isAllowed } = useIsAllowed({
-    contractAddresses: token ? [token.confidentialTokenAddress] : [],
-    query: { enabled: Boolean(token) },
+    contractAddresses: token ? [token.confidentialTokenAddress] : [ZERO_ADDRESS],
   });
 
   // Metadata for the selected token pair — sourced directly from the registry response
@@ -160,6 +162,12 @@ export default function Home() {
   const erc20Decimals = token?.underlying.decimals ?? 0;
   const confidentialSymbol = token?.confidential.symbol ?? "";
   const erc20Symbol = token?.underlying.symbol ?? "";
+
+  // Read the wrapper's inferred total supply — a plaintext on-chain value that
+  // does not require FHE decryption or credentials. Stale after 30 s (SDK default).
+  const { data: totalSupply } = useTotalSupply(token?.confidentialTokenAddress ?? ZERO_ADDRESS, {
+    enabled: !!token && isSepolia,
+  });
 
   // Triggers the EIP-712 wallet signature to create FHE decrypt credentials.
   // All registry pairs are passed at once — a single signature covers all tokens,
@@ -288,7 +296,7 @@ export default function Home() {
     // any operation that changes the confidential balance (shield, unshield, transfer).
     if (token) {
       queryClient.invalidateQueries({
-        queryKey: zamaQueryKeys.confidentialHandle.token(token.confidentialTokenAddress),
+        queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
       });
     }
   };
@@ -438,14 +446,17 @@ export default function Home() {
         {!isRegistryPending && !isRegistryError && validPairs.length === 0 && (
           <p className="token-meta">No tokens available.</p>
         )}
+        {token && totalSupply !== undefined && (
+          <p className="token-meta">
+            Total supply: {formatUnits(totalSupply, decimals)} {confidentialSymbol}
+          </p>
+        )}
       </div>
 
       <BalancesCard
         formattedErc20={formattedErc20}
         formattedConfidential={formattedConfidential}
-        // handleQuery.isLoading: fetching the encrypted handle from chain (Phase 1).
-        // balance.isLoading: decrypting it via RelayerWeb (Phase 2).
-        isLoadingConfidential={balance.handleQuery.isLoading || balance.isLoading}
+        isLoadingConfidential={balance.isLoading}
         erc20Symbol={erc20Symbol}
         onMint={() => mint.mutate()}
         isMinting={mint.isPending}

--- a/examples/react-ethers/src/components/TransferCard.tsx
+++ b/examples/react-ethers/src/components/TransferCard.tsx
@@ -38,7 +38,7 @@ export function TransferCard({
     transfer.mutate({
       to: recipient as Address,
       amount: parsedAmount,
-      callbacks: { onEncryptComplete: () => setStep(2) },
+      onEncryptComplete: () => setStep(2),
     });
   }
 

--- a/examples/react-ethers/src/components/UnshieldCard.tsx
+++ b/examples/react-ethers/src/components/UnshieldCard.tsx
@@ -57,10 +57,8 @@ export function UnshieldCard({
     setActiveUnshieldToken(tokenAddress);
     unshield.mutate({
       amount: parsedAmount,
-      callbacks: {
-        // onFinalizing fires between the two on-chain transactions, marking step 2.
-        onFinalizing: () => setStep(2),
-      },
+      // onFinalizing fires between the two on-chain transactions, marking step 2.
+      onFinalizing: () => setStep(2),
     });
   }
 

--- a/examples/react-viem/package.json
+++ b/examples/react-viem/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "2.2.0-alpha.3",
-    "@zama-fhe/sdk": "2.2.0-alpha.3",
+    "@zama-fhe/react-sdk": "2.5.0-alpha.5",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "next": "^16.1.7",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/examples/react-viem/src/app/page.tsx
+++ b/examples/react-viem/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
   useAllow,
   useListPairs,
   useZamaSDK,
+  useTotalSupply,
   balanceOfContract,
 } from "@zama-fhe/react-sdk";
 import type { TokenWrapperPairWithMetadata } from "@zama-fhe/sdk";
@@ -134,9 +135,10 @@ export default function Home() {
   const token = validPairs.find((p) => p.confidentialTokenAddress === selectedTokenAddress);
 
   // Check whether cached credentials cover the currently selected confidential token.
+  // ZERO_ADDRESS is used as a non-empty placeholder when no token is selected —
+  // credentials will never match it, so isAllowed stays false until a real token loads.
   const { data: isAllowed } = useIsAllowed({
-    contractAddresses: token ? [token.confidentialTokenAddress] : [],
-    query: { enabled: Boolean(token) },
+    contractAddresses: token ? [token.confidentialTokenAddress] : [ZERO_ADDRESS],
   });
 
   // Metadata for the selected token pair — sourced directly from the registry response
@@ -145,6 +147,12 @@ export default function Home() {
   const erc20Decimals = token?.underlying.decimals ?? 0;
   const confidentialSymbol = token?.confidential.symbol ?? "";
   const erc20Symbol = token?.underlying.symbol ?? "";
+
+  // Read the wrapper's inferred total supply — a plaintext on-chain value that
+  // does not require FHE decryption or credentials. Stale after 30 s (SDK default).
+  const { data: totalSupply } = useTotalSupply(token?.confidentialTokenAddress ?? ZERO_ADDRESS, {
+    enabled: !!token && isSepolia,
+  });
 
   // Triggers the EIP-712 wallet signature to create FHE decrypt credentials.
   // All registry pairs are passed at once — a single signature covers all tokens,
@@ -272,7 +280,7 @@ export default function Home() {
     // any operation that changes the confidential balance (shield, unshield, transfer).
     if (token) {
       queryClient.invalidateQueries({
-        queryKey: zamaQueryKeys.confidentialHandle.token(token.confidentialTokenAddress),
+        queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
       });
     }
   };
@@ -423,14 +431,17 @@ export default function Home() {
         {!isRegistryPending && !isRegistryError && validPairs.length === 0 && (
           <p className="token-meta">No tokens available.</p>
         )}
+        {token && totalSupply !== undefined && (
+          <p className="token-meta">
+            Total supply: {formatUnits(totalSupply, decimals)} {confidentialSymbol}
+          </p>
+        )}
       </div>
 
       <BalancesCard
         formattedErc20={formattedErc20}
         formattedConfidential={formattedConfidential}
-        // handleQuery.isLoading: fetching the encrypted handle from chain (Phase 1).
-        // balance.isLoading: decrypting it via RelayerWeb (Phase 2).
-        isLoadingConfidential={balance.handleQuery.isLoading || balance.isLoading}
+        isLoadingConfidential={balance.isLoading}
         erc20Symbol={erc20Symbol}
         onMint={() => mint.mutate()}
         isMinting={mint.isPending}

--- a/examples/react-viem/src/components/TransferCard.tsx
+++ b/examples/react-viem/src/components/TransferCard.tsx
@@ -38,7 +38,7 @@ export function TransferCard({
     transfer.mutate({
       to: recipient as Address,
       amount: parsedAmount,
-      callbacks: { onEncryptComplete: () => setStep(2) },
+      onEncryptComplete: () => setStep(2),
     });
   }
 

--- a/examples/react-viem/src/components/UnshieldCard.tsx
+++ b/examples/react-viem/src/components/UnshieldCard.tsx
@@ -57,10 +57,8 @@ export function UnshieldCard({
     setActiveUnshieldToken(tokenAddress);
     unshield.mutate({
       amount: parsedAmount,
-      callbacks: {
-        // onFinalizing fires between the two on-chain transactions, marking step 2.
-        onFinalizing: () => setStep(2),
-      },
+      // onFinalizing fires between the two on-chain transactions, marking step 2.
+      onFinalizing: () => setStep(2),
     });
   }
 

--- a/examples/react-wagmi/package.json
+++ b/examples/react-wagmi/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "2.2.0-alpha.3",
-    "@zama-fhe/sdk": "2.2.0-alpha.3",
+    "@zama-fhe/react-sdk": "2.5.0-alpha.5",
+    "@zama-fhe/sdk": "2.5.0-alpha.5",
     "next": "^16.2.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/examples/react-wagmi/src/app/page.tsx
+++ b/examples/react-wagmi/src/app/page.tsx
@@ -19,6 +19,7 @@ import {
   useAllow,
   useListPairs,
   useZamaSDK,
+  useTotalSupply,
 } from "@zama-fhe/react-sdk";
 import type { TokenWrapperPairWithMetadata } from "@zama-fhe/sdk";
 import { zamaQueryKeys } from "@zama-fhe/sdk/query";
@@ -102,9 +103,10 @@ export default function Home() {
   const token = validPairs.find((p) => p.confidentialTokenAddress === selectedTokenAddress);
 
   // Check whether cached credentials cover the currently selected confidential token.
+  // ZERO_ADDRESS is used as a non-empty placeholder when no token is selected —
+  // credentials will never match it, so isAllowed stays false until a real token loads.
   const { data: isAllowed } = useIsAllowed({
-    contractAddresses: token ? [token.confidentialTokenAddress] : [],
-    query: { enabled: Boolean(token) },
+    contractAddresses: token ? [token.confidentialTokenAddress] : [ZERO_ADDRESS],
   });
 
   // Metadata for the selected token pair — sourced directly from the registry response
@@ -113,6 +115,12 @@ export default function Home() {
   const erc20Decimals = token?.underlying.decimals ?? 0;
   const confidentialSymbol = token?.confidential.symbol ?? "";
   const erc20Symbol = token?.underlying.symbol ?? "";
+
+  // Read the wrapper's inferred total supply — a plaintext on-chain value that
+  // does not require FHE decryption or credentials. Stale after 30 s (SDK default).
+  const { data: totalSupply } = useTotalSupply(token?.confidentialTokenAddress ?? ZERO_ADDRESS, {
+    enabled: !!token && isSepolia,
+  });
 
   // Triggers the EIP-712 wallet signature to create FHE decrypt credentials.
   // All registry pairs are passed at once — a single signature covers all tokens,
@@ -146,7 +154,7 @@ export default function Home() {
     // any operation that changes the confidential balance (shield, unshield, transfer).
     if (token) {
       queryClient.invalidateQueries({
-        queryKey: zamaQueryKeys.confidentialHandle.token(token.confidentialTokenAddress),
+        queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
       });
     }
   };
@@ -305,14 +313,17 @@ export default function Home() {
         {!isRegistryPending && !isRegistryError && validPairs.length === 0 && (
           <p className="token-meta">No tokens available.</p>
         )}
+        {token && totalSupply !== undefined && (
+          <p className="token-meta">
+            Total supply: {formatUnits(totalSupply, decimals)} {confidentialSymbol}
+          </p>
+        )}
       </div>
 
       <BalancesCard
         formattedErc20={formattedErc20}
         formattedConfidential={formattedConfidential}
-        // handleQuery.isLoading: fetching the encrypted handle from chain (Phase 1).
-        // balance.isLoading: decrypting it via RelayerWeb (Phase 2).
-        isLoadingConfidential={balance.handleQuery.isLoading || balance.isLoading}
+        isLoadingConfidential={balance.isLoading}
         erc20Symbol={erc20Symbol}
         onMint={() => mint.mutate()}
         isMinting={mint.isPending}

--- a/examples/react-wagmi/src/components/TransferCard.tsx
+++ b/examples/react-wagmi/src/components/TransferCard.tsx
@@ -38,7 +38,7 @@ export function TransferCard({
     transfer.mutate({
       to: recipient as Address,
       amount: parsedAmount,
-      callbacks: { onEncryptComplete: () => setStep(2) },
+      onEncryptComplete: () => setStep(2),
     });
   }
 

--- a/examples/react-wagmi/src/components/UnshieldCard.tsx
+++ b/examples/react-wagmi/src/components/UnshieldCard.tsx
@@ -57,10 +57,8 @@ export function UnshieldCard({
     setActiveUnshieldToken(tokenAddress);
     unshield.mutate({
       amount: parsedAmount,
-      callbacks: {
-        // onFinalizing fires between the two on-chain transactions, marking step 2.
-        onFinalizing: () => setStep(2),
-      },
+      // onFinalizing fires between the two on-chain transactions, marking step 2.
+      onFinalizing: () => setStep(2),
     });
   }
 


### PR DESCRIPTION
## Summary

- **Bump SDK versions** across all 6 examples from 2.2.0-alpha.x to 2.5.0-alpha.5
- **Add `publicDecrypt` + `inferredTotalSupplyContract`** demos to node-ethers and node-viem (new Section 5) showcasing credential-free public decryption of confidential total supply
- **Add `useTotalSupply` hook** to all 4 React examples (react-viem, react-ethers, react-wagmi, example-hoodi) displaying the wrapper's inferred total supply in the token selector card
- **Fix API breaking changes** from SDK 2.2 → 2.5:
  - Flatten `callbacks` in transfer/unshield mutation params (`callbacks.onX` → `onX`)
  - Rename `zamaQueryKeys.confidentialHandle` → `confidentialBalance`
  - Remove `balance.handleQuery` (`useConfidentialBalance` is now a single query)
  - Update `useIsAllowed` to use non-empty tuple `contractAddresses` (removed `query` option)

## Test plan

- [x] `pnpm build` passes (SDK + React SDK)
- [x] `pnpm typecheck` passes (monorepo-level)
- [x] `pnpm format` passes (oxfmt)
- [x] node-ethers example typechecks via local symlink
- [x] node-viem example typechecks via local symlink
- [x] react-viem src/ typechecks via local symlink (only pre-existing playwright type errors remain)
- [ ] Verify React examples render correctly in browser after npm publish

https://claude.ai/code/session_014e7HVnqZzDi5eTEGW4Nizn