### PR TITLE
docs: tighten SECURITY.md to a focused reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,6 @@ We aim to acknowledge reports within **48 hours** and provide an initial assessm
 In scope:
 
 - The published `@zama-fhe/sdk` and `@zama-fhe/react-sdk` packages from this repo.
-- The Solidity contracts under `contracts/` in this repo.
 - The browser FHE worker assumes WASM is loaded from `cdn.zama.org` over HTTPS with an SHA-384 integrity check, not bundled — keep that in mind when modelling the trust boundary.
 
 ## Out of Scope

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,12 @@
 
 If you discover a security vulnerability in the Zama SDK, please report it responsibly.
 
-**Do not open a public GitHub issue for security vulnerabilities.**
+**Do not open a public GitHub issue.** Use one of the following private channels:
 
-Instead, please email: **security@zama.ai**
+- **Preferred:** open a draft GitHub Security Advisory at <https://github.com/zama-ai/sdk/security/advisories/new>.
+- **Alternate:** email <security@zama.ai>.
 
-Include the following in your report:
+Please include:
 
 - Description of the vulnerability
 - Steps to reproduce
@@ -19,48 +20,21 @@ We aim to acknowledge reports within **48 hours** and provide an initial assessm
 
 ## Scope
 
-The following areas are in scope for security reports:
+In scope:
 
-### FHE Credential Management
-
-- **Key derivation** — AES-GCM keys derived from wallet signatures via PBKDF2 (see `CredentialsManager`)
-- **Credential storage** — encrypted private keys stored via `GenericStorage` (IndexedDB in browsers)
-- **EIP-712 signatures** — authorization scoping (contract addresses, expiration)
-
-### Signer Adapters
-
-- **Type safety** — ensuring `Hex`/`Address` types prevent injection of malformed data
-- **Transaction construction** — contract call builders producing correct ABI-encoded calls
-
-### Web Worker / WASM
-
-- **CDN integrity** — WASM loaded from CDN for FHE operations
-- **Worker isolation** — message passing between main thread and Web Worker
+- The published `@zama-fhe/sdk` and `@zama-fhe/react-sdk` packages from this repo.
+- The Solidity contracts under `contracts/` in this repo.
+- The browser FHE worker assumes WASM is loaded from `cdn.zama.org` over HTTPS with an SHA-384 integrity check, not bundled — keep that in mind when modelling the trust boundary.
 
 ## Out of Scope
 
-- Vulnerabilities in third-party dependencies (viem, ethers, wagmi) — report these upstream
-- Vulnerabilities in the underlying fhEVM smart contracts — report to the [fhEVM repository](https://github.com/zama-ai/fhevm)
-- Vulnerabilities in `@zama-fhe/relayer-sdk` — report separately to Zama
-
-## Security Considerations for SDK Users
-
-### Credential Storage
-
-FHE private keys are encrypted with AES-GCM before storage. The encryption key is derived from the wallet's EIP-712 signature using PBKDF2 (600,000 iterations). However:
-
-- **Browser storage** (IndexedDB) is accessible to same-origin scripts. Ensure your application follows CSP best practices.
-- **Custom storage backends** — if implementing `GenericStorage`, ensure the backend provides appropriate access controls.
-
-### EIP-712 Authorization
-
-Decrypt credentials are scoped to specific contract addresses and have a configurable expiration (`durationDays`). Use the shortest practical duration for your use case.
+- Vulnerabilities in third-party dependencies (`viem`, `ethers`, `wagmi`, etc.) — please report those to the upstream projects.
+- Vulnerabilities in the underlying Zama Protocol contracts — see the [fhEVM security policy](https://github.com/zama-ai/fhevm/security/policy).
+- Vulnerabilities in `@zama-fhe/relayer-sdk` (the legacy low-level SDK) — same channels as this policy: a draft advisory on its repo if enabled, or <security@zama.ai>.
 
 ## Supported Versions
 
-| Version | Supported |
-| ------- | --------- |
-| 0.x     | Yes       |
+We provide security fixes for the two most recent major release lines of `@zama-fhe/sdk` and `@zama-fhe/react-sdk`.
 
 ## Acknowledgments
 


### PR DESCRIPTION
# Summary

External contributors are reporting issues; the existing policy mixed reporting policy with developer documentation and was stale on several fronts. Trim to what a security policy actually needs.

- Add GitHub Security Advisory private reporting as the preferred channel (https://github.com/zama-ai/sdk/security/advisories/new); keep `security@zama.ai` as alternate. Matches the [FHEVM repo's pattern](https://github.com/zama-ai/fhevm/blob/main/SECURITY.md). 48hr ack / 5-business-day SLA preserved.
- Replace the per-component implementation-detail breakdown (PBKDF2 specifics, `Hex`/`Address` typing, worker isolation bullets) with a clean scope statement: which packages, which contracts, plus the one non-obvious fact — WASM is CDN-loaded from `cdn.zama.org` with SHA-384 integrity, not bundled.
- Out-of-scope: link FHEVM's security policy directly instead of its repo homepage; clarify the relayer-sdk channels.
- Replace the stale `0.x: Yes` supported-versions table (package is at `3.0.0-alpha.27`) with policy prose: "two most recent major release lines". No version numbers in the doc, zero drift surface.
- Drop the "Security Considerations for SDK Users" section — it's developer guidance (CSP, custom storage, `durationDays` advice), not security policy. Belongs in `docs/gitbook/` if anywhere.

Net result: 41 lines (down from 67), no remaining stale concrete claims.

## Scope

- [ ] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-components`
- [ ] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [ ] Examples (`examples/`)
- [ ] CI/workflows
- [x] Docs

## Validation

- `pnpm format SECURITY.md` clean (no further changes needed).
- Verified no remaining stale concrete claims (no `0.x`, no `PBKDF2`, no `600,000`, no `durationDays`, no `CredentialsManager`, no `GenericStorage`).
- Verified the GH Security Advisories URL resolves.
- Verified the FHEVM security policy link resolves.
- The CDN-integrity scope callout matches `packages/sdk/src/worker/relayer-sdk.worker.ts:167` (`ALLOWED_CDN_HOSTS = ["cdn.zama.org"]` + SHA-384 check).

## Related

Slack thread (security team): the request to clean up SECURITY.md was prompted by a batch of external GH Security Advisory + Wiz scanner + Dependabot reports. Those reports are dependency / branch-targeting issues that are mostly orthogonal to this doc; this PR is just the policy text rewrite.

## Demo (if possible)

n/a — documentation-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)