### PR TITLE
refactor(sdk): migrate from zod to zod/mini

### DIFF
--- a/packages/sdk/src/config/web.ts
+++ b/packages/sdk/src/config/web.ts
@@ -1,12 +1,12 @@
-import { z } from "zod";
+import { z } from "zod/mini";
 import { CDN_INTEGRITY, CDN_URL, RelayerWeb } from "../relayer/relayer-web";
 import { parseConfiguration } from "../validation";
 import { RelayerWorkerClient } from "../worker/worker.client";
 import type { WebRelayerConfig, WebRelayerOptions } from "./types";
 
 const WebRelayerOptionsSchema = z.object({
-  threads: z.number().int().positive().optional(),
-  fheArtifactCacheTTL: z.number().int().nonnegative().optional(),
+  threads: z.optional(z.int().check(z.positive())),
+  fheArtifactCacheTTL: z.optional(z.int().check(z.nonnegative())),
 });
 
 /**

--- a/packages/sdk/src/credentials/schemas.ts
+++ b/packages/sdk/src/credentials/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/mini";
 import {
   checksummedAddress,
   chainId,
@@ -15,21 +15,21 @@ const permitTTLError = "permitTTL must be a positive integer number of days";
 /** Maximum keypairTTL accepted by the fhevm ACL contract (365 days, in seconds). */
 export const MAX_KEYPAIR_TTL_SECONDS = 365 * SECONDS_PER_DAY;
 
+// z.int already rejects NaN, Infinity, and non-integers, so it covers
+// the previous .finite() + .int() combo with a single schema.
 export const KeypairTTLSchema = z
