### PR TITLE
ci: only bump versions from commit subject, not body

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -24,12 +24,9 @@ module.exports = {
       "@semantic-release/commit-analyzer",
       {
         preset: "conventionalcommits",
-        // Scope version-bump decisions to the squash commit's subject line only.
-        // Empty noteKeywords stops `BREAKING CHANGE:` in commit bodies (e.g. inner
-        // commits rolled into a squash) from escalating the release type. The `!`
-        // marker in the header still triggers major bumps via headerPattern.
-        // release-notes-generator below keeps its default noteKeywords so the
-        // changelog continues to surface BREAKING CHANGE prose from bodies.
+        // Breaking detection from header `!` only; ignore `BREAKING CHANGE`
+        // in bodies. Notes generator below keeps defaults so the changelog
+        // still surfaces body prose.
         parserOpts: {
           noteKeywords: [],
         },

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -24,6 +24,15 @@ module.exports = {
       "@semantic-release/commit-analyzer",
       {
         preset: "conventionalcommits",
+        // Scope version-bump decisions to the squash commit's subject line only.
+        // Empty noteKeywords stops `BREAKING CHANGE:` in commit bodies (e.g. inner
+        // commits rolled into a squash) from escalating the release type. The `!`
+        // marker in the header still triggers major bumps via headerPattern.
+        // release-notes-generator below keeps its default noteKeywords so the
+        // changelog continues to surface BREAKING CHANGE prose from bodies.
+        parserOpts: {
+          noteKeywords: [],
+        },
         releaseRules: [
           { breaking: true, release: "major" },
           { scope: "security", release: "patch" },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ Release behavior:
 
 1. PR titles are validated against Conventional Commits.
 2. Squash-merging into a release branch (`main` or `prerelease`) preserves that title as the release signal.
-3. semantic-release computes the next version (`patch`/`minor`/`major`) from merged commits.
+3. semantic-release computes the next version (`patch`/`minor`/`major`) from merged commits. Breaking changes must be signaled with `!` in the PR title (e.g. `feat!: drop deprecated API`); `BREAKING CHANGE:` text in commit bodies is preserved in the changelog but does not affect the version bump.
 4. `@zama-fhe/sdk` and `@zama-fhe/react-sdk` are versioned and published together in lockstep.
 5. `main` publishes stable versions to npm `latest`, while `prerelease` publishes prerelease versions to npm `alpha`.
 6. GitHub release notes and tags are generated automatically.


### PR DESCRIPTION
## Summary

- Add `parserOpts.noteKeywords: []` to `@semantic-release/commit-analyzer` so `BREAKING CHANGE:` text inside commit bodies no longer escalates the release type. The `!` marker in the header still triggers a major bump via the default `headerPattern`.
- `@semantic-release/release-notes-generator` is intentionally left untouched — its default `noteKeywords` means the generated changelog and GitHub release notes continue to include the `⚠ BREAKING CHANGES` section pulled from commit bodies.
- Motivated by the 3.x bump in `5784dba`, where an inner squashed commit carried a `!` + `BREAKING CHANGE:` footer that promoted a minor-intent PR to major.

## Test plan

- [x] `node -e "require('./.releaserc.cjs')"` loads cleanly (verified locally).
- [ ] `pnpm release:dry-run` on this branch: a `feat!: …` subject still produces a major bump.
- [ ] `pnpm release:dry-run`: a `feat: …` subject with `BREAKING CHANGE:` in the body now produces a minor bump (previously major).
- [ ] Dry-run release notes: confirm the `BREAKING CHANGES` section still renders when commit bodies contain `BREAKING CHANGE:` prose — proving the notes generator wasn't affected.
- [ ] `release-preview` workflow green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)