### PR TITLE
refactor(sdk): remove viem as hard dependency

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -12,6 +12,6 @@
   {
     "name": "@zama-fhe/react-sdk (all JS)",
     "path": "packages/react-sdk/dist/**/*.js",
-    "limit": "15 KB"
+    "limit": "7 KB"
   }
 ]

--- a/packages/sdk/etc/sdk-ethers.api.md
+++ b/packages/sdk/etc/sdk-ethers.api.md
@@ -10,23 +10,43 @@ import { Bytes32Hex } from '@zama-fhe/relayer-sdk/bundle';
 import { ContractFunctionArgs } from 'viem';
 import { ContractFunctionName } from 'viem';
 import { ContractFunctionReturnType } from 'viem';
-import { EIP1193EventMap } from 'viem';
-import { EIP1193Events } from 'viem';
-import { EIP1193Provider } from 'viem';
 import { ethers } from 'ethers';
 import { Hex } from 'viem';
 import { KmsDelegatedUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
 import { KmsUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
-import { ProviderConnectInfo } from 'viem';
-import { ProviderMessage } from 'viem';
-import { ProviderRpcError } from 'viem';
 import { Signer } from 'ethers';
 
-export { EIP1193EventMap }
+// @public
+export interface EIP1193EventMap {
+    // Warning: (ae-forgotten-export) The symbol "Address$1" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    accountsChanged: (accounts: Address$1[]) => void;
+    // (undocumented)
+    chainChanged: (chainId: string) => void;
+    // (undocumented)
+    connect: (connectInfo: ProviderConnectInfo) => void;
+    // (undocumented)
+    disconnect: (error: ProviderRpcError) => void;
+    // (undocumented)
+    message: (message: ProviderMessage) => void;
+}
 
-export { EIP1193Events }
+// @public
+export interface EIP1193Events {
+    // (undocumented)
+    on<TEvent extends keyof EIP1193EventMap>(event: TEvent, listener: EIP1193EventMap[TEvent]): void;
+    // (undocumented)
+    removeListener<TEvent extends keyof EIP1193EventMap>(event: TEvent, listener: EIP1193EventMap[TEvent]): void;
+}
 
-export { EIP1193Provider }
+// @public
+export interface EIP1193Provider extends EIP1193Events {
+    // Warning: (ae-forgotten-export) The symbol "EIP1193RequestFn" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    request: EIP1193RequestFn;
+}
 
 // Warning: (ae-forgotten-export) The symbol "GenericSigner" needs to be exported by the entry point index.d.ts
 //
@@ -34,7 +54,7 @@ export { EIP1193Provider }
 export class EthersSigner implements GenericSigner {
     constructor(config: EthersSignerConfig);
     // (undocumented)
-    getAddress(): Promise<Address>;
+    getAddress(): Promise<Address$1>;
     // (undocumented)
     getBlockTimestamp(): Promise<bigint>;
     // (undocumented)
@@ -44,9 +64,10 @@ export class EthersSigner implements GenericSigner {
     // (undocumented)
     readContract<const TAbi extends Abi | readonly unknown[], TFunctionName extends ContractFunctionName<TAbi, "pure" | "view">, const TArgs extends ContractFunctionArgs<TAbi, "pure" | "view", TFunctionName>>(config: ReadContractConfig<TAbi, TFunctionName, TArgs>): Promise<ContractFunctionReturnType<TAbi, "pure" | "view", TFunctionName, TArgs>>;
     // Warning: (ae-forgotten-export) The symbol "EIP712TypedData" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "Hex$1" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    signTypedData(typedData: EIP712TypedData): Promise<Hex>;
+    signTypedData(typedData: EIP712TypedData): Promise<Hex$1>;
     // Warning: (ae-forgotten-export) The symbol "SignerLifecycleCallbacks" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -54,11 +75,11 @@ export class EthersSigner implements GenericSigner {
     // Warning: (ae-forgotten-export) The symbol "TransactionReceipt" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt>;
+    waitForTransactionReceipt(hash: Hex$1): Promise<TransactionReceipt>;
     // Warning: (ae-forgotten-export) The symbol "WriteContractConfig" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    writeContract<const TAbi extends Abi | readonly unknown[], TFunctionName extends ContractFunctionName<TAbi, "nonpayable" | "payable">, const TArgs extends ContractFunctionArgs<TAbi, "nonpayable" | "payable", TFunctionName>>(config: WriteContractConfig<TAbi, TFunctionName, TArgs>): Promise<Hex>;
+    writeContract<const TAbi extends Abi | readonly unknown[], TFunctionName extends ContractFunctionName<TAbi, "nonpayable" | "payable">, const TArgs extends ContractFunctionArgs<TAbi, "nonpayable" | "payable", TFunctionName>>(config: WriteContractConfig<TAbi, TFunctionName, TArgs>): Promise<Hex$1>;
 }
 
 // @public
@@ -70,11 +91,28 @@ export type EthersSignerConfig = {
     provider: ethers.Provider;
 };
 
-export { ProviderConnectInfo }
+// @public
+export interface ProviderConnectInfo {
+    // (undocumented)
+    readonly chainId: string;
+}
 
-export { ProviderMessage }
+// @public
+export interface ProviderMessage {
+    // (undocumented)
+    readonly data: unknown;
+    // (undocumented)
+    readonly type: string;
+}
 
-export { ProviderRpcError }
+// @public
+export class ProviderRpcError extends Error {
+    constructor(code: number, message: string, data?: unknown);
+    // (undocumented)
+    readonly code: number;
+    // (undocumented)
+    readonly data?: unknown;
+}
 
 // Warning: (ae-forgotten-export) The symbol "EthersCallProvider" needs to be exported by the entry point index.d.ts
 //

--- a/packages/sdk/etc/sdk-node.api.md
+++ b/packages/sdk/etc/sdk-node.api.md
@@ -4,12 +4,10 @@
 
 ```ts
 
-import { Address } from 'viem';
 import { Bytes32Hex } from '@zama-fhe/relayer-sdk/bundle';
 import { ClearValueType } from '@zama-fhe/relayer-sdk/bundle';
 import { FhevmInstanceConfig } from '@zama-fhe/relayer-sdk/bundle';
 import { FhevmInstanceConfig as FhevmInstanceConfig_2 } from '@zama-fhe/relayer-sdk/node';
-import { Hex } from 'viem';
 import { InputProofBytesType } from '@zama-fhe/relayer-sdk/bundle';
 import { InputProofBytesType as InputProofBytesType_2 } from '@zama-fhe/relayer-sdk/node';
 import { KeypairType } from '@zama-fhe/relayer-sdk/bundle';
@@ -111,9 +109,9 @@ export type CreateDelegatedEIP712Payload = CreateDelegatedEIP712Request["payload
 export interface CreateDelegatedEIP712Request extends BaseRequest {
     // (undocumented)
     payload: {
-        publicKey: Hex;
-        contractAddresses: Address[];
-        delegatorAddress: Address;
+        publicKey: Hex$1;
+        contractAddresses: Address$1[];
+        delegatorAddress: Address$1;
         startTimestamp: number;
         durationDays: number;
     };
@@ -131,8 +129,8 @@ export type CreateEIP712Payload = CreateEIP712Request["payload"];
 export interface CreateEIP712Request extends BaseRequest {
     // (undocumented)
     payload: {
-        publicKey: Hex;
-        contractAddresses: Address[];
+        publicKey: Hex$1;
+        contractAddresses: Address$1[];
         startTimestamp: number;
         durationDays: number;
     };
@@ -146,23 +144,23 @@ export type CreateEIP712ResponseData = KmsUserDecryptEIP712Type;
 // @public
 export interface DelegatedUserDecryptParams {
     // (undocumented)
-    contractAddress: Address;
+    contractAddress: Address$1;
     // (undocumented)
-    delegateAddress: Address;
+    delegateAddress: Address$1;
     // (undocumented)
-    delegatorAddress: Address;
+    delegatorAddress: Address$1;
     // (undocumented)
     durationDays: number;
     // (undocumented)
     handles: Handle[];
     // (undocumented)
-    privateKey: Hex;
+    privateKey: Hex$1;
     // (undocumented)
-    publicKey: Hex;
+    publicKey: Hex$1;
     // (undocumented)
-    signature: Hex;
+    signature: Hex$1;
     // (undocumented)
-    signedContractAddresses: Address[];
+    signedContractAddresses: Address$1[];
     // (undocumented)
     startTimestamp: number;
 }
@@ -175,13 +173,13 @@ export interface DelegatedUserDecryptRequest extends BaseRequest {
     // (undocumented)
     payload: {
         handles: Handle[];
-        contractAddress: Address;
-        signedContractAddresses: Address[];
-        privateKey: Hex;
-        publicKey: Hex;
-        signature: Hex;
-        delegatorAddress: Address;
-        delegateAddress: Address;
+        contractAddress: Address$1;
+        signedContractAddresses: Address$1[];
+        privateKey: Hex$1;
+        publicKey: Hex$1;
+        signature: Hex$1;
+        delegatorAddress: Address$1;
+        delegateAddress: Address$1;
         startTimestamp: number;
         durationDays: number;
     };
@@ -201,9 +199,9 @@ export type EIP712TypedData = KmsUserDecryptEIP712Type | KmsDelegatedUserDecrypt
 // @public
 export interface EncryptParams {
     // (undocumented)
-    contractAddress: Address;
+    contractAddress: Address$1;
     // (undocumented)
-    userAddress: Address;
+    userAddress: Address$1;
     // Warning: (ae-forgotten-export) The symbol "EncryptInput" needs to be exported by the entry point index.d.ts
     values: EncryptInput[];
 }
@@ -216,8 +214,8 @@ export interface EncryptRequest extends BaseRequest {
     // (undocumented)
     payload: {
         values: EncryptInput[];
-        contractAddress: Address;
-        userAddress: Address;
+        contractAddress: Address$1;
+        userAddress: Address$1;
     };
     // (undocumented)
     type: "ENCRYPT";
@@ -251,9 +249,9 @@ export interface GenerateKeypairRequest extends BaseRequest {
 // @public (undocumented)
 export interface GenerateKeypairResponseData {
     // (undocumented)
-    privateKey: Hex;
+    privateKey: Hex$1;
     // (undocumented)
-    publicKey: Hex;
+    publicKey: Hex$1;
 }
 
 // @public
@@ -435,11 +433,11 @@ export interface PublicDecryptRequest extends BaseRequest {
 // @public (undocumented)
 export interface PublicDecryptResponseData {
     // (undocumented)
-    abiEncodedClearValues: Hex;
+    abiEncodedClearValues: Hex$1;
     // (undocumented)
     clearValues: Readonly<Record<Handle, ClearValueType>>;
     // (undocumented)
-    decryptionProof: Hex;
+    decryptionProof: Hex$1;
 }
 
 // @public
@@ -450,17 +448,17 @@ export class RelayerNode implements RelayerSDK, Disposable {
     [Symbol.dispose](): void;
     constructor(config: RelayerNodeConfig);
     // (undocumented)
-    createDelegatedUserDecryptEIP712(publicKey: Hex, contractAddresses: Address[], delegatorAddress: Address, startTimestamp: number, durationDays?: number): Promise<KmsDelegatedUserDecryptEIP712Type_2>;
+    createDelegatedUserDecryptEIP712(publicKey: Hex$1, contractAddresses: Address$1[], delegatorAddress: Address$1, startTimestamp: number, durationDays?: number): Promise<KmsDelegatedUserDecryptEIP712Type_2>;
     // (undocumented)
-    createEIP712(publicKey: Hex, contractAddresses: Address[], startTimestamp: number, durationDays?: number): Promise<EIP712TypedData>;
+    createEIP712(publicKey: Hex$1, contractAddresses: Address$1[], startTimestamp: number, durationDays?: number): Promise<EIP712TypedData>;
     // (undocumented)
     delegatedUserDecrypt(params: DelegatedUserDecryptParams): Promise<Readonly<Record<Handle, ClearValueType>>>;
     // (undocumented)
     encrypt(params: EncryptParams): Promise<EncryptResult>;
     // (undocumented)
-    generateKeypair(): Promise<KeypairType_2<Hex>>;
+    generateKeypair(): Promise<KeypairType_2<Hex$1>>;
     // (undocumented)
-    getAclAddress(): Promise<Address>;
+    getAclAddress(): Promise<Address$1>;
     // Warning: (ae-forgotten-export) The symbol "PublicKeyData" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -493,12 +491,12 @@ export interface RelayerNodeConfig {
 
 // @public
 export interface RelayerSDK {
-    createDelegatedUserDecryptEIP712(publicKey: Hex, contractAddresses: Address[], delegatorAddress: Address, startTimestamp: number, durationDays?: number): Promise<KmsDelegatedUserDecryptEIP712Type>;
-    createEIP712(publicKey: Hex, contractAddresses: Address[], startTimestamp: number, durationDays?: number): Promise<EIP712TypedData>;
+    createDelegatedUserDecryptEIP712(publicKey: Hex$1, contractAddresses: Address$1[], delegatorAddress: Address$1, startTimestamp: number, durationDays?: number): Promise<KmsDelegatedUserDecryptEIP712Type>;
+    createEIP712(publicKey: Hex$1, contractAddresses: Address$1[], startTimestamp: number, durationDays?: number): Promise<EIP712TypedData>;
     delegatedUserDecrypt(params: DelegatedUserDecryptParams): Promise<Readonly<Record<Handle, ClearValueType>>>;
     encrypt(params: EncryptParams): Promise<EncryptResult>;
-    generateKeypair(): Promise<KeypairType<Hex>>;
-    getAclAddress(): Promise<Address>;
+    generateKeypair(): Promise<KeypairType<Hex$1>>;
+    getAclAddress(): Promise<Address$1>;
     getPublicKey(): Promise<PublicKeyData | null>;
     getPublicParams(bits: number): Promise<PublicParamsData | null>;
     publicDecrypt(handles: Handle[]): Promise<PublicDecryptResult>;
@@ -555,21 +553,21 @@ export interface UpdateCsrfRequest extends BaseRequest {
 // @public
 export interface UserDecryptParams {
     // (undocumented)
-    contractAddress: Address;
+    contractAddress: Address$1;
     // (undocumented)
     durationDays: number;
     // (undocumented)
     handles: Handle[];
     // (undocumented)
-    privateKey: Hex;
+    privateKey: Hex$1;
     // (undocumented)
-    publicKey: Hex;
+    publicKey: Hex$1;
     // (undocumented)
-    signature: Hex;
+    signature: Hex$1;
     // (undocumented)
-    signedContractAddresses: Address[];
+    signedContractAddresses: Address$1[];
     // (undocumented)
-    signerAddress: Address;
+    signerAddress: Address$1;
     // (undocumented)
     startTimestamp: number;
 }
@@ -582,12 +580,12 @@ export interface UserDecryptRequest extends BaseRequest {
     // (undocumented)
     payload: {
         handles: Handle[];
-        contractAddress: Address;
-        signedContractAddresses: Address[];
-        privateKey: Hex;
-        publicKey: Hex;
-        signature: Hex;
-        signerAddress: Address;
+        contractAddress: Address$1;
+        signedContractAddresses: Address$1[];
+        privateKey: Hex$1;
+        publicKey: Hex$1;
+        signature: Hex$1;
+        signerAddress: Address$1;
         startTimestamp: number;
         durationDays: number;
     };
@@ -609,6 +607,11 @@ export type WorkerRequestType = "INIT" | "NODE_INIT" | "UPDATE_CSRF" | "ENCRYPT"
 
 // @public (undocumented)
 export type WorkerResponse<T> = SuccessResponse<T> | ErrorResponse;
+
+// Warnings were encountered during analysis:
+//
+// dist/esm/relayer-sdk.types-7ysZXmRt.d.ts:292:5 - (ae-forgotten-export) The symbol "Hex$1" needs to be exported by the entry point index.d.ts
+// dist/esm/relayer-sdk.types-7ysZXmRt.d.ts:293:5 - (ae-forgotten-export) The symbol "Address$1" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -11,7 +11,6 @@ import { ClearValueType } from '@zama-fhe/relayer-sdk/bundle';
 import { ContractFunctionArgs } from 'viem';
 import { ContractFunctionName } from 'viem';
 import { ContractFunctionReturnType } from 'viem';
-import { Hex } from 'viem';
 import { InputProofBytesType } from '@zama-fhe/relayer-sdk/bundle';
 import { KeypairType } from '@zama-fhe/relayer-sdk/bundle';
 import { KmsDelegatedUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
@@ -26,19 +25,23 @@ import { skipToken } from '@tanstack/query-core';
 import { UserDecryptResults } from '@zama-fhe/relayer-sdk/bundle';
 import { ZKProofLike } from '@zama-fhe/relayer-sdk/bundle';
 
+// Warning: (ae-forgotten-export) The symbol "Address$1" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export function allowMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.allow"], Address[], void>;
+export function allowMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.allow"], Address$1[], void>;
 
 // @public (undocumented)
 export interface ApproveSubmittedEvent extends BaseEvent {
+    // Warning: (ae-forgotten-export) The symbol "Hex$1" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    txHash: Hex;
+    txHash: Hex$1;
     // (undocumented)
     type: typeof ZamaSDKEvents.ApproveSubmitted;
 }
 
 // @public (undocumented)
-export function approveUnderlyingMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.approveUnderlying", Address], ApproveUnderlyingParams, TransactionResult>;
+export function approveUnderlyingMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.approveUnderlying", Address$1], ApproveUnderlyingParams, TransactionResult>;
 
 // @public
 export interface ApproveUnderlyingParams {
@@ -49,7 +52,7 @@ export interface ApproveUnderlyingParams {
 // @public (undocumented)
 export interface ApproveUnderlyingSubmittedEvent extends BaseEvent {
     // (undocumented)
-    txHash: Hex;
+    txHash: Hex$1;
     // (undocumented)
     type: typeof ZamaSDKEvents.ApproveUnderlyingSubmitted;
 }
@@ -60,27 +63,27 @@ export interface BaseEvent {
     // (undocumented)
     timestamp: number;
     // (undocumented)
-    tokenAddress?: Address;
+    tokenAddress?: Address$1;
 }
 
 // @public
 export interface BatchBalancesResult {
     // Warning: (ae-forgotten-export) The symbol "ZamaError" needs to be exported by the entry point index.d.ts
-    errors: Map<Address, ZamaError>;
-    results: Map<Address, bigint>;
+    errors: Map<Address$1, ZamaError>;
+    results: Map<Address$1, bigint>;
 }
 
 // @public
 export interface BatchDecryptAsOptions {
-    accountAddress?: Address;
-    delegatorAddress: Address;
+    accountAddress?: Address$1;
+    delegatorAddress: Address$1;
     handles?: Handle[];
     maxConcurrency?: number;
-    onError?: (error: Error, address: Address) => bigint;
+    onError?: (error: Error, address: Address$1) => bigint;
 }
 
 // @public (undocumented)
-export function batchDecryptBalancesAsMutationOptions(tokens: ReadonlyToken[]): MutationFactoryOptions<readonly ["zama.batchDecryptBalancesAs", ...Address[]], BatchDecryptBalancesAsParams, Map<Address, bigint>>;
+export function batchDecryptBalancesAsMutationOptions(tokens: ReadonlyToken[]): MutationFactoryOptions<readonly ["zama.batchDecryptBalancesAs", ...Address$1[]], BatchDecryptBalancesAsParams, Map<Address$1, bigint>>;
 
 // @public
 export type BatchDecryptBalancesAsParams = BatchDecryptAsOptions;
@@ -88,12 +91,12 @@ export type BatchDecryptBalancesAsParams = BatchDecryptAsOptions;
 export { ClearValueType }
 
 // @public (undocumented)
-export function confidentialApproveMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.confidentialApprove", Address], ConfidentialApproveParams, TransactionResult>;
+export function confidentialApproveMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.confidentialApprove", Address$1], ConfidentialApproveParams, TransactionResult>;
 
 // @public
 export interface ConfidentialApproveParams {
     // (undocumented)
-    spender: Address;
+    spender: Address$1;
     // (undocumented)
     until?: number;
 }
@@ -101,11 +104,11 @@ export interface ConfidentialApproveParams {
 // @public (undocumented)
 export interface ConfidentialBalanceQueryConfig {
     // (undocumented)
-    owner?: Address;
+    owner?: Address$1;
     // (undocumented)
     query?: Record<string, unknown>;
     // (undocumented)
-    tokenAddress: Address;
+    tokenAddress: Address$1;
 }
 
 // @public (undocumented)
@@ -114,7 +117,7 @@ export function confidentialBalanceQueryOptions(token: ReadonlyToken, config: Co
 // @public (undocumented)
 export interface ConfidentialBalancesQueryConfig {
     // (undocumented)
-    owner?: Address;
+    owner?: Address$1;
     // (undocumented)
     query?: Record<string, unknown>;
 }
@@ -125,36 +128,36 @@ export function confidentialBalancesQueryOptions(tokens: ReadonlyToken[], config
 // @public (undocumented)
 export interface ConfidentialIsApprovedQueryConfig {
     // (undocumented)
-    holder?: Address;
+    holder?: Address$1;
     // (undocumented)
     query?: Record<string, unknown>;
     // (undocumented)
-    spender?: Address;
+    spender?: Address$1;
 }
 
 // @public (undocumented)
-export function confidentialIsApprovedQueryOptions(signer: GenericSigner, tokenAddress: Address | undefined, config: ConfidentialIsApprovedQueryConfig): QueryFactoryOptions<boolean, Error, boolean, ReturnType<typeof zamaQueryKeys.confidentialIsApproved.scope>>;
+export function confidentialIsApprovedQueryOptions(signer: GenericSigner, tokenAddress: Address$1 | undefined, config: ConfidentialIsApprovedQueryConfig): QueryFactoryOptions<boolean, Error, boolean, ReturnType<typeof zamaQueryKeys.confidentialIsApproved.scope>>;
 
 // @public (undocumented)
 export interface ConfidentialTokenAddressQueryConfig extends WrappersRegistryQueryConfig {
     // (undocumented)
-    tokenAddress?: Address;
+    tokenAddress?: Address$1;
 }
 
 // @public (undocumented)
-export function confidentialTokenAddressQueryOptions(signer: GenericSigner, config: ConfidentialTokenAddressQueryConfig): QueryFactoryOptions<readonly [boolean, Address], Error, readonly [boolean, Address], ReturnType<typeof zamaQueryKeys.wrappersRegistry.confidentialTokenAddress>>;
+export function confidentialTokenAddressQueryOptions(signer: GenericSigner, config: ConfidentialTokenAddressQueryConfig): QueryFactoryOptions<readonly [boolean, Address$1], Error, readonly [boolean, Address$1], ReturnType<typeof zamaQueryKeys.wrappersRegistry.confidentialTokenAddress>>;
 
 // @public
 export interface ConfidentialTransferEvent {
     readonly encryptedAmountHandle: Handle;
     // (undocumented)
     readonly eventName: "ConfidentialTransfer";
-    readonly from: Address;
-    readonly to: Address;
+    readonly from: Address$1;
+    readonly to: Address$1;
 }
 
 // @public (undocumented)
-export function confidentialTransferFromMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.confidentialTransferFrom", Address], ConfidentialTransferFromParams, TransactionResult>;
+export function confidentialTransferFromMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.confidentialTransferFrom", Address$1], ConfidentialTransferFromParams, TransactionResult>;
 
 // @public
 export interface ConfidentialTransferFromParams {
@@ -162,20 +165,20 @@ export interface ConfidentialTransferFromParams {
     amount: bigint;
     callbacks?: TransferCallbacks;
     // (undocumented)
-    from: Address;
+    from: Address$1;
     // (undocumented)
-    to: Address;
+    to: Address$1;
 }
 
 // @public (undocumented)
-export function confidentialTransferMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.confidentialTransfer", Address], ConfidentialTransferParams, TransactionResult>;
+export function confidentialTransferMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.confidentialTransfer", Address$1], ConfidentialTransferParams, TransactionResult>;
 
 // @public
 export interface ConfidentialTransferParams extends TransferOptions {
     // (undocumented)
     amount: bigint;
     // (undocumented)
-    to: Address;
+    to: Address$1;
 }
 
 // @public (undocumented)
@@ -184,13 +187,13 @@ export function createDelegatedUserDecryptEIP712MutationOptions(sdk: ZamaSDK): M
 // @public
 export interface CreateDelegatedUserDecryptEIP712Params {
     // (undocumented)
-    contractAddresses: Address[];
+    contractAddresses: Address$1[];
     // (undocumented)
-    delegatorAddress: Address;
+    delegatorAddress: Address$1;
     // (undocumented)
     durationDays?: number;
     // (undocumented)
-    publicKey: Hex;
+    publicKey: Hex$1;
     // (undocumented)
     startTimestamp: number;
 }
@@ -200,21 +203,21 @@ export function createEIP712MutationOptions(sdk: ZamaSDK): MutationFactoryOption
 
 // @public
 export type CreateEIP712Params = Pick<KmsUserDecryptEIP712UserArgsType, "startTimestamp"> & {
-    publicKey: Hex;
-    contractAddresses: Address[];
+    publicKey: Hex$1;
+    contractAddresses: Address$1[];
     durationDays?: number;
 };
 
 // @public (undocumented)
 export interface CredentialsAllowedEvent extends BaseEvent {
-    contractAddresses?: Address[];
+    contractAddresses?: Address$1[];
     // (undocumented)
     type: typeof ZamaSDKEvents.CredentialsAllowed;
 }
 
 // @public (undocumented)
 export interface CredentialsCachedEvent extends BaseEvent {
-    contractAddresses?: Address[];
+    contractAddresses?: Address$1[];
     // (undocumented)
     type: typeof ZamaSDKEvents.CredentialsCached;
 }
@@ -228,28 +231,28 @@ export interface CredentialsCorruptedEvent extends BaseEvent {
 
 // @public (undocumented)
 export interface CredentialsCreatedEvent extends BaseEvent {
-    contractAddresses?: Address[];
+    contractAddresses?: Address$1[];
     // (undocumented)
     type: typeof ZamaSDKEvents.CredentialsCreated;
 }
 
 // @public (undocumented)
 export interface CredentialsCreatingEvent extends BaseEvent {
-    contractAddresses?: Address[];
+    contractAddresses?: Address$1[];
     // (undocumented)
     type: typeof ZamaSDKEvents.CredentialsCreating;
 }
 
 // @public (undocumented)
 export interface CredentialsExpiredEvent extends BaseEvent {
-    contractAddresses?: Address[];
+    contractAddresses?: Address$1[];
     // (undocumented)
     type: typeof ZamaSDKEvents.CredentialsExpired;
 }
 
 // @public (undocumented)
 export interface CredentialsLoadingEvent extends BaseEvent {
-    contractAddresses?: Address[];
+    contractAddresses?: Address$1[];
     // (undocumented)
     type: typeof ZamaSDKEvents.CredentialsLoading;
 }
@@ -260,26 +263,26 @@ export interface CredentialsLoadingEvent extends BaseEvent {
 // @public
 export class CredentialsManager extends BaseCredentialsManager<StoredCredentials, EncryptedCredentials$1> {
     constructor(config: CredentialsManagerConfig);
-    allow(...contractAddresses: Address[]): Promise<StoredCredentials>;
+    allow(...contractAddresses: Address$1[]): Promise<StoredCredentials>;
     // (undocumented)
     protected assertEncrypted(data: unknown): asserts data is EncryptedCredentials$1;
     clear(): Promise<void>;
     // (undocumented)
     protected clearCaches(): void;
-    static computeStoreKey(address: Address, chainId: number): Promise<string>;
-    create(contractAddresses: Address[]): Promise<StoredCredentials>;
+    static computeStoreKey(address: Address$1, chainId: number): Promise<string>;
+    create(contractAddresses: Address$1[]): Promise<StoredCredentials>;
     // (undocumented)
-    protected decryptCredentials(encrypted: EncryptedCredentials$1, signature: Hex): Promise<StoredCredentials>;
+    protected decryptCredentials(encrypted: EncryptedCredentials$1, signature: Hex$1): Promise<StoredCredentials>;
     // (undocumented)
     protected encryptCredentials(creds: StoredCredentials): Promise<EncryptedCredentials$1>;
-    isAllowed(contractAddresses: [Address, ...Address[]]): Promise<boolean>;
-    isExpired(contractAddress?: Address): Promise<boolean>;
-    revoke(...contractAddresses: Address[]): Promise<void>;
+    isAllowed(contractAddresses: [Address$1, ...Address$1[]]): Promise<boolean>;
+    isExpired(contractAddress?: Address$1): Promise<boolean>;
+    revoke(...contractAddresses: Address$1[]): Promise<void>;
     revokeByKey(key: string): Promise<void>;
     // Warning: (ae-forgotten-export) The symbol "SigningMeta" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    protected signForContracts(meta: SigningMeta, contractAddresses: Address[]): Promise<Hex>;
+    protected signForContracts(meta: SigningMeta, contractAddresses: Address$1[]): Promise<Hex$1>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "CredentialsConfig" needs to be exported by the entry point index.d.ts
@@ -299,20 +302,20 @@ export interface CredentialsPersistFailedEvent extends BaseEvent {
 // @public (undocumented)
 export interface CredentialsRevokedEvent extends BaseEvent {
     // (undocumented)
-    contractAddresses?: Address[];
+    contractAddresses?: Address$1[];
     // (undocumented)
     type: typeof ZamaSDKEvents.CredentialsRevoked;
 }
 
 // @public (undocumented)
-export function decryptBalanceAsMutationOptions(readonlyToken: ReadonlyToken): MutationFactoryOptions<readonly ["zama.decryptBalanceAs", Address], DecryptBalanceAsParams, bigint>;
+export function decryptBalanceAsMutationOptions(readonlyToken: ReadonlyToken): MutationFactoryOptions<readonly ["zama.decryptBalanceAs", Address$1], DecryptBalanceAsParams, bigint>;
 
 // @public
 export interface DecryptBalanceAsParams {
     // (undocumented)
-    accountAddress?: Address;
+    accountAddress?: Address$1;
     // (undocumented)
-    delegatorAddress: Address;
+    delegatorAddress: Address$1;
 }
 
 // @public (undocumented)
@@ -338,7 +341,7 @@ export interface DecryptErrorEvent extends BaseEvent {
 // @public (undocumented)
 export interface DecryptHandle {
     // (undocumented)
-    contractAddress: Address;
+    contractAddress: Address$1;
     // (undocumented)
     handle: Handle;
 }
@@ -354,12 +357,12 @@ export interface DecryptStartEvent extends BaseEvent {
 }
 
 // @public (undocumented)
-export function delegateDecryptionMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.delegateDecryption", Address], DelegateDecryptionParams, TransactionResult>;
+export function delegateDecryptionMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.delegateDecryption", Address$1], DelegateDecryptionParams, TransactionResult>;
 
 // @public
 export interface DelegateDecryptionParams {
     // (undocumented)
-    delegateAddress: Address;
+    delegateAddress: Address$1;
     // (undocumented)
     expirationDate?: Date;
 }
@@ -370,23 +373,23 @@ export function delegatedUserDecryptMutationOptions(sdk: ZamaSDK): MutationFacto
 // @public
 export interface DelegatedUserDecryptParams {
     // (undocumented)
-    contractAddress: Address;
+    contractAddress: Address$1;
     // (undocumented)
-    delegateAddress: Address;
+    delegateAddress: Address$1;
     // (undocumented)
-    delegatorAddress: Address;
+    delegatorAddress: Address$1;
     // (undocumented)
     durationDays: number;
     // (undocumented)
     handles: Handle[];
     // (undocumented)
-    privateKey: Hex;
+    privateKey: Hex$1;
     // (undocumented)
-    publicKey: Hex;
+    publicKey: Hex$1;
     // (undocumented)
-    signature: Hex;
+    signature: Hex$1;
     // (undocumented)
-    signedContractAddresses: Address[];
+    signedContractAddresses: Address$1[];
     // (undocumented)
     startTimestamp: number;
 }
@@ -402,13 +405,13 @@ export interface DelegationStatusData {
 // @public (undocumented)
 export interface DelegationStatusQueryConfig {
     // (undocumented)
-    delegateAddress?: Address;
+    delegateAddress?: Address$1;
     // (undocumented)
-    delegatorAddress?: Address;
+    delegatorAddress?: Address$1;
     // (undocumented)
     query?: Record<string, unknown>;
     // (undocumented)
-    tokenAddress: Address | undefined;
+    tokenAddress: Address$1 | undefined;
 }
 
 // @public (undocumented)
@@ -420,7 +423,7 @@ export function delegationStatusQueryOptions(sdk: {
 // @public (undocumented)
 export interface DelegationSubmittedEvent extends BaseEvent {
     // (undocumented)
-    txHash: Hex;
+    txHash: Hex$1;
     // (undocumented)
     type: typeof ZamaSDKEvents.DelegationSubmitted;
 }
@@ -453,7 +456,7 @@ export type EncryptInput = {
     value: bigint;
     type: Exclude<SDK.FheTypeName, "ebool" | "eaddress">;
 } | {
-    value: Address;
+    value: Address$1;
     type: "eaddress";
 };
 
@@ -463,9 +466,9 @@ export function encryptMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<rea
 // @public
 export interface EncryptParams {
     // (undocumented)
-    contractAddress: Address;
+    contractAddress: Address$1;
     // (undocumented)
-    userAddress: Address;
+    userAddress: Address$1;
     values: EncryptInput[];
 }
 
@@ -482,7 +485,7 @@ export interface EncryptStartEvent extends BaseEvent {
 export function filterQueryOptions<TOptions extends Record<string, unknown>>(options: TOptions): Omit<TOptions, StrippedQueryOptionKeys>;
 
 // @public (undocumented)
-export function finalizeUnwrapMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.finalizeUnwrap", Address], FinalizeUnwrapParams, TransactionResult>;
+export function finalizeUnwrapMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.finalizeUnwrap", Address$1], FinalizeUnwrapParams, TransactionResult>;
 
 // @public
 export type FinalizeUnwrapParams = /** Preferred input from upgraded `UnwrapRequested` events. */{
@@ -496,17 +499,17 @@ export type FinalizeUnwrapParams = /** Preferred input from upgraded `UnwrapRequ
 // @public (undocumented)
 export interface FinalizeUnwrapSubmittedEvent extends BaseEvent {
     // (undocumented)
-    txHash: Hex;
+    txHash: Hex$1;
     // (undocumented)
     type: typeof ZamaSDKEvents.FinalizeUnwrapSubmitted;
 }
 
 // @public (undocumented)
-export function generateKeypairMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.generateKeypair"], void, KeypairType<Hex>>;
+export function generateKeypairMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.generateKeypair"], void, KeypairType<Hex$1>>;
 
 // @public
 export interface GenericSigner {
-    getAddress: () => Promise<Address>;
+    getAddress: () => Promise<Address$1>;
     getBlockTimestamp: () => Promise<bigint>;
     getChainId(): Promise<number>;
     // Warning: (ae-forgotten-export) The symbol "ReadFunctionName" needs to be exported by the entry point index.d.ts
@@ -514,14 +517,14 @@ export interface GenericSigner {
     // Warning: (ae-forgotten-export) The symbol "ReadContractConfig" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ReadContractReturnType" needs to be exported by the entry point index.d.ts
     readContract<const TAbi extends ContractAbi, TFunctionName extends ReadFunctionName<TAbi>, const TArgs extends ReadContractArgs<TAbi, TFunctionName>>(config: ReadContractConfig<TAbi, TFunctionName, TArgs>): Promise<ReadContractReturnType<TAbi, TFunctionName, TArgs>>;
-    signTypedData(typedData: EIP712TypedData): Promise<Hex>;
+    signTypedData(typedData: EIP712TypedData): Promise<Hex$1>;
     subscribe?: (callbacks: SignerLifecycleCallbacks) => () => void;
-    waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt>;
+    waitForTransactionReceipt(hash: Hex$1): Promise<TransactionReceipt>;
     // Warning: (ae-forgotten-export) The symbol "ContractAbi" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "WriteFunctionName" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "WriteContractArgs" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "WriteContractConfig" needs to be exported by the entry point index.d.ts
-    writeContract<const TAbi extends ContractAbi, TFunctionName extends WriteFunctionName<TAbi>, const TArgs extends WriteContractArgs<TAbi, TFunctionName>>(config: WriteContractConfig<TAbi, TFunctionName, TArgs>): Promise<Hex>;
+    writeContract<const TAbi extends ContractAbi, TFunctionName extends WriteFunctionName<TAbi>, const TArgs extends WriteContractArgs<TAbi, TFunctionName>>(config: WriteContractConfig<TAbi, TFunctionName, TArgs>): Promise<Hex$1>;
 }
 
 // @public
@@ -538,25 +541,25 @@ export type Handle = Bytes32Hex;
 export function hashFn(queryKey: readonly unknown[]): string;
 
 // @public (undocumented)
-export function invalidateAfterApprove(queryClient: QueryClientLike, tokenAddress: Address): void;
+export function invalidateAfterApprove(queryClient: QueryClientLike, tokenAddress: Address$1): void;
 
 // @public (undocumented)
-export function invalidateAfterApproveUnderlying(queryClient: QueryClientLike, tokenAddress: Address): void;
+export function invalidateAfterApproveUnderlying(queryClient: QueryClientLike, tokenAddress: Address$1): void;
 
 // @public (undocumented)
-export function invalidateAfterShield(queryClient: QueryClientLike, tokenAddress: Address): void;
+export function invalidateAfterShield(queryClient: QueryClientLike, tokenAddress: Address$1): void;
 
 // @public (undocumented)
-export function invalidateAfterTransfer(queryClient: QueryClientLike, tokenAddress: Address): void;
+export function invalidateAfterTransfer(queryClient: QueryClientLike, tokenAddress: Address$1): void;
 
 // @public (undocumented)
-export function invalidateAfterUnshield(queryClient: QueryClientLike, tokenAddress: Address): void;
+export function invalidateAfterUnshield(queryClient: QueryClientLike, tokenAddress: Address$1): void;
 
 // @public (undocumented)
-export function invalidateAfterUnwrap(queryClient: QueryClientLike, tokenAddress: Address): void;
+export function invalidateAfterUnwrap(queryClient: QueryClientLike, tokenAddress: Address$1): void;
 
 // @public (undocumented)
-export function invalidateBalanceQueries(queryClient: QueryClientLike, tokenAddress: Address): void;
+export function invalidateBalanceQueries(queryClient: QueryClientLike, tokenAddress: Address$1): void;
 
 // @public (undocumented)
 export function invalidateWagmiBalanceQueries(queryClient: QueryClientLike): void;
@@ -567,8 +570,8 @@ export function invalidateWalletLifecycleQueries(queryClient: QueryClientLike): 
 // @public (undocumented)
 export interface IsAllowedQueryConfig {
     // (undocumented)
-    account: Address;
-    contractAddresses: [Address, ...Address[]];
+    account: Address$1;
+    contractAddresses: [Address$1, ...Address$1[]];
     // (undocumented)
     query?: Record<string, unknown>;
 }
@@ -583,19 +586,19 @@ export interface IsConfidentialQueryConfig {
 }
 
 // @public (undocumented)
-export function isConfidentialQueryOptions(signer: GenericSigner, tokenAddress: Address, config?: IsConfidentialQueryConfig): QueryFactoryOptions<boolean, Error, boolean, ReturnType<typeof zamaQueryKeys.isConfidential.token>>;
+export function isConfidentialQueryOptions(signer: GenericSigner, tokenAddress: Address$1, config?: IsConfidentialQueryConfig): QueryFactoryOptions<boolean, Error, boolean, ReturnType<typeof zamaQueryKeys.isConfidential.token>>;
 
 // @public (undocumented)
 export interface IsConfidentialTokenValidQueryConfig extends WrappersRegistryQueryConfig {
     // (undocumented)
-    confidentialTokenAddress?: Address;
+    confidentialTokenAddress?: Address$1;
 }
 
 // @public (undocumented)
 export function isConfidentialTokenValidQueryOptions(signer: GenericSigner, config: IsConfidentialTokenValidQueryConfig): QueryFactoryOptions<boolean, Error, boolean, ReturnType<typeof zamaQueryKeys.wrappersRegistry.isConfidentialTokenValid>>;
 
 // @public (undocumented)
-export function isWrapperQueryOptions(signer: GenericSigner, tokenAddress: Address, config?: IsConfidentialQueryConfig): QueryFactoryOptions<boolean, Error, boolean, ReturnType<typeof zamaQueryKeys.isWrapper.token>>;
+export function isWrapperQueryOptions(signer: GenericSigner, tokenAddress: Address$1, config?: IsConfidentialQueryConfig): QueryFactoryOptions<boolean, Error, boolean, ReturnType<typeof zamaQueryKeys.isWrapper.token>>;
 
 // @public (undocumented)
 export interface ListPairsQueryConfig {
@@ -607,7 +610,7 @@ export interface ListPairsQueryConfig {
     pageSize?: number;
     // (undocumented)
     query?: Record<string, unknown>;
-    registryAddress: Address | undefined;
+    registryAddress: Address$1 | undefined;
 }
 
 // Warning: (ae-forgotten-export) The symbol "WrappersRegistry" needs to be exported by the entry point index.d.ts
@@ -690,59 +693,59 @@ export interface QueryLike {
 
 // @public
 export interface RawLog {
-    readonly data: Hex;
-    readonly topics: readonly Hex[];
+    readonly data: Hex$1;
+    readonly topics: readonly Hex$1[];
 }
 
 // @public
 export class ReadonlyToken {
-    constructor(sdk: ZamaSDK, address: Address);
+    constructor(sdk: ZamaSDK, address: Address$1);
     // (undocumented)
-    readonly address: Address;
+    readonly address: Address$1;
     allow(): Promise<void>;
     static allow(...tokens: ReadonlyToken[]): Promise<void>;
-    allowance(wrapper: Address, owner?: Address): Promise<bigint>;
-    balanceOf(owner?: Address): Promise<bigint>;
-    static batchBalancesOf(tokens: ReadonlyToken[], owner?: Address): Promise<BatchBalancesResult>;
-    static batchDecryptBalancesAs(tokens: ReadonlyToken[], options: BatchDecryptAsOptions): Promise<Map<Address, bigint>>;
-    confidentialBalanceOf(owner?: Address): Promise<Handle>;
+    allowance(wrapper: Address$1, owner?: Address$1): Promise<bigint>;
+    balanceOf(owner?: Address$1): Promise<bigint>;
+    static batchBalancesOf(tokens: ReadonlyToken[], owner?: Address$1): Promise<BatchBalancesResult>;
+    static batchDecryptBalancesAs(tokens: ReadonlyToken[], options: BatchDecryptAsOptions): Promise<Map<Address$1, bigint>>;
+    confidentialBalanceOf(owner?: Address$1): Promise<Handle>;
     decimals(): Promise<number>;
     decryptBalanceAs(input: {
-        delegatorAddress: Address;
-        accountAddress?: Address;
+        delegatorAddress: Address$1;
+        accountAddress?: Address$1;
     }): Promise<bigint>;
     protected emit(input: ZamaSDKEventInput): void;
     // (undocumented)
-    protected getAclAddress(): Promise<Address>;
+    protected getAclAddress(): Promise<Address$1>;
     getDelegationExpiry(input: {
-        delegatorAddress: Address;
-        delegateAddress: Address;
+        delegatorAddress: Address$1;
+        delegateAddress: Address$1;
     }): Promise<bigint>;
     isAllowed(): Promise<boolean>;
     isConfidential(): Promise<boolean>;
     isDelegated(params: {
-        delegatorAddress: Address;
-        delegateAddress: Address;
+        delegatorAddress: Address$1;
+        delegateAddress: Address$1;
     }): Promise<boolean>;
     isWrapper(): Promise<boolean>;
     name(): Promise<string>;
     // (undocumented)
-    protected readConfidentialBalanceOf(owner: Address): Promise<Handle>;
-    revoke(...contractAddresses: Address[]): Promise<void>;
+    protected readConfidentialBalanceOf(owner: Address$1): Promise<Handle>;
+    revoke(...contractAddresses: Address$1[]): Promise<void>;
     // (undocumented)
     readonly sdk: ZamaSDK;
     symbol(): Promise<string>;
-    underlyingToken(): Promise<Address>;
+    underlyingToken(): Promise<Address$1>;
 }
 
 // @public
 export interface RelayerSDK {
-    createDelegatedUserDecryptEIP712(publicKey: Hex, contractAddresses: Address[], delegatorAddress: Address, startTimestamp: number, durationDays?: number): Promise<KmsDelegatedUserDecryptEIP712Type>;
-    createEIP712(publicKey: Hex, contractAddresses: Address[], startTimestamp: number, durationDays?: number): Promise<EIP712TypedData>;
+    createDelegatedUserDecryptEIP712(publicKey: Hex$1, contractAddresses: Address$1[], delegatorAddress: Address$1, startTimestamp: number, durationDays?: number): Promise<KmsDelegatedUserDecryptEIP712Type>;
+    createEIP712(publicKey: Hex$1, contractAddresses: Address$1[], startTimestamp: number, durationDays?: number): Promise<EIP712TypedData>;
     delegatedUserDecrypt(params: DelegatedUserDecryptParams): Promise<Readonly<Record<Handle, ClearValueType>>>;
     encrypt(params: EncryptParams): Promise<EncryptResult>;
-    generateKeypair(): Promise<KeypairType<Hex>>;
-    getAclAddress(): Promise<Address>;
+    generateKeypair(): Promise<KeypairType<Hex$1>>;
+    getAclAddress(): Promise<Address$1>;
     getPublicKey(): Promise<PublicKeyData | null>;
     getPublicParams(bits: number): Promise<PublicParamsData | null>;
     publicDecrypt(handles: Handle[]): Promise<PublicDecryptResult>;
@@ -755,33 +758,33 @@ export interface RelayerSDK {
 export function requestZKProofVerificationMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.requestZKProofVerification"], ZKProofLike, InputProofBytesType>;
 
 // @public (undocumented)
-export function resumeUnshieldMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.resumeUnshield", Address], ResumeUnshieldParams, TransactionResult>;
+export function resumeUnshieldMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.resumeUnshield", Address$1], ResumeUnshieldParams, TransactionResult>;
 
 // @public
 export interface ResumeUnshieldParams extends UnshieldCallbacks {
     // (undocumented)
-    unwrapTxHash: Hex;
+    unwrapTxHash: Hex$1;
 }
 
 // @public (undocumented)
-export function revokeDelegationMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.revokeDelegation", Address], RevokeDelegationParams, TransactionResult>;
+export function revokeDelegationMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.revokeDelegation", Address$1], RevokeDelegationParams, TransactionResult>;
 
 // @public
 export interface RevokeDelegationParams {
     // (undocumented)
-    delegateAddress: Address;
+    delegateAddress: Address$1;
 }
 
 // @public (undocumented)
 export interface RevokeDelegationSubmittedEvent extends BaseEvent {
     // (undocumented)
-    txHash: Hex;
+    txHash: Hex$1;
     // (undocumented)
     type: typeof ZamaSDKEvents.RevokeDelegationSubmitted;
 }
 
 // @public (undocumented)
-export function revokeMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.revoke"], Address[], void>;
+export function revokeMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.revoke"], Address$1[], void>;
 
 // @public (undocumented)
 export function revokeSessionMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.revokeSession"], void, void>;
@@ -795,17 +798,17 @@ export interface SessionExpiredEvent extends BaseEvent {
 
 // @public
 export interface ShieldCallbacks {
-    onApprovalSubmitted?: (txHash: Hex) => void;
-    onShieldSubmitted?: (txHash: Hex) => void;
+    onApprovalSubmitted?: (txHash: Hex$1) => void;
+    onShieldSubmitted?: (txHash: Hex$1) => void;
 }
 
 // @public (undocumented)
-export function shieldMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.shield", Address], ShieldParams, TransactionResult>;
+export function shieldMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.shield", Address$1], ShieldParams, TransactionResult>;
 
 // @public
 export interface ShieldOptions extends ShieldCallbacks {
     approvalStrategy?: "max" | "exact" | "skip";
-    to?: Address;
+    to?: Address$1;
 }
 
 // @public
@@ -814,13 +817,13 @@ export interface ShieldParams extends ShieldCallbacks {
     amount: bigint;
     // (undocumented)
     approvalStrategy?: "max" | "exact" | "skip";
-    to?: Address;
+    to?: Address$1;
 }
 
 // @public (undocumented)
 export interface ShieldSubmittedEvent extends BaseEvent {
     // (undocumented)
-    txHash: Hex;
+    txHash: Hex$1;
     // (undocumented)
     type: typeof ZamaSDKEvents.ShieldSubmitted;
 }
@@ -832,22 +835,22 @@ export interface SignerAddressQueryConfig {
 }
 
 // @public (undocumented)
-export function signerAddressQueryOptions(signer: GenericSigner, config?: SignerAddressQueryConfig): QueryFactoryOptions<Address, Error, Address, ReturnType<typeof zamaQueryKeys.signerAddress.scope>>;
+export function signerAddressQueryOptions(signer: GenericSigner, config?: SignerAddressQueryConfig): QueryFactoryOptions<Address$1, Error, Address$1, ReturnType<typeof zamaQueryKeys.signerAddress.scope>>;
 
 // @public
 export interface SignerLifecycleCallbacks {
-    onAccountChange?: (newAddress: Address) => void;
+    onAccountChange?: (newAddress: Address$1) => void;
     onChainChange?: (newChainId: number) => void;
     onDisconnect?: () => void;
 }
 
 // @public
 export interface StoredCredentials {
-    contractAddresses: Address[];
+    contractAddresses: Address$1[];
     durationDays: number;
-    privateKey: Hex;
-    publicKey: Hex;
-    signature: Hex;
+    privateKey: Hex$1;
+    publicKey: Hex$1;
+    signature: Hex$1;
     startTimestamp: number;
 }
 
@@ -856,29 +859,29 @@ export type StrippedQueryOptionKeys = "gcTime" | "staleTime" | "enabled" | "sele
 
 // @public
 export class Token extends ReadonlyToken {
-    constructor(sdk: ZamaSDK, address: Address, wrapper?: Address);
-    approve(spender: Address, until?: number): Promise<TransactionResult>;
+    constructor(sdk: ZamaSDK, address: Address$1, wrapper?: Address$1);
+    approve(spender: Address$1, until?: number): Promise<TransactionResult>;
     approveUnderlying(amount?: bigint): Promise<TransactionResult>;
     static batchDelegateDecryption(input: {
         tokens: Token[];
-        delegateAddress: Address;
+        delegateAddress: Address$1;
         expirationDate?: Date;
-    }): Promise<Map<Address, TransactionResult | ZamaError>>;
+    }): Promise<Map<Address$1, TransactionResult | ZamaError>>;
     static batchRevokeDelegation(input: {
         tokens: Token[];
-        delegateAddress: Address;
-    }): Promise<Map<Address, TransactionResult | ZamaError>>;
-    confidentialTransfer(to: Address, amount: bigint, options?: TransferOptions): Promise<TransactionResult>;
-    confidentialTransferFrom(from: Address, to: Address, amount: bigint, callbacks?: TransferCallbacks): Promise<TransactionResult>;
+        delegateAddress: Address$1;
+    }): Promise<Map<Address$1, TransactionResult | ZamaError>>;
+    confidentialTransfer(to: Address$1, amount: bigint, options?: TransferOptions): Promise<TransactionResult>;
+    confidentialTransferFrom(from: Address$1, to: Address$1, amount: bigint, callbacks?: TransferCallbacks): Promise<TransactionResult>;
     delegateDecryption(input: {
-        delegateAddress: Address;
+        delegateAddress: Address$1;
         expirationDate?: Date;
     }): Promise<TransactionResult>;
     finalizeUnwrap(unwrapRequestIdOrAmount: Handle): Promise<TransactionResult>;
-    isApproved(spender: Address, holder?: Address): Promise<boolean>;
-    resumeUnshield(unwrapTxHash: Hex, callbacks?: UnshieldCallbacks): Promise<TransactionResult>;
+    isApproved(spender: Address$1, holder?: Address$1): Promise<boolean>;
+    resumeUnshield(unwrapTxHash: Hex$1, callbacks?: UnshieldCallbacks): Promise<TransactionResult>;
     revokeDelegation(input: {
-        delegateAddress: Address;
+        delegateAddress: Address$1;
     }): Promise<TransactionResult>;
     shield(amount: bigint, options?: ShieldOptions): Promise<TransactionResult>;
     unshield(amount: bigint, options?: UnshieldOptions): Promise<TransactionResult>;
@@ -886,19 +889,19 @@ export class Token extends ReadonlyToken {
     unwrap(amount: bigint): Promise<TransactionResult>;
     unwrapAll(): Promise<TransactionResult>;
     // (undocumented)
-    readonly wrapper: Address;
+    readonly wrapper: Address$1;
     // (undocumented)
-    static readonly ZERO_ADDRESS: Address;
+    static readonly ZERO_ADDRESS: Address$1;
 }
 
 // @public (undocumented)
 export interface TokenAddressQueryConfig extends WrappersRegistryQueryConfig {
     // (undocumented)
-    confidentialTokenAddress?: Address;
+    confidentialTokenAddress?: Address$1;
 }
 
 // @public (undocumented)
-export function tokenAddressQueryOptions(signer: GenericSigner, config: TokenAddressQueryConfig): QueryFactoryOptions<readonly [boolean, Address], Error, readonly [boolean, Address], ReturnType<typeof zamaQueryKeys.wrappersRegistry.tokenAddress>>;
+export function tokenAddressQueryOptions(signer: GenericSigner, config: TokenAddressQueryConfig): QueryFactoryOptions<readonly [boolean, Address$1], Error, readonly [boolean, Address$1], ReturnType<typeof zamaQueryKeys.wrappersRegistry.tokenAddress>>;
 
 // @public
 export interface TokenMetadata {
@@ -917,7 +920,7 @@ export interface TokenMetadataQueryConfig {
 }
 
 // @public (undocumented)
-export function tokenMetadataQueryOptions(signer: GenericSigner, tokenAddress: Address, config?: TokenMetadataQueryConfig): QueryFactoryOptions<TokenMetadata, Error, TokenMetadata, ReturnType<typeof zamaQueryKeys.tokenMetadata.token>>;
+export function tokenMetadataQueryOptions(signer: GenericSigner, tokenAddress: Address$1, config?: TokenMetadataQueryConfig): QueryFactoryOptions<TokenMetadata, Error, TokenMetadata, ReturnType<typeof zamaQueryKeys.tokenMetadata.token>>;
 
 // @public (undocumented)
 export interface TokenPairQueryConfig extends WrappersRegistryQueryConfig {
@@ -952,7 +955,7 @@ export interface TotalSupplyQueryConfig {
 }
 
 // @public (undocumented)
-export function totalSupplyQueryOptions(signer: GenericSigner, tokenAddress: Address, config?: TotalSupplyQueryConfig): QueryFactoryOptions<bigint, Error, bigint, ReturnType<typeof zamaQueryKeys.totalSupply.token>>;
+export function totalSupplyQueryOptions(signer: GenericSigner, tokenAddress: Address$1, config?: TotalSupplyQueryConfig): QueryFactoryOptions<bigint, Error, bigint, ReturnType<typeof zamaQueryKeys.totalSupply.token>>;
 
 // @public (undocumented)
 export interface TransactionErrorEvent extends BaseEvent {
@@ -970,19 +973,19 @@ export interface TransactionReceipt {
 // @public
 export interface TransactionResult {
     receipt: TransactionReceipt;
-    txHash: Hex;
+    txHash: Hex$1;
 }
 
 // @public
 export interface TransferCallbacks {
     onEncryptComplete?: () => void;
-    onTransferSubmitted?: (txHash: Hex) => void;
+    onTransferSubmitted?: (txHash: Hex$1) => void;
 }
 
 // @public (undocumented)
 export interface TransferFromSubmittedEvent extends BaseEvent {
     // (undocumented)
-    txHash: Hex;
+    txHash: Hex$1;
     // (undocumented)
     type: typeof ZamaSDKEvents.TransferFromSubmitted;
 }
@@ -995,7 +998,7 @@ export interface TransferOptions extends TransferCallbacks {
 // @public (undocumented)
 export interface TransferSubmittedEvent extends BaseEvent {
     // (undocumented)
-    txHash: Hex;
+    txHash: Hex$1;
     // (undocumented)
     type: typeof ZamaSDKEvents.TransferSubmitted;
 }
@@ -1003,31 +1006,31 @@ export interface TransferSubmittedEvent extends BaseEvent {
 // @public (undocumented)
 export interface UnderlyingAllowanceQueryConfig {
     // (undocumented)
-    owner?: Address;
+    owner?: Address$1;
     // (undocumented)
     query?: Record<string, unknown>;
     // (undocumented)
-    wrapperAddress?: Address;
+    wrapperAddress?: Address$1;
 }
 
 // @public (undocumented)
-export function underlyingAllowanceQueryOptions(signer: GenericSigner, tokenAddress: Address, config: UnderlyingAllowanceQueryConfig): QueryFactoryOptions<bigint, Error, bigint, ReturnType<typeof zamaQueryKeys.underlyingAllowance.scope>>;
+export function underlyingAllowanceQueryOptions(signer: GenericSigner, tokenAddress: Address$1, config: UnderlyingAllowanceQueryConfig): QueryFactoryOptions<bigint, Error, bigint, ReturnType<typeof zamaQueryKeys.underlyingAllowance.scope>>;
 
 // @public (undocumented)
-export function unshieldAllMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.unshieldAll", Address], UnshieldAllParams | void, TransactionResult>;
+export function unshieldAllMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.unshieldAll", Address$1], UnshieldAllParams | void, TransactionResult>;
 
 // @public
 export interface UnshieldAllParams extends UnshieldCallbacks {}
 
 // @public
 export interface UnshieldCallbacks {
-    onFinalizeSubmitted?: (txHash: Hex) => void;
+    onFinalizeSubmitted?: (txHash: Hex$1) => void;
     onFinalizing?: () => void;
-    onUnwrapSubmitted?: (txHash: Hex) => void;
+    onUnwrapSubmitted?: (txHash: Hex$1) => void;
 }
 
 // @public (undocumented)
-export function unshieldMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.unshield", Address], UnshieldParams, TransactionResult>;
+export function unshieldMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.unshield", Address$1], UnshieldParams, TransactionResult>;
 
 // @public
 export interface UnshieldOptions extends UnshieldCallbacks {
@@ -1043,7 +1046,7 @@ export interface UnshieldParams extends UnshieldOptions {
 // @public (undocumented)
 export interface UnshieldPhase1SubmittedEvent extends BaseEvent {
     // (undocumented)
-    txHash: Hex;
+    txHash: Hex$1;
     // (undocumented)
     type: typeof ZamaSDKEvents.UnshieldPhase1Submitted;
 }
@@ -1057,13 +1060,13 @@ export interface UnshieldPhase2StartedEvent extends BaseEvent {
 // @public (undocumented)
 export interface UnshieldPhase2SubmittedEvent extends BaseEvent {
     // (undocumented)
-    txHash: Hex;
+    txHash: Hex$1;
     // (undocumented)
     type: typeof ZamaSDKEvents.UnshieldPhase2Submitted;
 }
 
 // @public (undocumented)
-export function unwrapAllMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.unwrapAll", Address], void, TransactionResult>;
+export function unwrapAllMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.unwrapAll", Address$1], void, TransactionResult>;
 
 // @public
 export interface UnwrapFinalizedEvent {
@@ -1071,12 +1074,12 @@ export interface UnwrapFinalizedEvent {
     readonly encryptedAmount: Handle;
     // (undocumented)
     readonly eventName: "UnwrapFinalized";
-    readonly receiver: Address;
+    readonly receiver: Address$1;
     readonly unwrapRequestId?: Handle;
 }
 
 // @public (undocumented)
-export function unwrapMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.unwrap", Address], UnwrapParams, TransactionResult>;
+export function unwrapMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.unwrap", Address$1], UnwrapParams, TransactionResult>;
 
 // @public
 export interface UnwrapParams {
@@ -1093,7 +1096,7 @@ export interface UnwrappedFinalizedEvent {
     // (undocumented)
     readonly eventName: "UnwrappedFinalized";
     // (undocumented)
-    readonly receiver: Address;
+    readonly receiver: Address$1;
     // (undocumented)
     readonly unwrapRequestId?: Handle;
 }
@@ -1103,11 +1106,11 @@ export interface UnwrappedStartedEvent {
     readonly burnAmount: Handle;
     // (undocumented)
     readonly eventName: "UnwrappedStarted";
-    readonly refund: Address;
+    readonly refund: Address$1;
     readonly requestedAmount: Handle;
     readonly requestId: bigint;
     readonly returnVal: boolean;
-    readonly to: Address;
+    readonly to: Address$1;
     readonly txId: bigint;
 }
 
@@ -1116,14 +1119,14 @@ export interface UnwrapRequestedEvent {
     readonly encryptedAmount: Handle;
     // (undocumented)
     readonly eventName: "UnwrapRequested";
-    readonly receiver: Address;
+    readonly receiver: Address$1;
     readonly unwrapRequestId?: Handle;
 }
 
 // @public (undocumented)
 export interface UnwrapSubmittedEvent extends BaseEvent {
     // (undocumented)
-    txHash: Hex;
+    txHash: Hex$1;
     // (undocumented)
     type: typeof ZamaSDKEvents.UnwrapSubmitted;
 }
@@ -1131,21 +1134,21 @@ export interface UnwrapSubmittedEvent extends BaseEvent {
 // @public
 export interface UserDecryptParams {
     // (undocumented)
-    contractAddress: Address;
+    contractAddress: Address$1;
     // (undocumented)
     durationDays: number;
     // (undocumented)
     handles: Handle[];
     // (undocumented)
-    privateKey: Hex;
+    privateKey: Hex$1;
     // (undocumented)
-    publicKey: Hex;
+    publicKey: Hex$1;
     // (undocumented)
-    signature: Hex;
+    signature: Hex$1;
     // (undocumented)
-    signedContractAddresses: Address[];
+    signedContractAddresses: Address$1[];
     // (undocumented)
-    signerAddress: Address;
+    signerAddress: Address$1;
     // (undocumented)
     startTimestamp: number;
 }
@@ -1164,27 +1167,27 @@ export interface WrappedEvent {
     readonly amountIn: bigint;
     // (undocumented)
     readonly eventName: "Wrapped";
-    readonly to: Address;
+    readonly to: Address$1;
 }
 
 // @public (undocumented)
 export interface WrapperDiscoveryQueryConfig {
-    erc20Address?: Address;
+    erc20Address?: Address$1;
     // (undocumented)
     query?: Record<string, unknown>;
-    registryAddress?: Address;
-    tokenAddress?: Address;
+    registryAddress?: Address$1;
+    tokenAddress?: Address$1;
 }
 
 // @public (undocumented)
-export function wrapperDiscoveryQueryOptions(registry: WrappersRegistry, config: WrapperDiscoveryQueryConfig): QueryFactoryOptions<Address | null, Error, Address | null, ReturnType<typeof zamaQueryKeys.wrapperDiscovery.token>>;
+export function wrapperDiscoveryQueryOptions(registry: WrappersRegistry, config: WrapperDiscoveryQueryConfig): QueryFactoryOptions<Address$1 | null, Error, Address$1 | null, ReturnType<typeof zamaQueryKeys.wrapperDiscovery.token>>;
 
 // @public (undocumented)
 export interface WrappersRegistryQueryConfig {
     // (undocumented)
     query?: Record<string, unknown>;
     // (undocumented)
-    registryAddress: Address | undefined;
+    registryAddress: Address$1 | undefined;
 }
 
 // @public
@@ -1194,48 +1197,48 @@ export const zamaQueryKeys: {
         readonly scope: (scope: number) => readonly ["zama.signerAddress", {
             readonly scope: number;
         }];
-        readonly token: (tokenAddress: Address) => readonly ["zama.signerAddress", {
+        readonly token: (tokenAddress: Address$1) => readonly ["zama.signerAddress", {
             readonly tokenAddress: `0x${string}`;
         }];
     };
     readonly confidentialBalance: {
         readonly all: readonly ["zama.confidentialBalance"];
-        readonly token: (tokenAddress: Address) => readonly ["zama.confidentialBalance", {
+        readonly token: (tokenAddress: Address$1) => readonly ["zama.confidentialBalance", {
             readonly tokenAddress: `0x${string}`;
         }];
-        readonly owner: (tokenAddress: Address, owner?: Address) => readonly ["zama.confidentialBalance", {
+        readonly owner: (tokenAddress: Address$1, owner?: Address$1) => readonly ["zama.confidentialBalance", {
             readonly owner?: `0x${string}` | undefined;
             readonly tokenAddress: `0x${string}`;
         }];
     };
     readonly confidentialBalances: {
         readonly all: readonly ["zama.confidentialBalances"];
-        readonly tokens: (tokenAddresses: Address[], owner?: Address) => readonly ["zama.confidentialBalances", {
+        readonly tokens: (tokenAddresses: Address$1[], owner?: Address$1) => readonly ["zama.confidentialBalances", {
             readonly owner?: `0x${string}` | undefined;
             readonly tokenAddresses: `0x${string}`[];
         }];
     };
     readonly tokenMetadata: {
         readonly all: readonly ["zama.tokenMetadata"];
-        readonly token: (tokenAddress: Address) => readonly ["zama.tokenMetadata", {
+        readonly token: (tokenAddress: Address$1) => readonly ["zama.tokenMetadata", {
             readonly tokenAddress: `0x${string}`;
         }];
     };
     readonly isConfidential: {
         readonly all: readonly ["zama.isConfidential"];
-        readonly token: (tokenAddress: Address) => readonly ["zama.isConfidential", {
+        readonly token: (tokenAddress: Address$1) => readonly ["zama.isConfidential", {
             readonly tokenAddress: `0x${string}`;
         }];
     };
     readonly isWrapper: {
         readonly all: readonly ["zama.isWrapper"];
-        readonly token: (tokenAddress: Address) => readonly ["zama.isWrapper", {
+        readonly token: (tokenAddress: Address$1) => readonly ["zama.isWrapper", {
             readonly tokenAddress: `0x${string}`;
         }];
     };
     readonly wrapperDiscovery: {
         readonly all: readonly ["zama.wrapperDiscovery"];
-        readonly token: (tokenAddress?: Address, erc20Address?: Address, registryAddress?: Address) => readonly ["zama.wrapperDiscovery", {
+        readonly token: (tokenAddress?: Address$1, erc20Address?: Address$1, registryAddress?: Address$1) => readonly ["zama.wrapperDiscovery", {
             readonly registryAddress?: `0x${string}` | undefined;
             readonly erc20Address?: `0x${string}` | undefined;
             readonly tokenAddress?: `0x${string}` | undefined;
@@ -1243,10 +1246,10 @@ export const zamaQueryKeys: {
     };
     readonly underlyingAllowance: {
         readonly all: readonly ["zama.underlyingAllowance"];
-        readonly token: (tokenAddress: Address) => readonly ["zama.underlyingAllowance", {
+        readonly token: (tokenAddress: Address$1) => readonly ["zama.underlyingAllowance", {
             readonly tokenAddress: `0x${string}`;
         }];
-        readonly scope: (tokenAddress: Address, owner?: Address, wrapperAddress?: Address) => readonly ["zama.underlyingAllowance", {
+        readonly scope: (tokenAddress: Address$1, owner?: Address$1, wrapperAddress?: Address$1) => readonly ["zama.underlyingAllowance", {
             readonly wrapperAddress?: `0x${string}` | undefined;
             readonly owner?: `0x${string}` | undefined;
             readonly tokenAddress: `0x${string}`;
@@ -1254,12 +1257,12 @@ export const zamaQueryKeys: {
     };
     readonly confidentialIsApproved: {
         readonly all: readonly ["zama.confidentialIsApproved"];
-        readonly token: (tokenAddress?: Address) => readonly ["zama.confidentialIsApproved", {
+        readonly token: (tokenAddress?: Address$1) => readonly ["zama.confidentialIsApproved", {
             tokenAddress: `0x${string}`;
         } | {
             tokenAddress?: undefined;
         }];
-        readonly scope: (tokenAddress?: Address, holder?: Address, spender?: Address) => readonly ["zama.confidentialIsApproved", {
+        readonly scope: (tokenAddress?: Address$1, holder?: Address$1, spender?: Address$1) => readonly ["zama.confidentialIsApproved", {
             readonly spender?: `0x${string}` | undefined;
             readonly holder?: `0x${string}` | undefined;
             readonly tokenAddress?: `0x${string}` | undefined;
@@ -1267,13 +1270,13 @@ export const zamaQueryKeys: {
     };
     readonly totalSupply: {
         readonly all: readonly ["zama.totalSupply"];
-        readonly token: (tokenAddress: Address) => readonly ["zama.totalSupply", {
+        readonly token: (tokenAddress: Address$1) => readonly ["zama.totalSupply", {
             readonly tokenAddress: `0x${string}`;
         }];
     };
     readonly isAllowed: {
         readonly all: readonly ["zama.isAllowed"];
-        readonly scope: (account: Address, contractAddresses: Address[]) => readonly ["zama.isAllowed", {
+        readonly scope: (account: Address$1, contractAddresses: Address$1[]) => readonly ["zama.isAllowed", {
             readonly account: `0x${string}`;
             readonly contractAddresses: `0x${string}`[];
         }];
@@ -1289,12 +1292,12 @@ export const zamaQueryKeys: {
     };
     readonly delegationStatus: {
         readonly all: readonly ["zama.delegationStatus"];
-        readonly token: (tokenAddress?: Address) => readonly ["zama.delegationStatus", {
+        readonly token: (tokenAddress?: Address$1) => readonly ["zama.delegationStatus", {
             tokenAddress: `0x${string}`;
         } | {
             tokenAddress?: undefined;
         }];
-        readonly scope: (tokenAddress?: Address, delegator?: Address, delegate?: Address) => readonly ["zama.delegationStatus", {
+        readonly scope: (tokenAddress?: Address$1, delegator?: Address$1, delegate?: Address$1) => readonly ["zama.delegationStatus", {
             readonly delegateAddress?: `0x${string}` | undefined;
             readonly delegatorAddress?: `0x${string}` | undefined;
             readonly tokenAddress?: `0x${string}` | undefined;
@@ -1302,13 +1305,13 @@ export const zamaQueryKeys: {
     };
     readonly decryption: {
         readonly all: readonly ["zama.decryption"];
-        readonly handle: (handle: string, contractAddress?: Address) => readonly ["zama.decryption", {
+        readonly handle: (handle: string, contractAddress?: Address$1) => readonly ["zama.decryption", {
             readonly contractAddress?: `0x${string}` | undefined;
             readonly handle: string;
         }];
         readonly handles: (handles: readonly {
             handle: string;
-            contractAddress: Address;
+            contractAddress: Address$1;
         }[]) => readonly ["zama.decryption", {
             readonly handles: {
                 handle: string;
@@ -1321,41 +1324,41 @@ export const zamaQueryKeys: {
         readonly chainId: () => readonly ["zama.wrappersRegistry", {
             readonly type: "chainId";
         }];
-        readonly tokenPairs: (registryAddress: Address) => readonly ["zama.wrappersRegistry", {
+        readonly tokenPairs: (registryAddress: Address$1) => readonly ["zama.wrappersRegistry", {
             readonly type: "tokenPairs";
             readonly registryAddress: `0x${string}`;
         }];
-        readonly confidentialTokenAddress: (registryAddress: Address, tokenAddress: Address) => readonly ["zama.wrappersRegistry", {
+        readonly confidentialTokenAddress: (registryAddress: Address$1, tokenAddress: Address$1) => readonly ["zama.wrappersRegistry", {
             readonly type: "confidentialTokenAddress";
             readonly registryAddress: `0x${string}`;
             readonly tokenAddress: `0x${string}`;
         }];
-        readonly tokenAddress: (registryAddress: Address, confidentialTokenAddress: Address) => readonly ["zama.wrappersRegistry", {
+        readonly tokenAddress: (registryAddress: Address$1, confidentialTokenAddress: Address$1) => readonly ["zama.wrappersRegistry", {
             readonly type: "tokenAddress";
             readonly registryAddress: `0x${string}`;
             readonly confidentialTokenAddress: `0x${string}`;
         }];
-        readonly tokenPairsLength: (registryAddress: Address) => readonly ["zama.wrappersRegistry", {
+        readonly tokenPairsLength: (registryAddress: Address$1) => readonly ["zama.wrappersRegistry", {
             readonly type: "tokenPairsLength";
             readonly registryAddress: `0x${string}`;
         }];
-        readonly tokenPairsSlice: (registryAddress: Address, fromIndex: string, toIndex: string) => readonly ["zama.wrappersRegistry", {
+        readonly tokenPairsSlice: (registryAddress: Address$1, fromIndex: string, toIndex: string) => readonly ["zama.wrappersRegistry", {
             readonly type: "tokenPairsSlice";
             readonly registryAddress: `0x${string}`;
             readonly fromIndex: string;
             readonly toIndex: string;
         }];
-        readonly tokenPair: (registryAddress: Address, index: string) => readonly ["zama.wrappersRegistry", {
+        readonly tokenPair: (registryAddress: Address$1, index: string) => readonly ["zama.wrappersRegistry", {
             readonly type: "tokenPair";
             readonly registryAddress: `0x${string}`;
             readonly index: string;
         }];
-        readonly isConfidentialTokenValid: (registryAddress: Address, confidentialTokenAddress: Address) => readonly ["zama.wrappersRegistry", {
+        readonly isConfidentialTokenValid: (registryAddress: Address$1, confidentialTokenAddress: Address$1) => readonly ["zama.wrappersRegistry", {
             readonly type: "isConfidentialTokenValid";
             readonly registryAddress: `0x${string}`;
             readonly confidentialTokenAddress: `0x${string}`;
         }];
-        readonly listPairs: (registryAddress: Address, page: number, pageSize: number, metadata: boolean) => readonly ["zama.wrappersRegistry", {
+        readonly listPairs: (registryAddress: Address$1, page: number, pageSize: number, metadata: boolean) => readonly ["zama.wrappersRegistry", {
             readonly type: "listPairs";
             readonly registryAddress: `0x${string}`;
             readonly page: number;
@@ -1369,12 +1372,12 @@ export const zamaQueryKeys: {
 export class ZamaSDK {
     [Symbol.dispose](): void;
     constructor(config: ZamaSDKConfig);
-    allow(contractAddresses: Address[]): Promise<void>;
+    allow(contractAddresses: Address$1[]): Promise<void>;
     // Warning: (ae-forgotten-export) The symbol "DecryptCache" needs to be exported by the entry point index.d.ts
     readonly cache: DecryptCache;
-    createReadonlyToken(address: Address): ReadonlyToken;
-    createToken(address: Address, wrapper?: Address): Token;
-    createWrappersRegistry(registryAddresses?: Record<number, Address>): WrappersRegistry;
+    createReadonlyToken(address: Address$1): ReadonlyToken;
+    createToken(address: Address$1, wrapper?: Address$1): Token;
+    createWrappersRegistry(registryAddresses?: Record<number, Address$1>): WrappersRegistry;
     // (undocumented)
     readonly credentials: CredentialsManager;
     // Warning: (ae-forgotten-export) The symbol "DelegatedCredentialsManager" needs to be exported by the entry point index.d.ts
@@ -1383,7 +1386,7 @@ export class ZamaSDK {
     readonly delegatedCredentials: DelegatedCredentialsManager;
     dispose(): void;
     // @internal
-    emitEvent(input: ZamaSDKEventInput, tokenAddress?: Address): void;
+    emitEvent(input: ZamaSDKEventInput, tokenAddress?: Address$1): void;
     publicDecrypt(handles: Handle[]): Promise<PublicDecryptResult>;
     readonly registry: WrappersRegistry;
     // (undocumented)
@@ -1403,7 +1406,7 @@ export class ZamaSDK {
 export interface ZamaSDKConfig {
     keypairTTL?: number;
     onEvent?: ZamaSDKEventListener;
-    registryAddresses?: Record<number, Address>;
+    registryAddresses?: Record<number, Address$1>;
     registryTTL?: number;
     relayer: RelayerSDK;
     sessionStorage?: GenericStorage;

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 import { Abi } from 'viem';
-import { Address } from 'viem';
+import { Address as Address_2 } from 'viem';
 import { Bytes32Hex } from '@zama-fhe/relayer-sdk/bundle';
 import { ClearValueType } from '@zama-fhe/relayer-sdk/bundle';
 import { ContractFunctionArgs } from 'viem';
@@ -13,7 +13,6 @@ import { ContractFunctionName } from 'viem';
 import { ContractFunctionReturnType } from 'viem';
 import { FheTypeName } from '@zama-fhe/relayer-sdk/bundle';
 import { FhevmInstanceConfig } from '@zama-fhe/relayer-sdk/bundle';
-import { Hex } from 'viem';
 import { InputProofBytesType } from '@zama-fhe/relayer-sdk/bundle';
 import { KeypairType } from '@zama-fhe/relayer-sdk/bundle';
 import { KmsDelegatedUserDecryptEIP712Type } from '@zama-fhe/relayer-sdk/bundle';
@@ -40,41 +39,58 @@ export const AclTopics: {
     readonly RevokedDelegationForUserDecryption: `0x${string}`;
 };
 
-export { Address }
+// @public
+export type Address = `0x${string}`;
 
 // @public
 export function allowanceContract(tokenAddress: Address, owner: Address, spender: Address): {
     readonly address: `0x${string}`;
     readonly abi: readonly [{
-        readonly type: "event";
-        readonly name: "Approval";
-        readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "owner";
-            readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "spender";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        readonly type: "function";
+        readonly name: "name";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "symbol";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "decimals";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "uint8";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "totalSupply";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
-        readonly type: "event";
-        readonly name: "Transfer";
+        readonly type: "function";
+        readonly name: "balanceOf";
+        readonly stateMutability: "view";
         readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "from";
+            readonly name: "account";
             readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "to";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        }];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -89,6 +105,7 @@ export function allowanceContract(tokenAddress: Address, owner: Address, spender
             readonly type: "address";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -99,67 +116,26 @@ export function allowanceContract(tokenAddress: Address, owner: Address, spender
             readonly name: "spender";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "balanceOf";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [{
-            readonly name: "account";
-            readonly type: "address";
-        }];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "decimals";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint8";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "name";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "symbol";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "totalSupply";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
         }];
     }, {
         readonly type: "function";
         readonly name: "transfer";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
         }];
     }, {
@@ -167,17 +143,50 @@ export function allowanceContract(tokenAddress: Address, owner: Address, spender
         readonly name: "transferFrom";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "sender";
+            readonly name: "from";
             readonly type: "address";
         }, {
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Transfer";
+        readonly inputs: readonly [{
+            readonly name: "from";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "to";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Approval";
+        readonly inputs: readonly [{
+            readonly name: "owner";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "spender";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
         }];
     }];
     readonly functionName: "allowance";
@@ -193,35 +202,51 @@ export class ApprovalFailedError extends ZamaError {
 export function approveContract(tokenAddress: Address, spender: Address, value: bigint): {
     readonly address: `0x${string}`;
     readonly abi: readonly [{
-        readonly type: "event";
-        readonly name: "Approval";
-        readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "owner";
-            readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "spender";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        readonly type: "function";
+        readonly name: "name";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "symbol";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "decimals";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "uint8";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "totalSupply";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
-        readonly type: "event";
-        readonly name: "Transfer";
+        readonly type: "function";
+        readonly name: "balanceOf";
+        readonly stateMutability: "view";
         readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "from";
+            readonly name: "account";
             readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "to";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        }];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -236,6 +261,7 @@ export function approveContract(tokenAddress: Address, spender: Address, value: 
             readonly type: "address";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -246,67 +272,26 @@ export function approveContract(tokenAddress: Address, spender: Address, value: 
             readonly name: "spender";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "balanceOf";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [{
-            readonly name: "account";
-            readonly type: "address";
-        }];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "decimals";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint8";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "name";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "symbol";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "totalSupply";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
         }];
     }, {
         readonly type: "function";
         readonly name: "transfer";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
         }];
     }, {
@@ -314,17 +299,50 @@ export function approveContract(tokenAddress: Address, spender: Address, value: 
         readonly name: "transferFrom";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "sender";
+            readonly name: "from";
             readonly type: "address";
         }, {
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Transfer";
+        readonly inputs: readonly [{
+            readonly name: "from";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "to";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Approval";
+        readonly inputs: readonly [{
+            readonly name: "owner";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "spender";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
         }];
     }];
     readonly functionName: "approve";
@@ -366,35 +384,51 @@ export interface BalanceErrorDetails {
 export function balanceOfContract(tokenAddress: Address, account: Address): {
     readonly address: `0x${string}`;
     readonly abi: readonly [{
-        readonly type: "event";
-        readonly name: "Approval";
-        readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "owner";
-            readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "spender";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        readonly type: "function";
+        readonly name: "name";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "symbol";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "decimals";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "uint8";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "totalSupply";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
-        readonly type: "event";
-        readonly name: "Transfer";
+        readonly type: "function";
+        readonly name: "balanceOf";
+        readonly stateMutability: "view";
         readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "from";
+            readonly name: "account";
             readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "to";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        }];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -409,6 +443,7 @@ export function balanceOfContract(tokenAddress: Address, account: Address): {
             readonly type: "address";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -419,67 +454,26 @@ export function balanceOfContract(tokenAddress: Address, account: Address): {
             readonly name: "spender";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "balanceOf";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [{
-            readonly name: "account";
-            readonly type: "address";
-        }];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "decimals";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint8";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "name";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "symbol";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "totalSupply";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
         }];
     }, {
         readonly type: "function";
         readonly name: "transfer";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
         }];
     }, {
@@ -487,17 +481,50 @@ export function balanceOfContract(tokenAddress: Address, account: Address): {
         readonly name: "transferFrom";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "sender";
+            readonly name: "from";
             readonly type: "address";
         }, {
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Transfer";
+        readonly inputs: readonly [{
+            readonly name: "from";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "to";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Approval";
+        readonly inputs: readonly [{
+            readonly name: "owner";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "spender";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
         }];
     }];
     readonly functionName: "balanceOf";
@@ -5950,35 +5977,51 @@ export interface CredentialsRevokedEvent extends BaseEvent {
 export function decimalsContract(tokenAddress: Address): {
     readonly address: `0x${string}`;
     readonly abi: readonly [{
-        readonly type: "event";
-        readonly name: "Approval";
-        readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "owner";
-            readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "spender";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        readonly type: "function";
+        readonly name: "name";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "symbol";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "decimals";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "uint8";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "totalSupply";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
-        readonly type: "event";
-        readonly name: "Transfer";
+        readonly type: "function";
+        readonly name: "balanceOf";
+        readonly stateMutability: "view";
         readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "from";
+            readonly name: "account";
             readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "to";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        }];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -5993,6 +6036,7 @@ export function decimalsContract(tokenAddress: Address): {
             readonly type: "address";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -6003,67 +6047,26 @@ export function decimalsContract(tokenAddress: Address): {
             readonly name: "spender";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "balanceOf";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [{
-            readonly name: "account";
-            readonly type: "address";
-        }];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "decimals";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint8";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "name";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "symbol";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "totalSupply";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
         }];
     }, {
         readonly type: "function";
         readonly name: "transfer";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
         }];
     }, {
@@ -6071,17 +6074,50 @@ export function decimalsContract(tokenAddress: Address): {
         readonly name: "transferFrom";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "sender";
+            readonly name: "from";
             readonly type: "address";
         }, {
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Transfer";
+        readonly inputs: readonly [{
+            readonly name: "from";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "to";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Approval";
+        readonly inputs: readonly [{
+            readonly name: "owner";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "spender";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
         }];
     }];
     readonly functionName: "decimals";
@@ -8746,7 +8782,8 @@ export const HardhatConfig: {
     readonly registryAddress: undefined;
 };
 
-export { Hex }
+// @public
+export type Hex = `0x${string}`;
 
 // @public
 export class IndexedDBStorage implements GenericStorage {
@@ -11514,35 +11551,51 @@ export const memoryStorage: MemoryStorage;
 export function nameContract(tokenAddress: Address): {
     readonly address: `0x${string}`;
     readonly abi: readonly [{
-        readonly type: "event";
-        readonly name: "Approval";
-        readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "owner";
-            readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "spender";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        readonly type: "function";
+        readonly name: "name";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "symbol";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "decimals";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "uint8";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "totalSupply";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
-        readonly type: "event";
-        readonly name: "Transfer";
+        readonly type: "function";
+        readonly name: "balanceOf";
+        readonly stateMutability: "view";
         readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "from";
+            readonly name: "account";
             readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "to";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        }];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -11557,6 +11610,7 @@ export function nameContract(tokenAddress: Address): {
             readonly type: "address";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -11567,67 +11621,26 @@ export function nameContract(tokenAddress: Address): {
             readonly name: "spender";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "balanceOf";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [{
-            readonly name: "account";
-            readonly type: "address";
-        }];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "decimals";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint8";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "name";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "symbol";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "totalSupply";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
         }];
     }, {
         readonly type: "function";
         readonly name: "transfer";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
         }];
     }, {
@@ -11635,17 +11648,50 @@ export function nameContract(tokenAddress: Address): {
         readonly name: "transferFrom";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "sender";
+            readonly name: "from";
             readonly type: "address";
         }, {
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Transfer";
+        readonly inputs: readonly [{
+            readonly name: "from";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "to";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Approval";
+        readonly inputs: readonly [{
+            readonly name: "owner";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "spender";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
         }];
     }];
     readonly functionName: "name";
@@ -13028,7 +13074,7 @@ export type ReadContractArgs<TAbi extends ContractAbi = ContractAbi, TFunctionNa
 // @public
 export interface ReadContractConfig<TAbi extends ContractAbi = ContractAbi, TFunctionName extends ReadFunctionName<TAbi> = ReadFunctionName<TAbi>, TArgs extends ReadContractArgs<TAbi, TFunctionName> = ReadContractArgs<TAbi, TFunctionName>> {
     readonly abi: TAbi;
-    readonly address: Address;
+    readonly address: Address_2;
     readonly args: TArgs;
     readonly functionName: TFunctionName;
 }
@@ -14670,35 +14716,51 @@ export function supportsInterfaceContract(tokenAddress: Address, interfaceId: Ad
 export function symbolContract(tokenAddress: Address): {
     readonly address: `0x${string}`;
     readonly abi: readonly [{
-        readonly type: "event";
-        readonly name: "Approval";
-        readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "owner";
-            readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "spender";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        readonly type: "function";
+        readonly name: "name";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "symbol";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "string";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "decimals";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
+            readonly type: "uint8";
+        }];
+    }, {
+        readonly type: "function";
+        readonly name: "totalSupply";
+        readonly stateMutability: "view";
+        readonly inputs: readonly [];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
-        readonly type: "event";
-        readonly name: "Transfer";
+        readonly type: "function";
+        readonly name: "balanceOf";
+        readonly stateMutability: "view";
         readonly inputs: readonly [{
-            readonly indexed: true;
-            readonly name: "from";
+            readonly name: "account";
             readonly type: "address";
-        }, {
-            readonly indexed: true;
-            readonly name: "to";
-            readonly type: "address";
-        }, {
-            readonly indexed: false;
-            readonly name: "value";
+        }];
+        readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -14713,6 +14775,7 @@ export function symbolContract(tokenAddress: Address): {
             readonly type: "address";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "uint256";
         }];
     }, {
@@ -14723,67 +14786,26 @@ export function symbolContract(tokenAddress: Address): {
             readonly name: "spender";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "balanceOf";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [{
-            readonly name: "account";
-            readonly type: "address";
-        }];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "decimals";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint8";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "name";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "symbol";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "string";
-        }];
-    }, {
-        readonly type: "function";
-        readonly name: "totalSupply";
-        readonly stateMutability: "view";
-        readonly inputs: readonly [];
-        readonly outputs: readonly [{
-            readonly type: "uint256";
         }];
     }, {
         readonly type: "function";
         readonly name: "transfer";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
         }];
     }, {
@@ -14791,17 +14813,50 @@ export function symbolContract(tokenAddress: Address): {
         readonly name: "transferFrom";
         readonly stateMutability: "nonpayable";
         readonly inputs: readonly [{
-            readonly name: "sender";
+            readonly name: "from";
             readonly type: "address";
         }, {
-            readonly name: "recipient";
+            readonly name: "to";
             readonly type: "address";
         }, {
-            readonly name: "amount";
+            readonly name: "value";
             readonly type: "uint256";
         }];
         readonly outputs: readonly [{
+            readonly name: "";
             readonly type: "bool";
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Transfer";
+        readonly inputs: readonly [{
+            readonly name: "from";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "to";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
+        }];
+    }, {
+        readonly type: "event";
+        readonly name: "Approval";
+        readonly inputs: readonly [{
+            readonly name: "owner";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "spender";
+            readonly type: "address";
+            readonly indexed: true;
+        }, {
+            readonly name: "value";
+            readonly type: "uint256";
+            readonly indexed: false;
         }];
     }];
     readonly functionName: "symbol";
@@ -19814,7 +19869,7 @@ export type WriteContractArgs<TAbi extends ContractAbi = ContractAbi, TFunctionN
 // @public
 export interface WriteContractConfig<TAbi extends ContractAbi = ContractAbi, TFunctionName extends WriteFunctionName<TAbi> = WriteFunctionName<TAbi>, TArgs extends WriteContractArgs<TAbi, TFunctionName> = WriteContractArgs<TAbi, TFunctionName>> {
     readonly abi: TAbi;
-    readonly address: Address;
+    readonly address: Address_2;
     readonly args: TArgs;
     readonly functionName: TFunctionName;
     readonly gas?: bigint;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -131,8 +131,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@zama-fhe/relayer-sdk": "~0.4.2",
-    "viem": "^2.47.12"
+    "@noble/hashes": "^2.2.0",
+    "@zama-fhe/relayer-sdk": "~0.4.2"
   },
   "devDependencies": {
     "@tanstack/query-core": "^5.99.2",

--- a/packages/sdk/rolldown.config.ts
+++ b/packages/sdk/rolldown.config.ts
@@ -3,7 +3,15 @@ import { dts } from "rolldown-plugin-dts";
 import { iife } from "./iife-plugin";
 
 const shared = {
-  external: [/^viem/, /^ethers/, /^@zama-fhe\/relayer-sdk/, /^@tanstack\/query-core/, /^node:/],
+  external: [
+    /^viem/,
+    /^ethers/,
+    /^@zama-fhe\/relayer-sdk/,
+    /^@tanstack\/query-core/,
+    /^@noble\//,
+    /^@scure\//,
+    /^node:/,
+  ],
   resolve: {
     tsconfigFilename: "tsconfig.build.json",
   },

--- a/packages/sdk/src/abi/erc20.abi.ts
+++ b/packages/sdk/src/abi/erc20.abi.ts
@@ -1,0 +1,96 @@
+export const erc20Abi = [
+  {
+    type: "function",
+    name: "name",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "string" }],
+  },
+  {
+    type: "function",
+    name: "symbol",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "string" }],
+  },
+  {
+    type: "function",
+    name: "decimals",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint8" }],
+  },
+  {
+    type: "function",
+    name: "totalSupply",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "allowance",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "value", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "transfer",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "transferFrom",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "event",
+    name: "Transfer",
+    inputs: [
+      { name: "from", type: "address", indexed: true },
+      { name: "to", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+  {
+    type: "event",
+    name: "Approval",
+    inputs: [
+      { name: "owner", type: "address", indexed: true },
+      { name: "spender", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+] as const;

--- a/packages/sdk/src/contracts/acl.ts
+++ b/packages/sdk/src/contracts/acl.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import { aclAbi } from "../abi/acl.abi";
 
 /**

--- a/packages/sdk/src/contracts/encrypted.ts
+++ b/packages/sdk/src/contracts/encrypted.ts
@@ -1,5 +1,5 @@
-import type { Address } from "viem";
-import { toHex } from "viem";
+import type { Address } from "../utils/address";
+import { toHex } from "../utils/hex";
 import { encryptedAbi } from "../abi/encrypted.abi";
 import type { Handle } from "../relayer/relayer-sdk.types";
 

--- a/packages/sdk/src/contracts/erc165.ts
+++ b/packages/sdk/src/contracts/erc165.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import { erc165Abi } from "../abi/erc165.abi";
 
 /** ERC-165 interface ID for IERC7984 (confidential fungible token). */

--- a/packages/sdk/src/contracts/erc20.ts
+++ b/packages/sdk/src/contracts/erc20.ts
@@ -1,4 +1,5 @@
-import { erc20Abi, type Address } from "viem";
+import type { Address } from "../utils/address";
+import { erc20Abi } from "../abi/erc20.abi";
 
 /**
  * Returns the contract config to read a token's name.

--- a/packages/sdk/src/contracts/wrapper.ts
+++ b/packages/sdk/src/contracts/wrapper.ts
@@ -1,4 +1,5 @@
-import type { Address, Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import type { Handle } from "../relayer/relayer-sdk.types";
 import { wrapperAbi } from "../abi/wrapper.abi";
 

--- a/packages/sdk/src/contracts/wrappers-registry.ts
+++ b/packages/sdk/src/contracts/wrappers-registry.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 
 export const wrappersRegistryAbi = [
   {

--- a/packages/sdk/src/credentials/credential-crypto.ts
+++ b/packages/sdk/src/credentials/credential-crypto.ts
@@ -1,4 +1,5 @@
-import type { Address, Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import { prefixHex } from "../utils";
 
 /** Encrypted data format with IV for AES-GCM decryption. */

--- a/packages/sdk/src/credentials/credential-validation.ts
+++ b/packages/sdk/src/credentials/credential-validation.ts
@@ -25,7 +25,7 @@ export function assertBaseEncryptedCredentials(
   assertArray(data.contractAddresses, "credentials.contractAddresses");
   for (const addr of data.contractAddresses) {
     assertCondition(
-      typeof addr === "string" && isAddress(addr),
+      typeof addr === "string" && isAddress(addr, { strict: false }),
       `Expected each contractAddress to be a valid hex address`,
     );
   }
@@ -53,11 +53,11 @@ export function assertDelegatedFields(data: unknown): asserts data is BaseEncryp
   assertBaseEncryptedCredentials(data);
   const obj = data as unknown as Record<string, unknown>;
   assertCondition(
-    typeof obj.delegatorAddress === "string" && isAddress(obj.delegatorAddress),
+    typeof obj.delegatorAddress === "string" && isAddress(obj.delegatorAddress, { strict: false }),
     "Expected credentials.delegatorAddress to be a valid address",
   );
   assertCondition(
-    typeof obj.delegateAddress === "string" && isAddress(obj.delegateAddress),
+    typeof obj.delegateAddress === "string" && isAddress(obj.delegateAddress, { strict: false }),
     "Expected credentials.delegateAddress to be a valid address",
   );
   assertCondition(typeof obj.startTimestamp === "number", "Expected startTimestamp to be a number");

--- a/packages/sdk/src/credentials/credential-validation.ts
+++ b/packages/sdk/src/credentials/credential-validation.ts
@@ -1,4 +1,6 @@
-import { getAddress, isAddress, type Address, type Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
+import { getAddress, isAddress } from "../utils/address";
 import { assertArray, assertCondition, assertObject, assertString } from "../utils";
 import type { EncryptedData } from "./credential-crypto";
 
@@ -23,7 +25,7 @@ export function assertBaseEncryptedCredentials(
   assertArray(data.contractAddresses, "credentials.contractAddresses");
   for (const addr of data.contractAddresses) {
     assertCondition(
-      typeof addr === "string" && isAddress(addr, { strict: false }),
+      typeof addr === "string" && isAddress(addr),
       `Expected each contractAddress to be a valid hex address`,
     );
   }
@@ -51,11 +53,11 @@ export function assertDelegatedFields(data: unknown): asserts data is BaseEncryp
   assertBaseEncryptedCredentials(data);
   const obj = data as unknown as Record<string, unknown>;
   assertCondition(
-    typeof obj.delegatorAddress === "string" && isAddress(obj.delegatorAddress, { strict: false }),
+    typeof obj.delegatorAddress === "string" && isAddress(obj.delegatorAddress),
     "Expected credentials.delegatorAddress to be a valid address",
   );
   assertCondition(
-    typeof obj.delegateAddress === "string" && isAddress(obj.delegateAddress, { strict: false }),
+    typeof obj.delegateAddress === "string" && isAddress(obj.delegateAddress),
     "Expected credentials.delegateAddress to be a valid address",
   );
   assertCondition(typeof obj.startTimestamp === "number", "Expected startTimestamp to be a number");
@@ -80,7 +82,11 @@ export function coversContracts(signedAddresses: Address[], requiredContracts: A
  * Check if credentials are valid: not time-expired and covering all required contracts.
  */
 export function isCredentialValid(
-  creds: { startTimestamp: number; durationDays: number; contractAddresses: Address[] },
+  creds: {
+    startTimestamp: number;
+    durationDays: number;
+    contractAddresses: Address[];
+  },
   requiredContracts: Address[],
 ): boolean {
   if (!isTimeValid(creds)) {

--- a/packages/sdk/src/credentials/credentials-manager-base.ts
+++ b/packages/sdk/src/credentials/credentials-manager-base.ts
@@ -1,4 +1,5 @@
-import type { Address, Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import { ZamaError } from "../errors/base";
 import { wrapSigningError } from "../errors/signing";
 import type { ZamaSDKEventInput, ZamaSDKEventListener } from "../events/sdk-events";

--- a/packages/sdk/src/credentials/credentials-manager.ts
+++ b/packages/sdk/src/credentials/credentials-manager.ts
@@ -1,4 +1,6 @@
-import { getAddress, type Address, type Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
+import { getAddress } from "../utils/address";
 import type { RelayerSDK } from "../relayer/relayer-sdk";
 import type { StoredCredentials } from "../types";
 import { MemoryStorage } from "../storage/memory-storage";

--- a/packages/sdk/src/credentials/delegated-credentials-manager.ts
+++ b/packages/sdk/src/credentials/delegated-credentials-manager.ts
@@ -1,4 +1,6 @@
-import { getAddress, type Address, type Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
+import { getAddress } from "../utils/address";
 import type { RelayerSDK } from "../relayer/relayer-sdk";
 import type { DelegatedStoredCredentials } from "../types";
 import {

--- a/packages/sdk/src/credentials/session-signatures.ts
+++ b/packages/sdk/src/credentials/session-signatures.ts
@@ -1,4 +1,4 @@
-import type { Hex } from "viem";
+import type { Hex } from "../utils/hex";
 import { assertCondition, assertObject, assertString } from "../utils";
 import type { GenericStorage } from "../types";
 

--- a/packages/sdk/src/decrypt-cache.ts
+++ b/packages/sdk/src/decrypt-cache.ts
@@ -1,4 +1,5 @@
-import { getAddress, type Address } from "viem";
+import type { Address } from "./utils/address";
+import { getAddress } from "./utils/address";
 import type { ClearValueType, Handle } from "./relayer/relayer-sdk.types";
 import type { GenericStorage } from "./types";
 
@@ -84,7 +85,8 @@ export class DecryptCache {
     // Serialise with the index write queue to avoid racing with concurrent set() calls
     this.#indexWriteQueue = this.#indexWriteQueue.then(() =>
       this.#doClearForRequester(requester).catch((error) => {
-        console.warn("[zama-sdk] DecryptCache.clearForRequester failed:", error); // eslint-disable-line no-console
+        // oxlint-disable-next-line no-console
+        console.warn("[zama-sdk] DecryptCache.clearForRequester failed:", error);
       }),
     );
     await this.#indexWriteQueue;

--- a/packages/sdk/src/errors/balance.ts
+++ b/packages/sdk/src/errors/balance.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import { ZamaError, ZamaErrorCode } from "./base";
 
 /** Structured details shared by balance-related errors. */

--- a/packages/sdk/src/ethers/ethers-signer.ts
+++ b/packages/sdk/src/ethers/ethers-signer.ts
@@ -1,14 +1,14 @@
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
+import type { EIP1193Provider } from "../types/ethereum";
+import { getAddress } from "../utils/address";
+import { isHex } from "../utils/hex";
 import { ethers, BrowserProvider, type Signer } from "ethers";
-import {
-  getAddress,
-  isHex,
-  type Abi,
-  type Address,
-  type ContractFunctionArgs,
-  type ContractFunctionName,
-  type ContractFunctionReturnType,
-  type EIP1193Provider,
-  type Hex,
+import type {
+  Abi,
+  ContractFunctionArgs,
+  ContractFunctionName,
+  ContractFunctionReturnType,
 } from "viem";
 import type { EIP712TypedData } from "../relayer/relayer-sdk.types";
 import type {

--- a/packages/sdk/src/ethers/index.ts
+++ b/packages/sdk/src/ethers/index.ts
@@ -12,8 +12,8 @@ export type {
   EIP1193EventMap,
   ProviderConnectInfo,
   ProviderMessage,
-} from "viem";
-export { ProviderRpcError } from "viem";
+} from "../types/ethereum";
+export { ProviderRpcError } from "../types/ethereum";
 export {
   readConfidentialBalanceOfContract,
   readUnderlyingTokenContract,

--- a/packages/sdk/src/events/onchain-events.ts
+++ b/packages/sdk/src/events/onchain-events.ts
@@ -3,8 +3,11 @@
  * Works with raw log data from any provider.
  */
 
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
+import { getAddress } from "../utils/address";
+import { keccak256, toBytes } from "../utils/hex";
 import type { Handle } from "../relayer/relayer-sdk.types";
-import { getAddress, keccak256, toBytes, type Address, type Hex } from "viem";
 import { prefixHex } from "../utils";
 import type { RawLog } from "../types/transaction";
 export type { RawLog } from "../types/transaction";

--- a/packages/sdk/src/events/sdk-events.ts
+++ b/packages/sdk/src/events/sdk-events.ts
@@ -1,4 +1,5 @@
-import type { Address, Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import type { ClearValueType, Handle } from "../relayer/relayer-sdk.types";
 
 /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -105,7 +105,8 @@ export type {
   TransferCallbacks,
   TransferOptions,
 } from "./types";
-export type { Address, Hex } from "viem";
+export type { Address } from "./utils/address";
+export type { Hex } from "./utils/hex";
 export { ZamaSDKEvents } from "./events";
 export type {
   ZamaSDKEventType,

--- a/packages/sdk/src/query/allow.ts
+++ b/packages/sdk/src/query/allow.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import type { ZamaSDK } from "../zama-sdk";
 import type { MutationFactoryOptions } from "./factory-types";
 

--- a/packages/sdk/src/query/approve-underlying.ts
+++ b/packages/sdk/src/query/approve-underlying.ts
@@ -1,7 +1,7 @@
+import type { Address } from "../utils/address";
 import type { Token } from "../token/token";
 import type { TransactionResult } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address } from "viem";
 
 /** Variables for {@link approveUnderlyingMutationOptions}. */
 export interface ApproveUnderlyingParams {

--- a/packages/sdk/src/query/approve.ts
+++ b/packages/sdk/src/query/approve.ts
@@ -1,7 +1,7 @@
+import type { Address } from "../utils/address";
 import type { Token } from "../token/token";
 import type { TransactionResult } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address } from "viem";
 
 /** Variables for {@link confidentialApproveMutationOptions}. */
 export interface ConfidentialApproveParams {

--- a/packages/sdk/src/query/batch-decrypt-balances-as.ts
+++ b/packages/sdk/src/query/batch-decrypt-balances-as.ts
@@ -1,5 +1,5 @@
+import type { Address } from "../utils/address";
 import { ReadonlyToken, type BatchDecryptAsOptions } from "../token/readonly-token";
-import type { Address } from "viem";
 import type { MutationFactoryOptions } from "./factory-types";
 
 /** Variables for {@link batchDecryptBalancesAsMutationOptions}. */

--- a/packages/sdk/src/query/confidential-balance.ts
+++ b/packages/sdk/src/query/confidential-balance.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import type { ReadonlyToken } from "../token";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";

--- a/packages/sdk/src/query/confidential-balances.ts
+++ b/packages/sdk/src/query/confidential-balances.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import { ReadonlyToken, type BatchBalancesResult } from "../token/readonly-token";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";

--- a/packages/sdk/src/query/confidential-is-approved.ts
+++ b/packages/sdk/src/query/confidential-is-approved.ts
@@ -1,10 +1,10 @@
+import type { Address } from "../utils/address";
 import { isOperatorContract } from "../contracts";
 import type { GenericSigner } from "../types";
 import { assertNonNullable } from "../utils/assertions";
 import type { QueryFactoryOptions } from "./factory-types";
 import { filterQueryOptions } from "./utils";
 import { zamaQueryKeys } from "./query-keys";
-import type { Address } from "viem";
 
 export interface ConfidentialIsApprovedQueryConfig {
   holder?: Address;

--- a/packages/sdk/src/query/create-delegated-user-decrypt-eip712.ts
+++ b/packages/sdk/src/query/create-delegated-user-decrypt-eip712.ts
@@ -1,5 +1,6 @@
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import type { KmsDelegatedUserDecryptEIP712Type } from "@zama-fhe/relayer-sdk/bundle";
-import type { Address, Hex } from "viem";
 import type { ZamaSDK } from "../zama-sdk";
 import type { MutationFactoryOptions } from "./factory-types";
 

--- a/packages/sdk/src/query/create-eip712.ts
+++ b/packages/sdk/src/query/create-eip712.ts
@@ -1,5 +1,6 @@
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import type { KmsUserDecryptEIP712UserArgsType } from "@zama-fhe/relayer-sdk/bundle";
-import type { Address, Hex } from "viem";
 import type { EIP712TypedData } from "../relayer/relayer-sdk.types";
 import type { ZamaSDK } from "../zama-sdk";
 import type { MutationFactoryOptions } from "./factory-types";

--- a/packages/sdk/src/query/decrypt-balance-as.ts
+++ b/packages/sdk/src/query/decrypt-balance-as.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import type { ReadonlyToken } from "../token/readonly-token";
 import type { MutationFactoryOptions } from "./factory-types";
 

--- a/packages/sdk/src/query/delegate-decryption.ts
+++ b/packages/sdk/src/query/delegate-decryption.ts
@@ -1,5 +1,5 @@
+import type { Address } from "../utils/address";
 import type { Token } from "../token/token";
-import type { Address } from "viem";
 import type { TransactionResult } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
 

--- a/packages/sdk/src/query/delegation-status.ts
+++ b/packages/sdk/src/query/delegation-status.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import { MAX_UINT64 } from "../contracts";
 import { getDelegationExpiryContract } from "../contracts/acl";
 import type { RelayerSDK } from "../relayer/relayer-sdk";

--- a/packages/sdk/src/query/finalize-unwrap.ts
+++ b/packages/sdk/src/query/finalize-unwrap.ts
@@ -1,9 +1,9 @@
+import type { Address } from "../utils/address";
 import type { Handle } from "../relayer/relayer-sdk.types";
 import type { Token } from "../token/token";
 import type { TransactionResult } from "../types";
 import { ConfigurationError } from "../errors";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address } from "viem";
 /** Variables for {@link finalizeUnwrapMutationOptions}. */
 export type FinalizeUnwrapParams =
   /** Preferred input from upgraded `UnwrapRequested` events. */

--- a/packages/sdk/src/query/generate-keypair.ts
+++ b/packages/sdk/src/query/generate-keypair.ts
@@ -1,5 +1,5 @@
+import type { Hex } from "../utils/hex";
 import type { KeypairType } from "@zama-fhe/relayer-sdk/bundle";
-import type { Hex } from "viem";
 import type { ZamaSDK } from "../zama-sdk";
 import type { MutationFactoryOptions } from "./factory-types";
 

--- a/packages/sdk/src/query/invalidation.ts
+++ b/packages/sdk/src/query/invalidation.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import { zamaQueryKeys } from "./query-keys";
 
 export interface QueryLike {

--- a/packages/sdk/src/query/is-allowed.ts
+++ b/packages/sdk/src/query/is-allowed.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import type { ZamaSDK } from "../zama-sdk";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";

--- a/packages/sdk/src/query/is-confidential.ts
+++ b/packages/sdk/src/query/is-confidential.ts
@@ -1,3 +1,4 @@
+import type { Address } from "../utils/address";
 import {
   isConfidentialTokenContract,
   isConfidentialWrapperContract,
@@ -9,7 +10,6 @@ import { isContractCallError } from "../utils";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";
 import { filterQueryOptions } from "./utils";
-import type { Address } from "viem";
 
 export interface IsConfidentialQueryConfig {
   query?: Record<string, unknown>;

--- a/packages/sdk/src/query/query-keys.ts
+++ b/packages/sdk/src/query/query-keys.ts
@@ -1,6 +1,5 @@
-import { getAddress } from "viem";
-import type { Address } from "viem";
-
+import type { Address } from "../utils/address";
+import { getAddress } from "../utils/address";
 const normalizeAddresses = (addresses: Address[]): Address[] =>
   addresses.map((address) => getAddress(address));
 const normalizeAddress = (address?: Address): Address | undefined =>

--- a/packages/sdk/src/query/resume-unshield.ts
+++ b/packages/sdk/src/query/resume-unshield.ts
@@ -1,7 +1,8 @@
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import type { Token } from "../token/token";
 import type { TransactionResult, UnshieldCallbacks } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address, Hex } from "viem";
 
 /** Variables for {@link resumeUnshieldMutationOptions}. */
 export interface ResumeUnshieldParams extends UnshieldCallbacks {

--- a/packages/sdk/src/query/revoke-delegation.ts
+++ b/packages/sdk/src/query/revoke-delegation.ts
@@ -1,5 +1,5 @@
+import type { Address } from "../utils/address";
 import type { Token } from "../token/token";
-import type { Address } from "viem";
 import type { TransactionResult } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
 

--- a/packages/sdk/src/query/revoke.ts
+++ b/packages/sdk/src/query/revoke.ts
@@ -1,6 +1,6 @@
+import type { Address } from "../utils/address";
 import type { ZamaSDK } from "../zama-sdk";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address } from "viem";
 
 export function revokeMutationOptions(
   sdk: ZamaSDK,

--- a/packages/sdk/src/query/shield.ts
+++ b/packages/sdk/src/query/shield.ts
@@ -1,7 +1,7 @@
+import type { Address } from "../utils/address";
 import type { Token } from "../token/token";
 import type { ShieldCallbacks, TransactionResult } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address } from "viem";
 
 /** Variables for {@link shieldMutationOptions}. */
 export interface ShieldParams extends ShieldCallbacks {

--- a/packages/sdk/src/query/signer-address.ts
+++ b/packages/sdk/src/query/signer-address.ts
@@ -1,8 +1,8 @@
+import type { Address } from "../utils/address";
 import type { GenericSigner } from "../types";
 import type { QueryFactoryOptions } from "./factory-types";
 import { filterQueryOptions } from "./utils";
 import { zamaQueryKeys } from "./query-keys";
-import type { Address } from "viem";
 
 const signerScopes = new WeakMap<GenericSigner, number>();
 let nextSignerScope = 1;

--- a/packages/sdk/src/query/token-metadata.ts
+++ b/packages/sdk/src/query/token-metadata.ts
@@ -1,10 +1,10 @@
+import type { Address } from "../utils/address";
 import { decimalsContract, nameContract, symbolContract } from "../contracts";
 
 import type { GenericSigner } from "../types";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";
 import { filterQueryOptions } from "./utils";
-import type { Address } from "viem";
 
 /** ERC-20 token metadata returned by {@link tokenMetadataQueryOptions}. */
 export interface TokenMetadata {

--- a/packages/sdk/src/query/total-supply.ts
+++ b/packages/sdk/src/query/total-supply.ts
@@ -1,10 +1,10 @@
+import type { Address } from "../utils/address";
 import { inferredTotalSupplyContract, totalSupplyContract } from "../contracts";
 import type { GenericSigner } from "../types";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";
 import { filterQueryOptions } from "./utils";
 import { detectWrapperInterfaceVersion } from "./wrapper-interface-version";
-import type { Address } from "viem";
 
 export interface TotalSupplyQueryConfig {
   query?: Record<string, unknown>;

--- a/packages/sdk/src/query/transfer-from.ts
+++ b/packages/sdk/src/query/transfer-from.ts
@@ -1,7 +1,7 @@
+import type { Address } from "../utils/address";
 import type { Token } from "../token/token";
 import type { TransferCallbacks, TransactionResult } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address } from "viem";
 
 /** Variables for {@link confidentialTransferFromMutationOptions}. */
 export interface ConfidentialTransferFromParams {

--- a/packages/sdk/src/query/transfer.ts
+++ b/packages/sdk/src/query/transfer.ts
@@ -1,7 +1,7 @@
+import type { Address } from "../utils/address";
 import type { Token } from "../token/token";
 import type { TransactionResult, TransferOptions } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address } from "viem";
 
 /** Variables for {@link confidentialTransferMutationOptions}. */
 export interface ConfidentialTransferParams extends TransferOptions {

--- a/packages/sdk/src/query/underlying-allowance.ts
+++ b/packages/sdk/src/query/underlying-allowance.ts
@@ -1,10 +1,10 @@
+import type { Address } from "../utils/address";
 import { allowanceContract, underlyingContract } from "../contracts";
 import type { GenericSigner } from "../types";
 import { assertNonNullable } from "../utils/assertions";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";
 import { filterQueryOptions } from "./utils";
-import type { Address } from "viem";
 
 export interface UnderlyingAllowanceQueryConfig {
   owner?: Address;

--- a/packages/sdk/src/query/unshield-all.ts
+++ b/packages/sdk/src/query/unshield-all.ts
@@ -1,7 +1,7 @@
+import type { Address } from "../utils/address";
 import type { Token } from "../token/token";
 import type { TransactionResult, UnshieldCallbacks } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address } from "viem";
 
 /** Variables for {@link unshieldAllMutationOptions}. */
 export interface UnshieldAllParams extends UnshieldCallbacks {}

--- a/packages/sdk/src/query/unshield.ts
+++ b/packages/sdk/src/query/unshield.ts
@@ -1,7 +1,7 @@
+import type { Address } from "../utils/address";
 import type { Token } from "../token/token";
 import type { TransactionResult, UnshieldOptions } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address } from "viem";
 
 /** Variables for {@link unshieldMutationOptions}. */
 export interface UnshieldParams extends UnshieldOptions {

--- a/packages/sdk/src/query/unwrap-all.ts
+++ b/packages/sdk/src/query/unwrap-all.ts
@@ -1,7 +1,7 @@
+import type { Address } from "../utils/address";
 import type { Token } from "../token/token";
 import type { TransactionResult } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address } from "viem";
 
 export function unwrapAllMutationOptions(
   token: Token,

--- a/packages/sdk/src/query/unwrap.ts
+++ b/packages/sdk/src/query/unwrap.ts
@@ -1,7 +1,7 @@
+import type { Address } from "../utils/address";
 import type { Token } from "../token/token";
 import type { TransactionResult } from "../types";
 import type { MutationFactoryOptions } from "./factory-types";
-import type { Address } from "viem";
 
 /** Variables for {@link unwrapMutationOptions}. */
 export interface UnwrapParams {

--- a/packages/sdk/src/query/user-decrypt.ts
+++ b/packages/sdk/src/query/user-decrypt.ts
@@ -1,5 +1,5 @@
+import type { Address } from "../utils/address";
 import type { UserDecryptResults } from "@zama-fhe/relayer-sdk/bundle";
-import type { Address } from "viem";
 import type { Handle } from "../relayer/relayer-sdk.types";
 import type { ZamaSDK } from "../zama-sdk";
 import type { QueryFactoryOptions } from "./factory-types";

--- a/packages/sdk/src/query/wrapper-discovery.ts
+++ b/packages/sdk/src/query/wrapper-discovery.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import type { WrappersRegistry } from "../wrappers-registry";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";

--- a/packages/sdk/src/query/wrapper-interface-version.ts
+++ b/packages/sdk/src/query/wrapper-interface-version.ts
@@ -1,3 +1,4 @@
+import type { Address } from "../utils/address";
 import {
   ERC7984_WRAPPER_INTERFACE_ID,
   ERC7984_WRAPPER_INTERFACE_ID_LEGACY,
@@ -6,7 +7,6 @@ import {
 import { ConfigurationError } from "../errors";
 import type { GenericSigner } from "../types";
 import { isContractCallError } from "../utils";
-import type { Address } from "viem";
 
 export type WrapperInterfaceVersion = "legacy" | "upgraded";
 

--- a/packages/sdk/src/query/wrappers-registry.ts
+++ b/packages/sdk/src/query/wrappers-registry.ts
@@ -1,4 +1,5 @@
-import { type Address, zeroAddress } from "viem";
+import type { Address } from "../utils/address";
+import { zeroAddress } from "../utils/address";
 import {
   getTokenPairsContract,
   getTokenPairsLengthContract,

--- a/packages/sdk/src/relayer/cleartext/eip712.ts
+++ b/packages/sdk/src/relayer/cleartext/eip712.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../../utils/address";
 import type {
   CoprocessorEIP712DomainType,
   CoprocessorEIP712TypesType,

--- a/packages/sdk/src/relayer/cleartext/types.ts
+++ b/packages/sdk/src/relayer/cleartext/types.ts
@@ -1,4 +1,6 @@
-import type { Address, EIP1193Provider, Hex } from "viem";
+import type { Address } from "../../utils/address";
+import type { Hex } from "../../utils/hex";
+import type { EIP1193Provider } from "../../types/ethereum";
 
 export interface CleartextConfig {
   chainId: number;

--- a/packages/sdk/src/relayer/relayer-node.ts
+++ b/packages/sdk/src/relayer/relayer-node.ts
@@ -1,3 +1,5 @@
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import type {
   FhevmInstanceConfig,
   InputProofBytesType,
@@ -5,7 +7,6 @@ import type {
   KmsDelegatedUserDecryptEIP712Type,
   ZKProofLike,
 } from "@zama-fhe/relayer-sdk/node";
-import type { Address, Hex } from "viem";
 import { ConfigurationError, ZamaError } from "../errors";
 import { MemoryStorage } from "../storage/memory-storage";
 import type { GenericStorage } from "../types";

--- a/packages/sdk/src/relayer/relayer-sdk.ts
+++ b/packages/sdk/src/relayer/relayer-sdk.ts
@@ -1,3 +1,5 @@
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import type {
   InputProofBytesType,
   KeypairType,
@@ -16,7 +18,6 @@ import type {
   PublicParamsData,
   UserDecryptParams,
 } from "./relayer-sdk.types";
-import type { Address, Hex } from "viem";
 
 /**
  * Interface for FHE relayer operations.

--- a/packages/sdk/src/relayer/relayer-sdk.types.ts
+++ b/packages/sdk/src/relayer/relayer-sdk.types.ts
@@ -7,9 +7,10 @@ import type {
   KmsUserDecryptEIP712Type,
   PublicDecryptResults,
 } from "@zama-fhe/relayer-sdk/bundle";
-import type { Address, Hex } from "viem";
-import type { GenericLogger } from "../worker/worker.types";
 import type { GenericStorage } from "../types";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
+import type { GenericLogger } from "../worker/worker.types";
 
 // ============================================================================
 // Application Types

--- a/packages/sdk/src/relayer/relayer-utils.ts
+++ b/packages/sdk/src/relayer/relayer-utils.ts
@@ -1,5 +1,5 @@
+import type { Address } from "../utils/address";
 import type { FhevmInstanceConfig } from "@zama-fhe/relayer-sdk/bundle";
-import type { Address } from "viem";
 
 const MAX_RETRIES = 2;
 const RETRY_BASE_MS = 500;

--- a/packages/sdk/src/relayer/relayer-web.ts
+++ b/packages/sdk/src/relayer/relayer-web.ts
@@ -1,10 +1,11 @@
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import type {
   InputProofBytesType,
   KeypairType,
   KmsDelegatedUserDecryptEIP712Type,
   ZKProofLike,
 } from "@zama-fhe/relayer-sdk/bundle";
-import type { Address, Hex } from "viem";
 import { ConfigurationError, ZamaError } from "../errors";
 import { IndexedDBStorage } from "../storage/indexeddb-storage";
 import type { GenericStorage } from "../types";

--- a/packages/sdk/src/test-fixtures.ts
+++ b/packages/sdk/src/test-fixtures.ts
@@ -1,10 +1,11 @@
 /* eslint-disable no-empty-pattern */
+import type { Address } from "./utils/address";
+import type { Hex } from "./utils/hex";
 import { test as base, vi } from "vitest";
 import { ZamaSDKEvents } from "./events/sdk-events";
 import type { RelayerSDK } from "./relayer/relayer-sdk";
 import type { Handle } from "./relayer/relayer-sdk.types";
 import type { QueryClient } from "@tanstack/query-core";
-import type { Address, Hex } from "viem";
 import type { CredentialsManagerConfig } from "./credentials/credentials-manager";
 import { CredentialsManager } from "./credentials/credentials-manager";
 import type { DelegatedCredentialsManagerConfig } from "./credentials/delegated-credentials-manager";

--- a/packages/sdk/src/token/eip1193-subscribe.ts
+++ b/packages/sdk/src/token/eip1193-subscribe.ts
@@ -1,9 +1,6 @@
-import {
-  getAddress as checksumAddress,
-  type Address,
-  type EIP1193EventMap,
-  type EIP1193Provider,
-} from "viem";
+import type { Address } from "../utils/address";
+import type { EIP1193EventMap, EIP1193Provider } from "../types/ethereum";
+import { checksumAddress } from "../utils/address";
 import type { SignerLifecycleCallbacks } from "../types";
 
 /**

--- a/packages/sdk/src/token/pending-unshield.ts
+++ b/packages/sdk/src/token/pending-unshield.ts
@@ -1,4 +1,5 @@
-import type { Address, Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import type { GenericStorage } from "../types";
 import type { Handle } from "../relayer/relayer-sdk.types";
 

--- a/packages/sdk/src/token/readonly-token.ts
+++ b/packages/sdk/src/token/readonly-token.ts
@@ -1,4 +1,5 @@
-import { type Address, getAddress } from "viem";
+import type { Address } from "../utils/address";
+import { getAddress } from "../utils/address";
 import {
   allowanceContract,
   confidentialBalanceOfContract,

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -1,4 +1,6 @@
-import { type Address, getAddress, type Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
+import { getAddress } from "../utils/address";
 import {
   allowanceContract,
   approveContract,

--- a/packages/sdk/src/types/callbacks.ts
+++ b/packages/sdk/src/types/callbacks.ts
@@ -1,4 +1,4 @@
-import type { Hex } from "viem";
+import type { Hex } from "../utils/hex";
 
 /** Progress callbacks for multi-step unshield operations. */
 export interface UnshieldCallbacks {

--- a/packages/sdk/src/types/credentials.ts
+++ b/packages/sdk/src/types/credentials.ts
@@ -1,4 +1,5 @@
-import type { Address, Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 
 /** Stored FHE credential data (serialized as JSON in the credential store). */
 export interface StoredCredentials {

--- a/packages/sdk/src/types/ethereum.ts
+++ b/packages/sdk/src/types/ethereum.ts
@@ -1,0 +1,61 @@
+/**
+ * EIP-1193 provider types used by the SDK.
+ */
+
+import type { Address } from "../utils/address";
+
+// ---------------------------------------------------------------------------
+// EIP-1193 provider types
+// ---------------------------------------------------------------------------
+
+/** Minimal EIP-1193 JSON-RPC request shape. */
+export interface EIP1193RequestFn {
+  (args: { method: string; params?: readonly unknown[] }): Promise<unknown>;
+}
+
+/** Info returned by the `connect` EIP-1193 event. */
+export interface ProviderConnectInfo {
+  readonly chainId: string;
+}
+
+/** Provider message delivered by the `message` event. */
+export interface ProviderMessage {
+  readonly type: string;
+  readonly data: unknown;
+}
+
+/** Callback signatures for each EIP-1193 event. */
+export interface EIP1193EventMap {
+  accountsChanged: (accounts: Address[]) => void;
+  chainChanged: (chainId: string) => void;
+  connect: (connectInfo: ProviderConnectInfo) => void;
+  disconnect: (error: ProviderRpcError) => void;
+  message: (message: ProviderMessage) => void;
+}
+
+/** EIP-1193 event subscription / unsubscription shape. */
+export interface EIP1193Events {
+  on<TEvent extends keyof EIP1193EventMap>(event: TEvent, listener: EIP1193EventMap[TEvent]): void;
+  removeListener<TEvent extends keyof EIP1193EventMap>(
+    event: TEvent,
+    listener: EIP1193EventMap[TEvent],
+  ): void;
+}
+
+/** Minimal EIP-1193 provider interface used by the SDK. */
+export interface EIP1193Provider extends EIP1193Events {
+  request: EIP1193RequestFn;
+}
+
+/** EIP-1193 JSON-RPC error. */
+export class ProviderRpcError extends Error {
+  readonly code: number;
+  readonly data?: unknown;
+
+  constructor(code: number, message: string, data?: unknown) {
+    super(message);
+    this.name = "ProviderRpcError";
+    this.code = code;
+    this.data = data;
+  }
+}

--- a/packages/sdk/src/types/options.ts
+++ b/packages/sdk/src/types/options.ts
@@ -1,4 +1,4 @@
-import type { Address } from "viem";
+import type { Address } from "../utils/address";
 import type { ShieldCallbacks, TransferCallbacks, UnshieldCallbacks } from "./callbacks";
 
 /** Options for {@link ConfidentialToken.confidentialTransfer}. */

--- a/packages/sdk/src/types/signer.ts
+++ b/packages/sdk/src/types/signer.ts
@@ -1,4 +1,5 @@
-import type { Address, Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 import type { EIP712TypedData } from "../relayer/relayer-sdk.types";
 import type {
   ContractAbi,

--- a/packages/sdk/src/types/transaction.ts
+++ b/packages/sdk/src/types/transaction.ts
@@ -1,4 +1,4 @@
-import type { Hex } from "viem";
+import type { Hex } from "../utils/hex";
 
 /** Framework-agnostic log shape compatible with any Ethereum provider. */
 export interface RawLog {

--- a/packages/sdk/src/utils/__tests__/address.test.ts
+++ b/packages/sdk/src/utils/__tests__/address.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "../../test-fixtures";
+import { checksumAddress, getAddress, isAddress, zeroAddress } from "../address";
+
+describe("isAddress", () => {
+  it("accepts valid lowercase address", () => {
+    expect(isAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")).toBe(true);
+  });
+
+  it("accepts valid checksummed address", () => {
+    expect(isAddress("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")).toBe(true);
+  });
+
+  it("accepts zero address", () => {
+    expect(isAddress("0x0000000000000000000000000000000000000000")).toBe(true);
+  });
+
+  it("rejects too short", () => {
+    expect(isAddress("0xd8da6bf26964af9d7eed9e03")).toBe(false);
+  });
+
+  it("rejects too long", () => {
+    expect(isAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045aa")).toBe(false);
+  });
+
+  it("rejects missing 0x prefix", () => {
+    expect(isAddress("d8da6bf26964af9d7eed9e03e53415d37aa96045")).toBe(false);
+  });
+
+  it("rejects non-hex characters", () => {
+    expect(isAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa9604g")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isAddress("")).toBe(false);
+  });
+});
+
+describe("checksumAddress", () => {
+  it("checksums vitalik.eth address correctly", () => {
+    expect(checksumAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")).toBe(
+      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+    );
+  });
+
+  it("is idempotent on already-checksummed address", () => {
+    const checksummed = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+    expect(checksumAddress(checksummed)).toBe(checksummed);
+  });
+
+  it("checksums all-uppercase address", () => {
+    expect(checksumAddress("0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045")).toBe(
+      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+    );
+  });
+
+  it("checksums zero address", () => {
+    expect(checksumAddress(zeroAddress)).toBe(zeroAddress);
+  });
+
+  it("throws on invalid address", () => {
+    expect(() => checksumAddress("0xinvalid")).toThrow('Address "0xinvalid" is invalid.');
+    expect(() => checksumAddress("not-an-address")).toThrow("is invalid");
+    expect(() => checksumAddress("")).toThrow("is invalid");
+  });
+});
+
+describe("getAddress", () => {
+  it("is an alias for checksumAddress", () => {
+    expect(getAddress).toBe(checksumAddress);
+  });
+
+  it("returns checksummed address", () => {
+    expect(getAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")).toBe(
+      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+    );
+  });
+});
+
+describe("zeroAddress", () => {
+  it("is a valid address", () => {
+    expect(isAddress(zeroAddress)).toBe(true);
+  });
+
+  it("is 40 zeroes", () => {
+    expect(zeroAddress).toBe("0x0000000000000000000000000000000000000000");
+  });
+});

--- a/packages/sdk/src/utils/__tests__/address.test.ts
+++ b/packages/sdk/src/utils/__tests__/address.test.ts
@@ -1,3 +1,4 @@
+import { getAddress as viemGetAddress } from "viem";
 import { describe, it, expect } from "../../test-fixtures";
 import { checksumAddress, getAddress, isAddress, zeroAddress } from "../address";
 
@@ -10,15 +11,19 @@ describe("isAddress", () => {
     expect(isAddress("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")).toBe(true);
   });
 
+  it("accepts all-uppercase hex", () => {
+    expect(isAddress("0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045")).toBe(true);
+  });
+
   it("accepts zero address", () => {
-    expect(isAddress("0x0000000000000000000000000000000000000000")).toBe(true);
+    expect(isAddress(zeroAddress)).toBe(true);
   });
 
   it("rejects too short", () => {
     expect(isAddress("0xd8da6bf26964af9d7eed9e03")).toBe(false);
   });
 
-  it("rejects too long", () => {
+  it("rejects too long (42 hex chars after 0x)", () => {
     expect(isAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045aa")).toBe(false);
   });
 
@@ -33,46 +38,85 @@ describe("isAddress", () => {
   it("rejects empty string", () => {
     expect(isAddress("")).toBe(false);
   });
+
+  it("rejects bare 0x", () => {
+    expect(isAddress("0x")).toBe(false);
+  });
 });
 
+// ---------------------------------------------------------------------------
+// checksumAddress — EIP-55 compliance
+// ---------------------------------------------------------------------------
+
 describe("checksumAddress", () => {
-  it("checksums vitalik.eth address correctly", () => {
-    expect(checksumAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")).toBe(
-      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
-    );
+  // EIP-55 test vectors from the spec
+  const EIP55_VECTORS: [string, string][] = [
+    // all-caps
+    ["0x52908400098527886E0F7030069857D2E4169EE7", "0x52908400098527886E0F7030069857D2E4169EE7"],
+    ["0x8617E340B3D01FA5F11F306F4090FD50E238070D", "0x8617E340B3D01FA5F11F306F4090FD50E238070D"],
+    // all-lower
+    ["0xde709f2102306220921060314715629080e2fb77", "0xde709f2102306220921060314715629080e2fb77"],
+    ["0x27b1fdb04752bbc536007a920d24acb045561c26", "0x27b1fdb04752bbc536007a920d24acb045561c26"],
+    // mixed
+    ["0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed", "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"],
+    ["0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359", "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"],
+    ["0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB", "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"],
+    ["0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb", "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"],
+  ];
+
+  it.each(EIP55_VECTORS)("checksums %s correctly", (input, expected) => {
+    expect(checksumAddress(input.toLowerCase())).toBe(expected);
   });
 
-  it("is idempotent on already-checksummed address", () => {
-    const checksummed = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
-    expect(checksumAddress(checksummed)).toBe(checksummed);
+  it("matches viem getAddress for EIP-55 vectors", () => {
+    for (const [, expected] of EIP55_VECTORS) {
+      expect(checksumAddress(expected.toLowerCase())).toBe(viemGetAddress(expected.toLowerCase()));
+    }
   });
 
-  it("checksums all-uppercase address", () => {
+  it("matches viem for well-known addresses", () => {
+    const addresses = [
+      "0xd8da6bf26964af9d7eed9e03e53415d37aa96045", // vitalik.eth
+      "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", // USDC
+      "0xdac17f958d2ee523a2206206994597c13d831ec7", // USDT
+      "0x0000000000000000000000000000000000000000", // zero
+      "0xffffffffffffffffffffffffffffffffffffffff", // max
+    ];
+    for (const addr of addresses) {
+      expect(checksumAddress(addr)).toBe(viemGetAddress(addr));
+    }
+  });
+
+  it("is idempotent", () => {
+    const addr = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+    const once = checksumAddress(addr);
+    const twice = checksumAddress(once);
+    expect(twice).toBe(once);
+  });
+
+  it("handles all-uppercase input", () => {
     expect(checksumAddress("0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045")).toBe(
       "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
     );
   });
 
-  it("checksums zero address", () => {
+  it("checksums zero address (all nibbles < 8)", () => {
     expect(checksumAddress(zeroAddress)).toBe(zeroAddress);
   });
 
-  it("throws on invalid address", () => {
-    expect(() => checksumAddress("0xinvalid")).toThrow('Address "0xinvalid" is invalid.');
+  it("throws on invalid input", () => {
+    expect(() => checksumAddress("0xinvalid")).toThrow("is invalid");
     expect(() => checksumAddress("not-an-address")).toThrow("is invalid");
     expect(() => checksumAddress("")).toThrow("is invalid");
+    expect(() => checksumAddress("0x")).toThrow("is invalid");
+    // too short
+    expect(() => checksumAddress("0xdead")).toThrow("is invalid");
   });
 });
 
 describe("getAddress", () => {
-  it("is an alias for checksumAddress", () => {
+  it("is the same function as checksumAddress", () => {
     expect(getAddress).toBe(checksumAddress);
-  });
-
-  it("returns checksummed address", () => {
-    expect(getAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")).toBe(
-      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
-    );
   });
 });
 
@@ -81,7 +125,11 @@ describe("zeroAddress", () => {
     expect(isAddress(zeroAddress)).toBe(true);
   });
 
-  it("is 40 zeroes", () => {
+  it("equals the canonical zero address", () => {
     expect(zeroAddress).toBe("0x0000000000000000000000000000000000000000");
+  });
+
+  it("matches viem zero address checksum", () => {
+    expect(checksumAddress(zeroAddress)).toBe(viemGetAddress(zeroAddress));
   });
 });

--- a/packages/sdk/src/utils/__tests__/address.test.ts
+++ b/packages/sdk/src/utils/__tests__/address.test.ts
@@ -42,6 +42,32 @@ describe("isAddress", () => {
   it("rejects bare 0x", () => {
     expect(isAddress("0x")).toBe(false);
   });
+
+  describe("strict mode (default)", () => {
+    it("accepts all-lowercase (no checksum to verify)", () => {
+      expect(isAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045")).toBe(true);
+    });
+
+    it("accepts all-uppercase (no checksum to verify)", () => {
+      expect(isAddress("0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045")).toBe(true);
+    });
+
+    it("accepts correctly checksummed mixed-case", () => {
+      expect(isAddress("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")).toBe(true);
+    });
+
+    it("rejects incorrectly checksummed mixed-case", () => {
+      // Flip one letter's case to break the checksum
+      expect(isAddress("0xd8Da6BF26964aF9D7eEd9e03E53415D37aA96045")).toBe(false);
+    });
+  });
+
+  describe("strict: false", () => {
+    it("accepts any valid hex address regardless of casing", () => {
+      // Wrong checksum but valid hex — strict: false should accept
+      expect(isAddress("0xd8Da6BF26964aF9D7eEd9e03E53415D37aA96045", { strict: false })).toBe(true);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/sdk/src/utils/__tests__/hex.test.ts
+++ b/packages/sdk/src/utils/__tests__/hex.test.ts
@@ -1,3 +1,4 @@
+import { keccak256 as viemKeccak256, toBytes as viemToBytes, toHex as viemToHex } from "viem";
 import { describe, it, expect } from "../../test-fixtures";
 import { prefixHex, unprefixHex } from "..";
 import { toHex, toBytes, keccak256, isHex } from "../hex";
@@ -24,9 +25,120 @@ describe("toHex", () => {
     const bytes = new Uint8Array(32).fill(0xab);
     expect(toHex(bytes)).toBe("0x" + "ab".repeat(32));
   });
+
+  it("matches viem toHex for various inputs", () => {
+    const cases = [
+      new Uint8Array([]),
+      new Uint8Array([0]),
+      new Uint8Array([0xff]),
+      new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+      new Uint8Array(32).fill(0xab),
+      new Uint8Array(20).fill(0x01),
+    ];
+    for (const input of cases) {
+      expect(toHex(input)).toBe(viemToHex(input));
+    }
+  });
 });
 
-describe("hex prefix helpers", () => {
+describe("toBytes", () => {
+  it("encodes ASCII string", () => {
+    expect(toBytes("abc")).toEqual(new Uint8Array([0x61, 0x62, 0x63]));
+  });
+
+  it("encodes empty string", () => {
+    expect(toBytes("")).toEqual(new Uint8Array([]));
+  });
+
+  it("encodes UTF-8 multi-byte characters", () => {
+    const bytes = toBytes("\u00e9"); // é
+    expect(bytes.length).toBe(2);
+    expect(bytes[0]).toBe(0xc3);
+    expect(bytes[1]).toBe(0xa9);
+  });
+
+  it("roundtrips with toHex", () => {
+    const text = "hello world";
+    const bytes = toBytes(text);
+    const hex = toHex(bytes);
+    expect(hex).toBe("0x" + Buffer.from(text).toString("hex"));
+  });
+});
+
+describe("keccak256", () => {
+  it("hashes empty bytes to known value", () => {
+    expect(keccak256(new Uint8Array([]))).toBe(
+      "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+    );
+  });
+
+  it("returns 0x-prefixed 66-char string", () => {
+    const result = keccak256(new Uint8Array([0xff]));
+    expect(result).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it("matches viem keccak256 for various inputs", () => {
+    const cases = [
+      new Uint8Array([]),
+      new Uint8Array([0xff]),
+      new TextEncoder().encode("hello"),
+      new TextEncoder().encode("Transfer(address,address,uint256)"),
+      new Uint8Array(32).fill(0x00),
+      new Uint8Array(32).fill(0xff),
+    ];
+    for (const input of cases) {
+      expect(keccak256(input)).toBe(viemKeccak256(input));
+    }
+  });
+
+  it("produces correct event topic for Transfer signature", () => {
+    const sig = "Transfer(address,address,uint256)";
+    const topic = keccak256(toBytes(sig));
+    // Well-known Transfer topic0
+    expect(topic).toBe("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+  });
+
+  it("produces correct event topic for ConfidentialTransfer signature", () => {
+    const sig = "ConfidentialTransfer(address,address,bytes32)";
+    const topic = keccak256(toBytes(sig));
+    expect(topic).toBe(viemKeccak256(viemToBytes(sig)));
+  });
+
+  it("different inputs produce different hashes", () => {
+    const a = keccak256(new Uint8Array([0x01]));
+    const b = keccak256(new Uint8Array([0x02]));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("isHex", () => {
+  it("accepts bare 0x prefix", () => {
+    expect(isHex("0x")).toBe(true);
+  });
+
+  it("accepts valid hex strings", () => {
+    expect(isHex("0x0")).toBe(true);
+    expect(isHex("0xdeadbeef")).toBe(true);
+    expect(isHex("0xABCDEF0123456789")).toBe(true);
+    expect(isHex("0x" + "ab".repeat(32))).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(isHex("")).toBe(false);
+  });
+
+  it("rejects missing prefix", () => {
+    expect(isHex("deadbeef")).toBe(false);
+  });
+
+  it("rejects non-hex characters", () => {
+    expect(isHex("0xGHIJ")).toBe(false);
+    expect(isHex("0x123z")).toBe(false);
+    expect(isHex("0x ")).toBe(false);
+  });
+});
+
+describe("prefixHex / unprefixHex", () => {
   it("adds a prefix when the relayer SDK returns bare hex", () => {
     expect(prefixHex("abcd")).toBe("0xabcd");
   });
@@ -42,55 +154,9 @@ describe("hex prefix helpers", () => {
   it("throws when value lacks 0x prefix", () => {
     expect(() => unprefixHex("abcd" as `0x${string}`)).toThrow("Expected 0x-prefixed hex");
   });
-});
 
-describe("isHex", () => {
-  it("accepts valid hex strings", () => {
-    expect(isHex("0x")).toBe(true);
-    expect(isHex("0xdeadbeef")).toBe(true);
-    expect(isHex("0x0")).toBe(true);
-    expect(isHex("0xABCDEF0123456789")).toBe(true);
-  });
-
-  it("rejects invalid hex strings", () => {
-    expect(isHex("")).toBe(false);
-    expect(isHex("0x")).toBe(true);
-    expect(isHex("deadbeef")).toBe(false);
-    expect(isHex("0xGHIJ")).toBe(false);
-    expect(isHex("0x123z")).toBe(false);
-  });
-});
-
-describe("keccak256", () => {
-  it("hashes empty bytes", () => {
-    const result = keccak256(new Uint8Array([]));
-    // Known keccak256 of empty input
-    expect(result).toBe("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
-  });
-
-  it("hashes 'hello'", () => {
-    const result = keccak256(new TextEncoder().encode("hello"));
-    expect(result).toBe("0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8");
-  });
-
-  it("returns 0x-prefixed 66-char string", () => {
-    const result = keccak256(new Uint8Array([0xff]));
-    expect(result).toMatch(/^0x[0-9a-f]{64}$/);
-  });
-});
-
-describe("toBytes", () => {
-  it("encodes ASCII string", () => {
-    const bytes = toBytes("abc");
-    expect(bytes).toEqual(new Uint8Array([0x61, 0x62, 0x63]));
-  });
-
-  it("encodes empty string", () => {
-    expect(toBytes("")).toEqual(new Uint8Array([]));
-  });
-
-  it("encodes UTF-8 multi-byte characters", () => {
-    const bytes = toBytes("\u00e9"); // é
-    expect(bytes.length).toBe(2);
+  it("roundtrips", () => {
+    expect(unprefixHex(prefixHex("deadbeef"))).toBe("deadbeef");
+    expect(prefixHex(unprefixHex("0xdeadbeef"))).toBe("0xdeadbeef");
   });
 });

--- a/packages/sdk/src/utils/__tests__/hex.test.ts
+++ b/packages/sdk/src/utils/__tests__/hex.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "../../test-fixtures";
-import { toHex } from "viem";
 import { prefixHex, unprefixHex } from "..";
+import { toHex, toBytes, keccak256, isHex } from "../hex";
 
 describe("toHex", () => {
   it("converts empty Uint8Array to 0x", () => {
@@ -41,5 +41,56 @@ describe("hex prefix helpers", () => {
 
   it("throws when value lacks 0x prefix", () => {
     expect(() => unprefixHex("abcd" as `0x${string}`)).toThrow("Expected 0x-prefixed hex");
+  });
+});
+
+describe("isHex", () => {
+  it("accepts valid hex strings", () => {
+    expect(isHex("0x")).toBe(true);
+    expect(isHex("0xdeadbeef")).toBe(true);
+    expect(isHex("0x0")).toBe(true);
+    expect(isHex("0xABCDEF0123456789")).toBe(true);
+  });
+
+  it("rejects invalid hex strings", () => {
+    expect(isHex("")).toBe(false);
+    expect(isHex("0x")).toBe(true);
+    expect(isHex("deadbeef")).toBe(false);
+    expect(isHex("0xGHIJ")).toBe(false);
+    expect(isHex("0x123z")).toBe(false);
+  });
+});
+
+describe("keccak256", () => {
+  it("hashes empty bytes", () => {
+    const result = keccak256(new Uint8Array([]));
+    // Known keccak256 of empty input
+    expect(result).toBe("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
+  });
+
+  it("hashes 'hello'", () => {
+    const result = keccak256(new TextEncoder().encode("hello"));
+    expect(result).toBe("0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8");
+  });
+
+  it("returns 0x-prefixed 66-char string", () => {
+    const result = keccak256(new Uint8Array([0xff]));
+    expect(result).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+});
+
+describe("toBytes", () => {
+  it("encodes ASCII string", () => {
+    const bytes = toBytes("abc");
+    expect(bytes).toEqual(new Uint8Array([0x61, 0x62, 0x63]));
+  });
+
+  it("encodes empty string", () => {
+    expect(toBytes("")).toEqual(new Uint8Array([]));
+  });
+
+  it("encodes UTF-8 multi-byte characters", () => {
+    const bytes = toBytes("\u00e9"); // é
+    expect(bytes.length).toBe(2);
   });
 });

--- a/packages/sdk/src/utils/address.ts
+++ b/packages/sdk/src/utils/address.ts
@@ -1,0 +1,37 @@
+import { keccak_256 } from "@noble/hashes/sha3.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
+
+/** EVM address — 0x-prefixed, 40 hex chars. */
+export type Address = `0x${string}`;
+
+/** The zero address (`0x0000000000000000000000000000000000000000`). */
+export const zeroAddress: Address = "0x0000000000000000000000000000000000000000";
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+
+/** Check whether `value` is a valid 0x-prefixed, 20-byte hex address. */
+export function isAddress(value: string): value is Address {
+  return ADDRESS_RE.test(value);
+}
+
+/**
+ * Return the EIP-55 checksummed form of an Ethereum address.
+ * Throws if the input is not a valid 20-byte hex address.
+ */
+export function checksumAddress(address: string): Address {
+  if (!isAddress(address)) {
+    throw new Error(`Address "${address}" is invalid.`);
+  }
+  const bare = address.slice(2).toLowerCase();
+  const hash = bytesToHex(keccak_256(new TextEncoder().encode(bare)));
+
+  let result = "0x";
+  for (let i = 0; i < 40; i++) {
+    const nibble = parseInt(hash[i] as string, 16);
+    result += nibble >= 8 ? (bare[i] as string).toUpperCase() : bare[i];
+  }
+  return result as Address;
+}
+
+/** Alias for {@link checksumAddress} — drop-in replacement for viem's `getAddress`. */
+export const getAddress = checksumAddress;

--- a/packages/sdk/src/utils/address.ts
+++ b/packages/sdk/src/utils/address.ts
@@ -4,14 +4,46 @@ import { bytesToHex } from "@noble/hashes/utils.js";
 /** EVM address — 0x-prefixed, 40 hex chars. */
 export type Address = `0x${string}`;
 
-/** The zero address (`0x0000000000000000000000000000000000000000`). */
-export const zeroAddress: Address = "0x0000000000000000000000000000000000000000";
+/** The zero address */
+export const zeroAddress: Address = "0x0000000000000000000000000000000000000000" as const;
 
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
 
-/** Check whether `value` is a valid 0x-prefixed, 20-byte hex address. */
-export function isAddress(value: string): value is Address {
-  return ADDRESS_RE.test(value);
+/** Compute the EIP-55 checksummed form of a bare (no 0x) lowercase address. */
+function applyChecksum(bare: string): Address {
+  const hash = bytesToHex(keccak_256(new TextEncoder().encode(bare)));
+  let result: Address = "0x";
+  for (let i = 0; i < 40; i++) {
+    const nibble = parseInt(hash[i] as string, 16);
+    result += nibble >= 8 ? (bare[i] as string).toUpperCase() : bare[i];
+  }
+  return result;
+}
+
+/**
+ * Check whether `value` is a valid 0x-prefixed, 20-byte hex address.
+ *
+ * @param strict - When `true` (default), also verifies the EIP-55 checksum
+ *   if the address contains mixed-case letters. All-lowercase and all-uppercase
+ *   addresses pass regardless since they carry no checksum information.
+ */
+export function isAddress(
+  value: string,
+  { strict = true }: { strict?: boolean } = {},
+): value is Address {
+  if (!ADDRESS_RE.test(value)) {
+    return false;
+  }
+  if (!strict) {
+    return true;
+  }
+
+  const bare = value.slice(2);
+  if (bare === bare.toLowerCase() || bare === bare.toUpperCase()) {
+    return true;
+  }
+
+  return value === applyChecksum(bare.toLowerCase());
 }
 
 /**
@@ -19,18 +51,10 @@ export function isAddress(value: string): value is Address {
  * Throws if the input is not a valid 20-byte hex address.
  */
 export function checksumAddress(address: string): Address {
-  if (!isAddress(address)) {
+  if (!isAddress(address, { strict: false })) {
     throw new Error(`Address "${address}" is invalid.`);
   }
-  const bare = address.slice(2).toLowerCase();
-  const hash = bytesToHex(keccak_256(new TextEncoder().encode(bare)));
-
-  let result = "0x";
-  for (let i = 0; i < 40; i++) {
-    const nibble = parseInt(hash[i] as string, 16);
-    result += nibble >= 8 ? (bare[i] as string).toUpperCase() : bare[i];
-  }
-  return result as Address;
+  return applyChecksum(address.slice(2).toLowerCase());
 }
 
 /** Alias for {@link checksumAddress} — drop-in replacement for viem's `getAddress`. */

--- a/packages/sdk/src/utils/hex.ts
+++ b/packages/sdk/src/utils/hex.ts
@@ -1,5 +1,9 @@
-import type { Hex } from "viem";
+import { keccak_256 } from "@noble/hashes/sha3.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
 import { assertCondition } from "./assertions";
+
+/** Hex-encoded byte string — 0x-prefixed. */
+export type Hex = `0x${string}`;
 
 /** Normalize a un-prefixed hex payload to a 0x-prefixed `Hex` value. */
 export function prefixHex(value: string): Hex {
@@ -10,4 +14,24 @@ export function prefixHex(value: string): Hex {
 export function unprefixHex(value: Hex): string {
   assertCondition(value.startsWith("0x"), `Expected 0x-prefixed hex, got: ${value}`);
   return value.slice(2);
+}
+
+/** Check whether `value` is a valid 0x-prefixed hex string. */
+export function isHex(value: string): value is Hex {
+  return /^0x[0-9a-fA-F]*$/.test(value);
+}
+
+/** Keccak-256 hash of raw bytes, returned as a 0x-prefixed hex string. */
+export function keccak256(data: Uint8Array): Hex {
+  return `0x${bytesToHex(keccak_256(data))}`;
+}
+
+/** Convert a UTF-8 string to bytes. */
+export function toBytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+/** Convert a `Uint8Array` to a 0x-prefixed hex string. */
+export function toHex(value: Uint8Array): Hex {
+  return `0x${bytesToHex(value)}`;
 }

--- a/packages/sdk/src/worker/worker.types.ts
+++ b/packages/sdk/src/worker/worker.types.ts
@@ -6,7 +6,8 @@ import type {
   ZKProofLike,
 } from "@zama-fhe/relayer-sdk/bundle";
 import type { ClearValueType, EncryptInput, Handle } from "../relayer/relayer-sdk.types";
-import type { Address, Hex } from "viem";
+import type { Address } from "../utils/address";
+import type { Hex } from "../utils/hex";
 
 // ============================================================================
 // Logger

--- a/packages/sdk/src/wrappers-registry.ts
+++ b/packages/sdk/src/wrappers-registry.ts
@@ -1,4 +1,5 @@
-import { type Address, getAddress, zeroAddress } from "viem";
+import type { Address } from "./utils/address";
+import { getAddress, zeroAddress } from "./utils/address";
 import type { TokenWrapperPairWithMetadata, PaginatedResult, TokenWrapperPair } from "./contracts";
 import {
   decimalsContract,

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -1,4 +1,5 @@
-import { getAddress, type Address } from "viem";
+import type { Address } from "./utils/address";
+import { getAddress } from "./utils/address";
 import { CredentialsManager } from "./credentials/credentials-manager";
 import { DelegatedCredentialsManager } from "./credentials/delegated-credentials-manager";
 import { DecryptCache } from "./decrypt-cache";
@@ -463,7 +464,11 @@ export class ZamaSDK {
    */
   async publicDecrypt(handles: Handle[]): Promise<PublicDecryptResult> {
     if (handles.length === 0) {
-      return { clearValues: {}, decryptionProof: "0x", abiEncodedClearValues: "0x" };
+      return {
+        clearValues: {},
+        decryptionProof: "0x",
+        abiEncodedClearValues: "0x",
+      };
     }
 
     try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,7 +136,7 @@ importers:
         version: 5.1.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
   packages/react-sdk:
     dependencies:
@@ -165,6 +165,9 @@ importers:
 
   packages/sdk:
     dependencies:
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@zama-fhe/relayer-sdk':
         specifier: ~0.4.2
         version: 0.4.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -172,7 +175,7 @@ importers:
         specifier: '>=6'
         version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       viem:
-        specifier: ^2.47.12
+        specifier: '>=2'
         version: 2.47.12(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
     devDependencies:
       '@tanstack/query-core':
@@ -202,7 +205,7 @@ importers:
     devDependencies:
       '@fhevm/mock-utils':
         specifier: 0.4.2
-        version: 0.4.2(@zama-fhe/relayer-sdk@0.4.2(bufferutil@4.1.0)(utf-8-validate@5.0.10))(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@6.0.2)
+        version: 0.4.2(@zama-fhe/relayer-sdk@0.4.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@6.0.2)
       '@types/node':
         specifier: ^22.19.17
         version: 22.19.17
@@ -988,6 +991,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -2039,6 +2046,11 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  '@zama-fhe/relayer-sdk@0.4.1':
+    resolution: {integrity: sha512-bS7tVQbXnsPFgiqm5R4pJ8hbPMYZuRh/Pv89S+jxO60y0mD296F4qIKEO7dgiHjC87V5GFM9DqCLNejjCNVw2Q==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   '@zama-fhe/relayer-sdk@0.4.2':
     resolution: {integrity: sha512-3Q0tINKxz6YseaDxOrNP/648j5Wr2C4Utnjx5npZESjLAc20tWgWFE7BOfx0Kjhs8cx/ykU+tMZBq40+DsiUvA==}
@@ -4637,12 +4649,19 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
     optionalDependencies:
-      '@noble/hashes': 1.8.0
+      '@noble/hashes': 2.2.0
     optional: true
 
   '@faker-js/faker@10.4.0': {}
+
+  '@fhevm/mock-utils@0.4.2(@zama-fhe/relayer-sdk@0.4.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@6.0.2)':
+    dependencies:
+      '@zama-fhe/relayer-sdk': 0.4.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 6.0.2
 
   '@fhevm/mock-utils@0.4.2(@zama-fhe/relayer-sdk@0.4.2(bufferutil@4.1.0)(utf-8-validate@5.0.10))(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@6.0.2)':
     dependencies:
@@ -4856,6 +4875,8 @@ snapshots:
     optional: true
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@octokit/auth-token@6.0.0': {}
 
@@ -5613,7 +5634,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -5659,7 +5680,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -5693,6 +5714,21 @@ snapshots:
       - immer
       - react
       - use-sync-external-store
+
+  '@zama-fhe/relayer-sdk@0.4.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      commander: 14.0.3
+      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      fetch-retry: 6.0.0
+      keccak: 3.0.4
+      node-tfhe: 1.4.0-alpha.3
+      node-tkms: 0.12.8
+      tfhe: 1.4.0-alpha.3
+      tkms: 0.12.8
+      wasm-feature-detect: 1.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@zama-fhe/relayer-sdk@0.4.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
@@ -5991,10 +6027,10 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  data-urls@7.0.0(@noble/hashes@1.8.0):
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
     optional: true
@@ -6302,9 +6338,9 @@ snapshots:
     dependencies:
       lru-cache: 11.3.5
 
-  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
     optional: true
@@ -6442,16 +6478,16 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@28.1.0(@noble/hashes@1.8.0):
+  jsdom@28.1.0(@noble/hashes@2.2.0):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
       '@bramus/specificity': 2.4.2
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       cssstyle: 6.2.0
-      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
@@ -6463,7 +6499,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -7683,7 +7719,7 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.8.3
 
-  vitest@4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)):
+  vitest@4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
@@ -7710,7 +7746,7 @@ snapshots:
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
       '@vitest/ui': 4.1.4(vitest@4.1.4)
       happy-dom: 20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      jsdom: 28.1.0(@noble/hashes@1.8.0)
+      jsdom: 28.1.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -7765,9 +7801,9 @@ snapshots:
   whatwg-mimetype@5.0.0:
     optional: true
 
-  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Remove `viem` from `dependencies`, keep it as an optional `peerDependency` (`>=2`) alongside `ethers` (`>=6`)
- Replace all direct `viem` imports with lightweight local utilities backed by `@noble/hashes`
- Add local `Address` type, `getAddress`, `isAddress`, `isHex`, `toHex` helpers and an ERC-20 ABI module

## Motivation
`viem` is a large dependency that pulls in significant bundle weight. Users who only use `ethers` were forced to install it anyway. This change makes both `viem` and `ethers` peer-only, so consumers pay only for the library they actually use.

## Key changes
| Area | Before | After |
|------|--------|-------|
| `dependencies` | `viem ^2.47` | `@noble/hashes ^2.2` |
| `peerDependencies` | `ethers >=6` | `ethers >=6`, `viem >=2` (both optional) |
| Internal imports | `from "viem"` | `from "../utils/address"` / `"../utils/hex"` |
| New files | — | `utils/address.ts`, `types/ethereum.ts`, `abi/erc20.abi.ts` |

## Test plan
- [ ] Unit tests pass (`pnpm vitest`)
- [ ] Typecheck passes (`pnpm typecheck`)
- [ ] E2E tests with ethers-only consumer
- [ ] E2E tests with viem-only consumer
- [ ] Bundle size comparison before/after