### PR TITLE
chore: add Workaround CVE-2026-31431

### DIFF
--- a/.github/workflows/api-report.yml
+++ b/.github/workflows/api-report.yml
@@ -1,42 +1,35 @@
 name: API Report
-
 on:
   pull_request:
     branches: [main, prerelease]
   workflow_call:
-
 concurrency:
   group: api-report-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write
-
 jobs:
   api-report:
     runs-on: ubuntu-latest
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
-
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Check API reports are up to date
         run: pnpm api-report:check
-
       - name: Extract base branch reports
         if: github.event_name == 'pull_request'
         env:
@@ -47,7 +40,6 @@ jobs:
           for f in $(git ls-tree -r --name-only "$BASE_SHA" -- packages/sdk/etc packages/react-sdk/etc 2>/dev/null | grep '\.api\.md$'); do
             git show "$BASE_SHA:$f" > "/tmp/api-reports/base/$(basename "$f")" 2>/dev/null || true
           done
-
       - name: Generate API diff
         if: github.event_name == 'pull_request'
         id: api-diff
@@ -63,7 +55,6 @@ jobs:
           else
             echo "No public API changes detected." >> "$GITHUB_STEP_SUMMARY"
           fi
-
       - name: Post or update PR comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -3,15 +3,14 @@ on:
   schedule:
     - cron: "0 0 * * 0"
   workflow_dispatch:
-
 permissions:
   actions: write
-
 jobs:
   delete-caches:
     name: "Delete Actions caches"
     runs-on: ubuntu-latest
-
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: "Wipe Github Actions cache"
         uses: easimon/wipe-cache@e7ab82e64c328fd39c2e96933d426cd72ac2beba # v2

--- a/.github/workflows/example-hoodi-e2e.yml
+++ b/.github/workflows/example-hoodi-e2e.yml
@@ -1,18 +1,14 @@
 name: E2E — example-hoodi
-
 on:
   pull_request:
     branches: [main, prerelease]
     paths:
       - "examples/example-hoodi/**"
-
 concurrency:
   group: example-hoodi-e2e-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
-
 jobs:
   e2e:
     runs-on: ubuntu-latest
@@ -20,42 +16,36 @@ jobs:
     defaults:
       run:
         working-directory: examples/example-hoodi
-
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: examples/example-hoodi/package-lock.json
-
       - name: Install dependencies
         run: npm ci
-
       - name: Restore Playwright browsers cache
         id: playwright-cache
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('examples/example-hoodi/package-lock.json') }}
-
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
-
       - name: Save Playwright browsers cache
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('examples/example-hoodi/package-lock.json') }}
-
       - name: Run e2e tests
         run: npm run test:e2e
-
       - name: Upload test results
         if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/license-compat.yml
+++ b/.github/workflows/license-compat.yml
@@ -1,44 +1,37 @@
 name: License Compatibility
-
 on:
   pull_request:
     branches: [main, prerelease]
   push:
     branches: [main, prerelease]
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
-
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Generate license inventory
         run: |
           mkdir -p artifacts/license
           pnpm --filter @zama-fhe/sdk licenses list --json --prod > artifacts/license/licenses-sdk.json
           pnpm --filter @zama-fhe/react-sdk licenses list --json --prod > artifacts/license/licenses-react-sdk.json
           node -e 'const fs=require("node:fs"); const sdk=JSON.parse(fs.readFileSync("artifacts/license/licenses-sdk.json","utf8")); const react=JSON.parse(fs.readFileSync("artifacts/license/licenses-react-sdk.json","utf8")); fs.writeFileSync("artifacts/license/licenses-prod.json", JSON.stringify([sdk, react], null, 2));'
-
       - name: Check compatibility policy
         run: |
           node scripts/release/check-license-compat.mjs \
@@ -46,7 +39,6 @@ jobs:
             .github/license-policy.json \
             artifacts/license/report.md
           cat artifacts/license/report.md >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload license artifacts
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,46 +1,36 @@
 name: Lint
-
 on:
   pull_request:
     branches: [main, prerelease]
   workflow_call:
-
 concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
