### PR TITLE
feat: remove auto-signer resolving in hooks

### DIFF
--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -69,12 +69,13 @@ export function useConfidentialApprove(config: UseZamaConfig, options?: UseMutat
 // @public
 export function useConfidentialBalance(config: UseConfidentialBalanceConfig, options?: UseConfidentialBalanceOptions): _$_tanstack_react_query0.UseQueryResult<bigint, Error>;
 
-// @public
+// @public (undocumented)
 export interface UseConfidentialBalanceConfig {
+    account: Address | undefined;
     tokenAddress: Address;
 }
 
-// @public
+// @public (undocumented)
 export interface UseConfidentialBalanceOptions extends Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn" | "enabled"> {
     enabled?: boolean;
 }
@@ -82,12 +83,13 @@ export interface UseConfidentialBalanceOptions extends Omit<UseQueryOptions<bigi
 // @public
 export function useConfidentialBalances(config: UseConfidentialBalancesConfig, options?: UseConfidentialBalancesOptions): _$_tanstack_react_query0.UseQueryResult<BatchBalancesResult, Error>;
 
-// @public
+// @public (undocumented)
 export interface UseConfidentialBalancesConfig {
+    account: Address | undefined;
     tokenAddresses: Address[];
 }
 
-// @public
+// @public (undocumented)
 export interface UseConfidentialBalancesOptions extends Omit<UseQueryOptions<BatchBalancesResult>, "queryKey" | "queryFn" | "enabled"> {
     enabled?: boolean;
 }
