### PR TITLE
fix(sdk): run delegation check before cache lookup in decryptBalanceAs

### DIFF
--- a/docs/gitbook/src/reference/sdk/delegation.md
+++ b/docs/gitbook/src/reference/sdk/delegation.md
@@ -235,7 +235,7 @@ These are caught **before** submitting a transaction, saving gas and providing a
 | `DelegationSelfNotAllowedError`         | Delegate address equals the connected wallet (`delegate === msg.sender`)      |
 | `DelegationDelegateEqualsContractError` | Delegate address equals the token contract address                            |
 | `DelegationExpiryUnchangedError`        | New expiration date matches the current one (no on-chain change needed)       |
-| `DelegationNotFoundError`               | Attempting to revoke a delegation that was never established (expiry is zero) |
+| `DelegationNotFoundError`               | Revoking a delegation that was never established, or reading via `decryptBalanceAs` / `batchDecryptBalancesAs` when the delegation is missing or has been revoked (expiry is zero) |
 
 ### On-chain revert errors
 

--- a/docs/gitbook/src/reference/sdk/delegation.md
+++ b/docs/gitbook/src/reference/sdk/delegation.md
@@ -229,12 +229,12 @@ Because the ACL contract resets the expiry to `0n` on revocation, `DelegationNot
 
 These are caught **before** submitting a transaction, saving gas and providing actionable messages:
 
-| Error                                   | When                                                                          |
-| --------------------------------------- | ----------------------------------------------------------------------------- |
-| `DelegationExpirationTooSoonError`      | Expiration date is less than 1 hour in the future                             |
-| `DelegationSelfNotAllowedError`         | Delegate address equals the connected wallet (`delegate === msg.sender`)      |
-| `DelegationDelegateEqualsContractError` | Delegate address equals the token contract address                            |
-| `DelegationExpiryUnchangedError`        | New expiration date matches the current one (no on-chain change needed)       |
+| Error                                   | When                                                                                                                                                                               |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DelegationExpirationTooSoonError`      | Expiration date is less than 1 hour in the future                                                                                                                                  |
+| `DelegationSelfNotAllowedError`         | Delegate address equals the connected wallet (`delegate === msg.sender`)                                                                                                           |
+| `DelegationDelegateEqualsContractError` | Delegate address equals the token contract address                                                                                                                                 |
+| `DelegationExpiryUnchangedError`        | New expiration date matches the current one (no on-chain change needed)                                                                                                            |
 | `DelegationNotFoundError`               | Revoking a delegation that was never established, or reading via `decryptBalanceAs` / `batchDecryptBalancesAs` when the delegation is missing or has been revoked (expiry is zero) |
 
 ### On-chain revert errors

