### PR TITLE
docs(sdk): add Relayer API keys guide

### DIFF
--- a/docs/gitbook/src/SUMMARY.md
+++ b/docs/gitbook/src/SUMMARY.md
@@ -12,6 +12,7 @@
 
 - [Configuration](guides/configuration.md)
 - [Authentication](guides/authentication.md)
+- [Relayer API keys](guides/relayer-api-keys.md)
 - [Shield tokens](guides/shield-tokens.md)
 - [Transfer privately](guides/transfer-privately.md)
 - [Unshield tokens](guides/unshield-tokens.md)

--- a/docs/gitbook/src/guides/README.md
+++ b/docs/gitbook/src/guides/README.md
@@ -14,6 +14,8 @@ Otherwise:
 
 🟨 Go to [**Authentication**](authentication.md) to learn about API key management and backend proxies.
 
+🟨 Go to [**Relayer API keys**](relayer-api-keys.md) to obtain and securely manage your Zama-hosted Relayer API key.
+
 🟨 Go to [**Shield tokens**](shield-tokens.md) to convert public ERC-20 tokens into confidential form.
 
 🟨 Go to [**Transfer privately**](transfer-privately.md) to send encrypted amounts on-chain.

--- a/docs/gitbook/src/guides/authentication.md
+++ b/docs/gitbook/src/guides/authentication.md
@@ -7,6 +7,10 @@ description: How to authenticate with the relayer using a backend proxy or a dir
 
 The relayer requires an API key for every request. This guide covers the two authentication strategies: proxying through your backend (recommended for browser apps) and passing the key directly (suitable for server-side apps).
 
+{% hint style="info" %}
+Don't have an API key yet? See [Relayer API keys](relayer-api-keys.md) for how to apply for a Zama-hosted Relayer key (or self-host instead).
+{% endhint %}
+
 ## Steps
 
 ### 1. Understand the two options

--- a/docs/gitbook/src/guides/relayer-api-keys.md
+++ b/docs/gitbook/src/guides/relayer-api-keys.md
@@ -1,0 +1,69 @@
+---
+title: Relayer API keys
+description: How to obtain, configure, and securely manage your Zama Relayer API key.
+---
+
+# Relayer API keys
+
+The Relayer API key provides secure access to Zama's hosted Relayer service on mainnet. This guide explains how to obtain and use your API key.
+
+## Overview
+
+There are two options to access the FHEVM Relayer for mainnet deployment:
+
+**Self-hosted Relayer:** Deploy and operate your own Relayer instance, fund your own gateway wallet, and handle transactions independently. See the [Self-host Relayer](https://github.com/zama-ai/fhevm/blob/main/relayer/docs/SELF_HOSTING.md) documentation for set-up guides and configuration references.
+
+**Zama-hosted Relayer:** Connect to Zama's hosted Relayer using an API key for authentication. Transaction fees will be billed on a monthly basis according to the usage, with possible discounts and grants applied directly in the invoice.
+
+Start by submitting the form below, the Zama team will review your request and contact you with next steps.
+
+→ [Apply for an API key](https://forms.gle/jq84zEek1oiv3kBz9)
+
+{% hint style="warning" %}
+Before publishing your solution on mainnet, ensure that end-to-end integration has been successfully tested on testnet.
+{% endhint %}
+
+## Using your API key
+
+Once you receive your API key, wire it into the SDK using one of the two strategies covered in the [Authentication guide](authentication.md):
+
+- **Backend proxy** (recommended for browser apps) — the proxy injects the `x-api-key` header so the key never reaches the client.
+- **Direct API key** (server-side apps only) — pass the key in the relayer transport's `auth` field as `{ __type: "ApiKeyHeader", value: ... }`.
+
+The Authentication guide includes copy-paste examples for both, an Express proxy reference implementation, and the full table of supported `auth` methods.
+
+## Security best practices
+
+Your API key grants access to Zama's hosted Relayer with sponsored operations. Follow these security guidelines to protect your key:
+
+### Keep your key private
+
+- **Never expose your API key in client-side code** (frontend applications, mobile apps, etc.)
+- **Never commit your API key** to version control systems
+- **Never share your API key** with unauthorized parties
+
+### Secure implementation
+
+The recommended approach depends on your application architecture:
+
+- **In-browser applications**: Proxy all Relayer requests through your backend server so the API key remains server-side and never reaches the client.
+- **Server-side applications**: Store the API key in environment variables and load it securely at runtime.
+
+### Backend proxy pattern
+
+The proxy must add the `x-api-key` header to every forwarded request, so the key stays server-side and your frontend never sees it. See the [Authentication guide](authentication.md) for a working Express proxy and the matching client-side `relayerUrl` configuration — the patterns there apply unchanged when the upstream is the Zama-hosted Relayer.
+
+## Compromised keys
+
+If you suspect your API key has been compromised:
+
+1. **Immediately notify the Zama team** through [support@zama.org](mailto:support@zama.org).
+2. **Request a new API key** from the Zama team
+3. **Stop using the compromised key** in your applications
+
+If Zama identifies that an API key has been compromised, the key holder will be notified immediately and the key may be suspended to prevent unauthorized usage.
+
+## Next steps
+
+- [Authentication](authentication.md) — wire your API key into the SDK via a backend proxy or direct `auth` field
+- [Configuration](configuration.md) — full relayer, signer, and storage setup


### PR DESCRIPTION
## Summary

- Adds a new `Relayer API keys` page under Guides covering how to obtain a Zama-hosted Relayer API key, configure it in the SDK, security best practices, and what to do if a key is compromised.
- Links the page from `SUMMARY.md` and the guides `README.md`, placed right after Authentication.

## Test plan

- [ ] Build the GitBook docs locally (`docs/gitbook`) and verify the new page renders and the sidebar entry appears under Guides.
- [ ] Confirm the apply-form, support, and self-hosting links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)