### PR TITLE
docs(sdk): document shielding paths + add e2e routing coverage [SDK-148]

### DIFF
--- a/docs/gitbook/src/guides/shield-tokens.md
+++ b/docs/gitbook/src/guides/shield-tokens.md
@@ -7,6 +7,32 @@ description: How to convert public ERC-20 tokens into their confidential form.
 
 Shielding converts public ERC-20 tokens into confidential tokens. The SDK handles the ERC-20 approval and the shield transaction in a single call via `token.shield()`. In React, use the `useShield` hook.
 
+## Shielding paths
+
+`Token.shield()` exposes a single API but routes through one of two on-chain paths depending on the underlying ERC-20:
+
+| Path               | Triggered when                                | Wallet prompts | Notes                                                                                 |
+| ------------------ | --------------------------------------------- | -------------- | ------------------------------------------------------------------------------------- |
+| `transferAndCall`  | Underlying ERC-20 implements ERC-1363         | 1              | The wrapper's `onTransferReceived` mints the confidential balance in one transaction. |
+| `approve` + `wrap` | Underlying ERC-20 does not implement ERC-1363 | 2              | An ERC-20 `approve` followed by a `wrap` call on the wrapper.                         |
+
+The SDK detects ERC-1363 support automatically via ERC-165 `supportsInterface` against the underlying token. **You don't need to choose a path or detect ERC-1363 yourself** — `token.shield(amount)` routes correctly for any token. `approvalStrategy` only applies to the `approve` + `wrap` path; on the `transferAndCall` path there is no allowance step.
+
+### Which path will my token take?
+
+Among the wrapped tokens registered on Ethereum mainnet today, the routing is:
+
+| Confidential wrapper | Underlying | Shield path                   |
+| -------------------- | ---------- | ----------------------------- |
+| cTGBP                | tGBP       | `transferAndCall` (single tx) |
+| cZAMA                | ZAMA       | `transferAndCall` (single tx) |
+| cUSDC                | USDC       | `approve` + `wrap` (two txs)  |
+| cUSDT                | USDT       | `approve` + `wrap` (two txs)  |
+| cWETH                | WETH       | `approve` + `wrap` (two txs)  |
+| cBRON                | BRON       | `approve` + `wrap` (two txs)  |
+
+ERC-1363 is a conditional optimisation, not a recommended new default — only a small subset of tokens implement it today. Tokens that don't (USDC, USDT, DAI, and most existing ERC-20s) continue to use `approve` + `wrap`. Any newly deployed wrapper picks up the `transferAndCall` path automatically if its underlying ERC-20 implements ERC-1363 — no opt-in is required from your code. See the [`WrappersRegistry` reference](/reference/sdk/WrappersRegistry) for how to look up the wrapper for a given ERC-20.
+
 ## Steps
 
 ### 1. Create a token instance
@@ -90,11 +116,11 @@ const txHash = await shield({ amount: 1000n });
 {% endtab %}
 {% endtabs %}
 
-The SDK sends two transactions: an ERC-20 `approve` for 1000 tokens, followed by the shield (wrap) call. The user sees two wallet prompts.
+On the `approve` + `wrap` path, the SDK sends two transactions: an ERC-20 `approve` for 1000 tokens, followed by the shield (wrap) call. The user sees two wallet prompts. On the `transferAndCall` path (ERC-1363 underlyings), shielding completes in a single transaction and `approvalStrategy` doesn't apply — see [Shielding paths](#shielding-paths) for details.
 
 ### 3. Shield with max approval
 
-To avoid a separate approval transaction every time, pass `approvalStrategy: "max"`. This grants an unlimited allowance on the first shield, and subsequent shields skip the approval step:
+`approvalStrategy` only affects the `approve` + `wrap` path; on `transferAndCall` it's ignored. To avoid a separate approval transaction every time on `approve` + `wrap` tokens, pass `approvalStrategy: "max"`. This grants an unlimited allowance on the first shield, and subsequent shields skip the approval step:
 
 {% tabs %}
 {% tab title="Core SDK" %}

--- a/docs/gitbook/src/tutorials/wallet-exchange-integration.md
+++ b/docs/gitbook/src/tutorials/wallet-exchange-integration.md
@@ -146,7 +146,7 @@ In all cases, the user sees a single unified balance for the underlying asset.
 
 ### Shield (wrap)
 
