### PR TITLE
refactor(sdk): extract EncryptionService from ZamaSDK

### DIFF
--- a/packages/sdk/src/__tests__/zama-sdk.test.ts
+++ b/packages/sdk/src/__tests__/zama-sdk.test.ts
@@ -5,13 +5,11 @@ import {
   DecryptionFailedError,
   SignerNotConfiguredError,
   WalletAccountNotReadyError,
-  ZamaError,
-  ZamaErrorCode,
 } from "../errors";
-import { ZamaSDKEvents } from "../events/sdk-events";
 import type { GenericSigner, WalletAccountChange, WalletAccountListener } from "../types";
 import type { Address } from "viem";
 import type { DecryptHandle } from "../query/user-decrypt";
+import type { EncryptParams } from "../relayer/relayer-sdk.types";
 
 const NEXT_USER_ADDRESS = TEST_ADDR_B;
 
@@ -358,74 +356,26 @@ describe("ZamaSDK", () => {
   });
 
   describe("encrypt", () => {
-    const ENCRYPT_PARAMS = {
+    const ENCRYPT_PARAMS: EncryptParams = {
       values: [{ value: 100n, type: "euint64" as const }],
       contractAddress: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address,
       userAddress: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" as Address,
     };
 
-    it("delegates to relayer.encrypt and returns result", async ({ sdk, relayer }) => {
+    it("returns encrypted handles", async ({ sdk }) => {
       const result = await sdk.encrypt(ENCRYPT_PARAMS);
 
-      expect(relayer.encrypt).toHaveBeenCalledWith(ENCRYPT_PARAMS);
       expect(result.handles).toHaveLength(1);
       expect(result.inputProof).toBeInstanceOf(Uint8Array);
     });
 
-    it("emits EncryptStart and EncryptEnd events with tokenAddress", async ({ createSDK }) => {
-      const events: { type: string; tokenAddress?: Address }[] = [];
-      const sdk = createSDK({ onEvent: (e) => events.push(e) });
+    it("works without a signer", async ({ createSDK }) => {
+      const sdk = createSDK({ signer: undefined });
 
-      await sdk.encrypt(ENCRYPT_PARAMS);
-
-      expect(events).toContainEqual(
-        expect.objectContaining({
-          type: ZamaSDKEvents.EncryptStart,
-          tokenAddress: ENCRYPT_PARAMS.contractAddress,
-        }),
-      );
-      expect(events).toContainEqual(
-        expect.objectContaining({
-          type: ZamaSDKEvents.EncryptEnd,
-          tokenAddress: ENCRYPT_PARAMS.contractAddress,
-          durationMs: expect.any(Number),
-        }),
-      );
-    });
-
-    it("wraps non-ZamaError in EncryptionFailed", async ({ sdk, relayer }) => {
-      vi.mocked(relayer.encrypt).mockRejectedValueOnce(new Error("boom"));
-
-      await expect(sdk.encrypt(ENCRYPT_PARAMS)).rejects.toSatisfy((err: ZamaError) => {
-        return (
-          err instanceof ZamaError &&
-          err.code === ZamaErrorCode.EncryptionFailed &&
-          err.message === "Encryption failed"
-        );
+      await expect(sdk.encrypt(ENCRYPT_PARAMS)).resolves.toEqual({
+        handles: [new Uint8Array([1, 2, 3])],
+        inputProof: new Uint8Array([4, 5, 6]),
       });
-    });
-
-    it("re-throws ZamaError as-is", async ({ sdk, relayer }) => {
-      const original = new ZamaError(ZamaErrorCode.EncryptionFailed, "already wrapped");
-      vi.mocked(relayer.encrypt).mockRejectedValueOnce(original);
-
-      await expect(sdk.encrypt(ENCRYPT_PARAMS)).rejects.toBe(original);
-    });
-
-    it("emits EncryptError with tokenAddress on failure", async ({ createSDK, relayer }) => {
-      const events: { type: string; tokenAddress?: Address }[] = [];
-      const sdk = createSDK({ onEvent: (e) => events.push(e) });
-      vi.mocked(relayer.encrypt).mockRejectedValueOnce(new Error("boom"));
-
-      await expect(sdk.encrypt(ENCRYPT_PARAMS)).rejects.toThrow();
-
-      expect(events).toContainEqual(
-        expect.objectContaining({
-          type: ZamaSDKEvents.EncryptError,
-          tokenAddress: ENCRYPT_PARAMS.contractAddress,
-          durationMs: expect.any(Number),
-        }),
-      );
     });
   });
 

--- a/packages/sdk/src/query/__tests__/encrypt.test.ts
+++ b/packages/sdk/src/query/__tests__/encrypt.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from "../../test-fixtures";
+import { describe, expect, test, vi } from "../../test-fixtures";
 
 import { encryptMutationOptions } from "../encrypt";
 import type { Address } from "viem";
 
 describe("encryptMutationOptions", () => {
-  test("delegates sdk.relayer.encrypt", async ({ sdk, relayer }) => {
+  test("encrypts via the SDK mutation", async ({ sdk }) => {
     const options = encryptMutationOptions(sdk);
 
     expect(options.mutationKey).toEqual(["zama.encrypt"]);
@@ -13,8 +13,13 @@ describe("encryptMutationOptions", () => {
       contractAddress: "0x1a1A1A1A1a1A1A1a1A1a1a1a1a1a1a1A1A1a1a1a" as Address,
       userAddress: "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B" as Address,
     };
-    await options.mutationFn(params);
+    const encrypt = vi.spyOn(sdk, "encrypt");
+    const result = await options.mutationFn(params);
 
-    expect(relayer.encrypt).toHaveBeenCalledWith(params);
+    expect(encrypt).toHaveBeenCalledWith(params);
+    expect(result).toEqual({
+      handles: [new Uint8Array([1, 2, 3])],
+      inputProof: new Uint8Array([4, 5, 6]),
+    });
   });
 });

--- a/packages/sdk/src/services/__tests__/encryption-service.test.ts
+++ b/packages/sdk/src/services/__tests__/encryption-service.test.ts
@@ -1,0 +1,80 @@
+import type { Address } from "viem";
+import { EncryptionFailedError, ZamaError, ZamaErrorCode } from "../../errors";
+import type { EncryptParams } from "../../relayer/relayer-sdk.types";
+import { describe, expect, test, vi } from "../../test-fixtures";
+
+const ENCRYPT_PARAMS: EncryptParams = {
+  values: [{ value: 100n, type: "euint64" }],
+  contractAddress: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address,
+  userAddress: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" as Address,
+};
+
+describe("EncryptionService", () => {
+  test("encrypt returns relayer result and emits start/end events", async ({
+    createEncryptionService,
+    relayer,
+    events,
+  }) => {
+    const emitEvent = vi.fn();
+    const service = createEncryptionService({ emitEvent });
+
+    const result = await service.encrypt(ENCRYPT_PARAMS);
+
+    expect(result.handles).toHaveLength(1);
+    expect(result.inputProof).toBeInstanceOf(Uint8Array);
+    expect(relayer.encrypt).toHaveBeenCalledWith(ENCRYPT_PARAMS);
+    expect(emitEvent).toHaveBeenCalledWith(
+      { type: events.EncryptStart },
+      ENCRYPT_PARAMS.contractAddress,
+    );
+    expect(emitEvent).toHaveBeenCalledWith(
+      {
+        type: events.EncryptEnd,
+        durationMs: expect.any(Number),
+      },
+      ENCRYPT_PARAMS.contractAddress,
+    );
+  });
+
+  test("wraps non-ZamaError failures and emits EncryptError", async ({
+    createEncryptionService,
+    relayer,
+    events,
+  }) => {
+    const emitEvent = vi.fn();
+    const service = createEncryptionService({ emitEvent });
+    vi.mocked(relayer.encrypt).mockRejectedValueOnce(new Error("boom"));
+
+    await expect(service.encrypt(ENCRYPT_PARAMS)).rejects.toBeInstanceOf(EncryptionFailedError);
+
+    expect(emitEvent).toHaveBeenCalledWith(
+      {
+        type: events.EncryptError,
+        error: expect.objectContaining({ message: "boom" }),
+        durationMs: expect.any(Number),
+      },
+      ENCRYPT_PARAMS.contractAddress,
+    );
+  });
+
+  test("re-throws ZamaError failures as-is after emitting EncryptError", async ({
+    createEncryptionService,
+    relayer,
+    events,
+  }) => {
+    const original = new ZamaError(ZamaErrorCode.EncryptionFailed, "already wrapped");
+    const emitEvent = vi.fn();
+    const service = createEncryptionService({ emitEvent });
+    vi.mocked(relayer.encrypt).mockRejectedValueOnce(original);
+
+    await expect(service.encrypt(ENCRYPT_PARAMS)).rejects.toBe(original);
+    expect(emitEvent).toHaveBeenCalledWith(
+      {
+        type: events.EncryptError,
+        error: original,
+        durationMs: expect.any(Number),
+      },
+      ENCRYPT_PARAMS.contractAddress,
+    );
+  });
+});

--- a/packages/sdk/src/services/encryption-service.ts
+++ b/packages/sdk/src/services/encryption-service.ts
@@ -1,0 +1,56 @@
+import { EncryptionFailedError, ZamaError } from "../errors";
+import type { ZamaSDKEventInput } from "../events/sdk-events";
+import { ZamaSDKEvents } from "../events/sdk-events";
+import type { RelayerDispatcher } from "../relayer/relayer-dispatcher";
+import type { EncryptParams, EncryptResult } from "../relayer/relayer-sdk.types";
+import { toError } from "../utils";
+
+export class EncryptionService {
+  readonly #relayer: RelayerDispatcher;
+  readonly #emitEvent: (
+    input: ZamaSDKEventInput,
+    tokenAddress?: EncryptParams["contractAddress"],
+  ) => void;
+
+  constructor({
+    relayer,
+    emitEvent,
+  }: {
+    relayer: RelayerDispatcher;
+    emitEvent: (input: ZamaSDKEventInput, tokenAddress?: EncryptParams["contractAddress"]) => void;
+  }) {
+    this.#relayer = relayer;
+    this.#emitEvent = emitEvent;
+  }
+
+  async encrypt(params: EncryptParams): Promise<EncryptResult> {
+    const t0 = Date.now();
+    try {
+      this.#emitEvent({ type: ZamaSDKEvents.EncryptStart }, params.contractAddress);
+      const result = await this.#relayer.encrypt(params);
+      this.#emitEvent(
+        {
+          type: ZamaSDKEvents.EncryptEnd,
+          durationMs: Date.now() - t0,
+        },
+        params.contractAddress,
+      );
+      return result;
+    } catch (error) {
+      this.#emitEvent(
+        {
+          type: ZamaSDKEvents.EncryptError,
+          error: toError(error),
+          durationMs: Date.now() - t0,
+        },
+        params.contractAddress,
+      );
+      if (error instanceof ZamaError) {
+        throw error;
+      }
+      throw new EncryptionFailedError("Encryption failed", {
+        cause: error,
+      });
+    }
+  }
+}

--- a/packages/sdk/src/test-fixtures.ts
+++ b/packages/sdk/src/test-fixtures.ts
@@ -6,6 +6,7 @@ import type { FheChain } from "./chains/types";
 import type { ZamaConfig } from "./config/types";
 import { ZamaSDKEvents } from "./events/sdk-events";
 import type { RelayerSDK } from "./relayer/relayer-sdk";
+import type { RelayerDispatcher } from "./relayer/relayer-dispatcher";
 import type { Handle } from "./relayer/relayer-sdk.types";
 import { CachingService } from "./services/caching-service";
 import type { QueryClient } from "@tanstack/query-core";
@@ -19,6 +20,7 @@ import type { GenericProvider, GenericSigner, GenericStorage, TransactionResult 
 import { ZamaSDK } from "./zama-sdk";
 import { DecryptionService } from "./services/decryption-service";
 import { DelegationService } from "./services/delegation-service";
+import { EncryptionService } from "./services/encryption-service";
 import type { ZamaSDKEventInput } from "./events/sdk-events";
 export { afterEach, beforeEach, describe, expect, vi, type Mock } from "vitest";
 
@@ -227,6 +229,7 @@ interface SdkFixtures {
   cache: CachingService;
   delegationService: DelegationService;
   decryptionService: DecryptionService;
+  encryptionService: EncryptionService;
   storage: GenericStorage;
   createMockRelayer: typeof createMockRelayer;
   createMockSigner: (addressOrOverrides?: Address | Partial<GenericSigner>) => GenericSigner;
@@ -255,6 +258,10 @@ interface SdkFixtures {
     relayer?: RelayerSDK;
     emitEvent?: (input: ZamaSDKEventInput) => void;
   }) => DecryptionService;
+  createEncryptionService: (overrides?: {
+    relayer?: RelayerSDK;
+    emitEvent?: (input: ZamaSDKEventInput, tokenAddress?: Address) => void;
+  }) => EncryptionService;
   createToken: (sdk: ZamaSDK, address?: Address, wrapper?: Address) => Token;
   createReadonlyToken: (sdk: ZamaSDK, address?: Address) => ReadonlyToken;
   sdk: ZamaSDK;
@@ -357,6 +364,18 @@ export const test = base.extend<SdkFixtures>({
   },
   decryptionService: async ({ createDecryptionService }, use) => {
     await use(createDecryptionService());
+  },
+  createEncryptionService: async ({ relayer }, use) => {
+    await use(
+      (overrides = {}) =>
+        new EncryptionService({
+          relayer: (overrides.relayer ?? relayer) as unknown as RelayerDispatcher,
+          emitEvent: overrides.emitEvent ?? vi.fn(),
+        }),
+    );
+  },
+  encryptionService: async ({ createEncryptionService }, use) => {
+    await use(createEncryptionService());
   },
   createToken: async ({ tokenAddress }, use) => {
     await use(

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -3,14 +3,11 @@ import type { ZamaConfig } from "./config/types";
 import { CredentialService } from "./credentials/credential-service";
 import {
   ChainMismatchError,
-  EncryptionFailedError,
   SignerNotConfiguredError,
   WalletAccountNotReadyError,
   wrapDecryptError,
-  ZamaError,
 } from "./errors";
 import type { ZamaSDKEvent, ZamaSDKEventInput, ZamaSDKEventListener } from "./events/sdk-events";
-import { ZamaSDKEvents } from "./events/sdk-events";
 import type { DecryptHandle } from "./query/user-decrypt";
 import type { RelayerDispatcher } from "./relayer/relayer-dispatcher";
 import type {
@@ -31,10 +28,11 @@ import type {
   WalletAccountChange,
   WalletAccountListener,
 } from "./types";
-import { swallow, toError } from "./utils";
+import { swallow } from "./utils";
 import { CachingService } from "./services/caching-service";
 import { DecryptionService, type BatchDecryptHandlesResult } from "./services/decryption-service";
 import { DelegationService } from "./services/delegation-service";
+import { EncryptionService } from "./services/encryption-service";
 import { WrappersRegistry } from "./wrappers-registry";
 
 /**
@@ -58,6 +56,7 @@ export class ZamaSDK {
   readonly #credentialService: CredentialService | undefined;
   readonly #delegationService: DelegationService;
   readonly #decryptionService: DecryptionService | undefined;
+  readonly #encryptionService: EncryptionService;
   #unsubscribeSigner?: () => void;
 
   constructor(config: ZamaConfig) {
@@ -69,6 +68,10 @@ export class ZamaSDK {
     this.#onEvent = config.onEvent ?? function () {};
     this.#delegationService = new DelegationService({
       provider: this.provider,
+      relayer: this.relayer,
+      emitEvent: (input, tokenAddress) => this.emitEvent(input, tokenAddress),
+    });
+    this.#encryptionService = new EncryptionService({
       relayer: this.relayer,
       emitEvent: (input, tokenAddress) => this.emitEvent(input, tokenAddress),
     });
@@ -594,34 +597,7 @@ export class ZamaSDK {
    * ```
    */
   async encrypt(params: EncryptParams): Promise<EncryptResult> {
-    const t0 = Date.now();
-    try {
-      this.emitEvent({ type: ZamaSDKEvents.EncryptStart }, params.contractAddress);
-      const result = await this.relayer.encrypt(params);
-      this.emitEvent(
-        {
-          type: ZamaSDKEvents.EncryptEnd,
-          durationMs: Date.now() - t0,
-        },
-        params.contractAddress,
-      );
-      return result;
-    } catch (error) {
-      this.emitEvent(
-        {
-          type: ZamaSDKEvents.EncryptError,
-          error: toError(error),
-          durationMs: Date.now() - t0,
-        },
-        params.contractAddress,
-      );
-      if (error instanceof ZamaError) {
-        throw error;
-      }
-      throw new EncryptionFailedError("Encryption failed", {
-        cause: error,
-      });
-    }
+    return this.#encryptionService.encrypt(params);
   }
 
   /**


### PR DESCRIPTION
Closes SDK-165

## Summary
Extract encryption into a dedicated service so ZamaSDK stays focused on orchestration.
The service now owns EncryptStart/EncryptEnd/EncryptError and EncryptionFailedError wrapping.
This completes the SDK-161 service split direction and gives future encryption concerns a clear home.

## Rapid overlook
- Add EncryptionService with DI for relayer and event emission.
- Wire it unconditionally in ZamaSDK and forward sdk.encrypt().
- Move encryption lifecycle/error coverage into service tests.
- Keep query tests focused on the sdk.encrypt mutation boundary.
- Verified focused Vitest suite, SDK typecheck, and root lint.