@@ -95,9 +97,9 @@ export interface UseConfidentialBalancesOptions extends Omit<UseQueryOptions<Bat
 // @public
 export function useConfidentialIsApproved(config: UseConfidentialIsApprovedConfig, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<boolean, Error>;
 
-// @public
+// @public (undocumented)
 export interface UseConfidentialIsApprovedConfig {
-    holder?: Address;
+    holder: Address | undefined;
     spender: Address | undefined;
     tokenAddress: Address | undefined;
 }
@@ -105,10 +107,11 @@ export interface UseConfidentialIsApprovedConfig {
 // @public
 export function useConfidentialIsApprovedSuspense(config: UseConfidentialIsApprovedSuspenseConfig): _$_tanstack_react_query0.UseSuspenseQueryResult<boolean, Error>;
 
-// @public
-export interface UseConfidentialIsApprovedSuspenseConfig extends UseZamaConfig {
-    holder?: Address;
+// @public (undocumented)
+export interface UseConfidentialIsApprovedSuspenseConfig {
+    holder: Address;
     spender: Address;
+    tokenAddress: Address;
 }
 
 // @public
@@ -292,14 +295,22 @@ export function useTotalSupplySuspense(tokenAddress: Address): _$_tanstack_react
 // @public
 export function useUnderlyingAllowance(config: UseUnderlyingAllowanceConfig, options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">): _$_tanstack_react_query0.UseQueryResult<bigint, Error>;
 
-// @public
+// @public (undocumented)
 export interface UseUnderlyingAllowanceConfig {
+    owner: Address | undefined;
     tokenAddress: Address;
     wrapperAddress: Address;
 }
 
 // @public
-export function useUnderlyingAllowanceSuspense(config: UseUnderlyingAllowanceConfig): _$_tanstack_react_query0.UseSuspenseQueryResult<bigint, Error>;
+export function useUnderlyingAllowanceSuspense(config: UseUnderlyingAllowanceSuspenseConfig): _$_tanstack_react_query0.UseSuspenseQueryResult<bigint, Error>;
+
+// @public (undocumented)
+export interface UseUnderlyingAllowanceSuspenseConfig {
+    owner: Address;
+    tokenAddress: Address;
+    wrapperAddress: Address;
+}
 
 // @public
 export function useUnshield(config: UseZamaConfig, options?: UseMutationOptions<TransactionResult, Error, UnshieldParams, Address>): _$_tanstack_react_query0.UseMutationResult<TransactionResult, Error, UnshieldParams, `0x${string}`>;

--- a/packages/react-sdk/src/__tests__/provider-hooks-extended.test.tsx
+++ b/packages/react-sdk/src/__tests__/provider-hooks-extended.test.tsx
@@ -28,6 +28,7 @@ describe("useUnderlyingAllowance", () => {
         useUnderlyingAllowance({
           tokenAddress,
           wrapperAddress,
+          owner: USER,
         }),
       { signer },
     );

--- a/packages/react-sdk/src/balance/__tests__/use-confidential-balance.test.tsx
+++ b/packages/react-sdk/src/balance/__tests__/use-confidential-balance.test.tsx
@@ -10,7 +10,9 @@ describe("useConfidentialBalance", () => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
     vi.mocked(relayer.userDecrypt).mockResolvedValue({ [handle]: 123n });
 
-    const { result } = renderWithProviders(() => useConfidentialBalance({ tokenAddress: TOKEN }));
+    const { result } = renderWithProviders(() =>
+      useConfidentialBalance({ tokenAddress: TOKEN, account: USER }),
+    );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
 
@@ -22,17 +24,49 @@ describe("useConfidentialBalance", () => {
 
   test("behavior: disabled when user passes enabled=false", async ({
     renderWithProviders,
-    signer,
     provider,
   }) => {
     const { result } = renderWithProviders(() =>
-      useConfidentialBalance({ tokenAddress: TOKEN }, { enabled: false }),
+      useConfidentialBalance({ tokenAddress: TOKEN, account: USER }, { enabled: false }),
     );
 
-    await waitFor(() => expect(signer.getAddress).toHaveBeenCalled(), { timeout: 5_000 });
     expect(result.current.isPending).toBe(true);
     expect(result.current.fetchStatus).toBe("idle");
     expect(provider.readContract).not.toHaveBeenCalled();
+  });
+
+  test("behavior: disabled when account is undefined (signer-less mount)", ({
+    renderWithProviders,
+    provider,
+  }) => {
+    const { result } = renderWithProviders(() =>
+      useConfidentialBalance({ tokenAddress: TOKEN, account: undefined }),
+    );
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(provider.readContract).not.toHaveBeenCalled();
+  });
+
+  test("behavior: uses the caller-supplied account even when it differs from the connected signer", async ({
+    renderWithProviders,
+    relayer,
+    provider,
+  }) => {
+    const handle = `0x${"cd".repeat(32)}`;
+    vi.mocked(provider.readContract).mockResolvedValue(handle);
+    vi.mocked(relayer.userDecrypt).mockResolvedValue({ [handle]: 456n });
+
+    const OTHER = "0x9C9c9c9c9c9c9C9c9c9C9C9c9c9C9c9c9c9c9C9c" as Address;
+    const { result } = renderWithProviders(() =>
+      useConfidentialBalance({ tokenAddress: TOKEN, account: OTHER }),
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
+    expect(result.current.data).toBe(456n);
+    expect(provider.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: "confidentialBalanceOf", args: [OTHER] }),
+    );
   });
 
   describe("lifecycle", () => {
@@ -41,7 +75,9 @@ describe("useConfidentialBalance", () => {
       vi.mocked(provider.readContract).mockResolvedValue(handle);
       vi.mocked(relayer.userDecrypt).mockResolvedValue({ [handle]: 123n });
 
-      const { result } = renderWithProviders(() => useConfidentialBalance({ tokenAddress: TOKEN }));
+      const { result } = renderWithProviders(() =>
+        useConfidentialBalance({ tokenAddress: TOKEN, account: USER }),
+      );
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
 
@@ -79,55 +115,6 @@ describe("useConfidentialBalance", () => {
     `);
     });
 
-    test("behavior: query stays disabled when signer.getAddress rejects", async ({
-      renderWithProviders,
-      signer,
-    }) => {
-      // When signer.getAddress() rejects, ZamaProvider swallows the error in
-      // its useEffect and signerAddress stays undefined.  The balance query is
-      // gated on signerAddress !== undefined, so it must remain pending/idle
-      // rather than entering an error state.
-      vi.mocked(signer.getAddress).mockRejectedValue(new Error("no wallet"));
-
-      const { result } = renderWithProviders(() => useConfidentialBalance({ tokenAddress: TOKEN }));
-
-      // Give React time to run the effect
-      await waitFor(() => expect(signer.getAddress).toHaveBeenCalled());
-
-      expect(result.current.isPending).toBe(true);
-      expect(result.current.fetchStatus).toBe("idle");
-      expect(result.current.data).toBeUndefined();
-    });
-
-    test("behavior: signer undefined -> defined", async ({
-      renderWithProviders,
-      signer,
-      relayer,
-      provider,
-    }) => {
-      const handle = `0x${"ac".repeat(32)}`;
-      let resolveAddress: (value: Address) => void;
-      const addressPromise = new Promise<Address>((resolve) => {
-        resolveAddress = resolve;
-      });
-
-      vi.mocked(signer.getAddress).mockReturnValue(addressPromise);
-      vi.mocked(provider.readContract).mockResolvedValue(handle);
-      vi.mocked(relayer.userDecrypt).mockResolvedValue({ [handle]: 321n });
-
-      const { result, rerender } = renderWithProviders(() =>
-        useConfidentialBalance({ tokenAddress: TOKEN }),
-      );
-
-      expect(result.current.isPending).toBe(true);
-
-      resolveAddress!(USER);
-      rerender();
-
-      await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
-      expect(result.current.data).toBe(321n);
-    });
-
     test("behavior: balance updates on refetch when handle changes", async ({
       renderWithProviders,
       relayer,
@@ -142,7 +129,9 @@ describe("useConfidentialBalance", () => {
         return { [handles[0]]: value };
       });
 
-      const { result } = renderWithProviders(() => useConfidentialBalance({ tokenAddress: TOKEN }));
+      const { result } = renderWithProviders(() =>
+        useConfidentialBalance({ tokenAddress: TOKEN, account: USER }),
+      );
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
       expect(result.current.data).toBe(111n);
@@ -172,7 +161,7 @@ describe("useConfidentialBalance", () => {
       vi.mocked(relayer.userDecrypt).mockResolvedValue({ [handle]: 999n });
 
       const { result, rerender } = renderWithProviders(() =>
-        useConfidentialBalance({ tokenAddress: TOKEN }),
+        useConfidentialBalance({ tokenAddress: TOKEN, account: USER }),
       );
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
@@ -185,14 +174,11 @@ describe("useConfidentialBalance", () => {
 
     test("behavior: disabled when user passes enabled=false", async ({
       renderWithProviders,
-      signer,
       provider,
     }) => {
       const { result } = renderWithProviders(() =>
-        useConfidentialBalance({ tokenAddress: TOKEN }, { enabled: false }),
+        useConfidentialBalance({ tokenAddress: TOKEN, account: USER }, { enabled: false }),
       );
-
-      await waitFor(() => expect(signer.getAddress).toHaveBeenCalled(), { timeout: 5_000 });
 
       expect(result.current.isPending).toBe(true);
       expect(result.current.fetchStatus).toBe("idle");

--- a/packages/react-sdk/src/balance/__tests__/use-confidential-balances-enabled.test.tsx
+++ b/packages/react-sdk/src/balance/__tests__/use-confidential-balances-enabled.test.tsx
@@ -21,11 +21,6 @@ const mockSdk = {
 
 vi.mock("../../provider", () => ({
   useZamaSDK: vi.fn(() => mockSdk),
-  useSignerAddress: vi.fn(() => ({ data: OWNER })),
-}));
-
-vi.mock("../../use-signer-address", () => ({
-  useSignerAddress: vi.fn(() => ({ data: OWNER })),
 }));
 
 vi.mock("@zama-fhe/sdk/query", () => ({
@@ -48,7 +43,10 @@ describe("useConfidentialBalances enabled propagation", () => {
 
   test("disables balance query when user passes enabled=false", () => {
     renderHook(() =>
-      useConfidentialBalances({ tokenAddresses: [TOKEN, TOKEN_B] }, { enabled: false }),
+      useConfidentialBalances(
+        { tokenAddresses: [TOKEN, TOKEN_B], account: OWNER },
+        { enabled: false },
+      ),
     );
 
     const balanceQueryOptions = vi.mocked(useQuery).mock.calls[0]?.[0] as
@@ -62,7 +60,7 @@ describe("useConfidentialBalances enabled propagation", () => {
   test("disables balance query for other falsy enabled values", () => {
     renderHook(() =>
       useConfidentialBalances(
-        { tokenAddresses: [TOKEN, TOKEN_B] },
+        { tokenAddresses: [TOKEN, TOKEN_B], account: OWNER },
         { enabled: 0 as unknown as boolean },
       ),
     );

--- a/packages/react-sdk/src/balance/__tests__/use-confidential-balances.test.tsx
+++ b/packages/react-sdk/src/balance/__tests__/use-confidential-balances.test.tsx
@@ -23,7 +23,7 @@ describe("useConfidentialBalances", () => {
     });
 
     const { result } = renderWithProviders(() =>
-      useConfidentialBalances({ tokenAddresses: [TOKEN, TOKEN_B] }),
+      useConfidentialBalances({ tokenAddresses: [TOKEN, TOKEN_B], account: USER }),
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
@@ -50,7 +50,7 @@ describe("useConfidentialBalances", () => {
     vi.mocked(relayer.userDecrypt).mockResolvedValue({ [handle]: 33n });
 
     const { result } = renderWithProviders(() =>
-      useConfidentialBalances({ tokenAddresses: [mixedCaseToken] }),
+      useConfidentialBalances({ tokenAddresses: [mixedCaseToken], account: USER }),
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
@@ -58,19 +58,38 @@ describe("useConfidentialBalances", () => {
     expect(result.current.data?.results.get(mixedCaseToken)).toBe(33n);
   });
 
-  test("behavior: disabled when user passes enabled=false", async ({
-    renderWithProviders,
-    signer,
-    provider,
-  }) => {
+  test("behavior: disabled when user passes enabled=false", ({ renderWithProviders, provider }) => {
     const { result } = renderWithProviders(() =>
-      useConfidentialBalances({ tokenAddresses: [TOKEN, TOKEN_B] }, { enabled: false }),
+      useConfidentialBalances(
+        { tokenAddresses: [TOKEN, TOKEN_B], account: USER },
+        { enabled: false },
+      ),
     );
 
-    await waitFor(() => expect(signer.getAddress).toHaveBeenCalled(), { timeout: 5_000 });
     expect(result.current.isPending).toBe(true);
     expect(result.current.fetchStatus).toBe("idle");
     expect(provider.readContract).not.toHaveBeenCalled();
+  });
+
+  test("behavior: uses the caller-supplied account even when it differs from the connected signer", async ({
+    renderWithProviders,
+    relayer,
+    provider,
+  }) => {
+    const handle = `0x${"ef".repeat(32)}`;
+    vi.mocked(provider.readContract).mockResolvedValue(handle);
+    vi.mocked(relayer.userDecrypt).mockResolvedValue({ [handle]: 77n });
+
+    const OTHER = "0x9C9c9c9c9c9c9C9c9c9C9C9c9c9C9c9c9c9c9C9c" as Address;
+    const { result } = renderWithProviders(() =>
+      useConfidentialBalances({ tokenAddresses: [TOKEN], account: OTHER }),
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
+    expect(result.current.data?.results.get(TOKEN)).toBe(77n);
+    expect(provider.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: "confidentialBalanceOf", args: [OTHER] }),
+    );
   });
 
   describe("lifecycle", () => {
@@ -93,7 +112,7 @@ describe("useConfidentialBalances", () => {
 
       const tokens = [TOKEN, TOKEN_B];
       const { result } = renderWithProviders(() =>
-        useConfidentialBalances({ tokenAddresses: tokens }),
+        useConfidentialBalances({ tokenAddresses: tokens, account: USER }),
       );
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
@@ -134,66 +153,33 @@ describe("useConfidentialBalances", () => {
     });
 
     test("behavior: disabled when tokenAddresses empty", ({ renderWithProviders }) => {
-      const { result } = renderWithProviders(() => useConfidentialBalances({ tokenAddresses: [] }));
-
-      expect(result.current.isPending).toBe(true);
-      expect(result.current.fetchStatus).toBe("idle");
-    });
-
-    test("behavior: query stays disabled when signer.getAddress rejects", async ({
-      renderWithProviders,
-      signer,
-    }) => {
-      // When signer.getAddress() rejects, ZamaProvider swallows the error in
-      // its useEffect and signerAddress stays undefined.  The balances query is
-      // gated on signerAddress !== undefined, so it must remain pending/idle
-      // rather than entering an error state.
-      vi.mocked(signer.getAddress).mockRejectedValue(new Error("disconnected"));
-
       const { result } = renderWithProviders(() =>
-        useConfidentialBalances({ tokenAddresses: [TOKEN] }),
+        useConfidentialBalances({ tokenAddresses: [], account: USER }),
       );
 
-      // Give React time to run the effect
-      await waitFor(() => expect(signer.getAddress).toHaveBeenCalled());
-
       expect(result.current.isPending).toBe(true);
       expect(result.current.fetchStatus).toBe("idle");
-      expect(result.current.data).toBeUndefined();
     });
 
-    test("behavior: signer undefined -> defined", async ({
+    test("behavior: disabled when account is undefined (signer-less mount)", ({
       renderWithProviders,
-      signer,
-      relayer,
       provider,
     }) => {
-      const handle = `0x${"cc".repeat(32)}`;
-      let resolveAddress: (value: Address) => void;
-      const addressPromise = new Promise<Address>((resolve) => {
-        resolveAddress = resolve;
-      });
-
-      vi.mocked(signer.getAddress).mockReturnValue(addressPromise);
-      vi.mocked(provider.readContract).mockResolvedValue(handle);
-      vi.mocked(relayer.userDecrypt).mockResolvedValue({ [handle]: 456n });
-
-      const { result, rerender } = renderWithProviders(() =>
-        useConfidentialBalances({ tokenAddresses: [TOKEN] }),
+      const { result } = renderWithProviders(() =>
+        useConfidentialBalances({ tokenAddresses: [TOKEN], account: undefined }),
       );
 
       expect(result.current.isPending).toBe(true);
-
-      resolveAddress!(USER);
-      rerender();
-
-      await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
-      expect(result.current.data?.results.get(TOKEN)).toBe(456n);
+      expect(result.current.fetchStatus).toBe("idle");
+      expect(provider.readContract).not.toHaveBeenCalled();
     });
 
-    test("behavior: disabled when user passes enabled=false", async ({ renderWithProviders }) => {
+    test("behavior: disabled when user passes enabled=false", ({ renderWithProviders }) => {
       const { result } = renderWithProviders(() =>
-        useConfidentialBalances({ tokenAddresses: [TOKEN, TOKEN_B] }, { enabled: false }),
+        useConfidentialBalances(
+          { tokenAddresses: [TOKEN, TOKEN_B], account: USER },
+          { enabled: false },
+        ),
       );
 
       expect(result.current.isPending).toBe(true);

--- a/packages/react-sdk/src/balance/use-confidential-balance.ts
+++ b/packages/react-sdk/src/balance/use-confidential-balance.ts
@@ -5,37 +5,32 @@ import type { Address } from "@zama-fhe/sdk";
 import { confidentialBalanceQueryOptions } from "@zama-fhe/sdk/query";
 import { useReadonlyToken } from "../token/use-readonly-token";
 import { useQuery } from "../utils/query";
-import { useSignerAddress } from "../use-signer-address";
 
-/** Configuration for {@link useConfidentialBalance}. */
 export interface UseConfidentialBalanceConfig {
   /** Address of the confidential token contract. */
   tokenAddress: Address;
+  /** Account to fetch balance for. The query is disabled while `undefined`. */
+  account: Address | undefined;
 }
 
-/** Query options for {@link useConfidentialBalance}. */
 export interface UseConfidentialBalanceOptions extends Omit<
   UseQueryOptions<bigint>,
   "queryKey" | "queryFn" | "enabled"
 > {
-  /** Whether the query is enabled. Callback form is not supported in composite hooks. */
+  /** Set this to `false` to disable this query from automatically running. */
   enabled?: boolean;
 }
 
 /**
- * Declarative hook to read the connected wallet's confidential token balance.
- * Calls `token.balanceOf(owner)` which reads the on-chain handle and decrypts
- * via the SDK. Cached values are returned instantly — the relayer is only hit
- * when the handle changes.
- *
- * @param config - Token address configuration.
- * @param options - React Query options forwarded to the balance query.
- * @returns The balance query result.
+ * Hook for fetching a confidential token balance. Reads the on-chain handle and
+ * decrypts via the SDK; cached values are returned instantly and the relayer is
+ * only hit when the handle changes.
  *
  * @example
  * ```tsx
- * const { data: balance, isLoading } = useConfidentialBalance({
- *   tokenAddress: "0x...",
+ * const { data: balance } = useConfidentialBalance({
+ *   tokenAddress: "0xToken",
+ *   account: "0xAccount",
  * });
  * ```
  */
@@ -43,19 +38,18 @@ export function useConfidentialBalance(
   config: UseConfidentialBalanceConfig,
   options?: UseConfidentialBalanceOptions,
 ) {
-  const { tokenAddress } = config;
+  const { tokenAddress, account } = config;
   const { enabled = true } = options ?? {};
   const token = useReadonlyToken(tokenAddress);
-  const { data: owner } = useSignerAddress();
 
   const baseOptions = confidentialBalanceQueryOptions(token, {
     tokenAddress,
-    owner,
+    account,
   });
 
   return useQuery<bigint>({
     ...baseOptions,
     ...options,
-    enabled: Boolean(baseOptions.enabled) && enabled && owner !== undefined,
+    enabled: Boolean(baseOptions.enabled) && enabled,
   });
 }

--- a/packages/react-sdk/src/balance/use-confidential-balances.ts
+++ b/packages/react-sdk/src/balance/use-confidential-balances.ts
@@ -6,32 +6,26 @@ import type { UseQueryOptions } from "@tanstack/react-query";
 import type { Address, BatchBalancesResult } from "@zama-fhe/sdk";
 import { confidentialBalancesQueryOptions } from "@zama-fhe/sdk/query";
 import { useZamaSDK } from "../provider";
-import { useSignerAddress } from "../use-signer-address";
 
-/** Configuration for {@link useConfidentialBalances}. */
 export interface UseConfidentialBalancesConfig {
-  /** Addresses of the confidential token contracts to batch-query. */
+  /** Addresses of the confidential token contracts to batch-query. The query is disabled while empty. */
   tokenAddresses: Address[];
+  /** Account to fetch balances for. The query is disabled while `undefined`. */
+  account: Address | undefined;
 }
 
-/** Query options for {@link useConfidentialBalances}. */
 export interface UseConfidentialBalancesOptions extends Omit<
   UseQueryOptions<BatchBalancesResult>,
   "queryKey" | "queryFn" | "enabled"
 > {
-  /** Whether the query is enabled. Callback form is not supported in composite hooks. */
+  /** Set this to `false` to disable this query from automatically running. */
   enabled?: boolean;
 }
 
 /**
- * Declarative hook to read multiple confidential token balances in batch.
- * Calls `ReadonlyToken.batchBalancesOf()` which decrypts each token via the
- * SDK. Cached values are returned instantly — the relayer is only hit for
- * changed handles.
- *
- * Returns partial results when some tokens fail — successful balances are
- * always returned alongside per-token error information.
- *
+ * Hook for fetching multiple confidential token balances in batch. Returns
+ * partial results when some tokens fail — successful balances are available
+ * alongside per-token error information.
  * @param config - Token addresses configuration.
  * @param options - React Query options forwarded to the balance query.
  * @returns The balance query result.
@@ -40,6 +34,7 @@ export interface UseConfidentialBalancesOptions extends Omit<
  * ```tsx
  * const { data } = useConfidentialBalances({
  *   tokenAddresses: ["0xTokenA", "0xTokenB"],
+ *   account: "0xAccount",
  * });
  * const balance = data?.results.get("0xTokenA");
  * if (data && data.errors.size > 0) {
@@ -51,10 +46,9 @@ export function useConfidentialBalances(
   config: UseConfidentialBalancesConfig,
   options?: UseConfidentialBalancesOptions,
 ) {
-  const { tokenAddresses } = config;
+  const { tokenAddresses, account } = config;
   const { enabled = true } = options ?? {};
   const sdk = useZamaSDK();
-  const { data: owner } = useSignerAddress();
 
   const tokens = useMemo(
     () => tokenAddresses.map((addr) => sdk.createReadonlyToken(addr)),
@@ -62,12 +56,12 @@ export function useConfidentialBalances(
   );
 
   const baseOptions = confidentialBalancesQueryOptions(tokens, {
-    owner,
+    account,
   });
 
   return useQuery<BatchBalancesResult>({
     ...baseOptions,
     ...options,
-    enabled: Boolean(baseOptions.enabled) && enabled && owner !== undefined,
+    enabled: Boolean(baseOptions.enabled) && enabled,
   });
 }

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -69,6 +69,7 @@ export {
   useUnderlyingAllowance,
   useUnderlyingAllowanceSuspense,
   type UseUnderlyingAllowanceConfig,
+  type UseUnderlyingAllowanceSuspenseConfig,
 } from "./shield/use-underlying-allowance";
 export {
   useWrapperDiscovery,

--- a/packages/react-sdk/src/shield/__tests__/use-underlying-allowance.test.tsx
+++ b/packages/react-sdk/src/shield/__tests__/use-underlying-allowance.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, test, vi } from "../../test-fixtures";
 import { waitFor } from "@testing-library/react";
 import type { Address } from "@zama-fhe/sdk";
-import { useUnderlyingAllowance } from "../use-underlying-allowance";
+import {
+  useUnderlyingAllowance,
+  useUnderlyingAllowanceSuspense,
+} from "../use-underlying-allowance";
 import { TOKEN, WRAPPER, USER } from "../../__tests__/mutation-test-helpers";
 
 describe("useUnderlyingAllowance", () => {
@@ -11,7 +14,7 @@ describe("useUnderlyingAllowance", () => {
     vi.mocked(provider.readContract).mockResolvedValueOnce(UNDERLYING).mockResolvedValueOnce(1000n);
 
     const { result } = renderWithProviders(() =>
-      useUnderlyingAllowance({ tokenAddress: TOKEN, wrapperAddress: WRAPPER }),
+      useUnderlyingAllowance({ tokenAddress: TOKEN, wrapperAddress: WRAPPER, owner: USER }),
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -24,40 +27,74 @@ describe("useUnderlyingAllowance", () => {
     );
   });
 
-  test("behavior: signer undefined -> defined", async ({
+  test("behavior: queries allowance for the caller-supplied owner, not the connected signer", async ({
     renderWithProviders,
-    signer,
     provider,
   }) => {
-    let resolveAddress: (value: Address) => void;
-    const addressPromise = new Promise<Address>((resolve) => {
-      resolveAddress = resolve;
-    });
-    vi.mocked(signer.getAddress).mockReturnValue(addressPromise);
-    vi.mocked(provider.readContract).mockResolvedValueOnce(UNDERLYING).mockResolvedValueOnce(1000n);
+    vi.mocked(provider.readContract).mockResolvedValueOnce(UNDERLYING).mockResolvedValueOnce(2000n);
 
-    const { result, rerender } = renderWithProviders(() =>
-      useUnderlyingAllowance({ tokenAddress: TOKEN, wrapperAddress: WRAPPER }),
+    const OTHER = "0x9C9c9c9c9c9c9C9c9c9C9C9c9c9C9c9c9c9c9C9c" as Address;
+    const { result } = renderWithProviders(() =>
+      useUnderlyingAllowance({ tokenAddress: TOKEN, wrapperAddress: WRAPPER, owner: OTHER }),
     );
 
-    expect(result.current.isPending).toBe(true);
-    expect(result.current.fetchStatus).toBe("idle");
-
-    resolveAddress!(USER);
-    rerender();
-
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toBe(1000n);
+    expect(result.current.data).toBe(2000n);
+    expect(provider.readContract).toHaveBeenLastCalledWith(
+      expect.objectContaining({ functionName: "allowance", args: [OTHER, WRAPPER] }),
+    );
   });
 
   test("behavior: disabled when user passes enabled=false", ({ renderWithProviders, provider }) => {
     vi.mocked(provider.readContract).mockResolvedValueOnce(UNDERLYING).mockResolvedValueOnce(1000n);
 
     const { result } = renderWithProviders(() =>
-      useUnderlyingAllowance({ tokenAddress: TOKEN, wrapperAddress: WRAPPER }, { enabled: false }),
+      useUnderlyingAllowance(
+        { tokenAddress: TOKEN, wrapperAddress: WRAPPER, owner: USER },
+        { enabled: false },
+      ),
     );
 
     expect(result.current.isPending).toBe(true);
     expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  test("behavior: disabled when owner is undefined (signer-less mount)", ({
+    renderWithProviders,
+    provider,
+  }) => {
+    const { result } = renderWithProviders(() =>
+      useUnderlyingAllowance({ tokenAddress: TOKEN, wrapperAddress: WRAPPER, owner: undefined }),
+    );
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(provider.readContract).not.toHaveBeenCalled();
+  });
+});
+
+describe("useUnderlyingAllowanceSuspense", () => {
+  const UNDERLYING = "0x5e5E5e5e5E5e5E5E5e5E5E5e5e5E5E5E5e5E5E5e";
+
+  test("reads allowance for the caller-supplied owner", async ({
+    renderWithProviders,
+    provider,
+  }) => {
+    vi.mocked(provider.readContract).mockResolvedValueOnce(UNDERLYING).mockResolvedValueOnce(500n);
+
+    const OTHER = "0x9C9c9c9c9c9c9C9c9c9C9C9c9c9C9c9c9c9c9C9c" as Address;
+    const { result } = renderWithProviders(() =>
+      useUnderlyingAllowanceSuspense({
+        tokenAddress: TOKEN,
+        wrapperAddress: WRAPPER,
+        owner: OTHER,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(500n);
+    expect(provider.readContract).toHaveBeenLastCalledWith(
+      expect.objectContaining({ functionName: "allowance", args: [OTHER, WRAPPER] }),
+    );
   });
 });

--- a/packages/react-sdk/src/shield/use-underlying-allowance.ts
+++ b/packages/react-sdk/src/shield/use-underlying-allowance.ts
@@ -5,31 +5,37 @@ import type { UseQueryOptions } from "@tanstack/react-query";
 import type { Address } from "@zama-fhe/sdk";
 import { underlyingAllowanceQueryOptions } from "@zama-fhe/sdk/query";
 import { useZamaSDK } from "../provider";
-import { useSignerAddress, useSignerAddressSuspense } from "../use-signer-address";
 
 export { underlyingAllowanceQueryOptions };
 
-/** Configuration for {@link useUnderlyingAllowance}. */
 export interface UseUnderlyingAllowanceConfig {
   /** Address of the confidential token contract used to scope the query cache. */
   tokenAddress: Address;
   /** Address of the wrapper contract whose underlying ERC-20 allowance is checked. */
   wrapperAddress: Address;
+  /** Owner to fetch allowance for. The query is disabled while `undefined`. */
+  owner: Address | undefined;
+}
+
+export interface UseUnderlyingAllowanceSuspenseConfig {
+  /** Address of the confidential token contract used to scope the query cache. */
+  tokenAddress: Address;
+  /** Address of the wrapper contract whose underlying ERC-20 allowance is checked. */
+  wrapperAddress: Address;
+  /** Owner to fetch allowance for. */
+  owner: Address;
 }
 
 /**
- * Read the underlying ERC-20 allowance granted to the wrapper contract.
- * Useful to check if an approval is needed before shielding.
- *
- * @param config - Token and wrapper addresses.
- * @param options - React Query options (forwarded to `useQuery`).
- * @returns Query result with `data: bigint` (current allowance).
+ * Hook for fetching the underlying ERC-20 allowance granted to the wrapper
+ * contract. Useful to check if an approval is needed before shielding.
  *
  * @example
  * ```tsx
  * const { data: allowance } = useUnderlyingAllowance({
  *   tokenAddress: "0xConfidentialToken",
  *   wrapperAddress: "0xWrapper",
+ *   owner: "0xOwner",
  * });
  * ```
  */
@@ -37,9 +43,8 @@ export function useUnderlyingAllowance(
   config: UseUnderlyingAllowanceConfig,
   options?: Omit<UseQueryOptions<bigint>, "queryKey" | "queryFn">,
 ) {
-  const { tokenAddress, wrapperAddress } = config;
+  const { tokenAddress, wrapperAddress, owner } = config;
   const sdk = useZamaSDK();
-  const { data: owner } = useSignerAddress();
 
   const baseOpts = underlyingAllowanceQueryOptions(sdk, tokenAddress, {
     owner,
@@ -54,24 +59,21 @@ export function useUnderlyingAllowance(
 }
 
 /**
- * Suspense variant of {@link useUnderlyingAllowance}.
- * Suspends rendering until the allowance is loaded.
- *
- * @param config - Token and wrapper addresses.
- * @returns Suspense query result with `data: bigint`.
+ * Suspense variant of {@link useUnderlyingAllowance}. Suspends rendering until
+ * the allowance resolves.
  *
  * @example
  * ```tsx
  * const { data: allowance } = useUnderlyingAllowanceSuspense({
  *   tokenAddress: "0xConfidentialToken",
  *   wrapperAddress: "0xWrapper",
+ *   owner: "0xOwner",
  * });
  * ```
  */
-export function useUnderlyingAllowanceSuspense(config: UseUnderlyingAllowanceConfig) {
-  const { tokenAddress, wrapperAddress } = config;
+export function useUnderlyingAllowanceSuspense(config: UseUnderlyingAllowanceSuspenseConfig) {
+  const { tokenAddress, wrapperAddress, owner } = config;
   const sdk = useZamaSDK();
-  const { data: owner } = useSignerAddressSuspense();
 
   return useSuspenseQuery<bigint>(
     underlyingAllowanceQueryOptions(sdk, tokenAddress, {

--- a/packages/react-sdk/src/transfer/__tests__/use-confidential-is-approved.test.tsx
+++ b/packages/react-sdk/src/transfer/__tests__/use-confidential-is-approved.test.tsx
@@ -7,10 +7,12 @@ import {
 } from "../use-confidential-is-approved";
 import { TOKEN, SPENDER } from "../../__tests__/mutation-test-helpers";
 
+const HOLDER = "0x4D4d4D4d4d4D4D4d4D4D4D4d4d4d4d4D4D4d4d4D" as Address;
+
 describe("useConfidentialIsApproved", () => {
   test("behavior: disabled when tokenAddress is undefined", ({ renderWithProviders }) => {
     const { result } = renderWithProviders(() =>
-      useConfidentialIsApproved({ tokenAddress: undefined, spender: SPENDER }),
+      useConfidentialIsApproved({ tokenAddress: undefined, spender: SPENDER, holder: HOLDER }),
     );
 
     expect(result.current.isPending).toBe(true);
@@ -20,7 +22,7 @@ describe("useConfidentialIsApproved", () => {
 
   test("behavior: disabled when spender is undefined", ({ renderWithProviders }) => {
     const { result } = renderWithProviders(() =>
-      useConfidentialIsApproved({ tokenAddress: TOKEN, spender: undefined }),
+      useConfidentialIsApproved({ tokenAddress: TOKEN, spender: undefined, holder: HOLDER }),
     );
 
     expect(result.current.isPending).toBe(true);
@@ -28,12 +30,25 @@ describe("useConfidentialIsApproved", () => {
     expect(result.current.data).toBeUndefined();
   });
 
+  test("behavior: disabled when holder is undefined (signer-less mount)", ({
+    renderWithProviders,
+    provider,
+  }) => {
+    const { result } = renderWithProviders(() =>
+      useConfidentialIsApproved({ tokenAddress: TOKEN, spender: SPENDER, holder: undefined }),
+    );
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(provider.readContract).not.toHaveBeenCalled();
+  });
+
   test("behavior: spender undefined -> defined", async ({ createWrapper, signer, provider }) => {
     vi.mocked(provider.readContract).mockResolvedValue(true);
 
     const ctx = createWrapper({ signer });
     const { result, rerender } = renderHook(
-      ({ spender }) => useConfidentialIsApproved({ tokenAddress: TOKEN, spender }),
+      ({ spender }) => useConfidentialIsApproved({ tokenAddress: TOKEN, spender, holder: HOLDER }),
       {
         wrapper: ctx.Wrapper,
         initialProps: { spender: undefined as Address | undefined },
@@ -58,7 +73,8 @@ describe("useConfidentialIsApproved", () => {
 
     const ctx = createWrapper({ signer });
     const { result, rerender } = renderHook(
-      ({ tokenAddress }) => useConfidentialIsApproved({ tokenAddress, spender: SPENDER }),
+      ({ tokenAddress }) =>
+        useConfidentialIsApproved({ tokenAddress, spender: SPENDER, holder: HOLDER }),
       {
         wrapper: ctx.Wrapper,
         initialProps: { tokenAddress: undefined as Address | undefined },
@@ -82,6 +98,7 @@ describe("useConfidentialIsApproved", () => {
         {
           tokenAddress: TOKEN,
           spender: SPENDER,
+          holder: HOLDER,
         },
         { enabled: false },
       ),
@@ -98,6 +115,7 @@ describe("useConfidentialIsApproved", () => {
       useConfidentialIsApproved({
         tokenAddress: TOKEN,
         spender: SPENDER,
+        holder: HOLDER,
       }),
     );
 
@@ -111,7 +129,7 @@ describe("useConfidentialIsApproved", () => {
     );
   });
 
-  test("skips signer resolution when holder is provided", async ({
+  test("uses caller-supplied holder verbatim — never resolves signer address", async ({
     renderWithProviders,
     signer,
     provider,
@@ -119,14 +137,11 @@ describe("useConfidentialIsApproved", () => {
     vi.mocked(provider.readContract).mockResolvedValue(true);
     const getAddressSpy = vi.mocked(signer.getAddress);
 
-    // Record the call count before rendering; the SDK itself may call
-    // getAddress from internal lifecycle handlers, but the hook must not
-    // trigger an additional useSignerAddress query when holder is provided.
     const { result } = renderWithProviders(() =>
       useConfidentialIsApproved({
         tokenAddress: TOKEN,
         spender: SPENDER,
-        holder: "0x4D4d4D4d4d4D4D4d4D4D4D4d4d4d4d4D4D4d4d4D",
+        holder: HOLDER,
       }),
     );
 
@@ -135,24 +150,25 @@ describe("useConfidentialIsApproved", () => {
     expect(provider.readContract).toHaveBeenCalledWith(
       expect.objectContaining({
         functionName: "isOperator",
-        args: ["0x4D4d4D4d4d4D4D4d4D4D4D4d4d4d4d4D4D4d4d4D", SPENDER],
+        args: [HOLDER, SPENDER],
       }),
     );
-    // When holder is supplied, the hook never queries the signer address.
-    // At most the SDK's internal identity bootstrap runs once.
+    // Hook must not trigger a signer-address query. SDK lifecycle code may
+    // still call signer.getAddress for its own identity bootstrap, so allow
+    // at most one call.
     expect(getAddressSpy.mock.calls.length).toBeLessThanOrEqual(1);
   });
 });
 
 describe("useConfidentialIsApprovedSuspense", () => {
-  test("uses explicit holder address when provided", async ({ renderWithProviders, provider }) => {
+  test("uses the caller-supplied holder address", async ({ renderWithProviders, provider }) => {
     vi.mocked(provider.readContract).mockResolvedValue(true);
 
     const { result } = renderWithProviders(() =>
       useConfidentialIsApprovedSuspense({
         tokenAddress: TOKEN,
         spender: SPENDER,
-        holder: "0x4D4d4D4d4d4D4D4d4D4D4D4d4d4d4d4D4D4d4d4D",
+        holder: HOLDER,
       }),
     );
 
@@ -161,33 +177,32 @@ describe("useConfidentialIsApprovedSuspense", () => {
     expect(provider.readContract).toHaveBeenCalledWith(
       expect.objectContaining({
         functionName: "isOperator",
-        args: ["0x4D4d4D4d4d4D4D4d4D4D4D4d4d4d4d4D4D4d4d4D", SPENDER],
+        args: [HOLDER, SPENDER],
       }),
     );
   });
 
-  test("falls back to connected signer address when holder is omitted", async ({
+  test("queries the caller-supplied holder verbatim, independent of the connected signer", async ({
     renderWithProviders,
-    signer,
     provider,
-    userAddress,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(true);
 
+    const OTHER = "0x9C9c9c9c9c9c9C9c9c9C9C9c9c9C9c9c9c9c9C9c" as Address;
     const { result } = renderWithProviders(() =>
       useConfidentialIsApprovedSuspense({
         tokenAddress: TOKEN,
         spender: SPENDER,
+        holder: OTHER,
       }),
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(signer.getAddress).toHaveBeenCalled();
+    expect(result.current.data).toBe(true);
     expect(provider.readContract).toHaveBeenCalledWith(
       expect.objectContaining({
         functionName: "isOperator",
-        args: [userAddress, SPENDER],
+        args: [OTHER, SPENDER],
       }),
     );
   });

--- a/packages/react-sdk/src/transfer/__tests__/use-confidential-transfer.test.tsx
+++ b/packages/react-sdk/src/transfer/__tests__/use-confidential-transfer.test.tsx
@@ -256,7 +256,7 @@ describe("useConfidentialTransfer", () => {
     const { Wrapper } = createWrapper({ signer, relayer });
     const { result } = renderHook(
       () => ({
-        balance: useConfidentialBalance({ tokenAddress: TOKEN }),
+        balance: useConfidentialBalance({ tokenAddress: TOKEN, account: USER }),
         transfer: useConfidentialTransfer({ tokenAddress: TOKEN }),
       }),
       { wrapper: Wrapper },

--- a/packages/react-sdk/src/transfer/use-confidential-is-approved.ts
+++ b/packages/react-sdk/src/transfer/use-confidential-is-approved.ts
@@ -3,34 +3,31 @@
 import { useQuery, useSuspenseQuery } from "../utils/query";
 import type { UseQueryOptions } from "@tanstack/react-query";
 import type { Address } from "@zama-fhe/sdk";
-import { confidentialIsApprovedQueryOptions, signerAddressQueryOptions } from "@zama-fhe/sdk/query";
+import { confidentialIsApprovedQueryOptions } from "@zama-fhe/sdk/query";
 import { useZamaSDK } from "../provider";
-import type { UseZamaConfig } from "../token/use-token";
-import { useSignerAddressSuspense } from "../use-signer-address";
 
 export { confidentialIsApprovedQueryOptions };
 
-/** Configuration for {@link useConfidentialIsApproved}. */
 export interface UseConfidentialIsApprovedConfig {
-  /** Address of the confidential token contract. Pass `undefined` to disable the query. */
+  /** Address of the confidential token contract. The query is disabled while `undefined`. */
   tokenAddress: Address | undefined;
-  /** Address to check approval for. Pass `undefined` to disable the query. */
+  /** Address to check approval for. The query is disabled while `undefined`. */
   spender: Address | undefined;
-  /** Token holder address. Defaults to the connected wallet. */
-  holder?: Address;
+  /** Token holder address. The query is disabled while `undefined`. */
+  holder: Address | undefined;
 }
 
-/** Configuration for {@link useConfidentialIsApprovedSuspense}. */
-export interface UseConfidentialIsApprovedSuspenseConfig extends UseZamaConfig {
+export interface UseConfidentialIsApprovedSuspenseConfig {
+  /** Address of the confidential token contract. */
+  tokenAddress: Address;
   /** Address to check approval for. */
   spender: Address;
-  /** Token holder address. Defaults to the connected signer address. */
-  holder?: Address;
+  /** Token holder address. */
+  holder: Address;
 }
 
 /**
- * Check if a spender is an approved operator for a given holder (defaults to connected wallet).
- *
+ * Check if a spender is an approved operator for a holder.
  * @param config - Token address, spender, and optional holder to check.
  * @param options - React Query options (forwarded to `useQuery`).
  * @returns Query result with `data: boolean`.
@@ -40,7 +37,7 @@ export interface UseConfidentialIsApprovedSuspenseConfig extends UseZamaConfig {
  * const { data: isApproved } = useConfidentialIsApproved({
  *   tokenAddress: "0xToken",
  *   spender: "0xSpender",
- *   holder: "0xHolder", // optional, defaults to connected wallet
+ *   holder: "0xHolder",
  * });
  * ```
  */
@@ -50,15 +47,8 @@ export function useConfidentialIsApproved(
 ) {
   const { tokenAddress, spender, holder } = config;
   const sdk = useZamaSDK();
-  // Skip signer-address resolution entirely when an explicit holder is supplied —
-  // callers passing `holder` must never incur signer.getAddress() failures/retries.
-  const signerAddressQuery = useQuery<Address>({
-    ...signerAddressQueryOptions(sdk.signer),
-    enabled: holder === undefined,
-  });
-  const resolvedHolder = holder ?? signerAddressQuery.data;
   const baseOpts = confidentialIsApprovedQueryOptions(sdk, tokenAddress, {
-    holder: resolvedHolder,
+    holder,
     spender,
   });
 
@@ -70,20 +60,11 @@ export function useConfidentialIsApproved(
 }
 
 /**
- * Suspense variant of {@link useConfidentialIsApproved}.
- * Suspends rendering until the approval check resolves.
- * When `holder` is omitted, the connected signer address is resolved via a
- * suspending query (mirrors the non-suspense hook's implicit fallback).
+ * Suspense variant of {@link useConfidentialIsApproved}. Suspends rendering
+ * until the approval check resolves.
  *
  * @example
  * ```tsx
- * // Implicit holder (connected signer)
- * const { data: isApproved } = useConfidentialIsApprovedSuspense({
- *   tokenAddress: "0xToken",
- *   spender: "0xSpender",
- * });
- *
- * // Explicit holder
  * const { data: isApproved } = useConfidentialIsApprovedSuspense({
  *   tokenAddress: "0xToken",
  *   spender: "0xSpender",
@@ -94,12 +75,10 @@ export function useConfidentialIsApproved(
 export function useConfidentialIsApprovedSuspense(config: UseConfidentialIsApprovedSuspenseConfig) {
   const { spender, holder, tokenAddress } = config;
   const sdk = useZamaSDK();
-  const { data: signerAddress } = useSignerAddressSuspense();
-  const resolvedHolder = holder ?? signerAddress;
 
   return useSuspenseQuery<boolean>(
     confidentialIsApprovedQueryOptions(sdk, tokenAddress, {
-      holder: resolvedHolder,
+      holder,
       spender,
     }),
   );

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -101,7 +101,7 @@ export interface ConfidentialApproveParams {
 // @public (undocumented)
 export interface ConfidentialBalanceQueryConfig {
     // (undocumented)
-    owner?: Address;
+    account?: Address;
     // (undocumented)
     query?: Record<string, unknown>;
     // (undocumented)
@@ -114,7 +114,7 @@ export function confidentialBalanceQueryOptions(token: ReadonlyToken, config: Co
 // @public (undocumented)
 export interface ConfidentialBalancesQueryConfig {
     // (undocumented)
-    owner?: Address;
+    account?: Address;
     // (undocumented)
     query?: Record<string, unknown>;
 }

--- a/packages/sdk/src/query/__tests__/confidential-balance.test.ts
+++ b/packages/sdk/src/query/__tests__/confidential-balance.test.ts
@@ -10,23 +10,31 @@ describe("confidentialBalanceQueryOptions", () => {
     const token = createMockReadonlyToken(tokenAddress);
     const options = confidentialBalanceQueryOptions(token, {
       tokenAddress,
-      owner,
+      account: owner,
     });
 
     expect(options.queryKey).toEqual(["zama.confidentialBalance", { tokenAddress, owner }]);
   });
 
-  test("enabled defaults to true", ({ createMockReadonlyToken }) => {
+  test("enabled is true when owner is provided", ({ createMockReadonlyToken }) => {
+    const token = createMockReadonlyToken(tokenAddress);
+    const options = confidentialBalanceQueryOptions(token, { tokenAddress, account: owner });
+
+    expect(options.enabled).toBe(true);
+  });
+
+  test("enabled is false when owner is undefined", ({ createMockReadonlyToken }) => {
     const token = createMockReadonlyToken(tokenAddress);
     const options = confidentialBalanceQueryOptions(token, { tokenAddress });
 
-    expect(options.enabled).toBe(true);
+    expect(options.enabled).toBe(false);
   });
 
   test("enabled is false when query.enabled is false", ({ createMockReadonlyToken }) => {
     const token = createMockReadonlyToken(tokenAddress);
     const options = confidentialBalanceQueryOptions(token, {
       tokenAddress,
+      account: owner,
       query: { enabled: false },
     });
 
@@ -41,7 +49,7 @@ describe("confidentialBalanceQueryOptions", () => {
 
     const options = confidentialBalanceQueryOptions(token, {
       tokenAddress,
-      owner,
+      account: owner,
     });
 
     const value = await options.queryFn(mockQueryContext(options.queryKey));

--- a/packages/sdk/src/query/__tests__/confidential-balances.test.ts
+++ b/packages/sdk/src/query/__tests__/confidential-balances.test.ts
@@ -14,7 +14,7 @@ describe("confidentialBalancesQueryOptions", () => {
   }) => {
     const t1 = createMockReadonlyToken(tokenA);
     const t2 = createMockReadonlyToken(tokenB);
-    const options = confidentialBalancesQueryOptions([t1, t2], { owner });
+    const options = confidentialBalancesQueryOptions([t1, t2], { account: owner });
 
     expect(options.queryKey).toEqual([
       "zama.confidentialBalances",
@@ -22,15 +22,22 @@ describe("confidentialBalancesQueryOptions", () => {
     ]);
   });
 
-  test("enabled defaults to true when tokens are provided", ({ createMockReadonlyToken }) => {
+  test("enabled is true when tokens and owner are provided", ({ createMockReadonlyToken }) => {
     const t1 = createMockReadonlyToken(tokenA);
-    const options = confidentialBalancesQueryOptions([t1]);
+    const options = confidentialBalancesQueryOptions([t1], { account: owner });
 
     expect(options.enabled).toBe(true);
   });
 
+  test("enabled is false when owner is undefined", ({ createMockReadonlyToken }) => {
+    const t1 = createMockReadonlyToken(tokenA);
+    const options = confidentialBalancesQueryOptions([t1]);
+
+    expect(options.enabled).toBe(false);
+  });
+
   test("enabled is false when the token list is empty", () => {
-    const options = confidentialBalancesQueryOptions([]);
+    const options = confidentialBalancesQueryOptions([], { account: owner });
 
     expect(options.enabled).toBe(false);
   });
@@ -38,6 +45,7 @@ describe("confidentialBalancesQueryOptions", () => {
   test("enabled is false when query.enabled is false", ({ createMockReadonlyToken }) => {
     const t1 = createMockReadonlyToken(tokenA);
     const options = confidentialBalancesQueryOptions([t1], {
+      account: owner,
       query: { enabled: false },
     });
 
@@ -58,7 +66,7 @@ describe("confidentialBalancesQueryOptions", () => {
     };
     const spy = vi.spyOn(ReadonlyToken, "batchBalancesOf").mockResolvedValue(mockResult);
 
-    const options = confidentialBalancesQueryOptions([t1, t2], { owner });
+    const options = confidentialBalancesQueryOptions([t1, t2], { account: owner });
 
     const query = await options.queryFn(mockQueryContext(options.queryKey));
 
@@ -77,7 +85,7 @@ describe("confidentialBalancesQueryOptions", () => {
       new DecryptionFailedError("all failed"),
     );
 
-    const options = confidentialBalancesQueryOptions([t1], { owner });
+    const options = confidentialBalancesQueryOptions([t1], { account: owner });
 
     await expect(options.queryFn(mockQueryContext(options.queryKey))).rejects.toThrow(
       DecryptionFailedError,

--- a/packages/sdk/src/query/confidential-balance.ts
+++ b/packages/sdk/src/query/confidential-balance.ts
@@ -6,18 +6,11 @@ import { filterQueryOptions } from "./utils";
 
 export interface ConfidentialBalanceQueryConfig {
   tokenAddress: Address;
-  owner?: Address;
+  account?: Address;
   query?: Record<string, unknown>;
 }
 
-/**
- * Query options for a single confidential token balance.
- *
- * **Owner gating:** this factory does not gate on `owner !== undefined` because
- * it is also used outside React with an explicit owner. React consumers should
- * apply the gate at the hook level (e.g. `enabled: ... && owner !== undefined`),
- * as {@link useConfidentialBalance} does.
- */
+/** Query options for a single confidential token balance. Auto-gated on `account`. */
 export function confidentialBalanceQueryOptions(
   token: ReadonlyToken,
   config: ConfidentialBalanceQueryConfig,
@@ -31,11 +24,11 @@ export function confidentialBalanceQueryOptions(
 
   return {
     ...filterQueryOptions(queryOpts),
-    queryKey: zamaQueryKeys.confidentialBalance.owner(config.tokenAddress, config.owner),
+    queryKey: zamaQueryKeys.confidentialBalance.owner(config.tokenAddress, config.account),
     queryFn: async (context) => {
       const [, { owner: keyOwner }] = context.queryKey;
       return token.balanceOf(keyOwner);
     },
-    enabled: queryOpts?.enabled !== false,
+    enabled: Boolean(config.account) && queryOpts?.enabled !== false,
   };
 }

--- a/packages/sdk/src/query/confidential-balances.ts
+++ b/packages/sdk/src/query/confidential-balances.ts
@@ -5,7 +5,7 @@ import { zamaQueryKeys } from "./query-keys";
 import { filterQueryOptions } from "./utils";
 
 export interface ConfidentialBalancesQueryConfig {
-  owner?: Address;
+  account?: Address;
   query?: Record<string, unknown>;
 }
 
@@ -18,17 +18,17 @@ export function confidentialBalancesQueryOptions(
   BatchBalancesResult,
   ReturnType<typeof zamaQueryKeys.confidentialBalances.tokens>
 > {
-  const ownerKey = config?.owner;
+  const accountKey = config?.account;
   const queryOpts = config?.query ?? {};
   const tokenAddresses = tokens.map((token) => token.address);
 
   return {
     ...filterQueryOptions(queryOpts),
-    queryKey: zamaQueryKeys.confidentialBalances.tokens(tokenAddresses, ownerKey),
+    queryKey: zamaQueryKeys.confidentialBalances.tokens(tokenAddresses, accountKey),
     queryFn: async (context) => {
       const [, { owner: keyOwner }] = context.queryKey;
       return ReadonlyToken.batchBalancesOf(tokens, keyOwner);
     },
-    enabled: tokens.length > 0 && queryOpts?.enabled !== false,
+    enabled: Boolean(accountKey) && tokens.length > 0 && queryOpts?.enabled !== false,
   };
 }

--- a/test/test-components/src/approve-form.tsx
+++ b/test/test-components/src/approve-form.tsx
@@ -6,6 +6,7 @@ import {
   useMetadata,
 } from "@zama-fhe/react-sdk";
 import type { Address } from "@zama-fhe/sdk";
+import { useAccount } from "wagmi";
 
 export function ApproveForm({
   tokenAddress,
@@ -14,9 +15,14 @@ export function ApproveForm({
   tokenAddress: Address;
   defaultSpender?: Address;
 }) {
+  const { address } = useAccount();
   const { data: metadata } = useMetadata(tokenAddress);
   const approve = useConfidentialApprove({ tokenAddress });
-  const { data: isApproved } = useConfidentialIsApproved({ tokenAddress, spender: defaultSpender });
+  const { data: isApproved } = useConfidentialIsApproved({
+    tokenAddress,
+    spender: defaultSpender,
+    holder: address,
+  });
 
   return (
     <form

--- a/test/test-components/src/resume-unshield-form.tsx
+++ b/test/test-components/src/resume-unshield-form.tsx
@@ -8,6 +8,7 @@ import {
   useMetadata,
 } from "@zama-fhe/react-sdk";
 import type { Address } from "@zama-fhe/sdk";
+import { useAccount } from "wagmi";
 
 export function ResumeUnshieldForm({
   tokenAddress,
@@ -17,8 +18,9 @@ export function ResumeUnshieldForm({
   wrapperAddress?: Address;
 }) {
   const [unwrapTxHash, setUnwrapTxHash] = useState<string | null>(null);
+  const { address } = useAccount();
   const { data: metadata } = useMetadata(tokenAddress);
-  const { data: balance } = useConfidentialBalance({ tokenAddress });
+  const { data: balance } = useConfidentialBalance({ tokenAddress, account: address });
   const unwrap = useUnwrap({ tokenAddress, wrapperAddress });
   const resumeUnshield = useResumeUnshield({ tokenAddress, wrapperAddress });
 

--- a/test/test-components/src/shield-form.tsx
+++ b/test/test-components/src/shield-form.tsx
@@ -2,6 +2,7 @@
 
 import type { Address } from "@zama-fhe/sdk";
 import { useShield, useUnderlyingAllowance, useMetadata } from "@zama-fhe/react-sdk";
+import { useAccount } from "wagmi";
 
 export function ShieldForm({
   tokenAddress,
@@ -10,8 +11,13 @@ export function ShieldForm({
   tokenAddress: Address;
   wrapperAddress: Address;
 }) {
+  const { address } = useAccount();
   const { data: metadata } = useMetadata(tokenAddress);
-  const { data: allowance } = useUnderlyingAllowance({ tokenAddress, wrapperAddress });
+  const { data: allowance } = useUnderlyingAllowance({
+    tokenAddress,
+    wrapperAddress,
+    owner: address,
+  });
   const shield = useShield({ tokenAddress, wrapperAddress });
 
   return (

--- a/test/test-components/src/token-table.tsx
+++ b/test/test-components/src/token-table.tsx
@@ -5,7 +5,7 @@ import { balanceOfContract, decimalsContract, symbolContract } from "@zama-fhe/s
 import type { Address } from "@zama-fhe/sdk";
 import { useState } from "react";
 import { formatUnits } from "viem";
-import { useConnection, useReadContracts } from "wagmi";
+import { useAccount, useConnection, useReadContracts } from "wagmi";
 
 function TokenRow({
   address,
@@ -113,9 +113,11 @@ export function TokenTable({
   }>;
 }) {
   const [revealed, setRevealed] = useState(false);
+  const { address } = useAccount();
   const { mutate: allow } = useAllow();
   const { data, isFetching, isLoading } = useConfidentialBalances({
     tokenAddresses: revealed ? tokenAddresses : [],
+    account: address,
   });
 
   return (

--- a/test/test-components/src/transfer-form.tsx
+++ b/test/test-components/src/transfer-form.tsx
@@ -2,6 +2,7 @@
 
 import { useConfidentialTransfer, useConfidentialBalance, useMetadata } from "@zama-fhe/react-sdk";
 import type { Address } from "@zama-fhe/sdk";
+import { useAccount } from "wagmi";
 
 export function TransferForm({
   tokenAddress,
@@ -10,8 +11,9 @@ export function TransferForm({
   tokenAddress: Address;
   wrapperAddress?: Address;
 }) {
+  const { address } = useAccount();
   const { data: metadata } = useMetadata(tokenAddress);
-  const { data: balance } = useConfidentialBalance({ tokenAddress });
+  const { data: balance } = useConfidentialBalance({ tokenAddress, account: address });
   const transfer = useConfidentialTransfer({ tokenAddress, wrapperAddress });
 
   return (

--- a/test/test-components/src/transfer-from-form.tsx
+++ b/test/test-components/src/transfer-from-form.tsx
@@ -6,6 +6,7 @@ import {
   useMetadata,
 } from "@zama-fhe/react-sdk";
 import type { Address } from "@zama-fhe/sdk";
+import { useAccount } from "wagmi";
 
 export function TransferFromForm({
   tokenAddress,
@@ -16,8 +17,9 @@ export function TransferFromForm({
   defaultFrom?: Address;
   wrapperAddress?: Address;
 }) {
+  const { address } = useAccount();
   const { data: metadata } = useMetadata(tokenAddress);
-  const { data: balance } = useConfidentialBalance({ tokenAddress });
+  const { data: balance } = useConfidentialBalance({ tokenAddress, account: address });
   const transferFrom = useConfidentialTransferFrom({ tokenAddress, wrapperAddress });
 
   return (

--- a/test/test-components/src/unshield-all-form.tsx
+++ b/test/test-components/src/unshield-all-form.tsx
@@ -2,6 +2,7 @@
 
 import { useUnshieldAll, useConfidentialBalance, useMetadata } from "@zama-fhe/react-sdk";
 import type { Address } from "@zama-fhe/sdk";
+import { useAccount } from "wagmi";
 
 export function UnshieldAllForm({
   tokenAddress,
@@ -10,8 +11,9 @@ export function UnshieldAllForm({
   tokenAddress: Address;
   wrapperAddress?: Address;
 }) {
+  const { address } = useAccount();
   const { data: metadata } = useMetadata(tokenAddress);
-  const { data: balance } = useConfidentialBalance({ tokenAddress });
+  const { data: balance } = useConfidentialBalance({ tokenAddress, account: address });
   const unshieldAll = useUnshieldAll({ tokenAddress, wrapperAddress });
 
   return (

--- a/test/test-components/src/unshield-form.tsx
+++ b/test/test-components/src/unshield-form.tsx
@@ -2,6 +2,7 @@
 
 import { useUnshield, useConfidentialBalance, useMetadata } from "@zama-fhe/react-sdk";
 import type { Address } from "@zama-fhe/sdk";
+import { useAccount } from "wagmi";
 
 export function UnshieldForm({
   tokenAddress,
@@ -10,8 +11,9 @@ export function UnshieldForm({
   tokenAddress: Address;
   wrapperAddress?: Address;
 }) {
+  const { address } = useAccount();
   const { data: metadata } = useMetadata(tokenAddress);
-  const { data: balance } = useConfidentialBalance({ tokenAddress });
+  const { data: balance } = useConfidentialBalance({ tokenAddress, account: address });
   const unshield = useUnshield({ tokenAddress, wrapperAddress });
 
   return (

--- a/test/test-components/src/unwrap-manual-form.tsx
+++ b/test/test-components/src/unwrap-manual-form.tsx
@@ -8,6 +8,7 @@ import {
   useConfidentialBalance,
   useMetadata,
 } from "@zama-fhe/react-sdk";
+import { useAccount } from "wagmi";
 
 type FinalizeUnwrapInput =
   | { label: "Unwrap request ID"; params: { unwrapRequestId: Hex } }
@@ -21,8 +22,9 @@ export function UnwrapManualForm({
   wrapperAddress?: Address;
 }) {
   const [finalizeInput, setFinalizeInput] = useState<FinalizeUnwrapInput | null>(null);
+  const { address } = useAccount();
   const { data: metadata } = useMetadata(tokenAddress);
-  const { data: balance } = useConfidentialBalance({ tokenAddress });
+  const { data: balance } = useConfidentialBalance({ tokenAddress, account: address });
   const unwrap = useUnwrap({ tokenAddress, wrapperAddress });
   const finalizeUnwrap = useFinalizeUnwrap({ tokenAddress, wrapperAddress });
 


### PR DESCRIPTION
## Summary

Make the account identifier a caller-supplied parameter on read hooks instead of implicitly resolving it from the connected signer. This gives callers full control over which address is queried and eliminates hidden signer-address resolution, so that we can remove required signers for those queries.

## Changes

- `useConfidentialBalance` / `useConfidentialBalances`: add required `account` param
- `useConfidentialIsApproved` (+Suspense): add required `holder` param
- `useUnderlyingAllowance` (+Suspense): add required `owner` param
- Move auto-gating on `owner` into the Layer 2 query-options factories (`confidentialBalanceQueryOptions`, `confidentialBalancesQueryOptions`)
- Remove internal `useSignerAddress` calls from all affected hooks
- Non-suspense variants accept `Address | undefined` and auto-disable the query when unset (wagmi `useBalance` convention)
- Suspense variants require a defined value (no `enabled` on `useSuspenseQuery`)
- Update all test components to pass `useAccount().address` explicitly