-`Token.shield` wraps a standard ERC-20 into its ERC-7984 form. The SDK handles the underlying ERC-20 approval, the wrapper deposit, and decimal conversion. The encrypted balance lands in the recipient's address (defaulting to the connected wallet).
+`Token.shield` wraps a standard ERC-20 into its ERC-7984 form. The SDK handles the wrapping flow internally — using `transferAndCall` for ERC-1363 underlyings (one transaction) or `approve` + `wrap` for everything else (two transactions) — plus decimal conversion. The encrypted balance lands in the recipient's address (defaulting to the connected wallet). See [Shielding paths](/guides/shield-tokens#shielding-paths) for which currently-wrapped tokens use which path.
 
 {% tabs %}
 {% tab title="SDK" %}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1140,7 +1140,7 @@ In all cases, the user sees a single unified balance for the underlying asset.
 
 ### Shield (wrap)
 
-`Token.shield` wraps a standard ERC-20 into its ERC-7984 form. The SDK handles the underlying ERC-20 approval, the wrapper deposit, and decimal conversion. The encrypted balance lands in the recipient's address (defaulting to the connected wallet).
+`Token.shield` wraps a standard ERC-20 into its ERC-7984 form. The SDK handles the wrapping flow internally — using `transferAndCall` for ERC-1363 underlyings (one transaction) or `approve` + `wrap` for everything else (two transactions) — plus decimal conversion. The encrypted balance lands in the recipient's address (defaulting to the connected wallet). See [Shielding paths](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/guides/shield-tokens.md#shielding-paths) for which currently-wrapped tokens use which path.
 
 
 ### Tab: SDK
@@ -1906,6 +1906,32 @@ When using `RelayerWeb` with a proxy, you can also add CSRF protection via the `
 
 Shielding converts public ERC-20 tokens into confidential tokens. The SDK handles the ERC-20 approval and the shield transaction in a single call via `token.shield()`. In React, use the `useShield` hook.
 
+## Shielding paths
+
+`Token.shield()` exposes a single API but routes through one of two on-chain paths depending on the underlying ERC-20:
+
+| Path               | Triggered when                                | Wallet prompts | Notes                                                                                 |
+| ------------------ | --------------------------------------------- | -------------- | ------------------------------------------------------------------------------------- |
+| `transferAndCall`  | Underlying ERC-20 implements ERC-1363         | 1              | The wrapper's `onTransferReceived` mints the confidential balance in one transaction. |
+| `approve` + `wrap` | Underlying ERC-20 does not implement ERC-1363 | 2              | An ERC-20 `approve` followed by a `wrap` call on the wrapper.                         |
+
+The SDK detects ERC-1363 support automatically via ERC-165 `supportsInterface` against the underlying token. **You don't need to choose a path or detect ERC-1363 yourself** — `token.shield(amount)` routes correctly for any token. `approvalStrategy` only applies to the `approve` + `wrap` path; on the `transferAndCall` path there is no allowance step.
+
+### Which path will my token take?
+
+Among the wrapped tokens registered on Ethereum mainnet today, the routing is:
+
+| Confidential wrapper | Underlying | Shield path                   |
+| -------------------- | ---------- | ----------------------------- |
+| cTGBP                | tGBP       | `transferAndCall` (single tx) |
+| cZAMA                | ZAMA       | `transferAndCall` (single tx) |
+| cUSDC                | USDC       | `approve` + `wrap` (two txs)  |
+| cUSDT                | USDT       | `approve` + `wrap` (two txs)  |
+| cWETH                | WETH       | `approve` + `wrap` (two txs)  |
+| cBRON                | BRON       | `approve` + `wrap` (two txs)  |
+
+ERC-1363 is a conditional optimisation, not a recommended new default — only a small subset of tokens implement it today. Tokens that don't (USDC, USDT, DAI, and most existing ERC-20s) continue to use `approve` + `wrap`. Any newly deployed wrapper picks up the `transferAndCall` path automatically if its underlying ERC-20 implements ERC-1363 — no opt-in is required from your code. See the [`WrappersRegistry` reference](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/sdk/WrappersRegistry.md) for how to look up the wrapper for a given ERC-20.
+
 ## Steps
 
 ### 1. Create a token instance
@@ -1982,11 +2008,11 @@ const txHash = await shield({ amount: 1000n });
 ```
 
 
