### PR TITLE
refactor(sdk): move publicDecrypt into DecryptionService [SDK-166]

### DIFF
--- a/packages/react-sdk/src/__tests__/mutation-test-helpers.ts
+++ b/packages/react-sdk/src/__tests__/mutation-test-helpers.ts
@@ -1,8 +1,7 @@
 import { act } from "@testing-library/react";
 import { QueryClient, type QueryKey } from "@tanstack/react-query";
-import type { Address, GenericSigner, RawLog, Token } from "@zama-fhe/sdk";
+import { ZamaSDK, type Address, type GenericSigner, type RawLog, type Token } from "@zama-fhe/sdk";
 import { expect, vi } from "../test-fixtures";
-import type { createMockRelayer } from "../../../sdk/src/test-fixtures";
 import { createMockSigner } from "../../../sdk/src/test-fixtures";
 import { expectCacheInvalidated } from "../test-helpers";
 
@@ -53,8 +52,8 @@ export function createUnwrapRequestedLog(unwrapRequestId: Address): RawLog {
   };
 }
 
-export function mockPublicDecrypt(relayer: ReturnType<typeof createMockRelayer>) {
-  vi.mocked(relayer.publicDecrypt).mockImplementation((handles: string[]) => {
+export function mockPublicDecrypt() {
+  vi.spyOn(ZamaSDK.prototype, "publicDecrypt").mockImplementation((handles) => {
     const clearValues: Record<string, bigint> = {};
     for (const h of handles) {
       clearValues[h] = 1n;

--- a/packages/react-sdk/src/relayer/__tests__/use-public-decrypt.test.tsx
+++ b/packages/react-sdk/src/relayer/__tests__/use-public-decrypt.test.tsx
@@ -2,25 +2,25 @@ import { waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "../../test-fixtures";
 import { zamaQueryKeys } from "@zama-fhe/sdk/query";
 import { usePublicDecrypt } from "../use-public-decrypt";
+import { ZamaSDK, type Handle } from "@zama-fhe/sdk";
+
+const HANDLE = ("0x" + "aa".repeat(32)) as Handle;
 
 describe("usePublicDecrypt", () => {
-  it("delegates to relayer.publicDecrypt and populates cache", async ({
-    renderWithProviders,
-    relayer,
-  }) => {
-    vi.mocked(relayer.publicDecrypt).mockResolvedValue({
-      clearValues: { "0xhandle1": 500n },
+  it("delegates to sdk.publicDecrypt and populates cache", async ({ renderWithProviders }) => {
+    const publicDecrypt = vi.spyOn(ZamaSDK.prototype, "publicDecrypt").mockResolvedValue({
+      clearValues: { [HANDLE]: 500n },
       abiEncodedClearValues: "0x",
       decryptionProof: "0xproof",
     });
 
     const { result, queryClient } = renderWithProviders(() => usePublicDecrypt());
 
-    result.current.mutate(["0xhandle1"]);
+    result.current.mutate([HANDLE]);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(relayer.publicDecrypt).toHaveBeenCalledWith(["0xhandle1"]);
+    expect(publicDecrypt).toHaveBeenCalledWith([HANDLE]);
 
-    expect(queryClient.getQueryData(zamaQueryKeys.decryption.handle("0xhandle1"))).toBe(500n);
+    expect(queryClient.getQueryData(zamaQueryKeys.decryption.handle(HANDLE))).toBe(500n);
   });
 });

--- a/packages/react-sdk/src/unshield/__tests__/use-resume-unshield.test.tsx
+++ b/packages/react-sdk/src/unshield/__tests__/use-resume-unshield.test.tsx
@@ -26,13 +26,12 @@ describe("useResumeUnshield", () => {
 
   test("cache: invalidates balance, allowance, and wagmi after resume unshield", async ({
     renderWithProviders,
-    relayer,
     provider,
   }) => {
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
       logs: [createUnwrapRequestedLog(BURN_AMOUNT_HANDLE)],
     });
-    mockPublicDecrypt(relayer);
+    mockPublicDecrypt();
 
     const { result, queryClient } = renderWithProviders(() =>
       useResumeUnshield({ tokenAddress: TOKEN }),
@@ -57,15 +56,11 @@ describe("useResumeUnshield", () => {
     expectCacheUntouched(queryClient, otherAllowanceKey, 333n);
   });
 
-  test("behavior: forwards onSuccess callback", async ({
-    renderWithProviders,
-    relayer,
-    provider,
-  }) => {
+  test("behavior: forwards onSuccess callback", async ({ renderWithProviders, provider }) => {
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
       logs: [createUnwrapRequestedLog(BURN_AMOUNT_HANDLE)],
     });
-    mockPublicDecrypt(relayer);
+    mockPublicDecrypt();
 
     const balanceKey = zamaQueryKeys.confidentialBalance.owner(TOKEN, USER);
     const allowanceKey = zamaQueryKeys.underlyingAllowance.token(TOKEN);

--- a/packages/react-sdk/src/unshield/__tests__/use-unshield-all.test.tsx
+++ b/packages/react-sdk/src/unshield/__tests__/use-unshield-all.test.tsx
@@ -27,14 +27,13 @@ describe("useUnshieldAll", () => {
 
   test("cache: invalidates balance, allowance, and wagmi after unshield all", async ({
     renderWithProviders,
-    relayer,
     provider,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(HANDLE);
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
       logs: [createUnwrapRequestedLog(BURN_AMOUNT_HANDLE)],
     });
-    mockPublicDecrypt(relayer);
+    mockPublicDecrypt();
 
     const { result, queryClient } = renderWithProviders(() =>
       useUnshieldAll({ tokenAddress: TOKEN }),
@@ -59,16 +58,12 @@ describe("useUnshieldAll", () => {
     expectCacheUntouched(queryClient, otherAllowanceKey, 333n);
   });
 
-  test("behavior: forwards onSuccess callback", async ({
-    renderWithProviders,
-    relayer,
-    provider,
-  }) => {
+  test("behavior: forwards onSuccess callback", async ({ renderWithProviders, provider }) => {
     vi.mocked(provider.readContract).mockResolvedValue(HANDLE);
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
       logs: [createUnwrapRequestedLog(BURN_AMOUNT_HANDLE)],
     });
-    mockPublicDecrypt(relayer);
+    mockPublicDecrypt();
 
     const balanceKey = zamaQueryKeys.confidentialBalance.owner(TOKEN, USER);
     const allowanceKey = zamaQueryKeys.underlyingAllowance.token(TOKEN);

--- a/packages/react-sdk/src/unshield/__tests__/use-unshield.test.tsx
+++ b/packages/react-sdk/src/unshield/__tests__/use-unshield.test.tsx
@@ -26,13 +26,12 @@ describe("useUnshield", () => {
 
   test("cache: invalidates balance, allowance, and wagmi after unshield", async ({
     renderWithProviders,
-    relayer,
     provider,
   }) => {
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
       logs: [createUnwrapRequestedLog(BURN_AMOUNT_HANDLE)],
     });
-    mockPublicDecrypt(relayer);
+    mockPublicDecrypt();
 
     const { result, queryClient } = renderWithProviders(() => useUnshield({ tokenAddress: TOKEN }));
 
@@ -55,15 +54,11 @@ describe("useUnshield", () => {
     expectCacheUntouched(queryClient, otherAllowanceKey, 333n);
   });
 
-  test("behavior: forwards onSuccess callback", async ({
-    renderWithProviders,
-    relayer,
-    provider,
-  }) => {
+  test("behavior: forwards onSuccess callback", async ({ renderWithProviders, provider }) => {
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
       logs: [createUnwrapRequestedLog(BURN_AMOUNT_HANDLE)],
     });
-    mockPublicDecrypt(relayer);
+    mockPublicDecrypt();
 
     const balanceKey = zamaQueryKeys.confidentialBalance.owner(TOKEN, USER);
     const allowanceKey = zamaQueryKeys.underlyingAllowance.token(TOKEN);

--- a/packages/react-sdk/src/unwrap/__tests__/use-finalize-unwrap.test.tsx
+++ b/packages/react-sdk/src/unwrap/__tests__/use-finalize-unwrap.test.tsx
@@ -28,9 +28,8 @@ describe("useFinalizeUnwrap", () => {
 
   test("cache: invalidates balance, allowance, and wagmi after finalize", async ({
     renderWithProviders,
-    relayer,
   }) => {
-    mockPublicDecrypt(relayer);
+    mockPublicDecrypt();
 
     const { result, queryClient } = renderWithProviders(() =>
       useFinalizeUnwrap({ tokenAddress: TOKEN }),
@@ -55,8 +54,8 @@ describe("useFinalizeUnwrap", () => {
     expectCacheUntouched(queryClient, otherAllowanceKey, 333n);
   });
 
-  test("behavior: forwards onSuccess callback", async ({ renderWithProviders, relayer }) => {
-    mockPublicDecrypt(relayer);
+  test("behavior: forwards onSuccess callback", async ({ renderWithProviders }) => {
+    mockPublicDecrypt();
 
     const balanceKey = zamaQueryKeys.confidentialBalance.owner(TOKEN, USER);
     const allowanceKey = zamaQueryKeys.underlyingAllowance.token(TOKEN);

--- a/packages/sdk/src/__tests__/optional-signer.test.ts
+++ b/packages/sdk/src/__tests__/optional-signer.test.ts
@@ -33,10 +33,9 @@ describe("ZamaSDK without signer", () => {
     expect(sdk.createToken(tokenAddress)).toBeInstanceOf(Token);
   });
 
-  it("publicDecrypt works with no signer", async ({ createSDK, relayer }) => {
+  it("publicDecrypt requires a signer", async ({ createSDK }) => {
     const sdk = createSDK({ signer: undefined });
-    await sdk.publicDecrypt(["0xhandle"]);
-    expect(relayer.publicDecrypt).toHaveBeenCalled();
+    await expect(sdk.publicDecrypt(["0xhandle"])).rejects.toThrow(SignerNotConfiguredError);
   });
 
   it("isAllowed returns false (pure store lookup, no signer needed)", async ({ createSDK }) => {

--- a/packages/sdk/src/__tests__/zama-sdk.test.ts
+++ b/packages/sdk/src/__tests__/zama-sdk.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect, vi, TEST_ADDR_B } from "../test-fixtures";
 import { ReadonlyToken } from "../token/readonly-token";
 import { Token } from "../token/token";
-import {
-  DecryptionFailedError,
-  SignerNotConfiguredError,
-  WalletAccountNotReadyError,
-} from "../errors";
+import { SignerNotConfiguredError, WalletAccountNotReadyError } from "../errors";
 import type { GenericSigner, WalletAccountChange, WalletAccountListener } from "../types";
 import type { Address } from "viem";
 import type { DecryptHandle } from "../query/user-decrypt";
@@ -259,13 +255,8 @@ describe("ZamaSDK", () => {
   });
 
   describe("publicDecrypt", () => {
-    it("delegates to relayer.publicDecrypt and returns the result", async ({
-      sdk,
-      relayer,
-      handle,
-    }) => {
+    it("returns the public decrypt result", async ({ sdk, handle }) => {
       const result = await sdk.publicDecrypt([handle]);
-      expect(relayer.publicDecrypt).toHaveBeenCalledWith([handle]);
       expect(result).toEqual({
         clearValues: { [handle]: 500n },
         abiEncodedClearValues: "0x1f4",
@@ -273,30 +264,13 @@ describe("ZamaSDK", () => {
       });
     });
 
-    it("returns empty result for empty handles without calling relayer", async ({
-      sdk,
-      relayer,
-    }) => {
+    it("returns empty result for empty handles", async ({ sdk }) => {
       const result = await sdk.publicDecrypt([]);
       expect(result).toEqual({
         clearValues: {},
         decryptionProof: "0x",
         abiEncodedClearValues: "0x",
       });
-      expect(relayer.publicDecrypt).not.toHaveBeenCalled();
-    });
-
-    it("wraps error on failure", async ({ sdk, relayer, handle }) => {
-      vi.mocked(relayer.publicDecrypt).mockRejectedValueOnce(new Error("relayer down"));
-
-      await expect(sdk.publicDecrypt([handle])).rejects.toThrow(DecryptionFailedError);
-    });
-
-    it("re-throws DecryptionFailedError as-is", async ({ sdk, relayer, handle }) => {
-      const original = new DecryptionFailedError("already typed");
-      vi.mocked(relayer.publicDecrypt).mockRejectedValueOnce(original);
-
-      await expect(sdk.publicDecrypt([handle])).rejects.toBe(original);
     });
   });
 

--- a/packages/sdk/src/services/__tests__/decryption-service.test.ts
+++ b/packages/sdk/src/services/__tests__/decryption-service.test.ts
@@ -1,5 +1,6 @@
 import { getAddress, type Address } from "viem";
 import { MAX_UINT64 } from "../../contracts";
+import { DecryptionFailedError } from "../../errors";
 import type { DecryptHandle } from "../../query/user-decrypt";
 import type { Handle } from "../../relayer/relayer-sdk.types";
 import { describe, expect, test, TEST_PUBLIC_KEY, vi } from "../../test-fixtures";
@@ -245,5 +246,48 @@ describe("DecryptionService", () => {
     await expect(
       service.userDecrypt(handles([[HANDLE_A, CONTRACT_A]]), userAddress),
     ).resolves.toEqual({ [HANDLE_A]: 10n });
+  });
+
+  test("publicDecrypt delegates to relayer", async ({ createDecryptionService, relayer }) => {
+    const service = createDecryptionService();
+
+    await expect(service.publicDecrypt([HANDLE_A])).resolves.toEqual({
+      clearValues: { [HANDLE_A]: 500n },
+      abiEncodedClearValues: "0x1f4",
+      decryptionProof: "0xproof",
+    });
+    expect(relayer.publicDecrypt).toHaveBeenCalledWith([HANDLE_A]);
+  });
+
+  test("publicDecrypt returns empty result without relayer round-trip", async ({
+    createDecryptionService,
+    relayer,
+  }) => {
+    const service = createDecryptionService();
+
+    await expect(service.publicDecrypt([])).resolves.toEqual({
+      clearValues: {},
+      decryptionProof: "0x",
+      abiEncodedClearValues: "0x",
+    });
+    expect(relayer.publicDecrypt).not.toHaveBeenCalled();
+  });
+
+  test("publicDecrypt wraps relayer failures", async ({ createDecryptionService, relayer }) => {
+    const service = createDecryptionService();
+    vi.mocked(relayer.publicDecrypt).mockRejectedValueOnce(new Error("relayer down"));
+
+    await expect(service.publicDecrypt([HANDLE_A])).rejects.toThrow(DecryptionFailedError);
+  });
+
+  test("publicDecrypt rethrows DecryptionFailedError as-is", async ({
+    createDecryptionService,
+    relayer,
+  }) => {
+    const service = createDecryptionService();
+    const original = new DecryptionFailedError("already typed");
+    vi.mocked(relayer.publicDecrypt).mockRejectedValueOnce(original);
+
+    await expect(service.publicDecrypt([HANDLE_A])).rejects.toBe(original);
   });
 });

--- a/packages/sdk/src/services/decryption-service.ts
+++ b/packages/sdk/src/services/decryption-service.ts
@@ -10,7 +10,7 @@ import type { ZamaSDKEventInput } from "../events/sdk-events";
 import { ZamaSDKEvents } from "../events/sdk-events";
 import type { DecryptHandle } from "../query/user-decrypt";
 import type { RelayerDispatcher } from "../relayer/relayer-dispatcher";
-import type { ClearValueType, Handle } from "../relayer/relayer-sdk.types";
+import type { ClearValueType, Handle, PublicDecryptResult } from "../relayer/relayer-sdk.types";
 import { pLimit } from "../utils/concurrency";
 import { isZeroHandle } from "../utils/handles";
 import { toError } from "../utils";
@@ -183,6 +183,22 @@ export class DecryptionService {
     );
 
     return { items };
+  }
+
+  async publicDecrypt(handles: Handle[]): Promise<PublicDecryptResult> {
+    if (handles.length === 0) {
+      return {
+        clearValues: {},
+        decryptionProof: "0x",
+        abiEncodedClearValues: "0x",
+      };
+    }
+
+    try {
+      return await this.#relayer.publicDecrypt(handles);
+    } catch (error) {
+      throw wrapDecryptError(error, "Public decryption failed");
+    }
   }
 
   async #decrypt(

--- a/packages/sdk/src/token/__tests__/callbacks.test.ts
+++ b/packages/sdk/src/token/__tests__/callbacks.test.ts
@@ -165,13 +165,14 @@ describe("Unshield callbacks (P4)", () => {
   });
 
   it("throws DecryptionFailedError when publicDecrypt fails during finalize", async ({
-    relayer,
     userAddress,
     token,
     provider,
   }) => {
     mockReceiptWithUnwrapRequested(provider, userAddress);
-    vi.mocked(relayer.publicDecrypt).mockRejectedValue(new Error("decrypt error"));
+    vi.spyOn(token.sdk, "publicDecrypt").mockRejectedValue(
+      new DecryptionFailedError("decrypt error"),
+    );
 
     await expect(token.unshield(50n, { skipBalanceCheck: true })).rejects.toThrow(
       DecryptionFailedError,

--- a/packages/sdk/src/token/__tests__/integration.test.ts
+++ b/packages/sdk/src/token/__tests__/integration.test.ts
@@ -2,9 +2,10 @@ import { Topics } from "../../events";
 import type { RawLog } from "../../events";
 import { describe, expect, it, vi } from "../../test-fixtures";
 import type { Address } from "viem";
+import type { Handle } from "../../relayer/relayer-sdk.types";
 
 const RECIPIENT = "0x8b8b8b8b8B8B8b8B8B8b8b8b8b8B8B8B8B8b8B8b" as Address;
-const BURN_HANDLE = ("0x" + "ff".repeat(32)) as Address;
+const BURN_HANDLE = ("0x" + "ff".repeat(32)) as Handle;
 
 describe("Integration: multi-step workflows", () => {
   describe("shield flow: approve → shield → verify balance", () => {
@@ -106,6 +107,7 @@ describe("Integration: multi-step workflows", () => {
       userAddress,
       provider,
     }) => {
+      const publicDecrypt = vi.spyOn(token.sdk, "publicDecrypt");
       // Step 1: Execute unwrap (encrypts amount, sends tx)
       const unwrapResult = await token.unwrap(500n);
       expect(unwrapResult.txHash).toBe("0xtxhash");
@@ -138,8 +140,7 @@ describe("Integration: multi-step workflows", () => {
       const finalizeResult = await token.finalizeUnwrap(BURN_HANDLE);
       expect(finalizeResult.txHash).toBe("0xfinalizetx");
 
-      // Verify publicDecrypt was called with the burn handle
-      expect(relayer.publicDecrypt).toHaveBeenCalledWith([BURN_HANDLE]);
+      expect(publicDecrypt).toHaveBeenCalledWith([BURN_HANDLE]);
 
       // Verify finalizeUnwrap contract call
       expect(signer.writeContract).toHaveBeenCalledWith(
@@ -154,6 +155,7 @@ describe("Integration: multi-step workflows", () => {
       userAddress,
       provider,
     }) => {
+      const publicDecrypt = vi.spyOn(token.sdk, "publicDecrypt");
       // Mock receipt with UnwrapRequested event for the auto-finalize path.
       // unwrap() now calls waitForTransactionReceipt (1st call),
       // then #waitAndFinalizeUnshield calls it again (2nd call) to parse the event,
@@ -183,7 +185,7 @@ describe("Integration: multi-step workflows", () => {
         expect.objectContaining({ functionName: "unwrap" }),
       );
       expect(provider.waitForTransactionReceipt).toHaveBeenCalled();
-      expect(relayer.publicDecrypt).toHaveBeenCalledWith([BURN_HANDLE]);
+      expect(publicDecrypt).toHaveBeenCalledWith([BURN_HANDLE]);
       expect(signer.writeContract).toHaveBeenCalledWith(
         expect.objectContaining({ functionName: "finalizeUnwrap" }),
       );

--- a/packages/sdk/src/token/__tests__/token.test.ts
+++ b/packages/sdk/src/token/__tests__/token.test.ts
@@ -3,6 +3,7 @@ import { getAddress, type Address } from "viem";
 import { DecryptionFailedError, ZamaError, ZamaErrorCode } from "../../errors";
 import { isZeroHandle, ZERO_HANDLE } from "../../utils/handles";
 import { describe, expect, it, vi } from "../../test-fixtures";
+import type { Handle } from "../../relayer/relayer-sdk.types";
 
 describe("Token", () => {
   describe("balanceOf", () => {
@@ -337,17 +338,17 @@ describe("Token", () => {
   });
 
   describe("finalizeUnwrap", () => {
-    it("calls publicDecrypt with unwrapRequestId and finalizes on-chain", async ({
-      relayer,
+    it("calls SDK publicDecrypt with unwrapRequestId and finalizes on-chain", async ({
       signer,
       token,
     }) => {
       // unwrapRequestId comes from the UnwrapRequested event — it is a bytes32 identifier,
       // not the burn amount handle. publicDecrypt must receive this exact value.
-      const unwrapRequestId = ("0x" + "ab".repeat(32)) as `0x${string}`;
+      const unwrapRequestId = ("0x" + "ab".repeat(32)) as Handle;
+      const publicDecrypt = vi.spyOn(token.sdk, "publicDecrypt");
       const result = await token.finalizeUnwrap(unwrapRequestId);
 
-      expect(relayer.publicDecrypt).toHaveBeenCalledWith([unwrapRequestId]);
+      expect(publicDecrypt).toHaveBeenCalledWith([unwrapRequestId]);
       expect(signer.writeContract).toHaveBeenCalledWith(
         expect.objectContaining({ functionName: "finalizeUnwrap" }),
       );
@@ -357,8 +358,8 @@ describe("Token", () => {
   });
 
   describe("unshield", () => {
-    const BURN_HANDLE = "0x" + "ff".repeat(32);
-    const UNWRAP_REQUEST_ID = ("0x" + "aa".repeat(32)) as `0x${string}`;
+    const BURN_HANDLE = ("0x" + "ff".repeat(32)) as Handle;
+    const UNWRAP_REQUEST_ID = ("0x" + "aa".repeat(32)) as Handle;
 
     it("orchestrates unwrap → receipt → finalizeUnwrap", async ({
       relayer,
@@ -367,6 +368,7 @@ describe("Token", () => {
       token,
       provider,
     }) => {
+      const publicDecrypt = vi.spyOn(token.sdk, "publicDecrypt");
       vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
         logs: [
           {
@@ -387,7 +389,7 @@ describe("Token", () => {
         expect.objectContaining({ functionName: "unwrap" }),
       );
       expect(provider.waitForTransactionReceipt).toHaveBeenCalledWith("0xtxhash");
-      expect(relayer.publicDecrypt).toHaveBeenCalledWith([BURN_HANDLE]);
+      expect(publicDecrypt).toHaveBeenCalledWith([BURN_HANDLE]);
       expect(signer.writeContract).toHaveBeenCalledWith(
         expect.objectContaining({ functionName: "finalizeUnwrap" }),
       );
@@ -396,12 +398,12 @@ describe("Token", () => {
     });
 
     it("uses unwrapRequestId from upgraded UnwrapRequested events", async ({
-      relayer,
       signer,
       userAddress,
       token,
       provider,
     }) => {
+      const publicDecrypt = vi.spyOn(token.sdk, "publicDecrypt");
       vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
         logs: [
           {
@@ -417,7 +419,7 @@ describe("Token", () => {
 
       await token.unshield(50n, { skipBalanceCheck: true });
 
-      expect(relayer.publicDecrypt).toHaveBeenCalledWith([UNWRAP_REQUEST_ID]);
+      expect(publicDecrypt).toHaveBeenCalledWith([UNWRAP_REQUEST_ID]);
       expect(signer.writeContract).toHaveBeenCalledWith(
         expect.objectContaining({
           functionName: "finalizeUnwrap",
@@ -463,16 +465,16 @@ describe("Token", () => {
   });
 
   describe("unshieldAll", () => {
-    const BURN_HANDLE = "0x" + "ff".repeat(32);
+    const BURN_HANDLE = ("0x" + "ff".repeat(32)) as Handle;
 
     it("orchestrates unwrapAll → receipt → finalizeUnwrap", async ({
-      relayer,
       signer,
       userAddress,
       token,
       handle,
       provider,
     }) => {
+      const publicDecrypt = vi.spyOn(token.sdk, "publicDecrypt");
       vi.mocked(provider.readContract).mockResolvedValue(handle);
       vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
         logs: [
@@ -493,7 +495,7 @@ describe("Token", () => {
         expect.objectContaining({ functionName: "unwrap" }),
       );
       expect(provider.waitForTransactionReceipt).toHaveBeenCalledWith("0xtxhash");
-      expect(relayer.publicDecrypt).toHaveBeenCalledWith([BURN_HANDLE]);
+      expect(publicDecrypt).toHaveBeenCalledWith([BURN_HANDLE]);
       expect(result.txHash).toBe("0xtxhash");
       expect(result.receipt).toBeDefined();
     });
@@ -850,63 +852,41 @@ describe("Token", () => {
   });
 
   describe("finalizeUnwrap (error handling)", () => {
-    it("wraps publicDecrypt failure in DecryptionFailed", async ({
-      relayer,
-
-      token,
-    }) => {
-      vi.mocked(relayer.publicDecrypt).mockRejectedValueOnce(new Error("decrypt failed"));
-
-      await expect(token.finalizeUnwrap("0xburn" as Address)).rejects.toSatisfy(
-        (err: ZamaError) => {
-          return (
-            err instanceof ZamaError &&
-            err.code === ZamaErrorCode.DecryptionFailed &&
-            err.message === "Public decryption failed"
-          );
-        },
-      );
-    });
-
-    it("re-throws DecryptionFailedError from publicDecrypt as-is", async ({
-      relayer,
-
-      token,
-    }) => {
+    it("re-throws DecryptionFailedError from publicDecrypt as-is", async ({ token }) => {
+      const burnHandle = ("0x" + "bd".repeat(32)) as Handle;
       const original = new DecryptionFailedError("already wrapped");
-      vi.mocked(relayer.publicDecrypt).mockRejectedValueOnce(original);
+      vi.spyOn(token.sdk, "publicDecrypt").mockRejectedValueOnce(original);
 
-      await expect(token.finalizeUnwrap("0xburn" as Address)).rejects.toBe(original);
+      await expect(token.finalizeUnwrap(burnHandle)).rejects.toBe(original);
     });
 
-    it("throws TypeError when clearValues does not contain the handle", async ({
-      relayer,
-
-      token,
-    }) => {
-      vi.mocked(relayer.publicDecrypt).mockResolvedValueOnce({
+    it("throws TypeError when clearValues does not contain the handle", async ({ token }) => {
+      const burnHandle = ("0x" + "be".repeat(32)) as Handle;
+      vi.spyOn(token.sdk, "publicDecrypt").mockResolvedValueOnce({
         clearValues: {},
         abiEncodedClearValues: "0x00",
         decryptionProof: "0x12",
       });
 
-      await expect(token.finalizeUnwrap("0xburn" as Address)).rejects.toThrow(TypeError);
+      await expect(token.finalizeUnwrap(burnHandle)).rejects.toThrow(TypeError);
     });
 
     it("re-throws ZamaError from writeContract as-is", async ({ signer, token }) => {
+      const burnHandle = ("0x" + "bf".repeat(32)) as Handle;
       const original = new ZamaError(ZamaErrorCode.TransactionReverted, "already wrapped");
       vi.mocked(signer.writeContract).mockRejectedValueOnce(original);
 
-      await expect(token.finalizeUnwrap("0xburn" as Address)).rejects.toBe(original);
+      await expect(token.finalizeUnwrap(burnHandle)).rejects.toBe(original);
     });
 
     it("wraps non-ZamaError from writeContract in TransactionReverted", async ({
       signer,
       token,
     }) => {
+      const burnHandle = ("0x" + "c0".repeat(32)) as Handle;
       vi.mocked(signer.writeContract).mockRejectedValueOnce(new Error("tx failed"));
 
-      await expect(token.finalizeUnwrap("0xburn" as Address)).rejects.toMatchObject({
+      await expect(token.finalizeUnwrap(burnHandle)).rejects.toMatchObject({
         code: ZamaErrorCode.TransactionReverted,
         message: "Failed to finalize unshield",
       });
@@ -1054,15 +1034,11 @@ describe("Token", () => {
   });
 
   describe("resumeUnshield", () => {
-    const BURN_HANDLE = "0x" + "ff".repeat(32);
-    const UNWRAP_REQUEST_ID = ("0x" + "aa".repeat(32)) as `0x${string}`;
+    const BURN_HANDLE = ("0x" + "ff".repeat(32)) as Handle;
+    const UNWRAP_REQUEST_ID = ("0x" + "aa".repeat(32)) as Handle;
 
-    it("resumes from an existing unwrap tx hash", async ({
-      relayer,
-      userAddress,
-      token,
-      provider,
-    }) => {
+    it("resumes from an existing unwrap tx hash", async ({ userAddress, token, provider }) => {
+      const publicDecrypt = vi.spyOn(token.sdk, "publicDecrypt");
       vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
         logs: [
           {
@@ -1079,17 +1055,17 @@ describe("Token", () => {
       const result = await token.resumeUnshield("0xprevioustx" as `0x${string}`);
 
       expect(provider.waitForTransactionReceipt).toHaveBeenCalledWith("0xprevioustx");
-      expect(relayer.publicDecrypt).toHaveBeenCalledWith([BURN_HANDLE]);
+      expect(publicDecrypt).toHaveBeenCalledWith([BURN_HANDLE]);
       expect(result.txHash).toBe("0xtxhash");
     });
 
     it("uses unwrapRequestId from upgraded UnwrapRequested events", async ({
-      relayer,
       provider,
       signer,
       userAddress,
       token,
     }) => {
+      const publicDecrypt = vi.spyOn(token.sdk, "publicDecrypt");
       vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
         logs: [
           {
@@ -1106,7 +1082,7 @@ describe("Token", () => {
       await token.resumeUnshield("0xprevioustx" as `0x${string}`);
 
       expect(provider.waitForTransactionReceipt).toHaveBeenCalledWith("0xprevioustx");
-      expect(relayer.publicDecrypt).toHaveBeenCalledWith([UNWRAP_REQUEST_ID]);
+      expect(publicDecrypt).toHaveBeenCalledWith([UNWRAP_REQUEST_ID]);
       expect(signer.writeContract).toHaveBeenCalledWith(
         expect.objectContaining({
           functionName: "finalizeUnwrap",

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -1,12 +1,7 @@
 import { getAddress, type Address } from "viem";
 import type { ZamaConfig } from "./config/types";
 import { CredentialService } from "./credentials/credential-service";
-import {
-  ChainMismatchError,
-  SignerNotConfiguredError,
-  WalletAccountNotReadyError,
-  wrapDecryptError,
-} from "./errors";
+import { ChainMismatchError, SignerNotConfiguredError, WalletAccountNotReadyError } from "./errors";
 import type { ZamaSDKEvent, ZamaSDKEventInput, ZamaSDKEventListener } from "./events/sdk-events";
 import type { DecryptHandle } from "./query/user-decrypt";
 import type { RelayerDispatcher } from "./relayer/relayer-dispatcher";
@@ -104,7 +99,6 @@ export class ZamaSDK {
         relayer: this.relayer,
         emitEvent: (input) => this.emitEvent(input),
       });
-
       this.#unsubscribeSigner = signer.walletAccount.subscribe((change) => {
         this.#handleWalletAccountChange(change).catch((error) => {
           // oxlint-disable-next-line no-console
@@ -557,6 +551,7 @@ export class ZamaSDK {
    *
    * @param handles - FHE handles to decrypt publicly.
    * @returns Clear-text values, ABI-encoded values, and the decryption proof.
+   * @throws {@link SignerNotConfiguredError} if no signer is configured.
    *
    * @example
    * ```ts
@@ -565,19 +560,7 @@ export class ZamaSDK {
    * ```
    */
   async publicDecrypt(handles: Handle[]): Promise<PublicDecryptResult> {
-    if (handles.length === 0) {
-      return {
-        clearValues: {},
-        decryptionProof: "0x",
-        abiEncodedClearValues: "0x",
-      };
-    }
-
-    try {
-      return await this.relayer.publicDecrypt(handles);
-    } catch (error) {
-      throw wrapDecryptError(error, "Public decryption failed");
-    }
+    return this.#requireDecryptionService("publicDecrypt").publicDecrypt(handles);
   }
 
   /**


### PR DESCRIPTION
## Context

After SDK-161, `userDecrypt` and `delegatedUserDecrypt` live in `DecryptionService`, but `publicDecrypt` still lived directly in `ZamaSDK` — duplicating the error-wrapping seam and forcing developers to look in two places for decryption logic.

## Motivation

All decrypt paths should live behind the same service interface. Consolidating establishes a single owner for decrypt orchestration.

## Summary

- Add `publicDecrypt` method to `DecryptionService` (relayer delegation + `wrapDecryptError`)
- Replace `ZamaSDK.publicDecrypt` body with a forwarding call to the service
- `publicDecrypt` now requires a signer (guards via `#requireDecryptionService`)
- Update react-sdk tests to spy on `ZamaSDK.prototype.publicDecrypt` instead of `relayer.publicDecrypt`

Closes SDK-166