--- a/docs/gitbook/src/reference/sdk/errors.md
+++ b/docs/gitbook/src/reference/sdk/errors.md
@@ -400,7 +400,7 @@ matchZamaError(error, {
 
 **Code:** `DELEGATION_NOT_FOUND`
 
-No active delegation exists for the given `(delegator, delegate, contract)` tuple. Thrown when attempting to revoke a non-existent delegation.
+No active delegation exists for the given `(delegator, delegate, contract)` tuple. Thrown when attempting to revoke a non-existent delegation, and by `decryptBalanceAs` / `batchDecryptBalancesAs` (including on cache hits) when the delegation is missing or has been revoked.
 
 ```ts
 matchZamaError(error, {

--- a/packages/sdk/src/token/__tests__/batch-decrypt-as.test.ts
+++ b/packages/sdk/src/token/__tests__/batch-decrypt-as.test.ts
@@ -105,12 +105,12 @@ describe("ReadonlyToken.batchDecryptBalancesAs", () => {
 
     expect(balances.get(TOKEN_A)).toBe(0n);
     expect(relayer.delegatedUserDecrypt).not.toHaveBeenCalled();
-    // Pre-flight is skipped when all balances resolve from cache (zero handles),
-    // so getDelegationExpiry never calls readContract.
+    // Pre-flight is skipped only when every handle is zero — zero balances
+    // need no authorization — so getDelegationExpiry never calls readContract.
     expect(delegateSigner.readContract).toHaveBeenCalledTimes(1);
   });
 
-  test("skips pre-flight delegation check when balance is pre-cached", async ({
+  test("runs pre-flight delegation check even when balance is pre-cached", async ({
     relayer,
     createMockSigner,
     createSDK,
@@ -120,7 +120,9 @@ describe("ReadonlyToken.batchDecryptBalancesAs", () => {
     // Pre-populate cache: ownerAddress = DELEGATOR (default for batchDecryptBalancesAs)
     await delegateSdk.cache.set(DELEGATOR, TOKEN_A, HANDLE_A, 42n);
 
-    vi.mocked(delegateSigner.readContract).mockResolvedValueOnce(HANDLE_A);
+    vi.mocked(delegateSigner.readContract)
+      .mockResolvedValueOnce(HANDLE_A) // confidentialBalanceOf
+      .mockResolvedValueOnce(MAX_UINT64); // getDelegationExpiry → permanent
 
     const token = new ReadonlyToken(delegateSdk, TOKEN_A);
 
@@ -128,10 +130,34 @@ describe("ReadonlyToken.batchDecryptBalancesAs", () => {
       delegatorAddress: DELEGATOR,
     });
 
-    // Only confidentialBalanceOf — pre-flight skipped because cache resolved everything.
-    expect(delegateSigner.readContract).toHaveBeenCalledTimes(1);
+    // Delegation check now fires even when the cache resolves everything, so
+    // revoked delegations can't leak stale cached values.
+    expect(delegateSigner.readContract).toHaveBeenCalledTimes(2);
     expect(relayer.delegatedUserDecrypt).not.toHaveBeenCalled();
     expect(balances.get(TOKEN_A)).toBe(42n);
+  });
+
+  test("throws DelegationNotFoundError on cache hit when delegation is revoked", async ({
+    relayer,
+    createMockSigner,
+    createSDK,
+  }) => {
+    const delegateSigner = createMockSigner(DELEGATE);
+    const delegateSdk = createSDK({ signer: delegateSigner });
+    await delegateSdk.cache.set(DELEGATOR, TOKEN_A, HANDLE_A, 42n);
+
+    vi.mocked(delegateSigner.readContract)
+      .mockResolvedValueOnce(HANDLE_A) // confidentialBalanceOf
+      .mockResolvedValueOnce(0n); // getDelegationExpiry → revoked
+
+    const token = new ReadonlyToken(delegateSdk, TOKEN_A);
+
+    await expect(
+      ReadonlyToken.batchDecryptBalancesAs([token], {
+        delegatorAddress: DELEGATOR,
+      }),
+    ).rejects.toThrow(expect.objectContaining({ code: "DELEGATION_NOT_FOUND" }));
+    expect(relayer.delegatedUserDecrypt).not.toHaveBeenCalled();
   });
 
   test("calls onError callback when decryption fails for a token", async ({

--- a/packages/sdk/src/token/__tests__/delegation.test.ts
+++ b/packages/sdk/src/token/__tests__/delegation.test.ts
@@ -363,7 +363,8 @@ describe("decryptBalanceAs", () => {
     vi.mocked(signer.readContract)
       .mockResolvedValueOnce(handle) // confidentialBalanceOf (first call)
       .mockResolvedValueOnce(MAX_UINT64) // getDelegationExpiry (first call)
-      .mockResolvedValueOnce(handle); // confidentialBalanceOf (second call — cache hit skips delegation check)
+      .mockResolvedValueOnce(handle) // confidentialBalanceOf (second call)
+      .mockResolvedValueOnce(MAX_UINT64); // getDelegationExpiry (second call — runs before cache lookup)
     vi.mocked(relayer.createDelegatedUserDecryptEIP712).mockResolvedValue({
       domain: {
         name: "Decryption",
@@ -399,6 +400,54 @@ describe("decryptBalanceAs", () => {
       accountAddress: userAddress,
     });
     expect(balance).toBe(42n);
+    expect(relayer.delegatedUserDecrypt).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-checks delegation on cache hit and throws when revoked", async ({
+    signer,
+    relayer,
+    readonlyToken,
+    handle,
+    tokenAddress,
+    delegatorAddress,
+  }) => {
+    vi.mocked(signer.readContract)
+      .mockResolvedValueOnce(handle) // confidentialBalanceOf (first call)
+      .mockResolvedValueOnce(MAX_UINT64) // getDelegationExpiry → permanent
+      .mockResolvedValueOnce(handle) // confidentialBalanceOf (second call)
+      .mockResolvedValueOnce(0n); // getDelegationExpiry → revoked
+    vi.mocked(relayer.createDelegatedUserDecryptEIP712).mockResolvedValue({
+      domain: {
+        name: "Decryption",
+        version: "1",
+        chainId: 1n,
+        verifyingContract: "0xkms",
+      },
+      types: { DelegatedUserDecryptRequestVerification: [] },
+      message: {
+        publicKey: "0xpub",
+        contractAddresses: [tokenAddress],
+        delegatorAddress,
+        startTimestamp: "1000",
+        durationDays: "1",
+        extraData: "0x",
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    vi.mocked(relayer.delegatedUserDecrypt).mockResolvedValue({
+      [handle]: 42n,
+    });
+
+    // First call populates cache while delegation is active.
+    const first = await readonlyToken.decryptBalanceAs({ delegatorAddress });
+    expect(first).toBe(42n);
+    expect(relayer.delegatedUserDecrypt).toHaveBeenCalledTimes(1);
+
+    // Delegation revoked — second call must reject despite the cached value.
+    await expect(readonlyToken.decryptBalanceAs({ delegatorAddress })).rejects.toThrow(
+      expect.objectContaining({ code: "DELEGATION_NOT_FOUND" }),
+    );
+    // No second decryption was attempted; the check fired before cache lookup.
     expect(relayer.delegatedUserDecrypt).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/sdk/src/token/readonly-token.ts
+++ b/packages/sdk/src/token/readonly-token.ts
@@ -289,6 +289,15 @@ export class ReadonlyToken {
       );
     }
 
+    // Pre-flight delegation check — must run before cache lookups so that
+    // revoked delegations are caught even when stale cached values exist.
+    // Skipped only when every handle is zero (balance of 0 needs no
+    // authorization). Best-effort: checks the first token's contract only
+    // (delegations are typically granted per-delegator, not per-token).
+    if (resolvedHandles.some((h) => !isZeroHandle(h))) {
+      await firstToken.#assertDelegationActive(delegatorAddress);
+    }
+
     const results = new Map<Address, bigint>();
 
     // Parallel cache lookups — avoids sequential IDB round-trips.
@@ -321,11 +330,6 @@ export class ReadonlyToken {
     if (uncached.length === 0) {
       return results;
     }
-
-    // Pre-flight delegation check runs after cache lookups — skips RPC overhead
-    // when all balances are cached. Best-effort: checks the first token's
-    // contract only (delegations are typically granted per-delegator, not per-token).
-    await firstToken.#assertDelegationActive(delegatorAddress);
 
     const uncachedAddresses = uncached.map((entry) => entry.token.address);
     const creds = await firstToken.sdk.delegatedCredentials.allow(

--- a/packages/sdk/src/token/readonly-token.ts
+++ b/packages/sdk/src/token/readonly-token.ts
@@ -642,15 +642,15 @@ export class ReadonlyToken {
       return 0n;
     }
 
+    // Pre-flight delegation check — must run before cache lookup so that
+    // revoked delegations are caught even when a stale cached value exists.
+    await this.#assertDelegationActive(normalizedDelegator);
+
     const cached = await this.sdk.cache.get(normalizedAccount, this.address, handle);
     if (cached !== null) {
       assertBigint(cached, "decryptBalanceAs: cached");
       return cached;
     }
-
-    // Pre-flight delegation check — avoids wasting a wallet signature on an
-    // expired or non-existent delegation.
-    await this.#assertDelegationActive(normalizedDelegator);
 
     const t0 = Date.now();
     try {


### PR DESCRIPTION
## Summary

- **`decryptBalanceAs`** — pre-flight delegation check ran after the cache lookup, so a revoked delegation returned the stale cached plaintext. Moved the check above the cache lookup so revocations are enforced on every call.
- **`batchDecryptBalancesAs`** — had the same shape: it short-circuited with `return results` when every balance resolved from cache, skipping the delegation check. Moved the check ahead of the cache lookups, gated on "at least one non-zero handle" so batches of zero balances still skip the RPC.

## Scope

- [x] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-components`
- [ ] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [ ] Examples (`examples/`)
- [ ] CI/workflows
- [ ] Docs

## Validation

- `pnpm test:run packages/sdk/src/token` — 260/260 pass. New regression tests:
  - `re-checks delegation on cache hit and throws when revoked` (singular)
  - `runs pre-flight delegation check even when balance is pre-cached` (batch, happy path)
  - `throws DelegationNotFoundError on cache hit when delegation is revoked` (batch, revoked)
- `pnpm typecheck` — clean.
- `pnpm lint` — clean.
- `pnpm format:check` on changed files — clean.

## Tradeoff

The batch method loses an optimization that avoided one RPC round-trip when every balance in the batch was already cached. That optimization was explicitly called out as intentional in the old comment, but it was also the mechanism through which revoked delegations could leak stale data, so the revocation guarantee wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)