-The SDK sends two transactions: an ERC-20 `approve` for 1000 tokens, followed by the shield (wrap) call. The user sees two wallet prompts.
+On the `approve` + `wrap` path, the SDK sends two transactions: an ERC-20 `approve` for 1000 tokens, followed by the shield (wrap) call. The user sees two wallet prompts. On the `transferAndCall` path (ERC-1363 underlyings), shielding completes in a single transaction and `approvalStrategy` doesn't apply — see [Shielding paths](#shielding-paths) for details.
 
 ### 3. Shield with max approval
 
-To avoid a separate approval transaction every time, pass `approvalStrategy: "max"`. This grants an unlimited allowance on the first shield, and subsequent shields skip the approval step:
+`approvalStrategy` only affects the `approve` + `wrap` path; on `transferAndCall` it's ignored. To avoid a separate approval transaction every time on `approve` + `wrap` tokens, pass `approvalStrategy: "max"`. This grants an unlimited allowance on the first shield, and subsequent shields skip the approval step:
 
 
 ### Tab: Core SDK

--- a/test/playwright/tests/node/erc1363.node.spec.ts
+++ b/test/playwright/tests/node/erc1363.node.spec.ts
@@ -1,13 +1,34 @@
 /**
- * Scenario: Token.isPayable() detects ERC-1363 support on-chain using ERC-165
- * supportsInterface. Verifies detection works correctly against both ERC-1363
- * tokens (TestERC1363) and standard ERC-20s (TestERC20).
+ * Scenarios:
  *
- * These tests validate the SDK's on-chain detection path end-to-end against
- * real contracts on Anvil — the unit tests cover routing logic with mocks.
+ *  1. `Token.isPayable()` detects ERC-1363 support on-chain via ERC-165
+ *     `supportsInterface`. Verified against an ERC-1363 token (TestERC1363),
+ *     a standard ERC-20 (TestERC20), and a non-ERC-20 contract (ACL).
+ *
+ *  2. `Token.shield()` routes correctly based on detection: the wrapper
+ *     whose underlying implements ERC-1363 completes shielding in a single
+ *     `transferAndCall` transaction, while a plain ERC-20 wrapper still
+ *     uses `approve` + `wrap` (two transactions).
+ *
+ * The detection tests validate the SDK's on-chain detection path against
+ * real contracts on Anvil; the routing tests verify the user-visible
+ * promise of SDK-145 — single-tx shield for 1363 tokens — end-to-end.
+ * The unit tests cover detection and routing logic with mocks.
  */
 import { Token } from "@zama-fhe/sdk";
 import { expect, nodeTest as test } from "../../fixtures/node-test";
