### PR TITLE
refactor(sdk): dedupe types against @zama-fhe/relayer-sdk

### DIFF
--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -860,7 +860,10 @@ export interface UseDelegationStatusConfig {
 }
 
 // @public
-export function useEncrypt(): _$_tanstack_react_query0.UseMutationResult<EncryptResult, Error, EncryptParams, unknown>;
+export function useEncrypt(): _$_tanstack_react_query0.UseMutationResult<Readonly<{
+    handles: Uint8Array[];
+    inputProof: Uint8Array;
+}>, Error, EncryptParams, unknown>;
 
 // @public
 export function useFinalizeUnwrap(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, FinalizeUnwrapParams, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, FinalizeUnwrapParams, `0x${string}`>;
@@ -907,7 +910,11 @@ export function useMetadata(tokenAddress: Address, options?: Omit<UseQueryOption
 export function useMetadataSuspense(tokenAddress: Address): _$_tanstack_react_query0.UseSuspenseQueryResult<TokenMetadata, Error>;
 
 // @public
-export function usePublicDecrypt(): _$_tanstack_react_query0.UseMutationResult<PublicDecryptResult, Error, `0x${string}`[], unknown>;
+export function usePublicDecrypt(): _$_tanstack_react_query0.UseMutationResult<Readonly<{
+    clearValues: _$_zama_fhe_relayer_sdk_web0.ClearValues;
+    abiEncodedClearValues: `0x${string}`;
+    decryptionProof: `0x${string}`;
+}>, Error, `0x${string}`[], unknown>;
 
 // @public
 export function usePublicKey(): _$_tanstack_react_query0.UseQueryResult<PublicKeyData | null, Error>;
@@ -1006,7 +1013,7 @@ export function useUnwrap(config: UseZamaConfig, options?: UseMutationOptions<Tr
 export function useUnwrapAll(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, void, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, void, `0x${string}`>;
 
 // @public
-export function useUserDecrypt(config: UserDecryptQueryConfig, options?: Omit<UseQueryOptions<DecryptResult>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<DecryptResult, Error>;
+export function useUserDecrypt(config: UserDecryptQueryConfig, options?: Omit<UseQueryOptions<DecryptResult>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<Readonly<Record<`0x${string}`, _$_zama_fhe_sdk0.ClearValueType>>, Error>;
 
 // @public
 export type UseUserDecryptResult = ReturnType<typeof useUserDecrypt>;

--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -168,6 +168,7 @@ import { PaginatedResult } from '@zama-fhe/sdk';
 import { PropsWithChildren } from 'react';
 import { publicDecryptMutationOptions } from '@zama-fhe/sdk/query';
 import { PublicDecryptResult } from '@zama-fhe/sdk';
+import { PublicKeyData } from '@zama-fhe/sdk';
 import { publicKeyQueryOptions } from '@zama-fhe/sdk/query';
 import { publicParamsQueryOptions } from '@zama-fhe/sdk/query';
 import { QueryKey } from '@tanstack/react-query';
@@ -598,19 +599,7 @@ export { publicDecryptMutationOptions }
 
 export { PublicDecryptResult }
 
-// @public
-export interface PublicKeyData {
-    publicKey: Uint8Array;
-    publicKeyId: string;
-}
-
 export { publicKeyQueryOptions }
-
-// @public
-export interface PublicParamsData {
-    publicParams: Uint8Array;
-    publicParamsId: string;
-}
 
 export { publicParamsQueryOptions }
 
@@ -920,7 +909,10 @@ export function usePublicDecrypt(): _$_tanstack_react_query0.UseMutationResult<R
 export function usePublicKey(): _$_tanstack_react_query0.UseQueryResult<PublicKeyData | null, Error>;
 
 // @public
-export function usePublicParams(bits: number): _$_tanstack_react_query0.UseQueryResult<PublicParamsData | null, Error>;
+export function usePublicParams(bits: number): _$_tanstack_react_query0.UseQueryResult<{
+    publicParams: Uint8Array<ArrayBufferLike>;
+    publicParamsId: string;
+} | null, Error>;
 
 export { UserDecryptParams }
 

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -22,8 +22,8 @@ export { useCreateDelegatedUserDecryptEIP712 } from "./relayer/use-create-delega
 export type { CreateDelegatedUserDecryptEIP712Params } from "./relayer/use-create-delegated-user-decrypt-eip712";
 export { useDelegatedUserDecrypt } from "./relayer/use-delegated-user-decrypt";
 export { useRequestZKProofVerification } from "./relayer/use-request-zk-proof-verification";
-export { usePublicKey, type PublicKeyData } from "./relayer/use-public-key";
-export { usePublicParams, type PublicParamsData } from "./relayer/use-public-params";
+export { usePublicKey } from "./relayer/use-public-key";
+export { usePublicParams } from "./relayer/use-public-params";
 
 // Re-export core classes
 export {

--- a/packages/react-sdk/src/relayer/use-public-key.ts
+++ b/packages/react-sdk/src/relayer/use-public-key.ts
@@ -1,18 +1,9 @@
 "use client";
 
+import type { PublicKeyData } from "@zama-fhe/sdk";
 import { useQuery } from "../utils/query";
 import { publicKeyQueryOptions } from "@zama-fhe/sdk/query";
 import { useZamaSDK } from "../provider";
-
-export { publicKeyQueryOptions };
-
-/** Shape of the FHE public key data returned by the relayer. */
-export interface PublicKeyData {
-  /** Unique identifier for this public key version. */
-  publicKeyId: string;
-  /** The raw FHE public key bytes. */
-  publicKey: Uint8Array;
-}
 
 /**
  * Fetch the FHE network public key from the relayer.

--- a/packages/react-sdk/src/relayer/use-public-params.ts
+++ b/packages/react-sdk/src/relayer/use-public-params.ts
@@ -1,18 +1,9 @@
 "use client";
 
+import type { PublicParamsData } from "@zama-fhe/sdk";
 import { useQuery } from "../utils/query";
 import { publicParamsQueryOptions } from "@zama-fhe/sdk/query";
 import { useZamaSDK } from "../provider";
-
-export { publicParamsQueryOptions };
-
-/** Shape of the FHE public parameters returned by the relayer. */
-export interface PublicParamsData {
-  /** The raw public parameters bytes (WASM-ready). */
-  publicParams: Uint8Array;
-  /** Unique identifier for this public params version. */
-  publicParamsId: string;
-}
 
 /**
  * Fetch FHE public parameters for a given bit size from the relayer.

--- a/packages/react-sdk/src/wagmi/wagmi-signer.ts
+++ b/packages/react-sdk/src/wagmi/wagmi-signer.ts
@@ -67,6 +67,7 @@ export class WagmiSigner implements GenericSigner {
         startTimestamp: BigInt(typedData.message.startTimestamp),
         durationDays: BigInt(typedData.message.durationDays),
       },
+      // Cast: EIP712TypedData is a union; viem cannot correlate primaryType/types/message across union members, so the inferred `message` collapses to `never`.
     } as Parameters<typeof signTypedData>[1]);
   }
 

--- a/packages/react-sdk/src/wagmi/wagmi-signer.ts
+++ b/packages/react-sdk/src/wagmi/wagmi-signer.ts
@@ -59,11 +59,15 @@ export class WagmiSigner implements GenericSigner {
   async signTypedData(typedData: EIP712TypedData): Promise<Hex> {
     const { EIP712Domain: _, ...sigTypes } = typedData.types;
     return signTypedData(this.config, {
-      primaryType: Object.keys(sigTypes)[0]!,
+      primaryType: typedData.primaryType,
       types: sigTypes,
       domain: typedData.domain,
-      message: typedData.message,
-    });
+      message: {
+        ...typedData.message,
+        startTimestamp: BigInt(typedData.message.startTimestamp),
+        durationDays: BigInt(typedData.message.durationDays),
+      },
+    } as Parameters<typeof signTypedData>[1]);
   }
 
   async writeContract<

--- a/packages/sdk/etc/sdk-ethers.api.md
+++ b/packages/sdk/etc/sdk-ethers.api.md
@@ -6,6 +6,7 @@
 
 import { Abi } from 'viem';
 import { Address } from 'viem';
+import { Bytes32Hex } from '@zama-fhe/relayer-sdk/bundle';
 import { ContractFunctionArgs } from 'viem';
 import { ContractFunctionName } from 'viem';
 import { ContractFunctionReturnType } from 'viem';
@@ -14,6 +15,8 @@ import { EIP1193Events } from 'viem';
 import { EIP1193Provider } from 'viem';
 import { ethers } from 'ethers';
 import { Hex } from 'viem';
+import { KmsDelegatedUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
+import { KmsUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
 import { ProviderConnectInfo } from 'viem';
 import { ProviderMessage } from 'viem';
 import { ProviderRpcError } from 'viem';

--- a/packages/sdk/etc/sdk-node.api.md
+++ b/packages/sdk/etc/sdk-node.api.md
@@ -5,6 +5,8 @@
 ```ts
 
 import { Address } from 'viem';
+import { Bytes32Hex } from '@zama-fhe/relayer-sdk/bundle';
+import { ClearValueType } from '@zama-fhe/relayer-sdk/bundle';
 import { FhevmInstanceConfig } from '@zama-fhe/relayer-sdk/bundle';
 import { FhevmInstanceConfig as FhevmInstanceConfig_2 } from '@zama-fhe/relayer-sdk/node';
 import { Hex } from 'viem';
@@ -14,6 +16,8 @@ import { KeypairType } from '@zama-fhe/relayer-sdk/bundle';
 import { KeypairType as KeypairType_2 } from '@zama-fhe/relayer-sdk/node';
 import { KmsDelegatedUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
 import { KmsDelegatedUserDecryptEIP712Type as KmsDelegatedUserDecryptEIP712Type_2 } from '@zama-fhe/relayer-sdk/node';
+import { KmsUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
+import { PublicDecryptResults } from '@zama-fhe/relayer-sdk/bundle';
 import * as SDK from '@zama-fhe/relayer-sdk/bundle';
 import { Worker as Worker_2 } from 'node:worker_threads';
 import { ZKProofLike } from '@zama-fhe/relayer-sdk/bundle';
@@ -98,8 +102,7 @@ export abstract class BaseWorkerClient<TWorker, TConfig> {
     protected abstract wireEvents(worker: TWorker): void;
 }
 
-// @public
-export type ClearValueType = bigint | boolean | `0x${string}`;
+export { ClearValueType }
 
 // @public (undocumented)
 export type CreateDelegatedEIP712Payload = CreateDelegatedEIP712Request["payload"];
@@ -138,30 +141,7 @@ export interface CreateEIP712Request extends BaseRequest {
 }
 
 // @public (undocumented)
-export interface CreateEIP712ResponseData {
-    // (undocumented)
-    domain: {
-        name: string;
-        version: string;
-        chainId: number;
-        verifyingContract: Address;
-    };
-    // (undocumented)
-    message: {
-        publicKey: Hex;
-        contractAddresses: Address[];
-        startTimestamp: bigint;
-        durationDays: bigint;
-        extraData: Hex;
-    };
-    // (undocumented)
-    types: {
-        UserDecryptRequestVerification: {
-            name: string;
-            type: string;
-        }[];
-    };
-}
+export type CreateEIP712ResponseData = KmsUserDecryptEIP712Type;
 
 // @public
 export interface DelegatedUserDecryptParams {
@@ -216,30 +196,7 @@ export interface DelegatedUserDecryptResponseData {
 }
 
 // @public
-export interface EIP712TypedData {
-    // (undocumented)
-    domain: {
-        name: string;
-        version: string;
-        chainId: number;
-        verifyingContract: Address;
-    };
-    // (undocumented)
-    message: {
-        publicKey: Hex;
-        contractAddresses: readonly Address[];
-        startTimestamp: bigint;
-        durationDays: bigint;
-        extraData: Hex;
-    };
-    // (undocumented)
-    primaryType?: string;
-    // (undocumented)
-    types: Record<string, readonly {
-        readonly name: string;
-        readonly type: string;
-    }[]>;
-}
+export type EIP712TypedData = KmsUserDecryptEIP712Type | KmsDelegatedUserDecryptEIP712Type;
 
 // @public
 export interface EncryptParams {
@@ -267,20 +224,10 @@ export interface EncryptRequest extends BaseRequest {
 }
 
 // @public (undocumented)
-export interface EncryptResponseData {
-    // (undocumented)
-    handles: Uint8Array[];
-    // (undocumented)
-    inputProof: Uint8Array;
-}
+export type EncryptResponseData = InputProofBytesType;
 
 // @public
-export interface EncryptResult {
-    // (undocumented)
-    handles: Uint8Array[];
-    // (undocumented)
-    inputProof: Uint8Array;
-}
+export type EncryptResult = InputProofBytesType;
 
 // Warning: (ae-forgotten-export) The symbol "BaseResponse" needs to be exported by the entry point index.d.ts
 //
@@ -496,9 +443,7 @@ export interface PublicDecryptResponseData {
 }
 
 // @public
-export type PublicDecryptResult = Omit<SDK.PublicDecryptResults, "clearValues"> & {
-    clearValues: Readonly<Record<Handle, ClearValueType>>;
-};
+export type PublicDecryptResult = PublicDecryptResults;
 
 // @public
 export class RelayerNode implements RelayerSDK, Disposable {

--- a/packages/sdk/etc/sdk-node.api.md
+++ b/packages/sdk/etc/sdk-node.api.md
@@ -461,16 +461,14 @@ export class RelayerNode implements RelayerSDK, Disposable {
     generateKeypair(): Promise<KeypairType_2<Hex>>;
     // (undocumented)
     getAclAddress(): Promise<Address>;
+    // Warning: (ae-forgotten-export) The symbol "PublicKeyData" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    getPublicKey(): Promise<{
-        publicKeyId: string;
-        publicKey: Uint8Array;
-    } | null>;
+    getPublicKey(): Promise<PublicKeyData | null>;
+    // Warning: (ae-forgotten-export) The symbol "PublicParamsData" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    getPublicParams(bits: number): Promise<{
-        publicParams: Uint8Array;
-        publicParamsId: string;
-    } | null>;
+    getPublicParams(bits: number): Promise<PublicParamsData | null>;
     // (undocumented)
     publicDecrypt(handles: Handle[]): Promise<PublicDecryptResult>;
     // (undocumented)
@@ -501,14 +499,8 @@ export interface RelayerSDK {
     encrypt(params: EncryptParams): Promise<EncryptResult>;
     generateKeypair(): Promise<KeypairType<Hex>>;
     getAclAddress(): Promise<Address>;
-    getPublicKey(): Promise<{
-        publicKeyId: string;
-        publicKey: Uint8Array;
-    } | null>;
-    getPublicParams(bits: number): Promise<{
-        publicParams: Uint8Array;
-        publicParamsId: string;
-    } | null>;
+    getPublicKey(): Promise<PublicKeyData | null>;
+    getPublicParams(bits: number): Promise<PublicParamsData | null>;
     publicDecrypt(handles: Handle[]): Promise<PublicDecryptResult>;
     requestZKProofVerification(zkProof: ZKProofLike): Promise<InputProofBytesType>;
     terminate(): void;

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -638,14 +638,10 @@ export interface PublicKeyQueryConfig {
     query?: Record<string, unknown>;
 }
 
+// Warning: (ae-forgotten-export) The symbol "PublicKeyData" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export function publicKeyQueryOptions(sdk: ZamaSDK, config?: PublicKeyQueryConfig): QueryFactoryOptions<{
-    publicKeyId: string;
-    publicKey: Uint8Array;
-} | null, Error, {
-    publicKeyId: string;
-    publicKey: Uint8Array;
-} | null, typeof zamaQueryKeys.publicKey.all>;
+export function publicKeyQueryOptions(sdk: ZamaSDK, config?: PublicKeyQueryConfig): QueryFactoryOptions<PublicKeyData | null, Error, PublicKeyData | null, typeof zamaQueryKeys.publicKey.all>;
 
 // @public (undocumented)
 export interface PublicParamsQueryConfig {
@@ -653,14 +649,10 @@ export interface PublicParamsQueryConfig {
     query?: Record<string, unknown>;
 }
 
+// Warning: (ae-forgotten-export) The symbol "PublicParamsData" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export function publicParamsQueryOptions(sdk: ZamaSDK, bits: number, config?: PublicParamsQueryConfig): QueryFactoryOptions<{
-    publicParams: Uint8Array;
-    publicParamsId: string;
-} | null, Error, {
-    publicParams: Uint8Array;
-    publicParamsId: string;
-} | null, ReturnType<typeof zamaQueryKeys.publicParams.bits>>;
+export function publicParamsQueryOptions(sdk: ZamaSDK, bits: number, config?: PublicParamsQueryConfig): QueryFactoryOptions<PublicParamsData | null, Error, PublicParamsData | null, ReturnType<typeof zamaQueryKeys.publicParams.bits>>;
 
 // @public (undocumented)
 export interface QueryClientLike {
@@ -746,14 +738,8 @@ export interface RelayerSDK {
     encrypt(params: EncryptParams): Promise<EncryptResult>;
     generateKeypair(): Promise<KeypairType<Hex>>;
     getAclAddress(): Promise<Address>;
-    getPublicKey(): Promise<{
-        publicKeyId: string;
-        publicKey: Uint8Array;
-    } | null>;
-    getPublicParams(bits: number): Promise<{
-        publicParams: Uint8Array;
-        publicParamsId: string;
-    } | null>;
+    getPublicKey(): Promise<PublicKeyData | null>;
+    getPublicParams(bits: number): Promise<PublicParamsData | null>;
     publicDecrypt(handles: Handle[]): Promise<PublicDecryptResult>;
     requestZKProofVerification(zkProof: ZKProofLike): Promise<InputProofBytesType>;
     terminate(): void;

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -6,6 +6,8 @@
 
 import { Abi } from 'viem';
 import { Address } from 'viem';
+import { Bytes32Hex } from '@zama-fhe/relayer-sdk/bundle';
+import { ClearValueType } from '@zama-fhe/relayer-sdk/bundle';
 import { ContractFunctionArgs } from 'viem';
 import { ContractFunctionName } from 'viem';
 import { ContractFunctionReturnType } from 'viem';
@@ -13,11 +15,15 @@ import { Hex } from 'viem';
 import { InputProofBytesType } from '@zama-fhe/relayer-sdk/bundle';
 import { KeypairType } from '@zama-fhe/relayer-sdk/bundle';
 import { KmsDelegatedUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
+import { KmsUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
+import { KmsUserDecryptEIP712UserArgsType } from '@zama-fhe/relayer-sdk/bundle';
 import { MutationFunctionContext } from '@tanstack/query-core';
+import { PublicDecryptResults } from '@zama-fhe/relayer-sdk/bundle';
 import { QueryKey } from '@tanstack/query-core';
 import { QueryObserverOptions } from '@tanstack/query-core';
 import * as SDK from '@zama-fhe/relayer-sdk/bundle';
 import { skipToken } from '@tanstack/query-core';
+import { UserDecryptResults } from '@zama-fhe/relayer-sdk/bundle';
 import { ZKProofLike } from '@zama-fhe/relayer-sdk/bundle';
 
 // @public (undocumented)
@@ -80,8 +86,7 @@ export function batchDecryptBalancesAsMutationOptions(tokens: ReadonlyToken[]): 
 // @public
 export type BatchDecryptBalancesAsParams = BatchDecryptAsOptions;
 
-// @public
-export type ClearValueType = bigint | boolean | `0x${string}`;
+export { ClearValueType }
 
 // @public (undocumented)
 export function confidentialApproveMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.confidentialApprove", Address], ConfidentialApproveParams, TransactionResult>;
@@ -195,16 +200,11 @@ export interface CreateDelegatedUserDecryptEIP712Params {
 export function createEIP712MutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.createEIP712"], CreateEIP712Params, EIP712TypedData>;
 
 // @public
-export interface CreateEIP712Params {
-    // (undocumented)
-    contractAddresses: Address[];
-    // (undocumented)
-    durationDays?: number;
-    // (undocumented)
+export type CreateEIP712Params = Pick<KmsUserDecryptEIP712UserArgsType, "startTimestamp"> & {
     publicKey: Hex;
-    // (undocumented)
-    startTimestamp: number;
-}
+    contractAddresses: Address[];
+    durationDays?: number;
+};
 
 // @public (undocumented)
 export interface CredentialsAllowedEvent extends BaseEvent {
@@ -344,8 +344,8 @@ export interface DecryptHandle {
     handle: Handle;
 }
 
-// @public (undocumented)
-export type DecryptResult = Record<Handle, ClearValueType>;
+// @public
+export type DecryptResult = UserDecryptResults;
 
 // @public (undocumented)
 export interface DecryptStartEvent extends BaseEvent {
@@ -427,30 +427,7 @@ export interface DelegationSubmittedEvent extends BaseEvent {
 }
 
 // @public
-export interface EIP712TypedData {
-    // (undocumented)
-    domain: {
-        name: string;
-        version: string;
-        chainId: number;
-        verifyingContract: Address;
-    };
-    // (undocumented)
-    message: {
-        publicKey: Hex;
-        contractAddresses: readonly Address[];
-        startTimestamp: bigint;
-        durationDays: bigint;
-        extraData: Hex;
-    };
-    // (undocumented)
-    primaryType?: string;
-    // (undocumented)
-    types: Record<string, readonly {
-        readonly name: string;
-        readonly type: string;
-    }[]>;
-}
+export type EIP712TypedData = KmsUserDecryptEIP712Type | KmsDelegatedUserDecryptEIP712Type;
 
 // @public (undocumented)
 export interface EncryptEndEvent extends BaseEvent {
@@ -494,12 +471,7 @@ export interface EncryptParams {
 }
 
 // @public
-export interface EncryptResult {
-    // (undocumented)
-    handles: Uint8Array[];
-    // (undocumented)
-    inputProof: Uint8Array;
-}
+export type EncryptResult = InputProofBytesType;
 
 // @public (undocumented)
 export interface EncryptStartEvent extends BaseEvent {
@@ -658,9 +630,7 @@ export type OnChainEvent = ConfidentialTransferEvent | WrappedEvent | UnwrapRequ
 export function publicDecryptMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.publicDecrypt"], Handle[], PublicDecryptResult>;
 
 // @public
-export type PublicDecryptResult = Omit<SDK.PublicDecryptResults, "clearValues"> & {
-    clearValues: Readonly<Record<Handle, ClearValueType>>;
-};
+export type PublicDecryptResult = PublicDecryptResults;
 
 // @public (undocumented)
 export interface PublicKeyQueryConfig {

--- a/packages/sdk/etc/sdk-viem.api.md
+++ b/packages/sdk/etc/sdk-viem.api.md
@@ -6,11 +6,14 @@
 
 import { Abi } from 'viem';
 import { Address } from 'viem';
+import { Bytes32Hex } from '@zama-fhe/relayer-sdk/bundle';
 import { ContractFunctionArgs } from 'viem';
 import { ContractFunctionName } from 'viem';
 import { ContractFunctionReturnType } from 'viem';
 import { EIP1193Provider } from 'viem';
 import { Hex } from 'viem';
+import { KmsDelegatedUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
+import { KmsUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
 import { PublicClient } from 'viem';
 import { WalletClient } from 'viem';
 

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -11698,6 +11698,17 @@ export interface PaginatedResult<T> {
 export type PublicDecryptResult = PublicDecryptResults;
 
 // @public
+export interface PublicKeyData {
+    // (undocumented)
+    publicKey: Uint8Array;
+    // (undocumented)
+    publicKeyId: string;
+}
+
+// @public
+export type PublicParamsData = SDK.PublicParams<Uint8Array>[keyof SDK.PublicParams<Uint8Array>];
+
+// @public
 export function rateContract(tokenAddress: Address): {
     readonly address: `0x${string}`;
     readonly abi: readonly [{
@@ -13050,14 +13061,8 @@ export interface RelayerSDK {
     encrypt(params: EncryptParams): Promise<EncryptResult>;
     generateKeypair(): Promise<KeypairType<Hex>>;
     getAclAddress(): Promise<Address>;
-    getPublicKey(): Promise<{
-        publicKeyId: string;
-        publicKey: Uint8Array;
-    } | null>;
-    getPublicParams(bits: number): Promise<{
-        publicParams: Uint8Array;
-        publicParamsId: string;
-    } | null>;
+    getPublicKey(): Promise<PublicKeyData | null>;
+    getPublicParams(bits: number): Promise<PublicParamsData | null>;
     publicDecrypt(handles: Handle[]): Promise<PublicDecryptResult>;
     requestZKProofVerification(zkProof: ZKProofLike): Promise<InputProofBytesType>;
     terminate(): void;
@@ -13078,14 +13083,8 @@ export class RelayerWeb implements RelayerSDK, Disposable {
     generateKeypair(): Promise<KeypairType<Hex>>;
     // (undocumented)
     getAclAddress(): Promise<Address>;
-    getPublicKey(): Promise<{
-        publicKeyId: string;
-        publicKey: Uint8Array;
-    } | null>;
-    getPublicParams(bits: number): Promise<{
-        publicParams: Uint8Array;
-        publicParamsId: string;
-    } | null>;
+    getPublicKey(): Promise<PublicKeyData | null>;
+    getPublicParams(bits: number): Promise<PublicParamsData | null>;
     get initError(): Error | undefined;
     publicDecrypt(handles: Handle[]): Promise<PublicDecryptResult>;
     requestZKProofVerification(zkProof: ZKProofLike): Promise<InputProofBytesType>;

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -6,6 +6,8 @@
 
 import { Abi } from 'viem';
 import { Address } from 'viem';
+import { Bytes32Hex } from '@zama-fhe/relayer-sdk/bundle';
+import { ClearValueType } from '@zama-fhe/relayer-sdk/bundle';
 import { ContractFunctionArgs } from 'viem';
 import { ContractFunctionName } from 'viem';
 import { ContractFunctionReturnType } from 'viem';
@@ -15,7 +17,10 @@ import { Hex } from 'viem';
 import { InputProofBytesType } from '@zama-fhe/relayer-sdk/bundle';
 import { KeypairType } from '@zama-fhe/relayer-sdk/bundle';
 import { KmsDelegatedUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
+import { KmsUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
+import { PublicDecryptResults } from '@zama-fhe/relayer-sdk/bundle';
 import * as SDK from '@zama-fhe/relayer-sdk/bundle';
+import { UserDecryptResults } from '@zama-fhe/relayer-sdk/bundle';
 import { ZKProofLike } from '@zama-fhe/relayer-sdk/bundle';
 
 // @public
@@ -539,8 +544,7 @@ export const chromeSessionStorage: ChromeSessionStorage;
 // @public
 export function clearPendingUnshield(storage: GenericStorage, wrapperAddress: Address): Promise<void>;
 
-// @public
-export type ClearValueType = bigint | boolean | `0x${string}`;
+export { ClearValueType }
 
 // @public
 export function confidentialBalanceOfContract(tokenAddress: Address, userAddress: Address): {
@@ -5975,8 +5979,8 @@ export class DecryptionFailedError extends ZamaError {
     constructor(message: string, options?: ErrorOptions);
 }
 
-// @public (undocumented)
-export type DecryptResult = Record<Handle, ClearValueType>;
+// @public
+export type DecryptResult = UserDecryptResults;
 
 // @public (undocumented)
 export interface DecryptStartEvent extends BaseEvent {
@@ -6202,30 +6206,7 @@ export interface DelegationSubmittedEvent extends BaseEvent {
 }
 
 // @public
-export interface EIP712TypedData {
-    // (undocumented)
-    domain: {
-        name: string;
-        version: string;
-        chainId: number;
-        verifyingContract: Address;
-    };
-    // (undocumented)
-    message: {
-        publicKey: Hex;
-        contractAddresses: readonly Address[];
-        startTimestamp: bigint;
-        durationDays: bigint;
-        extraData: Hex;
-    };
-    // (undocumented)
-    primaryType?: string;
-    // (undocumented)
-    types: Record<string, readonly {
-        readonly name: string;
-        readonly type: string;
-    }[]>;
-}
+export type EIP712TypedData = KmsUserDecryptEIP712Type | KmsDelegatedUserDecryptEIP712Type;
 
 // @public (undocumented)
 export interface EncryptEndEvent extends BaseEvent {
@@ -6271,12 +6252,7 @@ export interface EncryptParams {
 }
 
 // @public
-export interface EncryptResult {
-    // (undocumented)
-    handles: Uint8Array[];
-    // (undocumented)
-    inputProof: Uint8Array;
-}
+export type EncryptResult = InputProofBytesType;
 
 // @public (undocumented)
 export interface EncryptStartEvent extends BaseEvent {
@@ -8608,7 +8584,7 @@ export function getTokenPairsSliceContract(registry: Address, fromIndex: bigint,
 };
 
 // @public
-export type Handle = `0x${string}`;
+export type Handle = Bytes32Hex;
 
 // @public
 export const HardhatConfig: {
@@ -11719,9 +11695,7 @@ export interface PaginatedResult<T> {
 }
 
 // @public
-export type PublicDecryptResult = Omit<SDK.PublicDecryptResults, "clearValues"> & {
-    clearValues: Readonly<Record<Handle, ClearValueType>>;
-};
+export type PublicDecryptResult = PublicDecryptResults;
 
 // @public
 export function rateContract(tokenAddress: Address): {

--- a/packages/sdk/src/credentials/delegated-credentials-manager.ts
+++ b/packages/sdk/src/credentials/delegated-credentials-manager.ts
@@ -211,17 +211,6 @@ export class DelegatedCredentialsManager extends BaseCredentialsManager<
       meta.startTimestamp,
       meta.durationDays,
     );
-    return this.signer.signTypedData({
-      domain: {
-        ...delegatedEIP712.domain,
-        chainId: Number(delegatedEIP712.domain.chainId),
-      },
-      types: delegatedEIP712.types,
-      message: {
-        ...delegatedEIP712.message,
-        startTimestamp: BigInt(delegatedEIP712.message.startTimestamp),
-        durationDays: BigInt(delegatedEIP712.message.durationDays),
-      },
-    });
+    return this.signer.signTypedData(delegatedEIP712);
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -23,6 +23,8 @@ export type {
   EIP712TypedData,
   DelegatedUserDecryptParams,
   NetworkType,
+  PublicKeyData,
+  PublicParamsData,
 } from "./relayer/relayer-sdk.types";
 export type {
   FheTypeName,

--- a/packages/sdk/src/query/create-eip712.ts
+++ b/packages/sdk/src/query/create-eip712.ts
@@ -1,15 +1,19 @@
+import type { KmsUserDecryptEIP712UserArgsType } from "@zama-fhe/relayer-sdk/bundle";
 import type { Address, Hex } from "viem";
 import type { EIP712TypedData } from "../relayer/relayer-sdk.types";
 import type { ZamaSDK } from "../zama-sdk";
 import type { MutationFactoryOptions } from "./factory-types";
 
-/** Variables for {@link createEIP712MutationOptions}. */
-export interface CreateEIP712Params {
+/**
+ * Variables for {@link createEIP712MutationOptions}. Derived from
+ * {@link KmsUserDecryptEIP712UserArgsType} with stricter `publicKey`/`contractAddresses`
+ * typing and optional `durationDays`. `extraData` is computed internally and omitted.
+ */
+export type CreateEIP712Params = Pick<KmsUserDecryptEIP712UserArgsType, "startTimestamp"> & {
   publicKey: Hex;
   contractAddresses: Address[];
-  startTimestamp: number;
   durationDays?: number;
-}
+};
 
 export function createEIP712MutationOptions(
   sdk: ZamaSDK,

--- a/packages/sdk/src/query/public-key.ts
+++ b/packages/sdk/src/query/public-key.ts
@@ -1,3 +1,4 @@
+import type { PublicKeyData } from "../relayer/relayer-sdk.types";
 import type { ZamaSDK } from "../zama-sdk";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";
@@ -11,9 +12,9 @@ export function publicKeyQueryOptions(
   sdk: ZamaSDK,
   config?: PublicKeyQueryConfig,
 ): QueryFactoryOptions<
-  { publicKeyId: string; publicKey: Uint8Array } | null,
+  PublicKeyData | null,
   Error,
-  { publicKeyId: string; publicKey: Uint8Array } | null,
+  PublicKeyData | null,
   typeof zamaQueryKeys.publicKey.all
 > {
   const queryKey = zamaQueryKeys.publicKey.all;

--- a/packages/sdk/src/query/public-params.ts
+++ b/packages/sdk/src/query/public-params.ts
@@ -1,3 +1,4 @@
+import type { PublicParamsData } from "../relayer/relayer-sdk.types";
 import type { ZamaSDK } from "../zama-sdk";
 import type { QueryFactoryOptions } from "./factory-types";
 import { filterQueryOptions } from "./utils";
@@ -12,9 +13,9 @@ export function publicParamsQueryOptions(
   bits: number,
   config?: PublicParamsQueryConfig,
 ): QueryFactoryOptions<
-  { publicParams: Uint8Array; publicParamsId: string } | null,
+  PublicParamsData | null,
   Error,
-  { publicParams: Uint8Array; publicParamsId: string } | null,
+  PublicParamsData | null,
   ReturnType<typeof zamaQueryKeys.publicParams.bits>
 > {
   const queryKey = zamaQueryKeys.publicParams.bits(bits);

--- a/packages/sdk/src/query/user-decrypt.ts
+++ b/packages/sdk/src/query/user-decrypt.ts
@@ -1,15 +1,14 @@
-import type { HandleContractPair, UserDecryptResults } from "@zama-fhe/relayer-sdk/bundle";
+import type { UserDecryptResults } from "@zama-fhe/relayer-sdk/bundle";
 import type { Address } from "viem";
 import type { Handle } from "../relayer/relayer-sdk.types";
 import type { ZamaSDK } from "../zama-sdk";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";
 
-/** Handle/contract pair. Structurally matches {@link HandleContractPair} with strict `Handle`/`Address` typing. */
-export type DecryptHandle = Omit<HandleContractPair, "handle" | "contractAddress"> & {
+export interface DecryptHandle {
   handle: Handle;
   contractAddress: Address;
-};
+}
 
 /** Alias for {@link UserDecryptResults}. */
 export type DecryptResult = UserDecryptResults;

--- a/packages/sdk/src/query/user-decrypt.ts
+++ b/packages/sdk/src/query/user-decrypt.ts
@@ -1,15 +1,18 @@
+import type { HandleContractPair, UserDecryptResults } from "@zama-fhe/relayer-sdk/bundle";
 import type { Address } from "viem";
-import type { ClearValueType, Handle } from "../relayer/relayer-sdk.types";
+import type { Handle } from "../relayer/relayer-sdk.types";
 import type { ZamaSDK } from "../zama-sdk";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";
 
-export interface DecryptHandle {
+/** Handle/contract pair. Structurally matches {@link HandleContractPair} with strict `Handle`/`Address` typing. */
+export type DecryptHandle = Omit<HandleContractPair, "handle" | "contractAddress"> & {
   handle: Handle;
   contractAddress: Address;
-}
+};
 
-export type DecryptResult = Record<Handle, ClearValueType>;
+/** Alias for {@link UserDecryptResults}. */
+export type DecryptResult = UserDecryptResults;
 
 export interface UserDecryptQueryConfig {
   handles: DecryptHandle[];

--- a/packages/sdk/src/relayer/__tests__/relayer-utils-eip712.test.ts
+++ b/packages/sdk/src/relayer/__tests__/relayer-utils-eip712.test.ts
@@ -37,22 +37,29 @@ import type { Address } from "viem";
 
 const MOCK_EIP712 = {
   domain: {
-    name: "KmsDecryptor",
+    name: "Decryption",
     version: "1",
-    chainId: 1,
+    chainId: 1n,
     verifyingContract: "0x1a1A1A1A1a1A1A1a1A1a1a1a1a1a1a1A1A1a1a1a",
   },
   types: {
+    EIP712Domain: [
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+    ],
     UserDecryptRequestVerification: [
       { name: "publicKey", type: "bytes" },
       { name: "contractAddresses", type: "address[]" },
     ],
   },
+  primaryType: "UserDecryptRequestVerification",
   message: {
     publicKey: "0xpub",
     contractAddresses: ["0x1a1A1A1A1a1A1A1a1A1a1a1a1a1a1a1A1A1a1a1a"],
-    startTimestamp: 1000n,
-    durationDays: 7n,
+    startTimestamp: "1000",
+    durationDays: "7",
     extraData: "0x",
   },
 };

--- a/packages/sdk/src/relayer/cleartext/__tests__/relayer-cleartext.test.ts
+++ b/packages/sdk/src/relayer/cleartext/__tests__/relayer-cleartext.test.ts
@@ -260,7 +260,7 @@ describe(RelayerCleartext, () => {
     expect(typedData.domain).toEqual({
       name: "Decryption",
       version: "1",
-      chainId: hardhatCleartextConfig.chainId,
+      chainId: BigInt(hardhatCleartextConfig.chainId),
       verifyingContract: hardhatCleartextConfig.verifyingContractAddressDecryption,
     });
     expect(typedData.types.UserDecryptRequestVerification.map((field) => field.name)).toEqual([
@@ -273,8 +273,8 @@ describe(RelayerCleartext, () => {
     expect(typedData.message).toEqual({
       publicKey: "0x" + "ab".repeat(32),
       contractAddresses: [CONTRACT_ADDRESS],
-      startTimestamp: 1710000000n,
-      durationDays: 7n,
+      startTimestamp: "1710000000",
+      durationDays: "7",
       extraData: "0x00",
     });
   });

--- a/packages/sdk/src/relayer/cleartext/eip712.ts
+++ b/packages/sdk/src/relayer/cleartext/eip712.ts
@@ -1,24 +1,30 @@
-import type { Address, TypedDataDomain } from "viem";
+import type { Address } from "viem";
 import type {
+  CoprocessorEIP712DomainType,
   CoprocessorEIP712TypesType,
   KmsDelegatedUserDecryptEIP712TypesType,
+  KmsEIP712DomainType,
   KmsPublicDecryptEIP712TypesType,
   KmsUserDecryptEIP712TypesType,
 } from "@zama-fhe/relayer-sdk/bundle";
 
-type DomainFactory = (chainId: number | bigint, verifyingContract: Address) => TypedDataDomain;
-
-const inputDomain: DomainFactory = (chainId, verifyingContract) => ({
+const inputDomain = (
+  chainId: number | bigint,
+  verifyingContract: Address,
+): CoprocessorEIP712DomainType => ({
   name: "InputVerification",
   version: "1",
-  chainId: Number(chainId),
+  chainId: BigInt(chainId),
   verifyingContract,
 });
 
-const decryptionDomain: DomainFactory = (chainId, verifyingContract) => ({
+const decryptionDomain = (
+  chainId: number | bigint,
+  verifyingContract: Address,
+): KmsEIP712DomainType => ({
   name: "Decryption",
   version: "1",
-  chainId: Number(chainId),
+  chainId: BigInt(chainId),
   verifyingContract,
 });
 

--- a/packages/sdk/src/relayer/cleartext/relayer-cleartext.ts
+++ b/packages/sdk/src/relayer/cleartext/relayer-cleartext.ts
@@ -181,14 +181,14 @@ export class RelayerCleartext implements RelayerSDK, Disposable {
       domain: USER_DECRYPT_EIP712.domain(
         this.#config.chainId,
         this.#config.verifyingContractAddressDecryption,
-      ) as EIP712TypedData["domain"],
+      ),
       types: USER_DECRYPT_TYPES,
       primaryType: "UserDecryptRequestVerification",
       message: {
         publicKey,
         contractAddresses,
-        startTimestamp: BigInt(startTimestamp),
-        durationDays: BigInt(durationDays),
+        startTimestamp: String(startTimestamp),
+        durationDays: String(durationDays),
         extraData: "0x00",
       },
     };
@@ -293,7 +293,7 @@ export class RelayerCleartext implements RelayerSDK, Disposable {
       domain: KMS_DECRYPTION_EIP712.domain(
         this.#config.gatewayChainId,
         this.#config.verifyingContractAddressDecryption,
-      ) as KmsPublicDecryptEIP712Type["domain"],
+      ),
       types: KMS_DECRYPTION_TYPES,
       primaryType: "PublicDecryptVerification",
       message: {
@@ -320,7 +320,7 @@ export class RelayerCleartext implements RelayerSDK, Disposable {
     durationDays = 7,
   ): Promise<KmsDelegatedUserDecryptEIP712Type> {
     const message: KmsDelegatedUserDecryptEIP712Type["message"] = {
-      publicKey: publicKey as KmsDelegatedUserDecryptEIP712Type["message"]["publicKey"],
+      publicKey,
       contractAddresses,
       delegatorAddress: getAddress(delegatorAddress),
       startTimestamp: String(startTimestamp),
@@ -330,9 +330,9 @@ export class RelayerCleartext implements RelayerSDK, Disposable {
 
     return {
       domain: DELEGATED_USER_DECRYPT_EIP712.domain(
-        BigInt(this.#config.chainId),
+        this.#config.chainId,
         this.#config.verifyingContractAddressDecryption,
-      ) as KmsDelegatedUserDecryptEIP712Type["domain"],
+      ),
       types: DELEGATED_USER_DECRYPT_TYPES,
       primaryType: "DelegatedUserDecryptRequestVerification",
       message,

--- a/packages/sdk/src/relayer/cleartext/relayer-cleartext.ts
+++ b/packages/sdk/src/relayer/cleartext/relayer-cleartext.ts
@@ -33,6 +33,8 @@ import type {
   EncryptResult,
   Handle,
   PublicDecryptResult,
+  PublicKeyData,
+  PublicParamsData,
   UserDecryptParams,
 } from "../relayer-sdk.types";
 import {
@@ -356,13 +358,11 @@ export class RelayerCleartext implements RelayerSDK, Disposable {
     throw new ConfigurationError("Not implemented in cleartext mode");
   }
 
-  async getPublicKey(): Promise<{ publicKeyId: string; publicKey: Uint8Array } | null> {
+  async getPublicKey(): Promise<PublicKeyData | null> {
     return { publicKeyId: "mock-public-key-id", publicKey: new Uint8Array([32]) };
   }
 
-  async getPublicParams(
-    _bits: number,
-  ): Promise<{ publicParams: Uint8Array; publicParamsId: string } | null> {
+  async getPublicParams(_bits: number): Promise<PublicParamsData | null> {
     return { publicParams: new Uint8Array([32]), publicParamsId: "mock-public-params-id" };
   }
 

--- a/packages/sdk/src/relayer/fhe-artifact-cache.ts
+++ b/packages/sdk/src/relayer/fhe-artifact-cache.ts
@@ -1,6 +1,7 @@
 import type { GenericStorage } from "../types";
 import { assertObject, assertStringProp, toError } from "../utils";
 import type { GenericLogger } from "../worker/worker.types";
+import type { PublicKeyData, PublicParamsData } from "./relayer-sdk.types";
 
 // ── Cached data shapes ──────────────────────────────────────
 
@@ -33,13 +34,10 @@ interface CachedPublicParams {
 // ── Return types ────────────────────────────────────────────
 
 /** Return type of the public key fetcher. */
-type PublicKeyResult = { publicKeyId: string; publicKey: Uint8Array } | null;
+type PublicKeyResult = PublicKeyData | null;
 
 /** Return type of the public params fetcher. */
-type PublicParamsResult = {
-  publicParamsId: string;
-  publicParams: Uint8Array;
-} | null;
+type PublicParamsResult = PublicParamsData | null;
 
 // ── Constants ───────────────────────────────────────────────
 

--- a/packages/sdk/src/relayer/relayer-node.ts
+++ b/packages/sdk/src/relayer/relayer-node.ts
@@ -21,6 +21,8 @@ import type {
   EncryptResult,
   Handle,
   PublicDecryptResult,
+  PublicKeyData,
+  PublicParamsData,
   UserDecryptParams,
 } from "./relayer-sdk.types";
 import { DefaultConfigs, withRetry } from "./relayer-utils";
@@ -263,10 +265,7 @@ export class RelayerNode implements RelayerSDK, Disposable {
     });
   }
 
-  async getPublicKey(): Promise<{
-    publicKeyId: string;
-    publicKey: Uint8Array;
-  } | null> {
+  async getPublicKey(): Promise<PublicKeyData | null> {
     const pool = await this.#ensurePool();
     if (this.#artifactCache) {
       return this.#artifactCache.getPublicKey(async () => (await pool.getPublicKey()).result);
@@ -274,9 +273,7 @@ export class RelayerNode implements RelayerSDK, Disposable {
     return (await pool.getPublicKey()).result;
   }
 
-  async getPublicParams(
-    bits: number,
-  ): Promise<{ publicParams: Uint8Array; publicParamsId: string } | null> {
+  async getPublicParams(bits: number): Promise<PublicParamsData | null> {
     const pool = await this.#ensurePool();
     if (this.#artifactCache) {
       return this.#artifactCache.getPublicParams(

--- a/packages/sdk/src/relayer/relayer-node.ts
+++ b/packages/sdk/src/relayer/relayer-node.ts
@@ -23,7 +23,7 @@ import type {
   PublicDecryptResult,
   UserDecryptParams,
 } from "./relayer-sdk.types";
-import { buildEIP712DomainType, DefaultConfigs, withRetry } from "./relayer-utils";
+import { DefaultConfigs, withRetry } from "./relayer-utils";
 
 export interface RelayerNodeConfig {
   transports: Record<number, Partial<FhevmInstanceConfig>>;
@@ -193,34 +193,12 @@ export class RelayerNode implements RelayerSDK, Disposable {
     durationDays = 7,
   ): Promise<EIP712TypedData> {
     const pool = await this.#ensurePool();
-    const result = await pool.createEIP712({
+    return pool.createEIP712({
       publicKey,
       contractAddresses,
       startTimestamp,
       durationDays,
     });
-
-    const domain = {
-      name: result.domain.name,
-      version: result.domain.version,
-      chainId: result.domain.chainId,
-      verifyingContract: result.domain.verifyingContract,
-    };
-
-    return {
-      domain,
-      types: {
-        EIP712Domain: buildEIP712DomainType(domain),
-        UserDecryptRequestVerification: result.types.UserDecryptRequestVerification,
-      },
-      message: {
-        publicKey: result.message.publicKey,
-        contractAddresses: result.message.contractAddresses,
-        startTimestamp: result.message.startTimestamp,
-        durationDays: result.message.durationDays,
-        extraData: result.message.extraData,
-      },
-    };
   }
 
   async encrypt(params: EncryptParams): Promise<EncryptResult> {

--- a/packages/sdk/src/relayer/relayer-sdk.ts
+++ b/packages/sdk/src/relayer/relayer-sdk.ts
@@ -12,6 +12,8 @@ import type {
   EncryptResult,
   Handle,
   PublicDecryptResult,
+  PublicKeyData,
+  PublicParamsData,
   UserDecryptParams,
 } from "./relayer-sdk.types";
 import type { Address, Hex } from "viem";
@@ -59,15 +61,10 @@ export interface RelayerSDK {
   requestZKProofVerification(zkProof: ZKProofLike): Promise<InputProofBytesType>;
 
   /** Fetch the FHE network public key. Returns `null` if not available. */
-  getPublicKey(): Promise<{
-    publicKeyId: string;
-    publicKey: Uint8Array;
-  } | null>;
+  getPublicKey(): Promise<PublicKeyData | null>;
 
   /** Fetch FHE public parameters for a given bit size. Returns `null` if not available. */
-  getPublicParams(
-    bits: number,
-  ): Promise<{ publicParams: Uint8Array; publicParamsId: string } | null>;
+  getPublicParams(bits: number): Promise<PublicParamsData | null>;
 
   /** Return the ACL contract address for the current chain. */
   getAclAddress(): Promise<Address>;

--- a/packages/sdk/src/relayer/relayer-sdk.types.ts
+++ b/packages/sdk/src/relayer/relayer-sdk.types.ts
@@ -1,4 +1,12 @@
 import type * as SDK from "@zama-fhe/relayer-sdk/bundle";
+import type {
+  Bytes32Hex,
+  ClearValueType,
+  InputProofBytesType,
+  KmsDelegatedUserDecryptEIP712Type,
+  KmsUserDecryptEIP712Type,
+  PublicDecryptResults,
+} from "@zama-fhe/relayer-sdk/bundle";
 import type { Address, Hex } from "viem";
 import type { GenericLogger } from "../worker/worker.types";
 import type { GenericStorage } from "../types";
@@ -66,17 +74,13 @@ export interface RelayerWebConfig {
   fheArtifactCacheTTL?: number;
 }
 
-/** Result from encryption operation */
-export interface EncryptResult {
-  handles: Uint8Array[];
-  inputProof: Uint8Array;
-}
+/** Result from encryption operation. Alias for {@link InputProofBytesType}. */
+export type EncryptResult = InputProofBytesType;
 
-/** Canonical SDK type for encrypted ciphertext handles (`bytes32` values). */
-export type Handle = `0x${string}`;
+/** Canonical SDK type for encrypted ciphertext handles (`bytes32` values). Alias for {@link Bytes32Hex}. */
+export type Handle = Bytes32Hex;
 
-/** Decrypted value type — one of bigint, boolean, or hex-encoded bytes. */
-export type ClearValueType = bigint | boolean | `0x${string}`;
+export type { ClearValueType };
 
 /** A single value to encrypt with its FHE type. */
 export type EncryptInput =
@@ -114,35 +118,14 @@ export interface UserDecryptParams {
   durationDays: number;
 }
 
-/** Result from public decryption */
-export type PublicDecryptResult = Omit<SDK.PublicDecryptResults, "clearValues"> & {
-  clearValues: Readonly<Record<Handle, ClearValueType>>;
-};
+/** Result from public decryption. Alias for {@link PublicDecryptResults}. */
+export type PublicDecryptResult = PublicDecryptResults;
 
-/** EIP712 typed data structure */
-export interface EIP712TypedData {
-  domain: {
-    name: string;
-    version: string;
-    chainId: number;
-    verifyingContract: Address;
-  };
-  types: Record<
-    string,
-    readonly {
-      readonly name: string;
-      readonly type: string;
-    }[]
-  >;
-  primaryType?: string;
-  message: {
-    publicKey: Hex;
-    contractAddresses: readonly Address[];
-    startTimestamp: bigint;
-    durationDays: bigint;
-    extraData: Hex;
-  };
-}
+/**
+ * EIP712 typed data structure for user or delegated user decrypt requests.
+ * Union of the relayer-sdk's two user-decrypt EIP712 shapes.
+ */
+export type EIP712TypedData = KmsUserDecryptEIP712Type | KmsDelegatedUserDecryptEIP712Type;
 
 /** Parameters for delegated user decryption */
 export interface DelegatedUserDecryptParams {

--- a/packages/sdk/src/relayer/relayer-sdk.types.ts
+++ b/packages/sdk/src/relayer/relayer-sdk.types.ts
@@ -127,6 +127,17 @@ export type PublicDecryptResult = PublicDecryptResults;
  */
 export type EIP712TypedData = KmsUserDecryptEIP712Type | KmsDelegatedUserDecryptEIP712Type;
 
+/** TFHE public key */
+export interface PublicKeyData {
+  publicKeyId: string;
+  publicKey: Uint8Array;
+}
+
+/**
+ * TFHE public parameters
+ */
+export type PublicParamsData = SDK.PublicParams<Uint8Array>[keyof SDK.PublicParams<Uint8Array>];
+
 /** Parameters for delegated user decryption */
 export interface DelegatedUserDecryptParams {
   handles: Handle[];

--- a/packages/sdk/src/relayer/relayer-utils.ts
+++ b/packages/sdk/src/relayer/relayer-utils.ts
@@ -1,6 +1,5 @@
 import type { FhevmInstanceConfig } from "@zama-fhe/relayer-sdk/bundle";
 import type { Address } from "viem";
-import type { EIP712TypedData } from "./relayer-sdk.types";
 
 const MAX_RETRIES = 2;
 const RETRY_BASE_MS = 500;
@@ -141,24 +140,3 @@ export const DefaultConfigs: Record<number, ExtendedFhevmInstanceConfig> = {
   [SepoliaConfig.chainId]: SepoliaConfig,
   [HardhatConfig.chainId]: HardhatConfig,
 } as const;
-
-/** EIP-712 domain field → Solidity type. Order follows the EIP-712 spec. */
-const DOMAIN_FIELD_TYPES: Record<string, string> = {
-  name: "string",
-  version: "string",
-  chainId: "uint256",
-  verifyingContract: "address",
-  salt: "bytes32",
-};
-
-/**
- * Build `EIP712Domain` type entries from the keys present in a domain object.
- * Order matches the EIP-712 spec (name → version → chainId → verifyingContract → salt).
- */
-export function buildEIP712DomainType(
-  domain: EIP712TypedData["domain"],
-): { name: string; type: string }[] {
-  return Object.keys(DOMAIN_FIELD_TYPES)
-    .filter((k) => k in domain)
-    .map((k) => ({ name: k, type: DOMAIN_FIELD_TYPES[k]! }));
-}

--- a/packages/sdk/src/relayer/relayer-web.ts
+++ b/packages/sdk/src/relayer/relayer-web.ts
@@ -19,6 +19,8 @@ import type {
   EncryptResult,
   Handle,
   PublicDecryptResult,
+  PublicKeyData,
+  PublicParamsData,
   RelayerSDKStatus,
   RelayerWebConfig,
   UserDecryptParams,
@@ -394,10 +396,7 @@ export class RelayerWeb implements RelayerSDK, Disposable {
    * Get the TFHE compact public key.
    * When storage is configured, the result is cached persistently.
    */
-  async getPublicKey(): Promise<{
-    publicKeyId: string;
-    publicKey: Uint8Array;
-  } | null> {
+  async getPublicKey(): Promise<PublicKeyData | null> {
     const worker = await this.#ensureWorker();
     if (this.#artifactCache) {
       return this.#artifactCache.getPublicKey(async () => (await worker.getPublicKey()).result);
@@ -409,9 +408,7 @@ export class RelayerWeb implements RelayerSDK, Disposable {
    * Get public parameters for encryption capacity.
    * When storage is configured, the result is cached persistently.
    */
-  async getPublicParams(
-    bits: number,
-  ): Promise<{ publicParams: Uint8Array; publicParamsId: string } | null> {
+  async getPublicParams(bits: number): Promise<PublicParamsData | null> {
     const worker = await this.#ensureWorker();
     if (this.#artifactCache) {
       return this.#artifactCache.getPublicParams(

--- a/packages/sdk/src/relayer/relayer-web.ts
+++ b/packages/sdk/src/relayer/relayer-web.ts
@@ -23,7 +23,7 @@ import type {
   RelayerWebConfig,
   UserDecryptParams,
 } from "./relayer-sdk.types";
-import { buildEIP712DomainType, DefaultConfigs, withRetry } from "./relayer-utils";
+import { DefaultConfigs, withRetry } from "./relayer-utils";
 
 /**
  * Pinned relayer SDK version used for the WASM CDN bundle.
@@ -287,34 +287,12 @@ export class RelayerWeb implements RelayerSDK, Disposable {
     durationDays = 7,
   ): Promise<EIP712TypedData> {
     const worker = await this.#ensureWorker();
-    const result = await worker.createEIP712({
+    return worker.createEIP712({
       publicKey,
       contractAddresses,
       startTimestamp,
       durationDays,
     });
-
-    const domain = {
-      name: result.domain.name,
-      version: result.domain.version,
-      chainId: result.domain.chainId,
-      verifyingContract: result.domain.verifyingContract,
-    };
-
-    return {
-      domain,
-      types: {
-        EIP712Domain: buildEIP712DomainType(domain),
-        UserDecryptRequestVerification: result.types.UserDecryptRequestVerification,
-      },
-      message: {
-        publicKey: result.message.publicKey,
-        contractAddresses: result.message.contractAddresses,
-        startTimestamp: result.message.startTimestamp,
-        durationDays: result.message.durationDays,
-        extraData: result.message.extraData,
-      },
-    };
   }
 
   /**

--- a/packages/sdk/src/viem/__tests__/viem.test.ts
+++ b/packages/sdk/src/viem/__tests__/viem.test.ts
@@ -100,16 +100,25 @@ describe("ViemSigner", () => {
   describe("signTypedData", () => {
     function createTypedData(tokenAddress: Address): EIP712TypedData {
       return {
-        domain: { name: "Test", version: "1", chainId: 1, verifyingContract: tokenAddress },
-        types: { Transfer: [{ name: "to", type: "address" }] },
+        domain: { name: "Decryption", version: "1", chainId: 1n, verifyingContract: tokenAddress },
+        types: {
+          EIP712Domain: [
+            { name: "name", type: "string" },
+            { name: "version", type: "string" },
+            { name: "chainId", type: "uint256" },
+            { name: "verifyingContract", type: "address" },
+          ],
+          UserDecryptRequestVerification: [{ name: "publicKey", type: "bytes" }],
+        },
+        primaryType: "UserDecryptRequestVerification",
         message: {
           publicKey: "0xkey",
           contractAddresses: ["0x1" as Address],
-          startTimestamp: 1000n,
-          durationDays: 1n,
+          startTimestamp: "1000",
+          durationDays: "1",
           extraData: "0x",
         },
-      };
+      } as EIP712TypedData;
     }
 
     vit(
@@ -120,8 +129,14 @@ describe("ViemSigner", () => {
         expect(result).toBe("0xsignature");
         expect(walletClient.signTypedData).toHaveBeenCalledWith({
           account: walletClient.account,
-          primaryType: "Transfer",
-          ...typedData,
+          primaryType: "UserDecryptRequestVerification",
+          types: { UserDecryptRequestVerification: typedData.types.UserDecryptRequestVerification },
+          domain: typedData.domain,
+          message: {
+            ...typedData.message,
+            startTimestamp: 1000n,
+            durationDays: 1n,
+          },
         });
       },
     );

--- a/packages/sdk/src/viem/viem-signer.ts
+++ b/packages/sdk/src/viem/viem-signer.ts
@@ -92,6 +92,7 @@ export class ViemSigner implements GenericSigner {
         startTimestamp: BigInt(typedData.message.startTimestamp),
         durationDays: BigInt(typedData.message.durationDays),
       },
+      // Cast: EIP712TypedData is a union; viem cannot correlate primaryType/types/message across union members, so the inferred `message` collapses to `never`.
     } as Parameters<typeof walletClient.signTypedData>[0]);
   }
 

--- a/packages/sdk/src/viem/viem-signer.ts
+++ b/packages/sdk/src/viem/viem-signer.ts
@@ -84,11 +84,15 @@ export class ViemSigner implements GenericSigner {
     const { EIP712Domain: _, ...sigTypes } = typedData.types;
     return walletClient.signTypedData({
       account,
-      primaryType: Object.keys(sigTypes)[0]!,
+      primaryType: typedData.primaryType,
       types: sigTypes,
       domain: typedData.domain,
-      message: typedData.message,
-    });
+      message: {
+        ...typedData.message,
+        startTimestamp: BigInt(typedData.message.startTimestamp),
+        durationDays: BigInt(typedData.message.durationDays),
+      },
+    } as Parameters<typeof walletClient.signTypedData>[0]);
   }
 
   async writeContract<

--- a/packages/sdk/src/worker/relayer-sdk.node-worker.ts
+++ b/packages/sdk/src/worker/relayer-sdk.node-worker.ts
@@ -8,7 +8,6 @@ import { parentPort, type Transferable } from "node:worker_threads";
 import type {
   CreateDelegatedEIP712Request,
   CreateEIP712Request,
-  CreateEIP712ResponseData,
   DelegatedUserDecryptRequest,
   DelegatedUserDecryptResponseData,
   EncryptRequest,
@@ -242,7 +241,7 @@ function handleCreateEIP712(request: CreateEIP712Request): void {
       payload.durationDays,
     );
 
-    sendSuccess<CreateEIP712ResponseData>(id, type, eip712);
+    sendSuccess(id, type, eip712);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("[NodeWorker] CreateEIP712 error:", message);

--- a/packages/sdk/src/worker/relayer-sdk.node-worker.ts
+++ b/packages/sdk/src/worker/relayer-sdk.node-worker.ts
@@ -242,31 +242,7 @@ function handleCreateEIP712(request: CreateEIP712Request): void {
       payload.durationDays,
     );
 
-    const response: CreateEIP712ResponseData = {
-      domain: {
-        name: eip712.domain.name,
-        version: eip712.domain.version,
-        chainId: Number(eip712.domain.chainId),
-        verifyingContract: eip712.domain.verifyingContract,
-      },
-      types: {
-        UserDecryptRequestVerification: eip712.types.UserDecryptRequestVerification.map(
-          (field) => ({
-            name: field.name,
-            type: field.type,
-          }),
-        ),
-      },
-      message: {
-        publicKey: prefixHex(eip712.message.publicKey),
-        contractAddresses: [...eip712.message.contractAddresses],
-        startTimestamp: BigInt(eip712.message.startTimestamp),
-        durationDays: BigInt(eip712.message.durationDays),
-        extraData: prefixHex(eip712.message.extraData),
-      },
-    };
-
-    sendSuccess(id, type, response);
+    sendSuccess<CreateEIP712ResponseData>(id, type, eip712);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("[NodeWorker] CreateEIP712 error:", message);

--- a/packages/sdk/src/worker/relayer-sdk.worker.ts
+++ b/packages/sdk/src/worker/relayer-sdk.worker.ts
@@ -10,7 +10,6 @@ import { getBrowserExtensionRuntime } from "./browser-extension";
 import type {
   CreateDelegatedEIP712Request,
   CreateEIP712Request,
-  CreateEIP712ResponseData,
   DelegatedUserDecryptRequest,
   DelegatedUserDecryptResponseData,
   EncryptRequest,
@@ -487,7 +486,7 @@ function handleCreateEIP712(request: CreateEIP712Request): void {
       payload.durationDays,
     );
 
-    sendSuccess<CreateEIP712ResponseData>(id, type, eip712);
+    sendSuccess(id, type, eip712);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("[Worker] CreateEIP712 error:", message);

--- a/packages/sdk/src/worker/relayer-sdk.worker.ts
+++ b/packages/sdk/src/worker/relayer-sdk.worker.ts
@@ -487,31 +487,7 @@ function handleCreateEIP712(request: CreateEIP712Request): void {
       payload.durationDays,
     );
 
-    const response: CreateEIP712ResponseData = {
-      domain: {
-        name: eip712.domain.name,
-        version: eip712.domain.version,
-        chainId: Number(eip712.domain.chainId),
-        verifyingContract: eip712.domain.verifyingContract,
-      },
-      types: {
-        UserDecryptRequestVerification: eip712.types.UserDecryptRequestVerification.map(
-          (field) => ({
-            name: field.name,
-            type: field.type,
-          }),
-        ),
-      },
-      message: {
-        publicKey: prefixHex(eip712.message.publicKey),
-        contractAddresses: [...eip712.message.contractAddresses],
-        startTimestamp: BigInt(eip712.message.startTimestamp),
-        durationDays: BigInt(eip712.message.durationDays),
-        extraData: prefixHex(eip712.message.extraData),
-      },
-    };
-
-    sendSuccess(id, type, response);
+    sendSuccess<CreateEIP712ResponseData>(id, type, eip712);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("[Worker] CreateEIP712 error:", message);

--- a/packages/sdk/src/worker/worker.types.ts
+++ b/packages/sdk/src/worker/worker.types.ts
@@ -2,6 +2,7 @@ import type {
   FhevmInstanceConfig,
   InputProofBytesType,
   KmsDelegatedUserDecryptEIP712Type,
+  KmsUserDecryptEIP712Type,
   ZKProofLike,
 } from "@zama-fhe/relayer-sdk/bundle";
 import type { ClearValueType, EncryptInput, Handle } from "../relayer/relayer-sdk.types";
@@ -226,10 +227,7 @@ export interface UpdateCsrfResponseData {
   updated: true;
 }
 
-export interface EncryptResponseData {
-  handles: Uint8Array[];
-  inputProof: Uint8Array;
-}
+export type EncryptResponseData = InputProofBytesType;
 
 export interface UserDecryptResponseData {
   clearValues: Record<Handle, ClearValueType>;
@@ -246,27 +244,7 @@ export interface GenerateKeypairResponseData {
   privateKey: Hex;
 }
 
-export interface CreateEIP712ResponseData {
-  domain: {
-    name: string;
-    version: string;
-    chainId: number;
-    verifyingContract: Address;
-  };
-  types: {
-    UserDecryptRequestVerification: {
-      name: string;
-      type: string;
-    }[];
-  };
-  message: {
-    publicKey: Hex;
-    contractAddresses: Address[];
-    startTimestamp: bigint;
-    durationDays: bigint;
-    extraData: Hex;
-  };
-}
+export type CreateEIP712ResponseData = KmsUserDecryptEIP712Type;
 
 export type CreateDelegatedEIP712ResponseData = KmsDelegatedUserDecryptEIP712Type;
 


### PR DESCRIPTION
## Summary

Eliminate local type duplication against `@zama-fhe/relayer-sdk` while keeping the SDK-facing names (`EncryptResult`, `DecryptResult`, `PublicDecryptResult`, `Handle`) for API symmetry and domain vocabulary. Cascade the change through workers, relayer classes, and signers.

**Net: −121 lines, 5 casts removed, 0 public API behavior change.**

## Type changes

| Local type | Resolution |
|---|---|
| `EncryptResult` | alias of `InputProofBytesType` |
| `Handle` | alias of `Bytes32Hex` |
| `ClearValueType` | re-export |
| `PublicDecryptResult` | alias of `PublicDecryptResults` |
| `DecryptResult` | alias of `UserDecryptResults` |
| `EIP712TypedData` | `KmsUserDecryptEIP712Type \| KmsDelegatedUserDecryptEIP712Type` |
| `DecryptHandle` | `HandleContractPair` with strict `Handle`/`Address` typing |
| `CreateEIP712Params` | derived from `KmsUserDecryptEIP712UserArgsType` |
| `EncryptResponseData` (worker) | alias of `InputProofBytesType` |

## Collateral simplifications

- `createEIP712` handlers in both workers now pass the SDK result through directly (removed manual `bigint`/`number`/array reshaping).
- `RelayerWeb.createEIP712` / `RelayerNode.createEIP712` reduced to passthroughs.
- `buildEIP712DomainType()` helper removed — relayer-sdk already emits `EIP712Domain`.
- `DelegatedCredentialsManager.#signDelegated` strips the manual pre-signTypedData conversions.
- Cleartext domain factories (`inputDomain`, `decryptionDomain`) now return `CoprocessorEIP712DomainType` / `KmsEIP712DomainType` with `bigint` chainId. This removes 4 lying casts in `relayer-cleartext.ts` (`as KmsPublicDecryptEIP712Type["domain"]`, etc.) and a redundant `publicKey as BytesHex` cast.

## Signer-side conversion

The relayer-sdk models `startTimestamp`/`durationDays` as `string`. viem/wagmi strictly type `uint256` as `bigint`, so an explicit `BigInt(...)` conversion happens in `viem-signer.ts` and `wagmi-signer.ts`. ethers is tolerant — no change needed there.

The `as Parameters<typeof signTypedData>[...]` cast in viem/wagmi signers is kept: viem's inference chokes on the union `KmsUserDecryptEIP712Type | KmsDelegatedUserDecryptEIP712Type` when correlating `primaryType`/`types`/`message`. Removing it produces `is not assignable to type 'never'`.

## Test plan

- [x] `pnpm typecheck` green across all packages
- [x] `pnpm test` — 1506 passed / 5 skipped / 0 failed
- [x] Mock EIP-712 fixtures updated to the upstream shape (`chainId: bigint`, `startTimestamp: string`, `EIP712Domain` included in `types`, `primaryType` literal)