### PR TITLE
docs(sdk): update official wrapper reference commit

### DIFF
--- a/contracts/VERSIONS.md
+++ b/contracts/VERSIONS.md
@@ -2,14 +2,14 @@
 
 ## confidential-wrapper
 
-Source: `zama-ai/protocol-apps` @ `da4afe387420` (March 26, 2026), imported through
+Source: `zama-ai/protocol-apps` @ `da4afe387420`, imported through
 the Soldeer dependency alias `protocol-apps-wrapper`.
 
-> **Deployment status:** this commit is the version **currently deployed** on testnet and mainnet
-> as of the time this PR was written (April 2026). It is NOT the upcoming April 21/28 upgrade.
-> The April 21 (testnet) / April 28 (mainnet) upgrade corresponds to the official
-> protocol-apps wrapper reference commit `b06eb263d64c788a27b6bc1baf46b7547f7ec594`
-> and is tracked in SDK-68 sub-tickets (SDK-69 → SDK-70 → SDK-71 → SDK-72).
+> **Deployment status:** this commit is the version currently deployed on testnet and mainnet.
+> It is NOT the upcoming upgrade.
+> The upcoming upgrade — rolling out first on testnet, then on mainnet — corresponds
+> to the official protocol-apps wrapper reference commit
+> `b06eb263d64c788a27b6bc1baf46b7547f7ec594`.
 
 Includes:
 
@@ -27,11 +27,11 @@ Key changes at this commit vs prior local (Zaiffer fork):
 - New functions: `unwrapAmount(bytes32)` and `unwrapRequester(bytes32)`
 - `emit Wrapped` removed from `wrap()` and `onTransferReceived()`
 - ERC-165 interfaceId: `0xd04584ba`
-- `totalSupply()` still present (will be renamed to `inferredTotalSupply` in SDK-71)
+- `totalSupply()` still present (will be renamed to `inferredTotalSupply`)
 
 ## confidential-token-wrappers-registry
 
-Source: `zama-ai/protocol-apps` @ `f51845b08cc2` (December 2025), imported through
+Source: `zama-ai/protocol-apps` @ `f51845b08cc2`, imported through
 the Soldeer dependency alias `protocol-apps-registry`.
 
 Includes:

--- a/contracts/VERSIONS.md
+++ b/contracts/VERSIONS.md
@@ -7,8 +7,9 @@ the Soldeer dependency alias `protocol-apps-wrapper`.
 
 > **Deployment status:** this commit is the version **currently deployed** on testnet and mainnet
 > as of the time this PR was written (April 2026). It is NOT the upcoming April 21/28 upgrade.
-> The April 21 (testnet) / April 28 (mainnet) upgrade corresponds to a later commit (`93c6e7a`,
-> April 7 2026) and is tracked in SDK-68 sub-tickets (SDK-69 → SDK-70 → SDK-71 → SDK-72).
+> The April 21 (testnet) / April 28 (mainnet) upgrade corresponds to the official
+> protocol-apps wrapper reference commit `b06eb263d64c788a27b6bc1baf46b7547f7ec594`
+> and is tracked in SDK-68 sub-tickets (SDK-69 → SDK-70 → SDK-71 → SDK-72).
 
 Includes:
 

--- a/packages/sdk/src/contracts/erc165.ts
+++ b/packages/sdk/src/contracts/erc165.ts
@@ -10,7 +10,7 @@ export const ERC7984_WRAPPER_INTERFACE_ID_LEGACY = "0xd04584ba" as const;
 /**
  * ERC-165 interface ID for IERC7984ERC20Wrapper (confidential wrapper) — upgraded interface.
  *
- * Verified against the protocol-apps upgraded wrapper line: commit 35dbefb asserts
+ * Verified against the protocol-apps upgraded wrapper line: commit b06eb263 asserts
  * `supportsInterface(0x1f1c62b2)` for `type(IERC7984ERC20Wrapper).interfaceId`,
  * and the implementation exposes `inferredTotalSupply()`.
  * During the transition period, both {@link ERC7984_WRAPPER_INTERFACE_ID_LEGACY} and this


### PR DESCRIPTION
  ## Summary

  Updates SDK-68 wrapper upgrade references to use the official Protocol Apps commit confirmed for the upcoming deployment:

  `b06eb263d64c788a27b6bc1baf46b7547f7ec594`

  ## Changes

  - Replaces the previous provisional upgraded wrapper reference in `erc165.ts`.
  - Updates `contracts/VERSIONS.md` to point to the official wrapper upgrade commit.

  No SDK logic changes.