-
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
       - name: Build packages
         run: pnpm build
-
       - run: pnpm lint
-
       - run: pnpm typecheck
-
       - run: pnpm format:check
-
       - name: Check bundle size
         run: pnpm size

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,34 +1,28 @@
 name: Playwright
-
 on:
   pull_request:
     branches: [main, prerelease]
   workflow_call:
-
 concurrency:
   group: playwright-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
-
 jobs:
   test-nextjs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Init submodules
         run: git submodule update --init --recursive
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
-
       - name: Install soldeer dependencies
         run: cd contracts/lib/forge-fhevm && forge soldeer install
-
       - name: Restore Forge build cache
         id: forge-build-cache
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -40,21 +34,17 @@ jobs:
             contracts/lib/forge-fhevm/out
             contracts/lib/forge-fhevm/dependencies
           key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml', 'contracts/lib/forge-fhevm/src/**/*.sol', 'contracts/lib/forge-fhevm/foundry.toml') }}
-
       - name: Install Soldeer dependencies
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: |
           cd contracts/lib/forge-fhevm && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
           cd "$GITHUB_WORKSPACE/contracts" && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
-
       - name: Build forge-fhevm contracts
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: cd contracts/lib/forge-fhevm && forge build
-
       - name: Build contracts
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: cd contracts && forge build
-
       - name: Save Forge build cache
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -66,37 +56,30 @@ jobs:
             contracts/lib/forge-fhevm/out
             contracts/lib/forge-fhevm/dependencies
           key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml', 'contracts/lib/forge-fhevm/src/**/*.sol', 'contracts/lib/forge-fhevm/foundry.toml') }}
-
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
       - name: Restore Playwright browsers cache
         id: playwright-cache
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: /home/runner/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @zama-fhe/playwright exec playwright install --with-deps chromium
-
       - name: Save Playwright browsers cache
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: /home/runner/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
       - name: Restore Next.js build cache
         id: nextjs-build-cache
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -105,25 +88,20 @@ jobs:
           key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('test/test-nextjs/src/**/*.ts', 'test/test-nextjs/src/**/*.tsx', 'packages/sdk/src/**/*.ts', 'packages/sdk/src/**/*.tsx', 'packages/react-sdk/src/**/*.ts', 'packages/react-sdk/src/**/*.tsx') }}
           restore-keys: |
             nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
-
       - name: Build SDK packages
         run: pnpm build
-
       - name: Build Next.js test-nextjs
         run: pnpm build:test-nextjs
         env:
           NEXT_PUBLIC_ANVIL_PORT: 8545
-
       - name: Save Next.js build cache
         if: steps.nextjs-build-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: test/test-nextjs/.next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('test/test-nextjs/src/**/*.ts', 'test/test-nextjs/src/**/*.tsx', 'packages/sdk/src/**/*.ts', 'packages/sdk/src/**/*.tsx', 'packages/react-sdk/src/**/*.ts', 'packages/react-sdk/src/**/*.tsx') }}
-
       - name: Run Next.js Playwright tests
         run: pnpm e2e:test:nextjs
-
       - name: Upload test results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: ${{ !cancelled() }}
@@ -131,23 +109,20 @@ jobs:
           name: nextjs-test-report
           path: test/playwright/test-results/
           retention-days: 7
-
   test-vite:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Init submodules
         run: git submodule update --init --recursive
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
-
       - name: Install soldeer dependencies
         run: cd contracts/lib/forge-fhevm && forge soldeer install
-
       - name: Restore Forge build cache
         id: forge-build-cache
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -159,21 +134,17 @@ jobs:
             contracts/lib/forge-fhevm/out
             contracts/lib/forge-fhevm/dependencies
           key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml', 'contracts/lib/forge-fhevm/src/**/*.sol', 'contracts/lib/forge-fhevm/foundry.toml') }}
-
       - name: Install Soldeer dependencies
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: |
           cd contracts/lib/forge-fhevm && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
           cd "$GITHUB_WORKSPACE/contracts" && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
