### PR TITLE
fix: align ManifestShape with actual /keyurl response

### DIFF
--- a/packages/sdk/src/relayer/__tests__/fhe-artifact-cache.test.ts
+++ b/packages/sdk/src/relayer/__tests__/fhe-artifact-cache.test.ts
@@ -369,14 +369,21 @@ describe("FheArtifactCache", () => {
     }
 
     const MANIFEST = {
-      fhePublicKey: {
-        dataId: "pk-id-1",
-        urls: [PK_ARTIFACT_URL],
-      },
-      crs: {
-        2048: {
-          dataId: "pp-id-1",
-          urls: [CRS_ARTIFACT_URL],
+      status: "succeeded",
+      response: {
+        fheKeyInfo: [
+          {
+            fhePublicKey: {
+              dataId: "pk-id-1",
+              urls: [PK_ARTIFACT_URL],
+            },
+          },
+        ],
+        crs: {
+          2048: {
+            dataId: "pp-id-1",
+            urls: [CRS_ARTIFACT_URL],
+          },
         },
       },
     };
@@ -551,9 +558,16 @@ describe("FheArtifactCache", () => {
       mockFetch({
         manifest: {
           ...MANIFEST,
-          fhePublicKey: {
-            dataId: "pk-id-1",
-            urls: ["https://new-cdn.example.com/pk-v2.bin"],
+          response: {
+            ...MANIFEST.response,
+            fheKeyInfo: [
+              {
+                fhePublicKey: {
+                  dataId: "pk-id-1",
+                  urls: ["https://new-cdn.example.com/pk-v2.bin"],
+                },
+              },
+            ],
           },
         },
       });
@@ -1014,8 +1028,17 @@ describe("FheArtifactCache", () => {
         status: 200,
         json: () =>
           Promise.resolve({
-            fhePublicKey: { urls: ["https://cdn.example.com/pk.bin"] },
-            crs: {},
+            status: "succeeded",
+            response: {
+              fheKeyInfo: [
+                {
+                  fhePublicKey: {
+                    urls: ["https://cdn.example.com/pk.bin"],
+                  },
+                },
+              ],
+              crs: {},
+            },
           }),
       });
 

--- a/packages/sdk/src/relayer/__tests__/relayer.test.ts
+++ b/packages/sdk/src/relayer/__tests__/relayer.test.ts
@@ -695,10 +695,17 @@ describe("RelayerWeb", () => {
             ok: true,
             json: () =>
               Promise.resolve({
-                fhePublicKey: {
-                  urls: ["https://cdn.example.com/pk.bin"],
+                status: "succeeded",
+                response: {
+                  fheKeyInfo: [
+                    {
+                      fhePublicKey: {
+                        urls: ["https://cdn.example.com/pk.bin"],
+                      },
+                    },
+                  ],
+                  crs: {},
                 },
-                crs: {},
               }),
           });
         }
@@ -1188,10 +1195,17 @@ describe("RelayerNode", () => {
             ok: true,
             json: () =>
               Promise.resolve({
-                fhePublicKey: {
-                  urls: ["https://cdn.example.com/pk.bin"],
+                status: "succeeded",
+                response: {
+                  fheKeyInfo: [
+                    {
+                      fhePublicKey: {
+                        urls: ["https://cdn.example.com/pk.bin"],
+                      },
+                    },
+                  ],
+                  crs: {},
                 },
-                crs: {},
               }),
           });
         }

--- a/packages/sdk/src/relayer/fhe-artifact-cache.ts
+++ b/packages/sdk/src/relayer/fhe-artifact-cache.ts
@@ -100,8 +100,13 @@ function assertCachedParams(v: unknown): asserts v is CachedPublicParams {
 
 /** Manifest shape returned by the relayer `/keyurl` endpoint. */
 interface ManifestShape {
-  fhePublicKey: { dataId: string; urls: string[] };
-  crs: Record<string, { dataId: string; urls: string[] }>;
+  status: string;
+  response: {
+    fheKeyInfo: Array<{
+      fhePublicKey: { dataId: string; urls: string[] };
+    }>;
+    crs: Record<string, { dataId: string; urls: string[] }>;
+  };
 }
 
 // ── ArtifactCache ──────────────────────────────────────────
@@ -412,18 +417,18 @@ export class FheArtifactCache {
         return false;
       }
 
-      const manifest = (await manifestRes.json()) as unknown;
+      const manifest: ManifestShape = await manifestRes.json();
 
       // Validate manifest shape — a malformed response indicates a permanent
       // config error (wrong relayer URL, API version mismatch), not a transient
       // network issue. Log at error level so it's actionable.
+      const fheKeyEntry = manifest?.response?.fheKeyInfo?.[0];
       if (
         !manifest ||
         typeof manifest !== "object" ||
-        !("fhePublicKey" in manifest) ||
-        !(manifest as ManifestShape).fhePublicKey?.urls?.length ||
-        !("crs" in manifest) ||
-        typeof (manifest as ManifestShape).crs !== "object"
+        manifest.status !== "succeeded" ||
+        !fheKeyEntry?.fhePublicKey?.urls?.length ||
+        typeof manifest.response?.crs !== "object"
       ) {
         this.#logger.error(
           "Relayer manifest has unexpected shape — check relayer URL and API version",
@@ -445,11 +450,10 @@ export class FheArtifactCache {
         this.#lastRevalidatedAt = retryTimestamp;
         return false;
       }
-      const validManifest = manifest as ManifestShape;
+      const validManifest = manifest.response;
 
       // ── 4. Check PK artifact ──────────────────────────
-      const pkArtifactUrl = validManifest.fhePublicKey.urls[0];
-
+      const pkArtifactUrl = fheKeyEntry.fhePublicKey.urls[0];
       // URL change → stale
       if (storedPk.artifactUrl && pkArtifactUrl && pkArtifactUrl !== storedPk.artifactUrl) {
         await this.#clearAll(pkKey, paramEntries);


### PR DESCRIPTION
## Summary
- Updated `ManifestShape` interface to match the real `/keyurl` endpoint shape: `{ status, response: { fheKeyInfo: [{ fhePublicKey }], crs } }` instead of flat `{ fhePublicKey, crs }`
- Updated validation and all access paths in the revalidation logic accordingly
- Without this fix, revalidation always treats the manifest as malformed and never validates cached artifacts

## Test plan
- [ ] Verify revalidation works against a live relayer (manifest is parsed correctly, 304/200 freshness checks proceed)
- [ ] Confirm malformed manifests still trigger the error-level log and fail-open with short retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)