### PR TITLE
feat(sdk): require explicit owner on token reads

### DIFF
--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -691,11 +691,11 @@ export class ReadonlyToken {
     readonly address: Address;
     allow(): Promise<void>;
     static allow(...tokens: ReadonlyToken[]): Promise<void>;
-    allowance(wrapper: Address, owner?: Address): Promise<bigint>;
-    balanceOf(owner?: Address): Promise<bigint>;
-    static batchBalancesOf(tokens: ReadonlyToken[], owner?: Address): Promise<BatchBalancesResult>;
+    allowance(wrapper: Address, owner: Address): Promise<bigint>;
+    balanceOf(owner: Address): Promise<bigint>;
+    static batchBalancesOf(tokens: ReadonlyToken[], owner: Address): Promise<BatchBalancesResult>;
     static batchDecryptBalancesAs(tokens: ReadonlyToken[], options: BatchDecryptAsOptions): Promise<Map<Address, bigint>>;
-    confidentialBalanceOf(owner?: Address): Promise<Handle>;
+    confidentialBalanceOf(owner: Address): Promise<Handle>;
     decimals(): Promise<number>;
     decryptBalanceAs(input: {
         delegatorAddress: Address;
@@ -859,7 +859,7 @@ export class Token extends ReadonlyToken {
         expirationDate?: Date;
     }): Promise<TransactionResult>;
     finalizeUnwrap(unwrapRequestIdOrAmount: Handle): Promise<TransactionResult>;
-    isApproved(spender: Address, holder?: Address): Promise<boolean>;
+    isApproved(spender: Address, holder: Address): Promise<boolean>;
     resumeUnshield(unwrapTxHash: Hex, callbacks?: UnshieldCallbacks): Promise<TransactionResult>;
     revokeDelegation(input: {
         delegateAddress: Address;

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -13066,11 +13066,11 @@ export class ReadonlyToken {
     readonly address: Address;
     allow(): Promise<void>;
     static allow(...tokens: ReadonlyToken[]): Promise<void>;
-    allowance(wrapper: Address, owner?: Address): Promise<bigint>;
-    balanceOf(owner?: Address): Promise<bigint>;
-    static batchBalancesOf(tokens: ReadonlyToken[], owner?: Address): Promise<BatchBalancesResult>;
+    allowance(wrapper: Address, owner: Address): Promise<bigint>;
+    balanceOf(owner: Address): Promise<bigint>;
+    static batchBalancesOf(tokens: ReadonlyToken[], owner: Address): Promise<BatchBalancesResult>;
     static batchDecryptBalancesAs(tokens: ReadonlyToken[], options: BatchDecryptAsOptions): Promise<Map<Address, bigint>>;
-    confidentialBalanceOf(owner?: Address): Promise<Handle>;
+    confidentialBalanceOf(owner: Address): Promise<Handle>;
     decimals(): Promise<number>;
     decryptBalanceAs(input: {
         delegatorAddress: Address;
@@ -14849,7 +14849,7 @@ export class Token extends ReadonlyToken {
         expirationDate?: Date;
     }): Promise<TransactionResult>;
     finalizeUnwrap(unwrapRequestIdOrAmount: Handle): Promise<TransactionResult>;
-    isApproved(spender: Address, holder?: Address): Promise<boolean>;
+    isApproved(spender: Address, holder: Address): Promise<boolean>;
     resumeUnshield(unwrapTxHash: Hex, callbacks?: UnshieldCallbacks): Promise<TransactionResult>;
     revokeDelegation(input: {
         delegateAddress: Address;

--- a/packages/sdk/src/__tests__/chain-alignment.test.ts
+++ b/packages/sdk/src/__tests__/chain-alignment.test.ts
@@ -110,7 +110,12 @@ describe("requireChainAlignment", () => {
     const allowSpy = vi.spyOn(sdk, "allow");
 
     const { ReadonlyToken } = await import("../token/readonly-token");
-    await expect(ReadonlyToken.batchBalancesOf([token])).rejects.toBeInstanceOf(ChainMismatchError);
+    await expect(
+      ReadonlyToken.batchBalancesOf(
+        [token],
+        "0x3F3f3f3F3F3f3F3f3F3f3f3F3F3f3F3f3f3f3f3F" as Address,
+      ),
+    ).rejects.toBeInstanceOf(ChainMismatchError);
 
     expect(allowSpy).not.toHaveBeenCalled();
     expect(signer.signTypedData).not.toHaveBeenCalled();

--- a/packages/sdk/src/query/__tests__/confidential-balance.test.ts
+++ b/packages/sdk/src/query/__tests__/confidential-balance.test.ts
@@ -53,22 +53,7 @@ describe("confidentialBalanceQueryOptions", () => {
     });
 
     const value = await options.queryFn(mockQueryContext(options.queryKey));
-
     expect(value).toBe(42n);
     expect(token.balanceOf).toHaveBeenCalledWith(owner);
-  });
-
-  test("queryFn passes undefined owner through to token.balanceOf when none is configured", async ({
-    createMockReadonlyToken,
-  }) => {
-    const token = createMockReadonlyToken(tokenAddress);
-    vi.mocked(token.balanceOf).mockResolvedValue(7n);
-
-    const options = confidentialBalanceQueryOptions(token, { tokenAddress });
-
-    const value = await options.queryFn(mockQueryContext(options.queryKey));
-
-    expect(value).toBe(7n);
-    expect(token.balanceOf).toHaveBeenCalledWith(undefined);
   });
 });

--- a/packages/sdk/src/query/confidential-balance.ts
+++ b/packages/sdk/src/query/confidential-balance.ts
@@ -1,5 +1,6 @@
 import type { Address } from "viem";
 import type { ReadonlyToken } from "../token";
+import { assertNonNullable } from "../utils/assertions";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";
 import { filterQueryOptions } from "./utils";
@@ -27,6 +28,7 @@ export function confidentialBalanceQueryOptions(
     queryKey: zamaQueryKeys.confidentialBalance.owner(config.tokenAddress, config.account),
     queryFn: async (context) => {
       const [, { owner: keyOwner }] = context.queryKey;
+      assertNonNullable(keyOwner, "confidentialBalanceQueryOptions: owner");
       return token.balanceOf(keyOwner);
     },
     enabled: Boolean(config.account) && queryOpts?.enabled !== false,

--- a/packages/sdk/src/query/confidential-balances.ts
+++ b/packages/sdk/src/query/confidential-balances.ts
@@ -1,5 +1,6 @@
 import type { Address } from "viem";
 import { ReadonlyToken, type BatchBalancesResult } from "../token/readonly-token";
+import { assertNonNullable } from "../utils/assertions";
 import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";
 import { filterQueryOptions } from "./utils";
@@ -27,6 +28,7 @@ export function confidentialBalancesQueryOptions(
     queryKey: zamaQueryKeys.confidentialBalances.tokens(tokenAddresses, accountKey),
     queryFn: async (context) => {
       const [, { owner: keyOwner }] = context.queryKey;
+      assertNonNullable(keyOwner, "confidentialBalancesQueryOptions: owner");
       return ReadonlyToken.batchBalancesOf(tokens, keyOwner);
     },
     enabled: Boolean(accountKey) && tokens.length > 0 && queryOpts?.enabled !== false,

--- a/packages/sdk/src/token/__tests__/error-throwing.test.ts
+++ b/packages/sdk/src/token/__tests__/error-throwing.test.ts
@@ -6,6 +6,7 @@ describe("NoCiphertextError detection (P3)", () => {
     relayer,
     token,
     handle,
+    userAddress,
     provider,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
@@ -13,13 +14,14 @@ describe("NoCiphertextError detection (P3)", () => {
     error.statusCode = 400;
     vi.mocked(relayer.userDecrypt).mockRejectedValue(error);
 
-    await expect(token.balanceOf()).rejects.toBeInstanceOf(NoCiphertextError);
+    await expect(token.balanceOf(userAddress)).rejects.toBeInstanceOf(NoCiphertextError);
   });
 
   it("throws RelayerRequestFailedError for non-400 HTTP errors", async ({
     relayer,
     token,
     handle,
+    userAddress,
     provider,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
@@ -27,9 +29,9 @@ describe("NoCiphertextError detection (P3)", () => {
     error.statusCode = 500;
     vi.mocked(relayer.userDecrypt).mockRejectedValue(error);
 
-    await expect(token.balanceOf()).rejects.toBeInstanceOf(RelayerRequestFailedError);
+    await expect(token.balanceOf(userAddress)).rejects.toBeInstanceOf(RelayerRequestFailedError);
     try {
-      await token.balanceOf();
+      await token.balanceOf(userAddress);
     } catch (error) {
       expect((error as RelayerRequestFailedError).statusCode).toBe(500);
     }
@@ -39,12 +41,13 @@ describe("NoCiphertextError detection (P3)", () => {
     relayer,
     token,
     handle,
+    userAddress,
     provider,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
     vi.mocked(relayer.userDecrypt).mockRejectedValue(new Error("unknown"));
 
-    await expect(token.balanceOf()).rejects.toBeInstanceOf(DecryptionFailedError);
+    await expect(token.balanceOf(userAddress)).rejects.toBeInstanceOf(DecryptionFailedError);
   });
 
   it("throws NoCiphertextError when sdk.userDecrypt receives 400", async ({
@@ -66,6 +69,7 @@ describe("NoCiphertextError detection (P3)", () => {
     relayer,
     token,
     handle,
+    userAddress,
     provider,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
@@ -73,7 +77,7 @@ describe("NoCiphertextError detection (P3)", () => {
     vi.mocked(relayer.userDecrypt).mockRejectedValue(original);
 
     try {
-      await token.balanceOf();
+      await token.balanceOf(userAddress);
     } catch (error) {
       expect(error).toBe(original);
     }
@@ -83,6 +87,7 @@ describe("NoCiphertextError detection (P3)", () => {
     relayer,
     token,
     handle,
+    userAddress,
     provider,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
@@ -90,7 +95,7 @@ describe("NoCiphertextError detection (P3)", () => {
     vi.mocked(relayer.userDecrypt).mockRejectedValue(original);
 
     try {
-      await token.balanceOf();
+      await token.balanceOf(userAddress);
     } catch (error) {
       expect(error).toBe(original);
     }
@@ -100,24 +105,26 @@ describe("NoCiphertextError detection (P3)", () => {
     relayer,
     token,
     handle,
+    userAddress,
     provider,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
     vi.mocked(relayer.userDecrypt).mockRejectedValue({ statusCode: 400, message: "bad" });
 
-    await expect(token.balanceOf()).rejects.toBeInstanceOf(NoCiphertextError);
+    await expect(token.balanceOf(userAddress)).rejects.toBeInstanceOf(NoCiphertextError);
   });
 
   it("wraps non-Error thrown value with other statusCode as RelayerRequestFailedError", async ({
     relayer,
     token,
     handle,
+    userAddress,
     provider,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
     vi.mocked(relayer.userDecrypt).mockRejectedValue({ statusCode: 502 });
 
-    const err = await token.balanceOf().catch((error) => error);
+    const err = await token.balanceOf(userAddress).catch((error) => error);
     expect(err).toBeInstanceOf(RelayerRequestFailedError);
     expect(err.statusCode).toBe(502);
   });

--- a/packages/sdk/src/token/__tests__/events.test.ts
+++ b/packages/sdk/src/token/__tests__/events.test.ts
@@ -97,6 +97,7 @@ describe("ReadonlyToken.balanceOf event emissions", () => {
     handle,
     storage,
     sessionStorage,
+    userAddress,
     provider,
   }) => {
     const { readonlyToken, events } = setupSdkWithEvents({
@@ -109,7 +110,7 @@ describe("ReadonlyToken.balanceOf event emissions", () => {
     });
     vi.mocked(provider.readContract).mockResolvedValue(handle);
 
-    await readonlyToken.balanceOf();
+    await readonlyToken.balanceOf(userAddress);
 
     const types = events.map((e) => e.type);
     expect(types).toContain(ZamaSDKEvents.DecryptStart);
@@ -125,6 +126,7 @@ describe("ReadonlyToken.balanceOf event emissions", () => {
     tokenAddress,
     storage,
     sessionStorage,
+    userAddress,
     provider,
   }) => {
     const { readonlyToken, events } = setupSdkWithEvents({
@@ -137,7 +139,7 @@ describe("ReadonlyToken.balanceOf event emissions", () => {
     });
     vi.mocked(provider.readContract).mockResolvedValue(ZERO_HANDLE);
 
-    await readonlyToken.balanceOf();
+    await readonlyToken.balanceOf(userAddress);
 
     const types = events.map((e) => e.type);
     expect(types).not.toContain(ZamaSDKEvents.DecryptStart);
@@ -151,6 +153,7 @@ describe("ReadonlyToken.balanceOf event emissions", () => {
     handle,
     storage,
     sessionStorage,
+    userAddress,
     provider,
   }) => {
     const { readonlyToken, events } = setupSdkWithEvents({
@@ -163,7 +166,7 @@ describe("ReadonlyToken.balanceOf event emissions", () => {
     });
     vi.mocked(provider.readContract).mockResolvedValue(handle);
 
-    await readonlyToken.balanceOf();
+    await readonlyToken.balanceOf(userAddress);
 
     const endEvent = events.find((e) => e.type === ZamaSDKEvents.DecryptEnd);
     expect(endEvent).toBeDefined();
@@ -179,6 +182,7 @@ describe("ReadonlyToken.balanceOf event emissions", () => {
     handle,
     storage,
     sessionStorage,
+    userAddress,
     provider,
   }) => {
     relayer.userDecrypt = vi.fn().mockRejectedValue(new Error("decrypt boom"));
@@ -192,7 +196,7 @@ describe("ReadonlyToken.balanceOf event emissions", () => {
     });
     vi.mocked(provider.readContract).mockResolvedValue(handle);
 
-    await expect(readonlyToken.balanceOf()).rejects.toThrow();
+    await expect(readonlyToken.balanceOf(userAddress)).rejects.toThrow();
 
     const errorEvent = events.find((e) => e.type === ZamaSDKEvents.DecryptError);
     expect(errorEvent).toBeDefined();
@@ -208,6 +212,7 @@ describe("ReadonlyToken.balanceOf event emissions", () => {
     handle,
     storage,
     sessionStorage,
+    userAddress,
     provider,
   }) => {
     const sdk = new ZamaSDK({
@@ -219,7 +224,7 @@ describe("ReadonlyToken.balanceOf event emissions", () => {
     });
     const token = new ReadonlyToken(sdk, tokenAddress);
     vi.mocked(provider.readContract).mockResolvedValue(handle);
-    await expect(token.balanceOf()).resolves.toBe(1000n);
+    await expect(token.balanceOf(userAddress)).resolves.toBe(1000n);
   });
 });
 

--- a/packages/sdk/src/token/__tests__/integration.test.ts
+++ b/packages/sdk/src/token/__tests__/integration.test.ts
@@ -13,6 +13,7 @@ describe("Integration: multi-step workflows", () => {
       signer,
       token,
       handle,
+      userAddress,
       provider,
     }) => {
       const UNDERLYING = "0x9C9c9c9c9c9c9C9c9c9C9C9c9c9C9c9c9c9c9C9c" as Address;
@@ -39,7 +40,7 @@ describe("Integration: multi-step workflows", () => {
       );
 
       // Step 3: Check balance after shield — should read the new handle
-      const balanceHandle = await token.confidentialBalanceOf();
+      const balanceHandle = await token.confidentialBalanceOf(userAddress);
       expect(balanceHandle).toBe(handle);
 
       // Step 4: Decrypt the balance through the SDK-level API
@@ -85,7 +86,7 @@ describe("Integration: multi-step workflows", () => {
 
       // Step 2: Check sender balance after transfer
       vi.mocked(provider.readContract).mockResolvedValueOnce(handle);
-      const senderHandle = await token.confidentialBalanceOf();
+      const senderHandle = await token.confidentialBalanceOf(userAddress);
       expect(senderHandle).toBe(handle);
 
       // Step 3: Check receiver balance (different token instance for same contract)

--- a/packages/sdk/src/token/__tests__/readonly-token.test.ts
+++ b/packages/sdk/src/token/__tests__/readonly-token.test.ts
@@ -5,6 +5,7 @@ import { getAddress, type Address } from "viem";
 
 const TOKEN2 = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address;
 const VALID_HANDLE2 = ("0x" + "cd".repeat(32)) as Address;
+const OWNER = "0x3F3f3f3F3F3f3F3f3F3f3f3F3F3f3F3f3f3f3f3F" as Address;
 
 describe("ReadonlyToken", () => {
   describe("balanceOf", () => {
@@ -13,7 +14,7 @@ describe("ReadonlyToken", () => {
       provider,
     }) => {
       vi.mocked(provider.readContract).mockResolvedValue(ZERO_HANDLE);
-      const balance = await readonlyToken.balanceOf();
+      const balance = await readonlyToken.balanceOf(OWNER);
 
       expect(balance).toBe(0n);
       expect(readonlyToken.sdk.relayer.userDecrypt).not.toHaveBeenCalled();
@@ -30,7 +31,7 @@ describe("ReadonlyToken", () => {
         [handle]: 1000n,
       });
 
-      const balance = await readonlyToken.balanceOf();
+      const balance = await readonlyToken.balanceOf(OWNER);
 
       expect(balance).toBe(1000n);
       expect(readonlyToken.sdk.relayer.userDecrypt).toHaveBeenCalledWith(
@@ -45,7 +46,7 @@ describe("ReadonlyToken", () => {
       vi.mocked(provider.readContract).mockResolvedValue(handle);
       vi.mocked(readonlyToken.sdk.relayer.userDecrypt).mockRejectedValue(new Error("relayer down"));
 
-      await expect(readonlyToken.balanceOf()).rejects.toBeInstanceOf(ZamaError);
+      await expect(readonlyToken.balanceOf(OWNER)).rejects.toBeInstanceOf(ZamaError);
     });
   });
 
@@ -58,6 +59,7 @@ describe("ReadonlyToken", () => {
 
       const result = await readonlyToken.allowance(
         "0x4D4d4D4d4d4D4D4d4D4D4D4d4d4d4d4D4D4d4d4D" as Address,
+        OWNER,
       );
 
       expect(result).toBe(500n);
@@ -75,7 +77,7 @@ describe("ReadonlyToken", () => {
 
   describe("batchBalancesOf", () => {
     it("returns empty maps for empty input", async () => {
-      const { results, errors } = await ReadonlyToken.batchBalancesOf([]);
+      const { results, errors } = await ReadonlyToken.batchBalancesOf([], OWNER);
       expect(results.size).toBe(0);
       expect(errors.size).toBe(0);
     });
@@ -105,7 +107,7 @@ describe("ReadonlyToken", () => {
         [VALID_HANDLE2]: 2000n,
       });
 
-      const { results, errors } = await ReadonlyToken.batchBalancesOf([token1, token2]);
+      const { results, errors } = await ReadonlyToken.batchBalancesOf([token1, token2], OWNER);
 
       expect(errors.size).toBe(0);
       expect(results.get(tokenAddress)).toBe(1000n);
@@ -143,7 +145,7 @@ describe("ReadonlyToken", () => {
         },
       );
 
-      const { results, errors } = await ReadonlyToken.batchBalancesOf([token1, token2]);
+      const { results, errors } = await ReadonlyToken.batchBalancesOf([token1, token2], OWNER);
 
       expect(results.get(tokenAddress)).toBe(1000n);
       expect(results.get(normalizedToken2)).toBeUndefined();
@@ -159,7 +161,7 @@ describe("ReadonlyToken", () => {
       const otherSdk = createSDK();
       const token2 = new ReadonlyToken(otherSdk, TOKEN2);
 
-      await expect(ReadonlyToken.batchBalancesOf([token1, token2])).rejects.toThrow(
+      await expect(ReadonlyToken.batchBalancesOf([token1, token2], OWNER)).rejects.toThrow(
         /must share the same ZamaSDK/,
       );
     });
@@ -177,7 +179,7 @@ describe("ReadonlyToken", () => {
         .mockResolvedValueOnce(VALID_HANDLE2);
       vi.mocked(sdk.relayer.userDecrypt).mockRejectedValue(new Error("relayer offline"));
 
-      await expect(ReadonlyToken.batchBalancesOf([token1, token2])).rejects.toBeInstanceOf(
+      await expect(ReadonlyToken.batchBalancesOf([token1, token2], OWNER)).rejects.toBeInstanceOf(
         ZamaError,
       );
     });
@@ -202,7 +204,7 @@ describe("ReadonlyToken", () => {
           throw rawError;
         });
 
-      const { errors } = await ReadonlyToken.batchBalancesOf([token1, token2]);
+      const { errors } = await ReadonlyToken.batchBalancesOf([token1, token2], OWNER);
 
       const err = errors.get(getAddress(TOKEN2));
       expect(err).toBeInstanceOf(DecryptionFailedError);
@@ -280,6 +282,6 @@ describe("ZamaSDK token factory", () => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
     vi.mocked(sdk.relayer.userDecrypt).mockResolvedValue({});
 
-    await expect(token.balanceOf()).rejects.toBeInstanceOf(DecryptionFailedError);
+    await expect(token.balanceOf(OWNER)).rejects.toBeInstanceOf(DecryptionFailedError);
   });
 });

--- a/packages/sdk/src/token/__tests__/shield.test.ts
+++ b/packages/sdk/src/token/__tests__/shield.test.ts
@@ -69,6 +69,7 @@ describe("Token.shield", () => {
     signer,
     relayer,
     handle: fixtureHandle,
+    userAddress,
     provider,
   }) => {
     vi.mocked(provider.readContract)
@@ -91,10 +92,10 @@ describe("Token.shield", () => {
       expect.objectContaining({ functionName: "wrap" }),
     );
 
-    const handle = await token.confidentialBalanceOf();
+    const handle = await token.confidentialBalanceOf(userAddress);
     expect(handle).toBe(fixtureHandle);
 
-    const balance = await token.balanceOf();
+    const balance = await token.balanceOf(userAddress);
     expect(balance).toBe(1000n);
     expect(relayer.userDecrypt).toHaveBeenCalledWith(
       expect.objectContaining({ handles: [fixtureHandle] }),

--- a/packages/sdk/src/token/__tests__/token.test.ts
+++ b/packages/sdk/src/token/__tests__/token.test.ts
@@ -6,10 +6,15 @@ import { describe, expect, it, vi } from "../../test-fixtures";
 
 describe("Token", () => {
   describe("balanceOf", () => {
-    it("returns 0n for zero handle without decrypting", async ({ relayer, token, provider }) => {
+    it("returns 0n for zero handle without decrypting", async ({
+      relayer,
+      token,
+      userAddress,
+      provider,
+    }) => {
       vi.mocked(provider.readContract).mockResolvedValue(ZERO_HANDLE);
 
-      const balance = await token.balanceOf();
+      const balance = await token.balanceOf(userAddress);
 
       expect(balance).toBe(0n);
       expect(relayer.userDecrypt).not.toHaveBeenCalled();
@@ -20,11 +25,12 @@ describe("Token", () => {
       signer,
       token,
       handle,
+      userAddress,
       provider,
     }) => {
       vi.mocked(provider.readContract).mockResolvedValue(handle);
 
-      const balance = await token.balanceOf();
+      const balance = await token.balanceOf(userAddress);
 
       expect(balance).toBe(1000n);
       expect(relayer.generateKeypair).toHaveBeenCalled();
@@ -32,27 +38,20 @@ describe("Token", () => {
       expect(relayer.userDecrypt).toHaveBeenCalled();
     });
 
-    it("defaults owner to signer address", async ({ userAddress, token, provider }) => {
-      vi.mocked(provider.readContract).mockResolvedValue(ZERO_HANDLE);
-
-      await token.balanceOf();
-
-      expect(provider.readContract).toHaveBeenCalledWith(
-        expect.objectContaining({
-          functionName: "confidentialBalanceOf",
-          args: [userAddress],
-        }),
-      );
-    });
-
-    it("accepts custom owner address", async ({ token, provider }) => {
+    it("passes the caller-supplied owner address to the contract read", async ({
+      token,
+      provider,
+    }) => {
       vi.mocked(provider.readContract).mockResolvedValue(ZERO_HANDLE);
       const otherAddress = "0xdddddddddddddddddddddddddddddddddddddddd" as Address;
 
       await token.balanceOf(otherAddress);
 
       expect(provider.readContract).toHaveBeenCalledWith(
-        expect.objectContaining({ args: [getAddress(otherAddress)] }),
+        expect.objectContaining({
+          functionName: "confidentialBalanceOf",
+          args: [getAddress(otherAddress)],
+        }),
       );
     });
   });
@@ -62,11 +61,12 @@ describe("Token", () => {
       relayer,
       token,
       handle,
+      userAddress,
       provider,
     }) => {
       vi.mocked(provider.readContract).mockResolvedValue(handle);
 
-      const result = await token.confidentialBalanceOf();
+      const result = await token.confidentialBalanceOf(userAddress);
 
       expect(result).toBe(handle);
       expect(relayer.userDecrypt).not.toHaveBeenCalled();
@@ -733,6 +733,7 @@ describe("Token", () => {
 
       const result = await token.isApproved(
         "0x3C3C3C3C3c3C3c3C3C3C3C3C3c3c3c3c3c3c3c3C" as Address,
+        "0x9F9f9F9F9F9f9F9f9F9f9F9f9F9F9F9F9F9f9F9f" as Address,
       );
 
       expect(result).toBe(true);

--- a/packages/sdk/src/token/readonly-token.ts
+++ b/packages/sdk/src/token/readonly-token.ts
@@ -85,19 +85,17 @@ export class ReadonlyToken {
    * Decrypt and return the plaintext balance for the given owner.
    * Acquires FHE credentials via a wallet signature if none are cached.
    *
-   * @param owner - Optional balance owner address. Defaults to the connected signer.
+   * @param owner - Balance owner address.
    * @returns The decrypted plaintext balance as a bigint.
    * @throws {@link DecryptionFailedError} if FHE decryption fails.
    *
    * @example
    * ```ts
-   * const balance = await token.balanceOf();
-   * // or for another address:
    * const balance = await token.balanceOf("0xOwner");
    * ```
    */
-  async balanceOf(owner?: Address): Promise<bigint> {
-    const ownerAddress = owner ? getAddress(owner) : await this.sdk.signer.getAddress();
+  async balanceOf(owner: Address): Promise<bigint> {
+    const ownerAddress = getAddress(owner);
     const handle = await this.readConfidentialBalanceOf(ownerAddress);
     const result = await this.sdk.userDecrypt([{ handle, contractAddress: this.address }]);
     const value = result[handle];
@@ -111,17 +109,16 @@ export class ReadonlyToken {
   /**
    * Return the raw encrypted balance handle without decrypting.
    *
-   * @param owner - Optional balance owner address. Defaults to the connected signer.
+   * @param owner - Balance owner address.
    * @returns The encrypted balance handle as a hex string.
    *
    * @example
    * ```ts
-   * const handle = await token.confidentialBalanceOf();
+   * const handle = await token.confidentialBalanceOf("0xOwner");
    * ```
    */
-  async confidentialBalanceOf(owner?: Address): Promise<Handle> {
-    const ownerAddress = owner ? getAddress(owner) : await this.sdk.signer.getAddress();
-    return this.readConfidentialBalanceOf(ownerAddress);
+  async confidentialBalanceOf(owner: Address): Promise<Handle> {
+    return this.readConfidentialBalanceOf(getAddress(owner));
   }
 
   /**
@@ -168,17 +165,17 @@ export class ReadonlyToken {
    * whole batch — caller decides how to surface them.
    *
    * @param tokens - Array of {@link ReadonlyToken} instances bound to the same SDK.
-   * @param owner - Optional balance owner address. Defaults to the connected signer.
+   * @param owner - Balance owner address.
    * @returns `{ results, errors }` partitioning the per-token outcomes.
    *
    * @example
    * ```ts
-   * const { results, errors } = await ReadonlyToken.batchBalancesOf(tokens);
+   * const { results, errors } = await ReadonlyToken.batchBalancesOf(tokens, owner);
    * ```
    */
   static async batchBalancesOf(
     tokens: ReadonlyToken[],
-    owner?: Address,
+    owner: Address,
   ): Promise<BatchBalancesResult> {
     const results = new Map<Address, bigint>();
     const errors = new Map<Address, ZamaError>();
@@ -428,15 +425,14 @@ export class ReadonlyToken {
    * Read the ERC-20 allowance of the underlying token for a given wrapper.
    *
    * @param wrapper - The wrapper contract address to check allowance for.
-   * @param owner - Optional owner address. Defaults to the connected signer.
+   * @param owner - The owner address whose allowance to read.
    * @returns The current allowance as a bigint.
    */
-  async allowance(wrapper: Address, owner?: Address): Promise<bigint> {
+  async allowance(wrapper: Address, owner: Address): Promise<bigint> {
     const normalizedWrapper = getAddress(wrapper);
     const underlying = await this.sdk.provider.readContract(underlyingContract(normalizedWrapper));
-    const userAddress = owner ? getAddress(owner) : await this.sdk.signer.getAddress();
     return this.sdk.provider.readContract(
-      allowanceContract(underlying, userAddress, normalizedWrapper),
+      allowanceContract(underlying, getAddress(owner), normalizedWrapper),
     );
   }
 
@@ -478,7 +474,7 @@ export class ReadonlyToken {
    * ```ts
    * await token.allow();
    * // Credentials are now cached — subsequent decrypts won't prompt
-   * const balance = await token.balanceOf();
+   * const balance = await token.balanceOf(owner);
    * ```
    */
   async allow(): Promise<void> {

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -322,23 +322,19 @@ export class Token extends ReadonlyToken {
    * Check if a spender is an approved operator for a given holder.
    *
    * @param spender - The address to check operator approval for.
-   * @param holder - The token holder address. Defaults to the connected wallet.
+   * @param holder - The token holder address.
    * @returns `true` if the spender is an approved operator for the holder.
    *
    * @example
    * ```ts
-   * if (await token.isApproved("0xSpender")) {
-   *   // spender can call transferFrom on behalf of connected wallet
+   * if (await token.isApproved("0xSpender", "0xHolder")) {
+   *   // spender can call transferFrom on behalf of holder
    * }
-   * // or check for a specific holder:
-   * if (await token.isApproved("0xSpender", "0xHolder")) { ... }
    * ```
    */
-  async isApproved(spender: Address, holder?: Address): Promise<boolean> {
-    const normalizedSpender = getAddress(spender);
-    const resolvedHolder = holder ? getAddress(holder) : await this.sdk.signer.getAddress();
+  async isApproved(spender: Address, holder: Address): Promise<boolean> {
     return this.sdk.provider.readContract(
-      isOperatorContract(this.address, resolvedHolder, normalizedSpender),
+      isOperatorContract(this.address, getAddress(holder), getAddress(spender)),
     );
   }
 
@@ -986,7 +982,7 @@ export class Token extends ReadonlyToken {
 
     let balance: bigint;
     try {
-      balance = await this.balanceOf();
+      balance = await this.balanceOf(await this.sdk.signer.getAddress());
     } catch (error) {
       if (error instanceof ZamaError) {
         throw error;

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -571,7 +571,7 @@ export class ZamaSDK {
    * {
    *   using sdk = new ZamaSDK({ relayer, provider, signer, storage });
    *   await sdk.allow([cUSDT]);
-   *   const balance = await sdk.createReadonlyToken(cUSDT).balanceOf();
+   *   const balance = await sdk.createReadonlyToken(cUSDT).balanceOf(owner);
    * } // sdk.terminate() called automatically here
    * ```
    */


### PR DESCRIPTION
Mirror the React hook change (#281) at the SDK layer: remove the implicit signer fallback on trivial `ReadonlyToken`/`Token` reads so callers always supply the owner/holder address.

- `ReadonlyToken.balanceOf(owner)`, `confidentialBalanceOf(owner)`, `allowance(wrapper, owner)`, `batchBalancesOf(tokens, owner)` — owner now required
- `Token.isApproved(spender, holder)` — holder now required
- `#assertConfidentialBalance` internal caller resolves the signer address once and passes it to `balanceOf`
- `confidentialBalance{,s}QueryOptions` keep `account` optional at the factory level (auto-gated via `enabled`) and pass it through to the SDK call
- Tests and `etc/*.api.md` updated accordingly