+
+const SHIELD_AMOUNT = 100n * 1_000_000n; // 100 tokens at 6 decimals
+
+const erc20BalanceOfAbi = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
 
 test("detects ERC-1363 support on a token that implements it", async ({ sdk, contracts }) => {
   const token = sdk.createToken(contracts.cERC1363);
@@ -29,4 +50,87 @@ test("detection works on a token where underlying has no ERC-165 (ACL address)",
   const token = new Token(sdk, contracts.acl);
   const supported = await token.isPayable();
   expect(supported).toBe(false);
+});
+
+test("shield routes via transferAndCall on a 1363 token (single transaction)", async ({
+  sdk,
+  contracts,
+  account,
+  viemClient,
+}) => {
+  const token = sdk.createToken(contracts.cERC1363);
+
+  const erc20Before = await viemClient.readContract({
+    address: contracts.ERC1363,
+    abi: erc20BalanceOfAbi,
+    functionName: "balanceOf",
+    args: [account.address],
+  });
+  const nonceBefore = await viemClient.getTransactionCount({ address: account.address });
+
+  // shield() throws on revert, so reaching this line means the tx mined.
+  await token.shield(SHIELD_AMOUNT);
+
+  const nonceAfter = await viemClient.getTransactionCount({ address: account.address });
+  // transferAndCall path: a single signed transaction — no separate approve.
+  expect(nonceAfter - nonceBefore).toBe(1);
+
+  const erc20After = await viemClient.readContract({
+    address: contracts.ERC1363,
+    abi: erc20BalanceOfAbi,
+    functionName: "balanceOf",
+    args: [account.address],
+  });
+  expect(erc20Before - erc20After).toBe(SHIELD_AMOUNT);
+});
+
+test("shield-to-other via transferAndCall encodes recipient and succeeds", async ({
+  sdk,
+  contracts,
+  account,
+  viemClient,
+}) => {
+  const token = sdk.createToken(contracts.cERC1363);
+  // Anvil default account #1 — distinct from the sender (account #0).
+  const recipient = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+
+  const erc20Before = await viemClient.readContract({
+    address: contracts.ERC1363,
+    abi: erc20BalanceOfAbi,
+    functionName: "balanceOf",
+    args: [account.address],
+  });
+  const nonceBefore = await viemClient.getTransactionCount({ address: account.address });
+
+  // The wrapper decodes the recipient via `address(bytes20(data))` — this
+  // exercises that the SDK's raw 20-byte encoding is accepted on-chain.
+  await token.shield(SHIELD_AMOUNT, { to: recipient });
+
+  const nonceAfter = await viemClient.getTransactionCount({ address: account.address });
+  expect(nonceAfter - nonceBefore).toBe(1);
+
+  const erc20After = await viemClient.readContract({
+    address: contracts.ERC1363,
+    abi: erc20BalanceOfAbi,
+    functionName: "balanceOf",
+    args: [account.address],
+  });
+  expect(erc20Before - erc20After).toBe(SHIELD_AMOUNT);
+});
+
+test("shield routes via approve + wrap on a non-1363 token (two transactions)", async ({
+  sdk,
+  contracts,
+  account,
+  viemClient,
+}) => {
+  const token = sdk.createToken(contracts.cUSDT);
+
+  const nonceBefore = await viemClient.getTransactionCount({ address: account.address });
+
+  await token.shield(SHIELD_AMOUNT);
+
+  const nonceAfter = await viemClient.getTransactionCount({ address: account.address });
+  // Default `approvalStrategy: "exact"` on a non-1363 token: approve + wrap.
+  expect(nonceAfter - nonceBefore).toBe(2);
 });


### PR DESCRIPTION
Closes [SDK-148](https://linear.app/zama/issue/SDK-148/integration-guide-add-shielding-paths-section-to-sdk-123-covering).

## Summary

- Add a **Shielding paths** section to `guides/shield-tokens.md` explaining that `Token.shield()` routes through one of two on-chain paths (`transferAndCall` vs `approve` + `wrap`), with a per-token mapping for the wrappers currently registered on mainnet (cTGBP/cZAMA → `transferAndCall`; cUSDC/cUSDT/cWETH/cBRON → `approve` + `wrap`).
- Frame ERC-1363 as a conditional optimisation, not a recommended new default, per SDK-148 invariants. Update the existing "two transactions" wording in steps 2/3 to be path-aware. Cross-link from the wallet/exchange integration tutorial.
- Add three node e2e tests in `test/playwright/tests/node/erc1363.node.spec.ts`: single-tx `transferAndCall` shield (nonce delta = 1, ERC-20 balance decreases), `transferAndCall` shield-to-other (exercises the raw 20-byte recipient encoding on-chain), and a two-tx `approve` + `wrap` shield as control.

## Notes

- SDK-148 says this content should ultimately live inside the SDK-123 transition guide. Until SDK-123 lands, the canonical shield page is the right home and the integration tutorial cross-references it; the section can be folded into SDK-123 verbatim later.
- Branched from `prerelease` since SDK-145 ([#320](https://github.com/zama-ai/sdk/pull/320)) merged there.

## Test plan

- [x] \`pnpm test:run\` — 1642 unit tests pass
- [x] \`pnpm e2e:test:node\` — all 6 ERC-1363 specs pass (3 detection + 3 new routing)
- [x] \`pnpm format:check\` + workspace typecheck clean
- [x] \`pnpm llm:check\` — corpus regenerated and verified
- [ ] Eyeball the rendered \`Shielding paths\` section once preview is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)