### PR TITLE
fix(token): await approval receipt before wrap in #ensureAllowance

### DIFF
--- a/packages/sdk/src/token/__tests__/shield.test.ts
+++ b/packages/sdk/src/token/__tests__/shield.test.ts
@@ -87,9 +87,6 @@ describe("Token.shield", () => {
 
     await token.shield(500n);
 
-    // Approval must be fully mined before the wrap TX is submitted.
-    // Regression guard: a missing waitForTransactionReceipt after approve
-    // causes Alchemy/Infura to revert the wrap (committed-state simulation).
     expect(callOrder).toEqual(["write:approve", "receipt", "write:wrap", "receipt"]);
   });
 

--- a/packages/sdk/src/token/__tests__/shield.test.ts
+++ b/packages/sdk/src/token/__tests__/shield.test.ts
@@ -64,6 +64,35 @@ describe("Token.shield", () => {
     expect(signer.writeContract).toHaveBeenCalled();
   });
 
+  it("awaits approval receipt before submitting the wrap TX", async ({
+    token,
+    signer,
+    provider,
+  }) => {
+    vi.mocked(provider.readContract)
+      .mockResolvedValueOnce(UNDERLYING) // underlying()
+      .mockResolvedValueOnce(1000n) // ERC-20 balanceOf
+      .mockResolvedValueOnce(0n); // allowance — forces approval path
+
+    const callOrder: string[] = [];
+
+    vi.mocked(signer.writeContract).mockImplementation(async (config) => {
+      callOrder.push(`write:${(config as { functionName: string }).functionName}`);
+      return "0xtxhash";
+    });
+    vi.mocked(provider.waitForTransactionReceipt).mockImplementation(async () => {
+      callOrder.push("receipt");
+      return { logs: [] };
+    });
+
+    await token.shield(500n);
+
+    // Approval must be fully mined before the wrap TX is submitted.
+    // Regression guard: a missing waitForTransactionReceipt after approve
+    // causes Alchemy/Infura to revert the wrap (committed-state simulation).
+    expect(callOrder).toEqual(["write:approve", "receipt", "write:wrap", "receipt"]);
+  });
+
   it("performs full shield flow with exact approval", async ({
     token,
     signer,

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -1070,13 +1070,8 @@ export class Token extends ReadonlyToken {
       const txHash = await signer.writeContract(
         approveContract(underlying, this.wrapper, approvalAmount),
       );
-      // Emit immediately so callers can show an optimistic "approval pending"
-      // indicator — consistent with how every other *Submitted event fires.
       this.emit({ type: ZamaSDKEvents.ApproveUnderlyingSubmitted, txHash });
       safeCallback(() => callbacks?.onApprovalSubmitted?.(txHash));
-      // Wait for the approval to be mined before shield() submits the wrap TX.
-      // Without this, RPC providers that simulate against committed state
-      // (Alchemy, Infura) see allowance = 0 during wrap simulation and revert.
       await this.sdk.provider.waitForTransactionReceipt(txHash);
     } catch (error) {
       if (error instanceof ZamaError) {

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -1061,7 +1061,8 @@ export class Token extends ReadonlyToken {
       // Required by non-standard tokens like USDT, and also mitigates the
       // ERC-20 approve race condition for all tokens.
       if (allowance > 0n) {
-        await signer.writeContract(approveContract(underlying, this.wrapper, 0n));
+        const resetHash = await signer.writeContract(approveContract(underlying, this.wrapper, 0n));
+        await this.sdk.provider.waitForTransactionReceipt(resetHash);
       }
 
       const approvalAmount = maxApproval ? 2n ** 256n - 1n : amount;
@@ -1069,6 +1070,10 @@ export class Token extends ReadonlyToken {
       const txHash = await signer.writeContract(
         approveContract(underlying, this.wrapper, approvalAmount),
       );
+      // Wait for the approval to be mined before shield() submits the wrap TX.
+      // Without this, RPC providers that simulate against committed state
+      // (Alchemy, Infura) see allowance = 0 during wrap simulation and revert.
+      await this.sdk.provider.waitForTransactionReceipt(txHash);
       this.emit({ type: ZamaSDKEvents.ApproveUnderlyingSubmitted, txHash });
       safeCallback(() => callbacks?.onApprovalSubmitted?.(txHash));
     } catch (error) {

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -1070,12 +1070,14 @@ export class Token extends ReadonlyToken {
       const txHash = await signer.writeContract(
         approveContract(underlying, this.wrapper, approvalAmount),
       );
+      // Emit immediately so callers can show an optimistic "approval pending"
+      // indicator — consistent with how every other *Submitted event fires.
+      this.emit({ type: ZamaSDKEvents.ApproveUnderlyingSubmitted, txHash });
+      safeCallback(() => callbacks?.onApprovalSubmitted?.(txHash));
       // Wait for the approval to be mined before shield() submits the wrap TX.
       // Without this, RPC providers that simulate against committed state
       // (Alchemy, Infura) see allowance = 0 during wrap simulation and revert.
       await this.sdk.provider.waitForTransactionReceipt(txHash);
-      this.emit({ type: ZamaSDKEvents.ApproveUnderlyingSubmitted, txHash });
-      safeCallback(() => callbacks?.onApprovalSubmitted?.(txHash));
     } catch (error) {
       if (error instanceof ZamaError) {
         throw error;


### PR DESCRIPTION
## Problem

`#ensureAllowance` submits the ERC-20 `approve` transaction via `signer.writeContract()` but does **not** await `provider.waitForTransactionReceipt()` before returning. `shield()` then immediately submits the `wrap` transaction.

RPC providers that simulate transactions against **committed** chain state (Alchemy, Infura) see `allowance = 0` at simulation time — the approval is still pending — and revert the wrap with `0xfb8f41b2`.

This is the only `writeContract` call in the `Token` class not followed by a receipt wait. Every other flow (`confidentialTransfer`, `unwrap`, `finalizeUnwrap`, `approve` operator) already awaits its receipt consistently.

## Reproduction

1. Use `@zama-fhe/sdk` with an Alchemy or Infura Sepolia RPC endpoint
2. Ensure the wallet has zero allowance for the wrapper contract
3. Call `token.shield(amount)` (any `approvalStrategy` other than `"skip"`)
4. Observe the wrap TX revert with selector `0xfb8f41b2`

## Fix

Capture the hash from both the reset-to-zero approve (when `allowance > 0`) and the main approve, then await `provider.waitForTransactionReceipt()` before proceeding to `wrapContract`.

## Impact

- No API changes
- Adds one block confirmation (~12s on Sepolia) to the shield flow when approval is needed — expected behaviour for an on-chain operation
- Unblocks users on Alchemy / Infura without requiring a manual `approvalStrategy: "skip"` workaround