### PR TITLE
chore: remove lint / typecheck edit hook in claude-setup

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 pnpm exec lint-staged
+pnpm typecheck

--- a/claude-setup/settings.json
+++ b/claude-setup/settings.json
@@ -43,24 +43,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm typecheck"
-          }
-        ]
-      },
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "pnpm lint"
-          }
-        ]
-      },
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
             "command": "pnpm format"
           }
         ]


### PR DESCRIPTION
why: because not all edit can pass typecheck/lints in the context of the entire codebase. Having a run of typecheck/lint on every edit is both 1) inefficient and 2) injects irrelevant context before we actually _want_ to run those commands, flooding the context window with possible, expected errors. They should be kept as precommit only.

I kept format because it's purely cosmetic; but it's debatable given that it will change the file and will cause subsequent edit to fail on the same blocks.