### PR TITLE
refactor: use wagmi compat layer for connection APIs

### DIFF
--- a/packages/react-sdk/src/wagmi/compat.ts
+++ b/packages/react-sdk/src/wagmi/compat.ts
@@ -1,10 +1,14 @@
 import * as wagmi from "wagmi";
 import { useAccount } from "wagmi";
 import * as actions from "wagmi/actions";
-import { getAccount } from "wagmi/actions";
+import { getAccount, watchAccount } from "wagmi/actions";
 
 // wagmi v3 renamed useAccount → useConnection
 export const useConnection = "useConnection" in wagmi ? wagmi.useConnection : useAccount;
 
 // wagmi v3 renamed getAccount → getConnection
 export const getConnection = "getConnection" in actions ? actions.getConnection : getAccount;
+
+// wagmi v3 renamed watchAccount → watchConnection
+export const watchConnection =
+  "watchConnection" in actions ? actions.watchConnection : watchAccount;

--- a/packages/react-sdk/src/wagmi/wagmi-signer.ts
+++ b/packages/react-sdk/src/wagmi/wagmi-signer.ts
@@ -19,13 +19,12 @@ import type { Config } from "wagmi";
 import {
   getBlock,
   getChainId,
-  getAccount,
   readContract,
   signTypedData,
   waitForTransactionReceipt,
-  watchConnection,
   writeContract,
 } from "wagmi/actions";
+import { getConnection, watchConnection } from "./compat";
 
 /** Configuration for {@link WagmiSigner}. */
 export interface WagmiSignerConfig {
@@ -49,7 +48,7 @@ export class WagmiSigner implements GenericSigner {
   }
 
   async getAddress(): Promise<Address> {
-    const account = getAccount(this.config);
+    const account = getConnection(this.config);
     if (!account?.address) {
       throw new TypeError("Invalid address");
     }


### PR DESCRIPTION
## Summary
- Import `getConnection` and `watchConnection` from `./compat` instead of directly from `wagmi/actions` in `WagmiSigner`
- Add `watchConnection` compat shim alongside existing `getConnection` and `useConnection` shims
- Ensures WagmiSigner works with both wagmi v2 (`getAccount`/`watchAccount`) and v3 (`getConnection`/`watchConnection`)

## Test plan
- [x] All 264 react-sdk tests pass (`npx vitest run --project react-sdk`)
- [x] `wagmi-signer-subscribe` tests verify subscribe/disconnect/account-change/chain-change behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)