-  .number(keypairTTLError)
-  .finite(keypairTTLError)
-  .int(keypairTTLError)
-  .positive(keypairTTLError)
-  .max(
-    MAX_KEYPAIR_TTL_SECONDS,
-    `keypairTTL must not exceed the fhevm ACL maximum of ${MAX_KEYPAIR_TTL_SECONDS}s (365 days)`,
+  .int({ error: keypairTTLError })
+  .check(
+    z.positive({ error: keypairTTLError }),
+    z.maximum(
+      MAX_KEYPAIR_TTL_SECONDS,
+      `keypairTTL must not exceed the fhevm ACL maximum of ${MAX_KEYPAIR_TTL_SECONDS}s (365 days)`,
+    ),
   );
 
 export const PermitTTLSchema = z
-  .number(permitTTLError)
-  .finite(permitTTLError)
-  .int(permitTTLError)
-  .positive(permitTTLError);
+  .int({ error: permitTTLError })
+  .check(z.positive({ error: permitTTLError }));
 
 export const StoredKeypairSchema = z.object({
   publicKey: hex,
@@ -43,7 +43,7 @@ export const PermissionSchema = z.object({
   signerAddress: checksummedAddress,
   delegatorAddress: checksummedAddress,
   chainId,
-  signedContractAddresses: z.array(checksummedAddress).max(MAX_CONTRACTS_PER_PERMIT),
+  signedContractAddresses: z.array(checksummedAddress).check(z.maxLength(MAX_CONTRACTS_PER_PERMIT)),
   signature: hex,
   startTimestamp: unixSeconds,
   durationDays: positiveDays,

--- a/packages/sdk/src/credentials/types.ts
+++ b/packages/sdk/src/credentials/types.ts
@@ -1,5 +1,5 @@
 import type { Hex } from "viem";
-import type { z } from "zod";
+import type { z } from "zod/mini";
 import type { PermissionSchema, StoredKeypairSchema } from "./schemas";
 
 /** In-memory FHE keypair (plaintext private key). */

--- a/packages/sdk/src/node/config.ts
+++ b/packages/sdk/src/node/config.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/mini";
 import type { RelayerConfig } from "../config/types";
 import { RelayerNode } from "../relayer/relayer-node";
 import type { FheChain } from "../chains/types";
@@ -24,8 +24,8 @@ export interface NodeRelayerConfig extends RelayerConfig {
 }
 
 const NodePoolOptionsSchema = z.object({
-  poolSize: z.number().int().positive().optional(),
-  fheArtifactCacheTTL: z.number().int().nonnegative().optional(),
+  poolSize: z.optional(z.int().check(z.positive())),
+  fheArtifactCacheTTL: z.optional(z.int().check(z.nonnegative())),
 });
 
 /**

--- a/packages/sdk/src/relayer/fhe-artifact-cache.ts
+++ b/packages/sdk/src/relayer/fhe-artifact-cache.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/mini";
 import type { GenericStorage } from "../types";
 import { assertNonNullable, toError } from "../utils";
 import type { GenericLogger } from "../worker/worker.types";
@@ -7,29 +7,29 @@ import type { PublicKeyData, PublicParamsData } from "./relayer-sdk.types";
 // ── Cached data shapes ──────────────────────────────────────
 
 const CachedArtifactBase = z.object({
-  artifactUrl: z.string().optional(),
-  etag: z.string().optional(),
-  lastModified: z.string().optional(),
+  artifactUrl: z.optional(z.string()),
+  etag: z.optional(z.string()),
+  lastModified: z.optional(z.string()),
   // Optional + default(0) preserves the prior `?? 0` fallback for entries
   // persisted before this field was added; 0 marks them stale via the TTL check.
-  lastValidatedAt: z.number().nonnegative().optional().default(0),
+  lastValidatedAt: z._default(z.optional(z.number().check(z.nonnegative())), 0),
 });
 
 /** Cached shape for the FHE network public key. */
-const CachedPublicKeySchema = CachedArtifactBase.extend({
+const CachedPublicKeySchema = z.extend(CachedArtifactBase, {
   publicKeyId: z.string(),
   publicKey: z.string(),
 });
 type CachedPublicKey = z.infer<typeof CachedPublicKeySchema>;
 
 /** Cached shape for FHE public params. */
-const CachedPublicParamsSchema = CachedArtifactBase.extend({
+const CachedPublicParamsSchema = z.extend(CachedArtifactBase, {
   publicParamsId: z.string(),
   publicParams: z.string(),
 });
 type CachedPublicParams = z.infer<typeof CachedPublicParamsSchema>;
 
-const ParamsIndexSchema = z.array(z.number().int().nonnegative());
+const ParamsIndexSchema = z.array(z.int().check(z.nonnegative()));
 
 /**
  * Manifest shape returned by the relayer `/keyurl` endpoint. Only the fields
@@ -43,15 +43,15 @@ const ManifestSchema = z.object({
       .array(
         z.object({
           fhePublicKey: z.object({
-            urls: z.array(z.string()).min(1),
+            urls: z.array(z.string()).check(z.minLength(1)),
           }),
         }),
       )
-      .min(1),
+      .check(z.minLength(1)),
     crs: z.record(
       z.string(),
       z.object({
-        urls: z.array(z.string()).min(1),
+        urls: z.array(z.string()).check(z.minLength(1)),
       }),
     ),
   }),
@@ -629,7 +629,7 @@ export class FheArtifactCache {
 
   async #readCachedEntry<T>(
     key: string,
-    schema: z.ZodType<T>,
+    schema: z.core.$ZodType<T>,
     label: string,
     readError: string,
     context: LogContext = {},
@@ -654,11 +654,11 @@ export class FheArtifactCache {
   async #parseCachedEntry<T>(
     key: string,
     raw: unknown,
-    schema: z.ZodType<T>,
+    schema: z.core.$ZodType<T>,
     label: string,
     context: LogContext = {},
   ): Promise<T | null> {
-    const parsed = schema.safeParse(raw);
+    const parsed = z.safeParse(schema, raw);
     if (parsed.success) {
       return parsed.data;
     }

--- a/packages/sdk/src/schemas/primitives.ts
+++ b/packages/sdk/src/schemas/primitives.ts
@@ -1,5 +1,5 @@
 import { type Address, getAddress, isAddress, isHex, type Hex } from "viem";
-import { z } from "zod";
+import { z } from "zod/mini";
 
 declare const checksummedTag: unique symbol;
 
@@ -12,29 +12,31 @@ export function checksum(value: Address): ChecksummedAddress {
 }
 
 /** `0x`-prefixed hex string. */
-export const hex = z
-  .string()
-  .refine((v): v is Hex => isHex(v, { strict: true }), "expected 0x-prefixed hex string");
+export const hex = z.custom<Hex>(
+  (v) => typeof v === "string" && isHex(v, { strict: true }),
+  "expected 0x-prefixed hex string",
+);
 
 /** Validates an EVM address string. Output type is `Address` (`` `0x${string}` ``). */
-export const evmAddress = z
-  .string()
-  .refine((v): v is Address => isAddress(v, { strict: false }), "expected EVM address");
+export const evmAddress = z.custom<Address>(
+  (v) => typeof v === "string" && isAddress(v, { strict: false }),
+  "expected EVM address",
+);
 
 /** Validates and EIP-55 checksums an EVM address. Output is {@link ChecksummedAddress}. */
-export const checksummedAddress = evmAddress.transform(checksum);
+export const checksummedAddress = z.pipe(evmAddress, z.transform(checksum));
 
 /** Non-negative integer Unix timestamp in seconds. */
-export const unixSeconds = z.number().int().nonnegative();
+export const unixSeconds = z.int().check(z.nonnegative());
 
 /** Positive integer count of seconds (e.g. a TTL). */
-export const positiveSeconds = z.number().int().positive();
+export const positiveSeconds = z.int().check(z.positive());
 
 /** Non-negative integer count of seconds (e.g. a cache TTL where 0 disables caching). */
-export const nonNegativeSeconds = z.number().int().nonnegative();
+export const nonNegativeSeconds = z.int().check(z.nonnegative());
 
 /** Positive integer count of days (e.g. a permit duration). */
-export const positiveDays = z.number().int().positive();
+export const positiveDays = z.int().check(z.positive());
 
 /** Positive integer EVM chain ID. */
-export const chainId = z.number().int().positive();
+export const chainId = z.int().check(z.positive());

--- a/packages/sdk/src/services/caching-service.ts
+++ b/packages/sdk/src/services/caching-service.ts
@@ -1,5 +1,5 @@
 import { getAddress, type Address } from "viem";
-import { z } from "zod";
+import { z } from "zod/mini";
 import type { ClearValueType, Handle } from "../relayer/relayer-sdk.types";
 import { checksummedAddress } from "../schemas/primitives";
 import type { GenericStorage } from "../types";

--- a/packages/sdk/src/token/pending-unshield.ts
+++ b/packages/sdk/src/token/pending-unshield.ts
@@ -1,5 +1,5 @@
 import type { Address, Hex } from "viem";
-import { z } from "zod";
+import { z } from "zod/mini";
 import { checksum, hex } from "../schemas/primitives";
 import type { GenericStorage } from "../types";
 import type { Handle } from "../relayer/relayer-sdk.types";
@@ -32,14 +32,27 @@ function storageKey(wrapperAddress: Address): string {
 }
 
 const PendingUnshieldRequestSchema = z.union([
-  hex.transform((unwrapTxHash) => ({ unwrapTxHash })),
-  z
-    .object({
+  z.pipe(
+    hex,
+    z.transform((unwrapTxHash: Hex) => ({ unwrapTxHash })),
+  ),
+  z.pipe(
+    z.object({
       version: z.literal(CURRENT_VERSION),
       unwrapTxHash: hex,
-      unwrapRequestId: hex.optional(),
-    })
-    .transform(({ unwrapTxHash, unwrapRequestId }) => ({ unwrapTxHash, unwrapRequestId })),
+      unwrapRequestId: z.optional(hex),
+    }),
+    z.transform(
+      ({
+        unwrapTxHash,
+        unwrapRequestId,
+      }: {
+        version: typeof CURRENT_VERSION;
+        unwrapTxHash: Hex;
+        unwrapRequestId?: Hex;
+      }) => ({ unwrapTxHash, unwrapRequestId }),
+    ),
+  ),
 ]);
 
 /**

--- a/packages/sdk/src/validation.ts
+++ b/packages/sdk/src/validation.ts
@@ -1,8 +1,8 @@
-import { z } from "zod";
+import { z } from "zod/mini";
 import { ConfigurationError } from "./errors";
 
-export function parseConfiguration<T>(schema: z.ZodType<T>, value: unknown): T {
-  const parsed = schema.safeParse(value);
+export function parseConfiguration<T>(schema: z.core.$ZodType<T>, value: unknown): T {
+  const parsed = z.safeParse(schema, value);
   if (parsed.success) {
     return parsed.data;
   }

--- a/packages/sdk/src/wrappers-registry.ts
+++ b/packages/sdk/src/wrappers-registry.ts
@@ -1,5 +1,5 @@
 import { type Address, getAddress, zeroAddress } from "viem";
-import { z } from "zod";
+import { z } from "zod/mini";
 import type { TokenWrapperPairWithMetadata, PaginatedResult, TokenWrapperPair } from "./contracts";
 import {
   decimalsContract,
@@ -35,7 +35,7 @@ export const DEFAULT_REGISTRY_TTL_SECONDS = 86_400;
 
 /** Per-chain wrappers-registry address overrides. */
 export const RegistryAddressesSchema = z.record(
-  z.string().regex(/^\d+$/, "expected numeric chain id key"),
+  z.string().check(z.regex(/^\d+$/, "expected numeric chain id key")),
   checksummedAddress,
 );
 
@@ -127,7 +127,7 @@ export class WrappersRegistry {
     this.#addresses = Object.assign(
       {},
       DefaultRegistryAddresses,
-      parseConfiguration(RegistryAddressesSchema.optional(), config.registryAddresses),
+      parseConfiguration(z.optional(RegistryAddressesSchema), config.registryAddresses),
     );
     this.#ttlMs =
       parseConfiguration(RegistryTTLSchema, config.registryTTL ?? DEFAULT_REGISTRY_TTL_SECONDS) *


### PR DESCRIPTION
## Summary

Switch all 10 SDK schema/validation files from `zod` to `zod/mini`, the tree-shakeable functional API introduced in zod 4. No public API change — peer dep stays `zod >= 4`.

## Bundle size (brotlied, via `size-limit`)

| Bundle | Before | After | Δ |
|---|---|---|---|
| `@zama-fhe/sdk` ESM | 65.55 kB | **56.19 kB** | −9.36 kB (~14%) |
| `@zama-fhe/sdk` CJS | 56.69 kB | **47.32 kB** | −9.37 kB (~17%) |
| `@zama-fhe/react-sdk` | 3.53 kB | 3.53 kB | unchanged (no zod usage) |

Both SDK bundles were within 1 kB of the `size-limit` ceiling; each now has ~10 kB of headroom.

## What changed

- Chained checks → top-level functions: `.min/.max/.regex` → `.check(z.minLength/z.maxLength/z.regex)`, `.nonnegative/.positive` → `.check(z.nonnegative/z.positive)`.
- `z.number().int()` → `z.int()` (rejects NaN/Infinity by construction, so the old `.finite().int()` collapses to one schema).
- `.optional()` → `z.optional(...)`; `.transform(fn)` → `z.pipe(schema, z.transform(fn))`; `.extend({...})` → `z.extend(schema, {...})`; `.default(v)` → `z._default(schema, v)`.
- Branded refines (`hex`, `evmAddress`) → `z.custom<T>(predicate, msg)` so the narrowed output type survives (a `.check(z.refine(predicate))` would not narrow).
- `parseConfiguration` now takes `z.core.$ZodType<T>` and uses top-level `z.safeParse(schema, value)`.

Files migrated: `schemas/primitives.ts`, `validation.ts`, `credentials/{schemas,types}.ts`, `wrappers-registry.ts`, `token/pending-unshield.ts`, `config/web.ts`, `node/config.ts`, `services/caching-service.ts`, `relayer/fhe-artifact-cache.ts`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:run` — 1377 passed, 5 skipped, 0 failed
- [x] `pnpm build:sdk && pnpm size` — well under limits
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)