### PR TITLE
ci: stop squash-merge bodies escalating every release to major

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -24,15 +24,10 @@ module.exports = {
       "@semantic-release/commit-analyzer",
       {
         preset: "conventionalcommits",
-        // Breaking detection from header `!` only; ignore `BREAKING CHANGE`
-        // in bodies. Notes generator below keeps defaults so the changelog
-        // still surfaces body prose.
-        //
-        // Must be a sentinel string, not []: an empty array makes
-        // conventional-commits-parser emit a zero-title note for every `* `
-        // bullet in a GitHub squash body, and the analyzer's `breaking: true`
-        // rule matches any commit with notes.length > 0 regardless of title.
-        // That escalated every squash-merge to major (see 3.0.0-alpha.12..14).
+        // Sentinel (not []): an empty array makes the parser emit empty-
+        // title notes for every `* ` bullet in a squash body, which the
+        // analyzer treats as breaking. Header `!` still escalates via
+        // breakingHeaderPattern, which ignores noteKeywords.
         parserOpts: {
           noteKeywords: ["__NO_BREAKING_NOTES__"],
         },

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -27,8 +27,14 @@ module.exports = {
         // Breaking detection from header `!` only; ignore `BREAKING CHANGE`
         // in bodies. Notes generator below keeps defaults so the changelog
         // still surfaces body prose.
+        //
+        // Must be a sentinel string, not []: an empty array makes
+        // conventional-commits-parser emit a zero-title note for every `* `
+        // bullet in a GitHub squash body, and the analyzer's `breaking: true`
+        // rule matches any commit with notes.length > 0 regardless of title.
+        // That escalated every squash-merge to major (see 3.0.0-alpha.12..14).
         parserOpts: {
-          noteKeywords: [],
+          noteKeywords: ["__NO_BREAKING_NOTES__"],
         },
         releaseRules: [
           { breaking: true, release: "major" },


### PR DESCRIPTION
## Summary

- Replace `parserOpts.noteKeywords: []` with a sentinel keyword that cannot appear in real commit text. Empty-array `noteKeywords` makes `conventional-commits-parser` emit a zero-title note for every `* ` bullet in a GitHub squash commit body, and the commit-analyzer's `{ breaking: true, release: "major" }` rule matches any commit with `notes.length > 0` regardless of title.
- Root cause of `3.0.0` on main (from #264 itself, a `ci:` squash) and `3.0.0-alpha.12..14` on prerelease (from `feat:`, `chore(deps-dev):`, and `docs:` squashes) — all were non-releasable commits that got bumped to major.
- Keeps #264's original intent: header `!` is the only breaking signal for version bumps, and `@semantic-release/release-notes-generator` still surfaces body `BREAKING CHANGE:` prose in the changelog.

## Root cause trace

Parsing the exact f8290597 (`docs(sdk): …`) message with the current config produced:

```
notes.length: 2
notes titles: [ '', '' ]   ← from "* docs(sdk): …" bullets
releaseType: major
```

Swapping `[]` → `["__NO_BREAKING_NOTES__"]` on the same message: `notes.length: 0`, `releaseType: null`.

## Why #264's dry-run missed it

The test plan used a single-line subject (`feat!: …`) and a hand-written `feat: … \n BREAKING CHANGE: …`. Neither replicates a real GitHub squash body with `* ` bullet lines, which is the only shape that triggers the empty-keyword behavior.

## Test plan

Verified locally against the actual `@semantic-release/commit-analyzer` 13.0.1:

- [x] `feat!: …` → major
- [x] `feat(sdk)!: …` → major
- [x] `feat: …` with body `BREAKING CHANGE: …` → minor (PR #264 intent preserved)
- [x] `feat: …` → minor
- [x] `fix: …` → patch
- [x] `docs(sdk): … (#276)` squash body with `* docs(sdk): …` bullets → no release
- [x] `chore(deps-dev): … (#197)` squash body with `* chore: …` bullets → no release
- [ ] `release-preview` workflow on this PR shows "no release" for a non-releasable change

🤖 Generated with [Claude Code](https://claude.com/claude-code)