### PR TITLE
docs(gitbook): force sidebar root label to "Overview"

### DIFF
--- a/docs/gitbook/book.toml
+++ b/docs/gitbook/book.toml
@@ -14,6 +14,6 @@ command = "node scripts/mdbook-gitbook-preprocessor.mjs"
 [output.html]
 default-theme = "light"
 preferred-dark-theme = "ayu"
-git-repository-url = "https://github.com/zama-ai/token-sdk"
+git-repository-url = "https://github.com/zama-ai/sdk"
 additional-css = ["theme/gitbook.css"]
 additional-js = ["theme/tabs.js"]

--- a/docs/gitbook/src/SUMMARY.md
+++ b/docs/gitbook/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Table of contents
 
-[Overview](README.md)
+[Overview](README.md "Overview")
 
 - [Getting started](tutorials/README.md)
   - [Quick start](tutorials/quick-start.md)


### PR DESCRIPTION
# Summary

Follow-up to #318. After that PR shipped, the GitBook sidebar still rendered the root entry as "README" instead of "Overview" — frontmatter `title:` and `# Overview` H1 didn't take effect for the root README.

Root cause: GitBook git-sync stores a page's "standard title" separately from file content. On the root README's first sync, the stored title was set from the filename, and subsequent body updates don't propagate to it. The documented override is the **page link title** syntax in SUMMARY.md (a quoted second title), which forces the sidebar label regardless of the stored standard title.

Also fixes a stale `git-repository-url` in [book.toml](docs/gitbook/book.toml) that still pointed at the old `zama-ai/token-sdk` repo. Affects mdbook's "Edit on GitHub" link only, not GitBook.

## Scope

- [ ] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-components`
- [ ] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [ ] Examples (`examples/`)
- [ ] CI/workflows
- [x] Docs

## Validation

- Confirmed with GitBook's docs that `[Title](path "Sidebar label")` is the documented override for the table-of-contents sidebar label.
- After the GitBook git-sync runs (~30s after merge), the sidebar root entry should switch to "Overview". If it's still stuck, the page title may need a one-time manual rename via the GitBook UI (Settings → Page → Title) — surfacing this as a fallback if the sync override doesn't clear the cached title.

## Related

Follow-up to #318. Yuxi's marketing review item ("preview shows README as title") was supposed to be fixed there, but the GitBook-side title cache outlasted my SUMMARY/frontmatter changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)