### PR TITLE
refactor(sdk): read cache-identity params from context.queryKey

### DIFF
--- a/packages/sdk/src/query/is-allowed.ts
+++ b/packages/sdk/src/query/is-allowed.ts
@@ -18,7 +18,10 @@ export function isAllowedQueryOptions(
   return {
     ...filterQueryOptions(config?.query ?? {}),
     queryKey: zamaQueryKeys.isAllowed.scope(config.account, config.contractAddresses),
-    queryFn: () => sdk.credentials.isAllowed(config.contractAddresses),
+    queryFn: (context) => {
+      const [, { contractAddresses }] = context.queryKey;
+      return sdk.credentials.isAllowed(contractAddresses as [Address, ...Address[]]);
+    },
     staleTime: 30_000,
     enabled: config.query?.enabled !== false,
   } as const;

--- a/packages/sdk/src/query/user-decrypt.ts
+++ b/packages/sdk/src/query/user-decrypt.ts
@@ -26,7 +26,10 @@ export function userDecryptQueryOptions(
 > {
   return {
     queryKey: zamaQueryKeys.decryption.handles(config.handles),
-    queryFn: () => sdk.userDecrypt(config.handles),
+    queryFn: (context) => {
+      const [, { handles }] = context.queryKey;
+      return sdk.userDecrypt(handles as DecryptHandle[]);
+    },
     staleTime: Infinity,
     enabled: config.handles.length > 0,
   };

--- a/packages/sdk/src/query/wrapper-discovery.ts
+++ b/packages/sdk/src/query/wrapper-discovery.ts
@@ -44,11 +44,12 @@ export function wrapperDiscoveryQueryOptions(
   return {
     ...filterQueryOptions(config.query ?? {}),
     queryKey,
-    queryFn: async () => {
-      if (!config.erc20Address) {
+    queryFn: async (context) => {
+      const [, { erc20Address }] = context.queryKey;
+      if (!erc20Address) {
         throw new Error("erc20Address is required for wrapper discovery query");
       }
-      const result = await registry.getConfidentialToken(config.erc20Address);
+      const result = await registry.getConfidentialToken(erc20Address);
       return result ? result.confidentialTokenAddress : null;
     },
     staleTime: Infinity,

--- a/packages/sdk/src/query/wrapper-discovery.ts
+++ b/packages/sdk/src/query/wrapper-discovery.ts
@@ -47,7 +47,7 @@ export function wrapperDiscoveryQueryOptions(
     queryKey,
     queryFn: async (context) => {
       const [, { erc20Address }] = context.queryKey;
-      assertNonNullable(erc20Address, "wrapperDiscoveryQueryOptions: erc20Address")
+      assertNonNullable(erc20Address, "wrapperDiscoveryQueryOptions: erc20Address");
       const result = await registry.getConfidentialToken(erc20Address);
       return result ? result.confidentialTokenAddress : null;
     },

--- a/packages/sdk/src/query/wrapper-discovery.ts
+++ b/packages/sdk/src/query/wrapper-discovery.ts
@@ -2,6 +2,7 @@ import type { Address } from "viem";
 import type { WrappersRegistry } from "../wrappers-registry";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";
+import { assertNonNullable } from "../utils/assertions";
 import { filterQueryOptions } from "./utils";
 
 export interface WrapperDiscoveryQueryConfig {
@@ -46,9 +47,7 @@ export function wrapperDiscoveryQueryOptions(
     queryKey,
     queryFn: async (context) => {
       const [, { erc20Address }] = context.queryKey;
-      if (!erc20Address) {
-        throw new Error("erc20Address is required for wrapper discovery query");
-      }
+      assertNonNullable(erc20Address, "wrapperDiscoveryQueryOptions: erc20Address")
       const result = await registry.getConfidentialToken(erc20Address);
       return result ? result.confidentialTokenAddress : null;
     },

--- a/packages/sdk/src/query/wrappers-registry.ts
+++ b/packages/sdk/src/query/wrappers-registry.ts
@@ -281,20 +281,20 @@ export function listPairsQueryOptions(
   PaginatedResult<TokenWrapperPair | TokenWrapperPairWithMetadata>,
   ReturnType<typeof zamaQueryKeys.wrappersRegistry.listPairs>
 > {
-  const page = config.page ?? 1;
-  const pageSize = config.pageSize ?? 100;
-  const metadata = config.metadata ?? false;
   const enabled = Boolean(config.registryAddress) && config.query?.enabled !== false;
   const queryKey = zamaQueryKeys.wrappersRegistry.listPairs(
     config.registryAddress ?? zeroAddress,
-    page,
-    pageSize,
-    metadata,
+    config.page ?? 1,
+    config.pageSize ?? 100,
+    config.metadata ?? false,
   );
   return {
     ...filterQueryOptions(config.query ?? {}),
     queryKey,
-    queryFn: async () => registry.listPairs({ page, pageSize, metadata }),
+    queryFn: async (context) => {
+      const [, { page, pageSize, metadata }] = context.queryKey;
+      return registry.listPairs({ page, pageSize, metadata });
+    },
     // Use the registry's own TTL so TanStack Query and the class-level cache
     // operate under the same freshness contract.
     staleTime: registry.ttlMs,


### PR DESCRIPTION
Closes SDK-92

## Context

Our TanStack Query factories follow a convention where `queryFn` extracts data-fetching parameters from `context.queryKey` rather than from the surrounding closure. This is a defensive best practice for externalized, reusable query factories — a stale closure could otherwise fetch data for parameter X while the cache entry is keyed by parameter Y.

## Changes

Aligns four query factories with the `confidential-balance.ts` reference pattern:

- `packages/sdk/src/query/is-allowed.ts` — destructure `contractAddresses` from `context.queryKey` (cast to non-empty tuple for the SDK signature).
- `packages/sdk/src/query/user-decrypt.ts` — destructure `handles` from `context.queryKey` (cast to `DecryptHandle[]`).
- `packages/sdk/src/query/wrapper-discovery.ts` — destructure `erc20Address` from `context.queryKey`, keep the existing guard.
- `packages/sdk/src/query/wrappers-registry.ts` (`listPairsQueryOptions`) — destructure `page`, `pageSize`, `metadata` from `context.queryKey`; inline the defaults into the key construction to avoid outer-scope shadowing.

## Test Plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:run packages/sdk/src/query` — 162/162 tests pass (existing tests already invoke `queryFn` with the real `queryKey` via `mockQueryContext`)