-
       - name: Build forge-fhevm contracts
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: cd contracts/lib/forge-fhevm && forge build
-
       - name: Build contracts
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: cd contracts && forge build
-
       - name: Save Forge build cache
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -185,48 +156,38 @@ jobs:
             contracts/lib/forge-fhevm/out
             contracts/lib/forge-fhevm/dependencies
           key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml', 'contracts/lib/forge-fhevm/src/**/*.sol', 'contracts/lib/forge-fhevm/foundry.toml') }}
-
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
       - name: Restore Playwright browsers cache
         id: playwright-cache
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: /home/runner/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @zama-fhe/playwright exec playwright install --with-deps chromium
-
       - name: Save Playwright browsers cache
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: /home/runner/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
       - name: Build SDK packages
         run: pnpm build
-
       - name: Build Vite test-vite
         run: pnpm build:test-vite
         env:
           VITE_ANVIL_PORT: 8546
-
       - name: Run Vite Playwright tests
         run: pnpm e2e:test:vite
-
       - name: Upload test results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: ${{ !cancelled() }}
@@ -234,23 +195,20 @@ jobs:
           name: vite-test-report
           path: test/playwright/test-results/
           retention-days: 7
-
   test-node:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Init submodules
         run: git submodule update --init --recursive
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
-
       - name: Install soldeer dependencies
         run: cd contracts/lib/forge-fhevm && forge soldeer install
-
       - name: Restore Forge build cache
         id: forge-build-cache
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -262,21 +220,17 @@ jobs:
             contracts/lib/forge-fhevm/out
             contracts/lib/forge-fhevm/dependencies
           key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml', 'contracts/lib/forge-fhevm/src/**/*.sol', 'contracts/lib/forge-fhevm/foundry.toml') }}
-
       - name: Install Soldeer dependencies
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: |
           cd contracts/lib/forge-fhevm && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
           cd "$GITHUB_WORKSPACE/contracts" && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
-
       - name: Build forge-fhevm contracts
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: cd contracts/lib/forge-fhevm && forge build
-
       - name: Build contracts
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: cd contracts && forge build
-
       - name: Save Forge build cache
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -288,22 +242,17 @@ jobs:
             contracts/lib/forge-fhevm/out
             contracts/lib/forge-fhevm/dependencies
           key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml', 'contracts/lib/forge-fhevm/src/**/*.sol', 'contracts/lib/forge-fhevm/foundry.toml') }}
-
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
       - name: Run Node e2e tests
         run: pnpm e2e:test:node
-
       - name: Upload test results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: ${{ !cancelled() }}

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,21 +1,19 @@
 name: PR Title Lint
-
 on:
   pull_request:
     branches: [main, prerelease]
     types: [opened, edited, synchronize, reopened]
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
 permissions:
   pull-requests: read
-
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Validate Conventional Commit PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,48 +1,43 @@
 name: Release Preview
-
 on:
   workflow_dispatch:
-
 permissions:
   contents: read
-
 defaults:
   run:
     shell: bash -euo pipefail {0}
-
 concurrency:
   group: release-preview-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   validate-branch:
     runs-on: ubuntu-latest
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Validate target branch
         run: |
           if [[ "${GITHUB_REF_NAME}" != "main" && "${GITHUB_REF_NAME}" != "prerelease" ]]; then
             echo "Release preview is only allowed from main or prerelease (got: ${GITHUB_REF_NAME})."
             exit 1
           fi
-
   preview:
     needs: [validate-branch]
     runs-on: ubuntu-latest
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: pnpm
-
       - name: Ensure npm >=11
         run: |
           npm_v="$(npm --version)"
@@ -54,18 +49,14 @@ jobs:
           fi
           echo "npm $(npm --version)"
           [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Build packages
         run: pnpm build
-
       - name: Semantic release (dry-run)
         run: pnpm release:dry-run 2>&1 | tee /tmp/dry-run-output.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Write preview summary
         if: always()
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 name: Release
-
 on:
   push:
     branches: [main, prerelease]
@@ -18,41 +17,36 @@ on:
         required: false
         type: boolean
         default: false
-
 permissions:
   contents: write
   issues: write
   pull-requests: write
   id-token: write
-
 defaults:
   run:
     shell: bash -euo pipefail {0}
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
-
 jobs:
   # ── Publish from tag (manual recovery) ──────────────────────────────
   publish-from-tag:
     if: inputs.publish-tag != ''
     runs-on: ubuntu-latest
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Checkout tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.publish-tag }}
-
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: pnpm
-
       - name: Ensure npm >=11
         run: |
           npm_v="$(npm --version)"
@@ -64,13 +58,10 @@ jobs:
           fi
           echo "npm $(npm --version)"
           [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Build packages
         run: pnpm build
-
       - name: Resolve version and npm tag
         id: npm-tag
         env:
@@ -94,7 +85,6 @@ jobs:
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
-
       - name: Publish to npm
         env:
           NPM_CONFIG_PROVENANCE: true
@@ -114,7 +104,6 @@ jobs:
           npm publish "${flags[@]}"
           cd ../react-sdk
           npm publish "${flags[@]}"
-
       - name: Summary
         if: success()
         env:
@@ -132,59 +121,54 @@ jobs:
           echo "|---------|---------|-----|" >> "$GITHUB_STEP_SUMMARY"
           echo "| \`@zama-fhe/sdk\` | \`${VERSION}\` | \`${NPM_TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| \`@zama-fhe/react-sdk\` | \`${VERSION}\` | \`${NPM_TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
-
   # ── Normal release flow ─────────────────────────────────────────────
   validate-branch:
     if: github.event_name == 'workflow_dispatch' && inputs.publish-tag == ''
     runs-on: ubuntu-latest
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Validate target branch
         run: |
           if [[ "${GITHUB_REF_NAME}" != "main" && "${GITHUB_REF_NAME}" != "prerelease" ]]; then
             echo "::error::Releases are only allowed from main or prerelease (got: ${GITHUB_REF_NAME})."
             exit 1
           fi
-
   lint:
     needs: [validate-branch]
     if: ${{ !cancelled() && !failure() && inputs.publish-tag == '' }}
     uses: ./.github/workflows/lint.yml
-
   vitest:
     needs: [validate-branch]
     if: ${{ !cancelled() && !failure() && inputs.publish-tag == '' }}
     uses: ./.github/workflows/vitest.yml
-
   playwright:
     needs: [validate-branch]
     if: ${{ !cancelled() && !failure() && inputs.publish-tag == '' }}
     uses: ./.github/workflows/playwright.yml
-
   api-report:
     needs: [validate-branch]
     if: ${{ !cancelled() && !failure() && inputs.publish-tag == '' }}
     uses: ./.github/workflows/api-report.yml
-
   release:
     needs: [lint, vitest, playwright, api-report]
     if: ${{ !cancelled() && !failure() && inputs.publish-tag == '' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: pnpm
-
       - name: Ensure npm >=11
         run: |
           npm_v="$(npm --version)"
@@ -196,13 +180,10 @@ jobs:
           fi
           echo "npm $(npm --version)"
           [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Build packages
         run: pnpm build
-
       - name: Semantic release
         id: release
         run: |
@@ -216,7 +197,6 @@ jobs:
           exit "$exit_code"
         env:
           GITHUB_TOKEN: ${{ secrets.SDK_RELEASER_TOKEN }}
-
       - name: Publish to npm
         if: steps.release.outputs.released == 'true'
         run: |
@@ -234,7 +214,6 @@ jobs:
           npm publish --access public --tag "${npm_tag}"
         env:
           NPM_CONFIG_PROVENANCE: true
-
       - name: Verify release was published
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,44 +1,36 @@
 name: Vitest
-
 on:
   pull_request:
     branches: [main, prerelease]
   workflow_call:
-
 concurrency:
   group: vitest-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write
-
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf; if lsmod | grep -q algif_aead; then sudo rmmod algif_aead; fi
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
-
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
       - name: Build packages
         run: pnpm build
-
       - run: pnpm test:coverage
-
       - name: Coverage report
         if: github.event_name == 'pull_request'
         uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2.11.2


### PR DESCRIPTION
Adds a kernel module blacklist step as the first step in every job as a workaround for CVE-2026-31431.