### PR TITLE
refactor: factorize tx submission

### DIFF
--- a/docs/gitbook/src/guides/handle-errors.md
+++ b/docs/gitbook/src/guides/handle-errors.md
@@ -13,28 +13,27 @@ All errors thrown by `@zama-fhe/sdk` and `@zama-fhe/react-sdk` extend `ZamaError
 
 Every SDK error is an instance of `ZamaError`, which extends the native `Error` class. Each subclass has a unique `.code` property:
 
-| Error                                  | Code                                | What happened                                            |
-| -------------------------------------- | ----------------------------------- | -------------------------------------------------------- |
-| `SigningRejectedError`                 | `SIGNING_REJECTED`                  | User rejected the wallet signature                       |
-| `SigningFailedError`                   | `SIGNING_FAILED`                    | Wallet signature failed (connectivity or firmware issue) |
-| `EncryptionFailedError`                | `ENCRYPTION_FAILED`                 | FHE encryption failed in the Web Worker                  |
-| `DecryptionFailedError`                | `DECRYPTION_FAILED`                 | FHE decryption failed                                    |
-| `ApprovalFailedError`                  | `APPROVAL_FAILED`                   | ERC-20 approval transaction failed                       |
-| `TransactionRevertedError`             | `TRANSACTION_REVERTED`              | On-chain transaction reverted                            |
-| `InvalidKeypairError`                  | `INVALID_KEYPAIR`                   | Relayer rejected FHE keypair (stale or malformed)        |
-| `KeypairExpiredError`                  | `KEYPAIR_EXPIRED`                   | FHE keypair expired -- user needs to re-sign             |
-| `NoCiphertextError`                    | `NO_CIPHERTEXT`                     | No encrypted balance exists for this account             |
-| `RelayerRequestFailedError`            | `RELAYER_REQUEST_FAILED`            | Relayer HTTP request failed (check `.statusCode`)        |
-| `ConfigurationError`                   | `CONFIGURATION`                     | Invalid SDK config or FHE worker failed to initialize    |
-| `InsufficientConfidentialBalanceError` | `INSUFFICIENT_CONFIDENTIAL_BALANCE` | Confidential balance too low for transfer or unshield    |
-| `InsufficientERC20BalanceError`        | `INSUFFICIENT_ERC20_BALANCE`        | ERC-20 balance too low for shield                        |
-| `BalanceCheckUnavailableError`         | `BALANCE_CHECK_UNAVAILABLE`         | Balance check impossible (no stored permits)             |
-| `ERC20ReadFailedError`                 | `ERC20_READ_FAILED`                 | Public ERC-20 read failed (network or contract error)    |
-| `DelegationSelfNotAllowedError`        | `DELEGATION_SELF_NOT_ALLOWED`       | Delegation cannot target self                            |
-| `DelegationCooldownError`              | `DELEGATION_COOLDOWN`               | Only one delegate/revoke per tuple per block             |
-| `DelegationNotFoundError`              | `DELEGATION_NOT_FOUND`              | No active delegation for this tuple                      |
-| `SignerRequiredError`                  | `SIGNER_REQUIRED`                   | Write/sign/decrypt called without a signer               |
-| `DelegationExpiredError`               | `DELEGATION_EXPIRED`                | The delegation has expired                               |
+| Error                                  | Code                                | What happened                                                                  |
+| -------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------ |
+| `SigningRejectedError`                 | `SIGNING_REJECTED`                  | User rejected the wallet signature                                             |
+| `SigningFailedError`                   | `SIGNING_FAILED`                    | Wallet signature failed (connectivity or firmware issue)                       |
+| `EncryptionFailedError`                | `ENCRYPTION_FAILED`                 | FHE encryption failed in the Web Worker                                        |
+| `DecryptionFailedError`                | `DECRYPTION_FAILED`                 | FHE decryption failed                                                          |
+| `TransactionRevertedError`             | `TRANSACTION_REVERTED`              | On-chain transaction reverted (includes failed ERC-20 approvals during shield) |
+| `InvalidKeypairError`                  | `INVALID_KEYPAIR`                   | Relayer rejected FHE keypair (stale or malformed)                              |
+| `KeypairExpiredError`                  | `KEYPAIR_EXPIRED`                   | FHE keypair expired -- user needs to re-sign                                   |
+| `NoCiphertextError`                    | `NO_CIPHERTEXT`                     | No encrypted balance exists for this account                                   |
+| `RelayerRequestFailedError`            | `RELAYER_REQUEST_FAILED`            | Relayer HTTP request failed (check `.statusCode`)                              |
+| `ConfigurationError`                   | `CONFIGURATION`                     | Invalid SDK config or FHE worker failed to initialize                          |
+| `InsufficientConfidentialBalanceError` | `INSUFFICIENT_CONFIDENTIAL_BALANCE` | Confidential balance too low for transfer or unshield                          |
+| `InsufficientERC20BalanceError`        | `INSUFFICIENT_ERC20_BALANCE`        | ERC-20 balance too low for shield                                              |
+| `BalanceCheckUnavailableError`         | `BALANCE_CHECK_UNAVAILABLE`         | Balance check impossible (no stored permits)                                   |
+| `ERC20ReadFailedError`                 | `ERC20_READ_FAILED`                 | Public ERC-20 read failed (network or contract error)                          |
+| `DelegationSelfNotAllowedError`        | `DELEGATION_SELF_NOT_ALLOWED`       | Delegation cannot target self                                                  |
+| `DelegationCooldownError`              | `DELEGATION_COOLDOWN`               | Only one delegate/revoke per tuple per block                                   |
+| `DelegationNotFoundError`              | `DELEGATION_NOT_FOUND`              | No active delegation for this tuple                                            |
+| `SignerRequiredError`                  | `SIGNER_REQUIRED`                   | Write/sign/decrypt called without a signer                                     |
+| `DelegationExpiredError`               | `DELEGATION_EXPIRED`                | The delegation has expired                                                     |
 
 ### 2. Catch with instanceof
 

--- a/docs/gitbook/src/reference/sdk/errors.md
+++ b/docs/gitbook/src/reference/sdk/errors.md
@@ -17,7 +17,6 @@ import {
   SigningFailedError,
   EncryptionFailedError,
   DecryptionFailedError,
-  ApprovalFailedError,
   TransactionRevertedError,
   InvalidKeypairError,
   KeypairExpiredError,
@@ -71,36 +70,35 @@ The `_` wildcard catches any `ZamaError` not explicitly handled.
 
 ## Error summary
 
-| Error class                             | Code                                  | Description                                                  |
-| --------------------------------------- | ------------------------------------- | ------------------------------------------------------------ |
-| `SigningRejectedError`                  | `SIGNING_REJECTED`                    | User rejected the wallet signature                           |
-| `SigningFailedError`                    | `SIGNING_FAILED`                      | Wallet signature failed (connectivity, firmware)             |
-| `EncryptionFailedError`                 | `ENCRYPTION_FAILED`                   | FHE encryption failed in the Web Worker                      |
-| `DecryptionFailedError`                 | `DECRYPTION_FAILED`                   | FHE decryption failed                                        |
-| `ApprovalFailedError`                   | `APPROVAL_FAILED`                     | ERC-20 approval transaction failed                           |
-| `TransactionRevertedError`              | `TRANSACTION_REVERTED`                | On-chain transaction reverted                                |
-| `InvalidKeypairError`                   | `INVALID_KEYPAIR`                     | Relayer rejected FHE keypair (stale or malformed)            |
-| `KeypairExpiredError`                   | `KEYPAIR_EXPIRED`                     | FHE keypair expired — user must re-sign                      |
-| `NoCiphertextError`                     | `NO_CIPHERTEXT`                       | No encrypted balance for this account                        |
-| `RelayerRequestFailedError`             | `RELAYER_REQUEST_FAILED`              | Relayer HTTP request failed                                  |
-| `ConfigurationError`                    | `CONFIGURATION`                       | Invalid SDK configuration or FHE worker failed to initialize |
-| `InsufficientConfidentialBalanceError`  | `INSUFFICIENT_CONFIDENTIAL_BALANCE`   | Confidential balance too low for transfer or unshield        |
-| `InsufficientERC20BalanceError`         | `INSUFFICIENT_ERC20_BALANCE`          | ERC-20 balance too low for shield                            |
-| `BalanceCheckUnavailableError`          | `BALANCE_CHECK_UNAVAILABLE`           | Balance validation impossible (no stored permits)            |
-| `ERC20ReadFailedError`                  | `ERC20_READ_FAILED`                   | Public ERC-20 read failed (network or contract error)        |
-| `DelegationSelfNotAllowedError`         | `DELEGATION_SELF_NOT_ALLOWED`         | Delegate equals connected wallet                             |
-| `DelegationDelegateEqualsContractError` | `DELEGATION_DELEGATE_EQUALS_CONTRACT` | Delegate equals contract address                             |
-| `DelegationExpiryUnchangedError`        | `DELEGATION_EXPIRY_UNCHANGED`         | New expiry matches the current value                         |
-| `DelegationNotFoundError`               | `DELEGATION_NOT_FOUND`                | No active delegation exists                                  |
-| `DelegationExpiredError`                | `DELEGATION_EXPIRED`                  | Delegation has expired                                       |
-| `DelegationCooldownError`               | `DELEGATION_COOLDOWN`                 | Same-block delegate/revoke not allowed                       |
-| `DelegationContractIsSelfError`         | `DELEGATION_CONTRACT_IS_SELF`         | Contract address equals caller                               |
-| `DelegationExpirationTooSoonError`      | `DELEGATION_EXPIRATION_TOO_SOON`      | Expiration date less than 1 hour in the future               |
-| `DelegationNotPropagatedError`          | `DELEGATION_NOT_PROPAGATED`           | Delegation exists on L1 but hasn't synced to gateway yet     |
-| `SignerNotConfiguredError`              | `SIGNER_NOT_CONFIGURED`               | SDK operation needs a signer but none is configured          |
-| `WalletNotConnectedError`               | `WALLET_NOT_CONNECTED`                | Signer exists but has no connected wallet account            |
-| `WalletAccountNotReadyError`            | `WALLET_ACCOUNT_NOT_READY`            | Async signer adapter has not resolved its account yet        |
-| `AclPausedError`                        | `ACL_PAUSED`                          | ACL contract is paused                                       |
+| Error class                             | Code                                  | Description                                                                    |
+| --------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------ |
+| `SigningRejectedError`                  | `SIGNING_REJECTED`                    | User rejected the wallet signature                                             |
+| `SigningFailedError`                    | `SIGNING_FAILED`                      | Wallet signature failed (connectivity, firmware)                               |
+| `EncryptionFailedError`                 | `ENCRYPTION_FAILED`                   | FHE encryption failed in the Web Worker                                        |
+| `DecryptionFailedError`                 | `DECRYPTION_FAILED`                   | FHE decryption failed                                                          |
+| `TransactionRevertedError`              | `TRANSACTION_REVERTED`                | On-chain transaction reverted (includes failed ERC-20 approvals during shield) |
+| `InvalidKeypairError`                   | `INVALID_KEYPAIR`                     | Relayer rejected FHE keypair (stale or malformed)                              |
+| `KeypairExpiredError`                   | `KEYPAIR_EXPIRED`                     | FHE keypair expired — user must re-sign                                        |
+| `NoCiphertextError`                     | `NO_CIPHERTEXT`                       | No encrypted balance for this account                                          |
+| `RelayerRequestFailedError`             | `RELAYER_REQUEST_FAILED`              | Relayer HTTP request failed                                                    |
+| `ConfigurationError`                    | `CONFIGURATION`                       | Invalid SDK configuration or FHE worker failed to initialize                   |
+| `InsufficientConfidentialBalanceError`  | `INSUFFICIENT_CONFIDENTIAL_BALANCE`   | Confidential balance too low for transfer or unshield                          |
+| `InsufficientERC20BalanceError`         | `INSUFFICIENT_ERC20_BALANCE`          | ERC-20 balance too low for shield                                              |
+| `BalanceCheckUnavailableError`          | `BALANCE_CHECK_UNAVAILABLE`           | Balance validation impossible (no stored permits)                              |
+| `ERC20ReadFailedError`                  | `ERC20_READ_FAILED`                   | Public ERC-20 read failed (network or contract error)                          |
+| `DelegationSelfNotAllowedError`         | `DELEGATION_SELF_NOT_ALLOWED`         | Delegate equals connected wallet                                               |
+| `DelegationDelegateEqualsContractError` | `DELEGATION_DELEGATE_EQUALS_CONTRACT` | Delegate equals contract address                                               |
+| `DelegationExpiryUnchangedError`        | `DELEGATION_EXPIRY_UNCHANGED`         | New expiry matches the current value                                           |
+| `DelegationNotFoundError`               | `DELEGATION_NOT_FOUND`                | No active delegation exists                                                    |
+| `DelegationExpiredError`                | `DELEGATION_EXPIRED`                  | Delegation has expired                                                         |
+| `DelegationCooldownError`               | `DELEGATION_COOLDOWN`                 | Same-block delegate/revoke not allowed                                         |
+| `DelegationContractIsSelfError`         | `DELEGATION_CONTRACT_IS_SELF`         | Contract address equals caller                                                 |
+| `DelegationExpirationTooSoonError`      | `DELEGATION_EXPIRATION_TOO_SOON`      | Expiration date less than 1 hour in the future                                 |
+| `DelegationNotPropagatedError`          | `DELEGATION_NOT_PROPAGATED`           | Delegation exists on L1 but hasn't synced to gateway yet                       |
+| `SignerNotConfiguredError`              | `SIGNER_NOT_CONFIGURED`               | SDK operation needs a signer but none is configured                            |
+| `WalletNotConnectedError`               | `WALLET_NOT_CONNECTED`                | Signer exists but has no connected wallet account                              |
+| `WalletAccountNotReadyError`            | `WALLET_ACCOUNT_NOT_READY`            | Async signer adapter has not resolved its account yet                          |
+| `AclPausedError`                        | `ACL_PAUSED`                          | ACL contract is paused                                                         |
 
 ## Error details
 
@@ -191,20 +189,6 @@ matchZamaError(error, {
 ```
 
 **How to handle:** If this happens after a page reload during unshield, use `loadPendingUnshield()` and `resumeUnshield()` to recover. Otherwise, calling `sdk.clearCredentials()` and retrying forces a fresh keypair.
-
-### ApprovalFailedError
-
-**Code:** `APPROVAL_FAILED`
-
-The ERC-20 `approve` transaction failed. This is the approval step before shielding, not the confidential operator approval.
-
-```ts
-matchZamaError(error, {
-  APPROVAL_FAILED: () => showError("Token approval failed"),
-});
-```
-
-**How to handle:** Check the user has sufficient gas and the token contract allows approvals. Retry the shield operation.
 
 ### TransactionRevertedError
 
@@ -542,7 +526,7 @@ matchZamaError(error, {
 **How to handle:** Wait for the ACL contract to be unpaused. This is an operator-level action — contact the protocol team if this persists.
 
 {% hint style="info" %}
-The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses via `matchAclRevert()`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation error reference](/reference/sdk/delegation#on-chain-revert-errors) for the full mapping.
+The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses on `delegateDecryption` and `revokeDelegation`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation error reference](/reference/sdk/delegation#on-chain-revert-errors) for the full mapping.
 {% endhint %}
 
 ## Common problems

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2698,28 +2698,27 @@ All errors thrown by `@zama-fhe/sdk` and `@zama-fhe/react-sdk` extend `ZamaError
 
 Every SDK error is an instance of `ZamaError`, which extends the native `Error` class. Each subclass has a unique `.code` property:
 
-| Error                                  | Code                                | What happened                                            |
-| -------------------------------------- | ----------------------------------- | -------------------------------------------------------- |
-| `SigningRejectedError`                 | `SIGNING_REJECTED`                  | User rejected the wallet signature                       |
-| `SigningFailedError`                   | `SIGNING_FAILED`                    | Wallet signature failed (connectivity or firmware issue) |
-| `EncryptionFailedError`                | `ENCRYPTION_FAILED`                 | FHE encryption failed in the Web Worker                  |
-| `DecryptionFailedError`                | `DECRYPTION_FAILED`                 | FHE decryption failed                                    |
-| `ApprovalFailedError`                  | `APPROVAL_FAILED`                   | ERC-20 approval transaction failed                       |
-| `TransactionRevertedError`             | `TRANSACTION_REVERTED`              | On-chain transaction reverted                            |
-| `InvalidKeypairError`                  | `INVALID_KEYPAIR`                   | Relayer rejected FHE keypair (stale or malformed)        |
-| `KeypairExpiredError`                  | `KEYPAIR_EXPIRED`                   | FHE keypair expired -- user needs to re-sign             |
-| `NoCiphertextError`                    | `NO_CIPHERTEXT`                     | No encrypted balance exists for this account             |
-| `RelayerRequestFailedError`            | `RELAYER_REQUEST_FAILED`            | Relayer HTTP request failed (check `.statusCode`)        |
-| `ConfigurationError`                   | `CONFIGURATION`                     | Invalid SDK config or FHE worker failed to initialize    |
-| `InsufficientConfidentialBalanceError` | `INSUFFICIENT_CONFIDENTIAL_BALANCE` | Confidential balance too low for transfer or unshield    |
-| `InsufficientERC20BalanceError`        | `INSUFFICIENT_ERC20_BALANCE`        | ERC-20 balance too low for shield                        |
-| `BalanceCheckUnavailableError`         | `BALANCE_CHECK_UNAVAILABLE`         | Balance check impossible (no stored permits)             |
-| `ERC20ReadFailedError`                 | `ERC20_READ_FAILED`                 | Public ERC-20 read failed (network or contract error)    |
-| `DelegationSelfNotAllowedError`        | `DELEGATION_SELF_NOT_ALLOWED`       | Delegation cannot target self                            |
-| `DelegationCooldownError`              | `DELEGATION_COOLDOWN`               | Only one delegate/revoke per tuple per block             |
-| `DelegationNotFoundError`              | `DELEGATION_NOT_FOUND`              | No active delegation for this tuple                      |
-| `SignerRequiredError`                  | `SIGNER_REQUIRED`                   | Write/sign/decrypt called without a signer               |
-| `DelegationExpiredError`               | `DELEGATION_EXPIRED`                | The delegation has expired                               |
+| Error                                  | Code                                | What happened                                                                  |
+| -------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------ |
+| `SigningRejectedError`                 | `SIGNING_REJECTED`                  | User rejected the wallet signature                                             |
+| `SigningFailedError`                   | `SIGNING_FAILED`                    | Wallet signature failed (connectivity or firmware issue)                       |
+| `EncryptionFailedError`                | `ENCRYPTION_FAILED`                 | FHE encryption failed in the Web Worker                                        |
+| `DecryptionFailedError`                | `DECRYPTION_FAILED`                 | FHE decryption failed                                                          |
+| `TransactionRevertedError`             | `TRANSACTION_REVERTED`              | On-chain transaction reverted (includes failed ERC-20 approvals during shield) |
+| `InvalidKeypairError`                  | `INVALID_KEYPAIR`                   | Relayer rejected FHE keypair (stale or malformed)                              |
+| `KeypairExpiredError`                  | `KEYPAIR_EXPIRED`                   | FHE keypair expired -- user needs to re-sign                                   |
+| `NoCiphertextError`                    | `NO_CIPHERTEXT`                     | No encrypted balance exists for this account                                   |
+| `RelayerRequestFailedError`            | `RELAYER_REQUEST_FAILED`            | Relayer HTTP request failed (check `.statusCode`)                              |
+| `ConfigurationError`                   | `CONFIGURATION`                     | Invalid SDK config or FHE worker failed to initialize                          |
+| `InsufficientConfidentialBalanceError` | `INSUFFICIENT_CONFIDENTIAL_BALANCE` | Confidential balance too low for transfer or unshield                          |
+| `InsufficientERC20BalanceError`        | `INSUFFICIENT_ERC20_BALANCE`        | ERC-20 balance too low for shield                                              |
+| `BalanceCheckUnavailableError`         | `BALANCE_CHECK_UNAVAILABLE`         | Balance check impossible (no stored permits)                                   |
+| `ERC20ReadFailedError`                 | `ERC20_READ_FAILED`                 | Public ERC-20 read failed (network or contract error)                          |
+| `DelegationSelfNotAllowedError`        | `DELEGATION_SELF_NOT_ALLOWED`       | Delegation cannot target self                                                  |
+| `DelegationCooldownError`              | `DELEGATION_COOLDOWN`               | Only one delegate/revoke per tuple per block                                   |
+| `DelegationNotFoundError`              | `DELEGATION_NOT_FOUND`              | No active delegation for this tuple                                            |
+| `SignerRequiredError`                  | `SIGNER_REQUIRED`                   | Write/sign/decrypt called without a signer                                     |
+| `DelegationExpiredError`               | `DELEGATION_EXPIRED`                | The delegation has expired                                                     |
 
 ### 2. Catch with instanceof
 
@@ -6132,7 +6131,6 @@ import {
   SigningFailedError,
   EncryptionFailedError,
   DecryptionFailedError,
-  ApprovalFailedError,
   TransactionRevertedError,
   InvalidKeypairError,
   KeypairExpiredError,
@@ -6186,36 +6184,35 @@ The `_` wildcard catches any `ZamaError` not explicitly handled.
 
 ## Error summary
 
-| Error class                             | Code                                  | Description                                                  |
-| --------------------------------------- | ------------------------------------- | ------------------------------------------------------------ |
-| `SigningRejectedError`                  | `SIGNING_REJECTED`                    | User rejected the wallet signature                           |
-| `SigningFailedError`                    | `SIGNING_FAILED`                      | Wallet signature failed (connectivity, firmware)             |
-| `EncryptionFailedError`                 | `ENCRYPTION_FAILED`                   | FHE encryption failed in the Web Worker                      |
-| `DecryptionFailedError`                 | `DECRYPTION_FAILED`                   | FHE decryption failed                                        |
-| `ApprovalFailedError`                   | `APPROVAL_FAILED`                     | ERC-20 approval transaction failed                           |
-| `TransactionRevertedError`              | `TRANSACTION_REVERTED`                | On-chain transaction reverted                                |
-| `InvalidKeypairError`                   | `INVALID_KEYPAIR`                     | Relayer rejected FHE keypair (stale or malformed)            |
-| `KeypairExpiredError`                   | `KEYPAIR_EXPIRED`                     | FHE keypair expired — user must re-sign                      |
-| `NoCiphertextError`                     | `NO_CIPHERTEXT`                       | No encrypted balance for this account                        |
-| `RelayerRequestFailedError`             | `RELAYER_REQUEST_FAILED`              | Relayer HTTP request failed                                  |
-| `ConfigurationError`                    | `CONFIGURATION`                       | Invalid SDK configuration or FHE worker failed to initialize |
-| `InsufficientConfidentialBalanceError`  | `INSUFFICIENT_CONFIDENTIAL_BALANCE`   | Confidential balance too low for transfer or unshield        |
-| `InsufficientERC20BalanceError`         | `INSUFFICIENT_ERC20_BALANCE`          | ERC-20 balance too low for shield                            |
-| `BalanceCheckUnavailableError`          | `BALANCE_CHECK_UNAVAILABLE`           | Balance validation impossible (no stored permits)            |
-| `ERC20ReadFailedError`                  | `ERC20_READ_FAILED`                   | Public ERC-20 read failed (network or contract error)        |
-| `DelegationSelfNotAllowedError`         | `DELEGATION_SELF_NOT_ALLOWED`         | Delegate equals connected wallet                             |
-| `DelegationDelegateEqualsContractError` | `DELEGATION_DELEGATE_EQUALS_CONTRACT` | Delegate equals contract address                             |
-| `DelegationExpiryUnchangedError`        | `DELEGATION_EXPIRY_UNCHANGED`         | New expiry matches the current value                         |
-| `DelegationNotFoundError`               | `DELEGATION_NOT_FOUND`                | No active delegation exists                                  |
-| `DelegationExpiredError`                | `DELEGATION_EXPIRED`                  | Delegation has expired                                       |
-| `DelegationCooldownError`               | `DELEGATION_COOLDOWN`                 | Same-block delegate/revoke not allowed                       |
-| `DelegationContractIsSelfError`         | `DELEGATION_CONTRACT_IS_SELF`         | Contract address equals caller                               |
-| `DelegationExpirationTooSoonError`      | `DELEGATION_EXPIRATION_TOO_SOON`      | Expiration date less than 1 hour in the future               |
-| `DelegationNotPropagatedError`          | `DELEGATION_NOT_PROPAGATED`           | Delegation exists on L1 but hasn't synced to gateway yet     |
-| `SignerNotConfiguredError`              | `SIGNER_NOT_CONFIGURED`               | SDK operation needs a signer but none is configured          |
-| `WalletNotConnectedError`               | `WALLET_NOT_CONNECTED`                | Signer exists but has no connected wallet account            |
-| `WalletAccountNotReadyError`            | `WALLET_ACCOUNT_NOT_READY`            | Async signer adapter has not resolved its account yet        |
-| `AclPausedError`                        | `ACL_PAUSED`                          | ACL contract is paused                                       |
+| Error class                             | Code                                  | Description                                                                    |
+| --------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------ |
+| `SigningRejectedError`                  | `SIGNING_REJECTED`                    | User rejected the wallet signature                                             |
+| `SigningFailedError`                    | `SIGNING_FAILED`                      | Wallet signature failed (connectivity, firmware)                               |
+| `EncryptionFailedError`                 | `ENCRYPTION_FAILED`                   | FHE encryption failed in the Web Worker                                        |
+| `DecryptionFailedError`                 | `DECRYPTION_FAILED`                   | FHE decryption failed                                                          |
+| `TransactionRevertedError`              | `TRANSACTION_REVERTED`                | On-chain transaction reverted (includes failed ERC-20 approvals during shield) |
+| `InvalidKeypairError`                   | `INVALID_KEYPAIR`                     | Relayer rejected FHE keypair (stale or malformed)                              |
+| `KeypairExpiredError`                   | `KEYPAIR_EXPIRED`                     | FHE keypair expired — user must re-sign                                        |
+| `NoCiphertextError`                     | `NO_CIPHERTEXT`                       | No encrypted balance for this account                                          |
+| `RelayerRequestFailedError`             | `RELAYER_REQUEST_FAILED`              | Relayer HTTP request failed                                                    |
+| `ConfigurationError`                    | `CONFIGURATION`                       | Invalid SDK configuration or FHE worker failed to initialize                   |
+| `InsufficientConfidentialBalanceError`  | `INSUFFICIENT_CONFIDENTIAL_BALANCE`   | Confidential balance too low for transfer or unshield                          |
+| `InsufficientERC20BalanceError`         | `INSUFFICIENT_ERC20_BALANCE`          | ERC-20 balance too low for shield                                              |
+| `BalanceCheckUnavailableError`          | `BALANCE_CHECK_UNAVAILABLE`           | Balance validation impossible (no stored permits)                              |
+| `ERC20ReadFailedError`                  | `ERC20_READ_FAILED`                   | Public ERC-20 read failed (network or contract error)                          |
+| `DelegationSelfNotAllowedError`         | `DELEGATION_SELF_NOT_ALLOWED`         | Delegate equals connected wallet                                               |
+| `DelegationDelegateEqualsContractError` | `DELEGATION_DELEGATE_EQUALS_CONTRACT` | Delegate equals contract address                                               |
+| `DelegationExpiryUnchangedError`        | `DELEGATION_EXPIRY_UNCHANGED`         | New expiry matches the current value                                           |
+| `DelegationNotFoundError`               | `DELEGATION_NOT_FOUND`                | No active delegation exists                                                    |
+| `DelegationExpiredError`                | `DELEGATION_EXPIRED`                  | Delegation has expired                                                         |
+| `DelegationCooldownError`               | `DELEGATION_COOLDOWN`                 | Same-block delegate/revoke not allowed                                         |
+| `DelegationContractIsSelfError`         | `DELEGATION_CONTRACT_IS_SELF`         | Contract address equals caller                                                 |
+| `DelegationExpirationTooSoonError`      | `DELEGATION_EXPIRATION_TOO_SOON`      | Expiration date less than 1 hour in the future                                 |
+| `DelegationNotPropagatedError`          | `DELEGATION_NOT_PROPAGATED`           | Delegation exists on L1 but hasn't synced to gateway yet                       |
+| `SignerNotConfiguredError`              | `SIGNER_NOT_CONFIGURED`               | SDK operation needs a signer but none is configured                            |
+| `WalletNotConnectedError`               | `WALLET_NOT_CONNECTED`                | Signer exists but has no connected wallet account                              |
+| `WalletAccountNotReadyError`            | `WALLET_ACCOUNT_NOT_READY`            | Async signer adapter has not resolved its account yet                          |
+| `AclPausedError`                        | `ACL_PAUSED`                          | ACL contract is paused                                                         |
 
 ## Error details
 
@@ -6306,20 +6303,6 @@ matchZamaError(error, {
 ```
 
 **How to handle:** If this happens after a page reload during unshield, use `loadPendingUnshield()` and `resumeUnshield()` to recover. Otherwise, calling `sdk.clearCredentials()` and retrying forces a fresh keypair.
-
-### ApprovalFailedError
-
-**Code:** `APPROVAL_FAILED`
-
-The ERC-20 `approve` transaction failed. This is the approval step before shielding, not the confidential operator approval.
-
-```ts
-matchZamaError(error, {
-  APPROVAL_FAILED: () => showError("Token approval failed"),
-});
-```
-
-**How to handle:** Check the user has sufficient gas and the token contract allows approvals. Retry the shield operation.
 
 ### TransactionRevertedError
 
@@ -6658,7 +6641,7 @@ matchZamaError(error, {
 
 
 > [!INFO]
-> The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses via `matchAclRevert()`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation error reference](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/sdk/delegation.md#on-chain-revert-errors) for the full mapping.
+> The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses on `delegateDecryption` and `revokeDelegation`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation error reference](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/sdk/delegation.md#on-chain-revert-errors) for the full mapping.
 
 
 ## Common problems

--- a/packages/react-sdk/src/shield/__tests__/use-shield.test.tsx
+++ b/packages/react-sdk/src/shield/__tests__/use-shield.test.tsx
@@ -1,5 +1,5 @@
 import { act, waitFor } from "@testing-library/react";
-import { ApprovalFailedError, TransactionRevertedError } from "@zama-fhe/sdk";
+import { TransactionRevertedError } from "@zama-fhe/sdk";
 import { shieldMutationOptions, zamaQueryKeys } from "@zama-fhe/sdk/query";
 import { describe, expect, test, vi } from "../../test-fixtures";
 import { expectCacheInvalidated, expectCacheUntouched } from "../../test-helpers";
@@ -370,15 +370,6 @@ describe("useShield optimistic updates", () => {
 });
 
 describe("useShield error propagation", () => {
-  test("shield surfaces ApprovalFailedError", async ({ token }) => {
-    const error = new ApprovalFailedError("ERC-20 approval failed");
-    vi.mocked(token.shield).mockRejectedValueOnce(error);
-
-    const opts = shieldMutationOptions(token, token.address);
-
-    await expect(opts.mutationFn({ amount: 100n })).rejects.toThrow(ApprovalFailedError);
-  });
-
   test("shield surfaces TransactionRevertedError", async ({ token }) => {
     const error = new TransactionRevertedError("Shield (wrap) transaction failed");
     vi.mocked(token.shield).mockRejectedValueOnce(error);

--- a/packages/react-sdk/src/shield/use-shield.ts
+++ b/packages/react-sdk/src/shield/use-shield.ts
@@ -29,8 +29,7 @@ export interface UseShieldConfig {
  *
  * Errors are {@link ZamaError} subclasses — use `instanceof` to handle specific failures:
  * - {@link SigningRejectedError} — user rejected the wallet prompt
- * - {@link ApprovalFailedError} — ERC-20 approval transaction failed
- * - {@link TransactionRevertedError} — shield transaction reverted
+ * - {@link TransactionRevertedError} — approval or shield transaction reverted
  *
  * @param config - Wrapper address (and optional `optimistic` flag).
  * @param options - React Query mutation options.

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -1368,7 +1368,7 @@ export const ZamaSDKEvents: {
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/index-61hqMvsZ.d.ts:19821:5 - (ae-forgotten-export) The symbol "ZamaErrorClass" needs to be exported by the entry point index.d.ts
+// dist/esm/index-ORLKqmQX.d.ts:19809:5 - (ae-forgotten-export) The symbol "ZamaErrorClass" needs to be exported by the entry point index.d.ts
 // dist/esm/types-DpM8lKYZ.d.ts:578:3 - (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
 // dist/esm/types-DpM8lKYZ.d.ts:579:3 - (ae-forgotten-export) The symbol "RelayerDispatcher" needs to be exported by the entry point index.d.ts
 // dist/esm/types-DpM8lKYZ.d.ts:580:3 - (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -45,6 +45,7 @@ export interface ApproveUnderlyingParams {
 
 // @public (undocumented)
 export interface ApproveUnderlyingSubmittedEvent extends BaseEvent {
+    step: "reset" | "approve";
     // (undocumented)
     txHash: Hex;
     // (undocumented)
@@ -715,6 +716,13 @@ export class Token {
     // (undocumented)
     readonly sdk: ZamaSDK;
     setOperator(operator: Address, until?: number): Promise<TransactionResult>;
+    // @internal
+    protected submitTransaction(params: {
+        operation: TransactionOperation;
+        config: WriteContractConfig;
+        onSubmitted?: (txHash: Hex) => void;
+        errorClass?: ZamaErrorClass;
+    }): Promise<TransactionResult>;
     symbol(): Promise<string>;
 }
 
@@ -784,13 +792,15 @@ export function totalSupplyQueryOptions(sdk: ZamaSDK, tokenAddress: Address, con
 // @public (undocumented)
 export interface TransactionErrorEvent extends BaseEvent {
     error: Error;
-    operation: TransactionErrorOperation;
+    operation: TransactionOperation;
     // (undocumented)
     type: typeof ZamaSDKEvents.TransactionError;
 }
 
+// Warning: (ae-forgotten-export) The symbol "SubmittedEventByOperation" needs to be exported by the entry point index.d.ts
+//
 // @public
-export type TransactionErrorOperation = "approveUnderlying" | "delegateDecryption" | "finalizeUnwrap" | "revokeDelegation" | "setOperator" | "shield:transferAndCall" | "shield:approveAndWrap" | "transfer" | "transferFrom" | "unwrap";
+export type TransactionOperation = keyof SubmittedEventByOperation;
 
 // @public
 export interface TransactionReceipt {
@@ -1358,9 +1368,10 @@ export const ZamaSDKEvents: {
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/types-57wtSyfb.d.ts:561:3 - (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
-// dist/esm/types-57wtSyfb.d.ts:562:3 - (ae-forgotten-export) The symbol "RelayerDispatcher" needs to be exported by the entry point index.d.ts
-// dist/esm/types-57wtSyfb.d.ts:563:3 - (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts
+// dist/esm/index-61hqMvsZ.d.ts:19821:5 - (ae-forgotten-export) The symbol "ZamaErrorClass" needs to be exported by the entry point index.d.ts
+// dist/esm/types-DpM8lKYZ.d.ts:578:3 - (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
+// dist/esm/types-DpM8lKYZ.d.ts:579:3 - (ae-forgotten-export) The symbol "RelayerDispatcher" needs to be exported by the entry point index.d.ts
+// dist/esm/types-DpM8lKYZ.d.ts:580:3 - (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -721,7 +721,6 @@ export class Token {
         operation: TransactionOperation;
         config: WriteContractConfig;
         onSubmitted?: (txHash: Hex) => void;
-        errorClass?: ZamaErrorClass;
     }): Promise<TransactionResult>;
     symbol(): Promise<string>;
 }
@@ -797,10 +796,10 @@ export interface TransactionErrorEvent extends BaseEvent {
     type: typeof ZamaSDKEvents.TransactionError;
 }
 
-// Warning: (ae-forgotten-export) The symbol "SubmittedEventByOperation" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "transactionOperationMetadata" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type TransactionOperation = keyof SubmittedEventByOperation;
+export type TransactionOperation = keyof typeof transactionOperationMetadata;
 
 // @public
 export interface TransactionReceipt {
@@ -1368,10 +1367,9 @@ export const ZamaSDKEvents: {
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/index-ORLKqmQX.d.ts:19809:5 - (ae-forgotten-export) The symbol "ZamaErrorClass" needs to be exported by the entry point index.d.ts
-// dist/esm/types-DpM8lKYZ.d.ts:578:3 - (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
-// dist/esm/types-DpM8lKYZ.d.ts:579:3 - (ae-forgotten-export) The symbol "RelayerDispatcher" needs to be exported by the entry point index.d.ts
-// dist/esm/types-DpM8lKYZ.d.ts:580:3 - (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts
+// dist/esm/types-C5dxoEW7.d.ts:652:3 - (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
+// dist/esm/types-C5dxoEW7.d.ts:653:3 - (ae-forgotten-export) The symbol "RelayerDispatcher" needs to be exported by the entry point index.d.ts
+// dist/esm/types-C5dxoEW7.d.ts:654:3 - (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -358,6 +358,7 @@ export function approveContract(tokenAddress: Address, spender: Address, value: 
 
 // @public (undocumented)
 export interface ApproveUnderlyingSubmittedEvent extends BaseEvent {
+    step: "reset" | "approve";
     // (undocumented)
     txHash: Hex;
     // (undocumented)
@@ -14850,6 +14851,13 @@ export class Token {
     // (undocumented)
     readonly sdk: ZamaSDK;
     setOperator(operator: Address, until?: number): Promise<TransactionResult>;
+    // @internal
+    protected submitTransaction(params: {
+        operation: TransactionOperation;
+        config: WriteContractConfig;
+        onSubmitted?: (txHash: Hex) => void;
+        errorClass?: ZamaErrorClass;
+    }): Promise<TransactionResult>;
     symbol(): Promise<string>;
 }
 
@@ -14916,13 +14924,15 @@ export function totalSupplyContract(wrapperAddress: Address): {
 // @public (undocumented)
 export interface TransactionErrorEvent extends BaseEvent {
     error: Error;
-    operation: TransactionErrorOperation;
+    operation: TransactionOperation;
     // (undocumented)
     type: typeof ZamaSDKEvents.TransactionError;
 }
 
+// Warning: (ae-forgotten-export) The symbol "SubmittedEventByOperation" needs to be exported by the entry point index.d.ts
+//
 // @public
-export type TransactionErrorOperation = "approveUnderlying" | "delegateDecryption" | "finalizeUnwrap" | "revokeDelegation" | "setOperator" | "shield:transferAndCall" | "shield:approveAndWrap" | "transfer" | "transferFrom" | "unwrap";
+export type TransactionOperation = keyof SubmittedEventByOperation;
 
 // @public
 export interface TransactionReceipt {
@@ -20120,6 +20130,10 @@ export type ZamaSDKEventType = (typeof ZamaSDKEvents)[keyof typeof ZamaSDKEvents
 export const ZERO_HANDLE: "0x0000000000000000000000000000000000000000000000000000000000000000";
 
 export { ZKProofLike }
+
+// Warnings were encountered during analysis:
+//
+// dist/esm/index-61hqMvsZ.d.ts:19821:5 - (ae-forgotten-export) The symbol "ZamaErrorClass" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -20133,7 +20133,7 @@ export { ZKProofLike }
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/index-61hqMvsZ.d.ts:19821:5 - (ae-forgotten-export) The symbol "ZamaErrorClass" needs to be exported by the entry point index.d.ts
+// dist/esm/index-ORLKqmQX.d.ts:19809:5 - (ae-forgotten-export) The symbol "ZamaErrorClass" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -207,11 +207,6 @@ export const anvil: {
 };
 
 // @public
-export class ApprovalFailedError extends ZamaError {
-    constructor(message: string, options?: ErrorOptions);
-}
-
-// @public
 export type ApprovalStrategy = "max" | "exact" | "skip";
 
 // @public
@@ -11509,9 +11504,6 @@ export const mainnet: {
 };
 
 // @public
-export function matchAclRevert(error: unknown): ZamaError | null;
-
-// @public
 export function matchZamaError<R>(error: unknown, handlers: Partial<Record<ZamaErrorCode, (error: ZamaError) => R>> & {
     _?: (error: unknown) => R;
 }): R | undefined;
@@ -14856,7 +14848,6 @@ export class Token {
         operation: TransactionOperation;
         config: WriteContractConfig;
         onSubmitted?: (txHash: Hex) => void;
-        errorClass?: ZamaErrorClass;
     }): Promise<TransactionResult>;
     symbol(): Promise<string>;
 }
@@ -14929,10 +14920,10 @@ export interface TransactionErrorEvent extends BaseEvent {
     type: typeof ZamaSDKEvents.TransactionError;
 }
 
-// Warning: (ae-forgotten-export) The symbol "SubmittedEventByOperation" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "transactionOperationMetadata" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type TransactionOperation = keyof SubmittedEventByOperation;
+export type TransactionOperation = keyof typeof transactionOperationMetadata;
 
 // @public
 export interface TransactionReceipt {
@@ -19999,8 +19990,7 @@ export const ZamaErrorCode: {
     readonly SigningRejected: "SIGNING_REJECTED"; /** Wallet signature failed for a reason other than rejection. */
     readonly SigningFailed: "SIGNING_FAILED"; /** FHE encryption failed. */
     readonly EncryptionFailed: "ENCRYPTION_FAILED"; /** FHE decryption failed. */
-    readonly DecryptionFailed: "DECRYPTION_FAILED"; /** ERC-20 approval transaction failed. */
-    readonly ApprovalFailed: "APPROVAL_FAILED"; /** On-chain transaction reverted. */
+    readonly DecryptionFailed: "DECRYPTION_FAILED"; /** On-chain transaction reverted. */
     readonly TransactionReverted: "TRANSACTION_REVERTED"; /** FHE keypair has expired and needs regeneration. */
     readonly KeypairExpired: "KEYPAIR_EXPIRED"; /** Relayer rejected FHE keypair (stale, expired, or malformed). */
     readonly InvalidKeypair: "INVALID_KEYPAIR"; /** No FHE ciphertext exists for this account (never shielded). */
@@ -20130,10 +20120,6 @@ export type ZamaSDKEventType = (typeof ZamaSDKEvents)[keyof typeof ZamaSDKEvents
 export const ZERO_HANDLE: "0x0000000000000000000000000000000000000000000000000000000000000000";
 
 export { ZKProofLike }
-
-// Warnings were encountered during analysis:
-//
-// dist/esm/index-ORLKqmQX.d.ts:19809:5 - (ae-forgotten-export) The symbol "ZamaErrorClass" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/src/errors/__tests__/errors.test-d.ts
+++ b/packages/sdk/src/errors/__tests__/errors.test-d.ts
@@ -4,7 +4,6 @@ import type {
   SigningFailedError,
   EncryptionFailedError,
   DecryptionFailedError,
-  ApprovalFailedError,
   TransactionRevertedError,
   KeypairExpiredError,
   InvalidKeypairError,
@@ -41,7 +40,6 @@ describe("error subclasses extend ZamaError", () => {
   });
 
   test("transaction errors", () => {
-    expectTypeOf<ApprovalFailedError>().toExtend<ZamaError>();
     expectTypeOf<TransactionRevertedError>().toExtend<ZamaError>();
   });
 

--- a/packages/sdk/src/errors/__tests__/errors.test.ts
+++ b/packages/sdk/src/errors/__tests__/errors.test.ts
@@ -357,16 +357,17 @@ describe("DelegationExpirationTooSoonError", () => {
 
 describe("matchAclRevert", () => {
   it("returns null for unrecognized errors", () => {
-    expect(matchAclRevert(new Error("SomeOtherRevert"))).toBeNull();
-    expect(matchAclRevert("string error")).toBeNull();
-    expect(matchAclRevert(null)).toBeNull();
+    const unknownRevert = new Error("SomeOtherRevert");
+    expect(matchAclRevert(unknownRevert, unknownRevert)).toBeNull();
+    expect(matchAclRevert("string error", "string error")).toBeNull();
+    expect(matchAclRevert(null, null)).toBeNull();
   });
 
   it("maps AlreadyDelegatedOrRevokedInSameBlock via structured viem error", () => {
     const viemError = Object.assign(new Error("revert"), {
       cause: { data: { errorName: "AlreadyDelegatedOrRevokedInSameBlock" } },
     });
-    const result = matchAclRevert(viemError);
+    const result = matchAclRevert(viemError, viemError);
     expect(result).toBeInstanceOf(DelegationCooldownError);
   });
 
@@ -374,7 +375,7 @@ describe("matchAclRevert", () => {
     const viemError = Object.assign(new Error("revert"), {
       cause: { data: { errorName: "SenderCannotBeDelegate" } },
     });
-    const result = matchAclRevert(viemError);
+    const result = matchAclRevert(viemError, viemError);
     expect(result).toBeInstanceOf(DelegationSelfNotAllowedError);
   });
 
@@ -382,7 +383,7 @@ describe("matchAclRevert", () => {
     const viemError = Object.assign(new Error("revert"), {
       cause: { data: { errorName: "DelegateCannotBeContractAddress" } },
     });
-    const result = matchAclRevert(viemError);
+    const result = matchAclRevert(viemError, viemError);
     expect(result).toBeInstanceOf(DelegationDelegateEqualsContractError);
   });
 
@@ -390,7 +391,7 @@ describe("matchAclRevert", () => {
     const viemError = Object.assign(new Error("revert"), {
       cause: { data: { errorName: "SenderCannotBeContractAddress" } },
     });
-    const result = matchAclRevert(viemError);
+    const result = matchAclRevert(viemError, viemError);
     expect(result).toBeInstanceOf(DelegationContractIsSelfError);
   });
 
@@ -398,7 +399,7 @@ describe("matchAclRevert", () => {
     const viemError = Object.assign(new Error("revert"), {
       cause: { data: { errorName: "EnforcedPause" } },
     });
-    const result = matchAclRevert(viemError);
+    const result = matchAclRevert(viemError, viemError);
     expect(result).toBeInstanceOf(AclPausedError);
   });
 
@@ -406,7 +407,7 @@ describe("matchAclRevert", () => {
     const viemError = Object.assign(new Error("revert"), {
       cause: { data: { errorName: "ExpirationDateBeforeOneHour" } },
     });
-    const result = matchAclRevert(viemError);
+    const result = matchAclRevert(viemError, viemError);
     expect(result).toBeInstanceOf(DelegationExpirationTooSoonError);
   });
 
@@ -414,7 +415,7 @@ describe("matchAclRevert", () => {
     const viemError = Object.assign(new Error("revert"), {
       cause: { data: { errorName: "ExpirationDateAlreadySetToSameValue" } },
     });
-    const result = matchAclRevert(viemError);
+    const result = matchAclRevert(viemError, viemError);
     expect(result).toBeInstanceOf(DelegationExpiryUnchangedError);
   });
 
@@ -422,26 +423,40 @@ describe("matchAclRevert", () => {
     const viemError = Object.assign(new Error("revert"), {
       cause: { data: { errorName: "NotDelegatedYet" } },
     });
-    const result = matchAclRevert(viemError);
+    const result = matchAclRevert(viemError, viemError);
     expect(result).toBeInstanceOf(DelegationNotFoundError);
   });
 
   it("falls back to string matching when no structured cause", () => {
     const plainError = new Error("Transaction reverted: NotDelegatedYet");
-    const result = matchAclRevert(plainError);
+    const result = matchAclRevert(plainError, plainError);
     expect(result).toBeInstanceOf(DelegationNotFoundError);
   });
 
   it("string fallback returns null when message does not match any key", () => {
     const plainError = new Error("execution reverted: OutOfGas");
-    expect(matchAclRevert(plainError)).toBeNull();
+    expect(matchAclRevert(plainError, plainError)).toBeNull();
   });
 
   it("preserves cause on returned error", () => {
     const original = Object.assign(new Error("revert"), {
       cause: { data: { errorName: "EnforcedPause" } },
     });
-    const result = matchAclRevert(original);
+    const result = matchAclRevert(original, original);
     expect(result?.cause).toBe(original);
+  });
+
+  it("allows callers to preserve a higher-level cause", () => {
+    const original = Object.assign(new Error("revert"), {
+      cause: { data: { errorName: "EnforcedPause" } },
+    });
+    const transactionError = new Error("Transaction failed during delegateDecryption", {
+      cause: original,
+    });
+
+    const result = matchAclRevert(original, transactionError);
+
+    expect(result).toBeInstanceOf(AclPausedError);
+    expect(result?.cause).toBe(transactionError);
   });
 });

--- a/packages/sdk/src/errors/acl-revert.ts
+++ b/packages/sdk/src/errors/acl-revert.ts
@@ -27,7 +27,7 @@ function extractRevertErrorName(error: unknown): string | null {
 }
 
 /** ACL error name -> typed SDK error mapping. */
-const ACL_ERROR_MAP: Record<string, (cause: Error | undefined) => ZamaError> = {
+const ACL_ERROR_MAP = {
   AlreadyDelegatedOrRevokedInSameBlock: (cause) =>
     new DelegationCooldownError(
       "Only one delegate/revoke per (delegator, delegate, contract) per block. Wait for the next block before retrying.",
@@ -61,30 +61,31 @@ const ACL_ERROR_MAP: Record<string, (cause: Error | undefined) => ZamaError> = {
     }),
   NotDelegatedYet: (cause) =>
     new DelegationNotFoundError("Cannot revoke: no active delegation exists.", { cause }),
-};
+} satisfies Record<string, (cause: unknown) => ZamaError>;
+
+function isAclRevertName(name: string): name is keyof typeof ACL_ERROR_MAP {
+  return name in ACL_ERROR_MAP;
+}
 
 /**
  * Map known ACL Solidity revert error names to typed ZamaError subclasses.
  * Prefers viem's structured `error.cause.data.errorName` when available,
  * falling back to string-includes matching on the error message.
  * Returns `null` if the revert reason is not recognized.
- * @public
+ * @internal
  */
-export function matchAclRevert(error: unknown): ZamaError | null {
-  const cause = error instanceof Error ? error : undefined;
-
+export function matchAclRevert(error: unknown, mappedCause: unknown): ZamaError | null {
   // Prefer structured error data from viem's ContractFunctionRevertedError
   const errorName = extractRevertErrorName(error);
-  if (errorName && errorName in ACL_ERROR_MAP) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by `in` check above
-    return ACL_ERROR_MAP[errorName]!(cause);
+  if (errorName && isAclRevertName(errorName)) {
+    return ACL_ERROR_MAP[errorName](mappedCause);
   }
 
   // Fallback: string matching for non-viem RPC providers
   const message = error instanceof Error ? error.message : String(error);
   for (const [name, factory] of Object.entries(ACL_ERROR_MAP)) {
     if (message.includes(name)) {
-      return factory(cause);
+      return factory(mappedCause);
     }
   }
 

--- a/packages/sdk/src/errors/base.ts
+++ b/packages/sdk/src/errors/base.ts
@@ -22,8 +22,6 @@ export const ZamaErrorCode = {
   EncryptionFailed: "ENCRYPTION_FAILED",
   /** FHE decryption failed. */
   DecryptionFailed: "DECRYPTION_FAILED",
-  /** ERC-20 approval transaction failed. */
-  ApprovalFailed: "APPROVAL_FAILED",
   /** On-chain transaction reverted. */
   TransactionReverted: "TRANSACTION_REVERTED",
   /** FHE keypair has expired and needs regeneration. */

--- a/packages/sdk/src/errors/delegation.ts
+++ b/packages/sdk/src/errors/delegation.ts
@@ -1,7 +1,7 @@
 import { ZamaError, ZamaErrorCode } from "./base";
 
-// Delegation errors — thrown by SDK pre-flight checks and by `matchAclRevert()`
-// when it maps ACL Solidity revert reasons to typed errors.
+// Delegation errors — thrown by SDK pre-flight checks and by delegation
+// transaction callsites when they map ACL Solidity revert reasons.
 
 /** Delegation cannot target self (delegate === msg.sender). */
 export class DelegationSelfNotAllowedError extends ZamaError {

--- a/packages/sdk/src/errors/index.ts
+++ b/packages/sdk/src/errors/index.ts
@@ -1,7 +1,7 @@
 export { ZamaError, ZamaErrorCode, matchZamaError } from "./base";
 export { SigningRejectedError, SigningFailedError } from "./signing";
 export { EncryptionFailedError, DecryptionFailedError } from "./encryption";
-export { ApprovalFailedError, TransactionRevertedError } from "./transaction";
+export { TransactionRevertedError } from "./transaction";
 export { KeypairExpiredError, InvalidKeypairError, NoCiphertextError } from "./credential";
 export { RelayerRequestFailedError, ConfigurationError } from "./relayer";
 export { ChainMismatchError } from "./chain";
@@ -30,6 +30,5 @@ export {
   ERC20ReadFailedError,
   type BalanceErrorDetails,
 } from "./balance";
-export { matchAclRevert } from "./acl-revert";
 export { wrapDecryptError } from "./decrypt";
 export { isFatalBatchError } from "./fatal-batch";

--- a/packages/sdk/src/errors/transaction.ts
+++ b/packages/sdk/src/errors/transaction.ts
@@ -1,13 +1,5 @@
 import { ZamaError, ZamaErrorCode } from "./base";
 
-/** ERC-20 approval transaction failed. */
-export class ApprovalFailedError extends ZamaError {
-  constructor(message: string, options?: ErrorOptions) {
-    super(ZamaErrorCode.ApprovalFailed, message, options);
-    this.name = "ApprovalFailedError";
-  }
-}
-
 /** On-chain transaction reverted. */
 export class TransactionRevertedError extends ZamaError {
   constructor(message: string, options?: ErrorOptions) {

--- a/packages/sdk/src/events/sdk-events.ts
+++ b/packages/sdk/src/events/sdk-events.ts
@@ -85,28 +85,10 @@ export interface DecryptErrorEvent extends BaseEvent {
   handles: Handle[];
 }
 
-/**
- * Identifier for the SDK operation that emitted a {@link TransactionErrorEvent}.
- * Shield failures encode the execution path in the operation string itself
- * (`shield:transferAndCall` or `shield:approveAndWrap`) so observers can route
- * on a single field.
- */
-export type TransactionErrorOperation =
-  | "approveUnderlying"
-  | "delegateDecryption"
-  | "finalizeUnwrap"
-  | "revokeDelegation"
-  | "setOperator"
-  | "shield:transferAndCall"
-  | "shield:approveAndWrap"
-  | "transfer"
-  | "transferFrom"
-  | "unwrap";
-
 export interface TransactionErrorEvent extends BaseEvent {
   type: typeof ZamaSDKEvents.TransactionError;
   /** Which SDK operation failed. */
-  operation: TransactionErrorOperation;
+  operation: TransactionOperation;
   /** The error that caused the transaction to fail. */
   error: Error;
 }
@@ -136,6 +118,8 @@ export interface SetOperatorSubmittedEvent extends BaseEvent {
 export interface ApproveUnderlyingSubmittedEvent extends BaseEvent {
   type: typeof ZamaSDKEvents.ApproveUnderlyingSubmitted;
   txHash: Hex;
+  /** Which approval transaction was submitted. */
+  step: "reset" | "approve";
 }
 
 export interface UnwrapSubmittedEvent extends BaseEvent {
@@ -208,3 +192,95 @@ export type ZamaSDKEventInput = ZamaSDKEvent extends infer E
     ? Omit<E, "timestamp" | "tokenAddress">
     : never
   : never;
+
+type SubmittedEventByOperation = {
+  approveUnderlying: ApproveUnderlyingSubmittedEvent;
+  "approveUnderlying:reset": ApproveUnderlyingSubmittedEvent;
+  delegateDecryption: DelegationSubmittedEvent;
+  finalizeUnwrap: FinalizeUnwrapSubmittedEvent;
+  revokeDelegation: RevokeDelegationSubmittedEvent;
+  setOperator: SetOperatorSubmittedEvent;
+  "shield:transferAndCall": ShieldSubmittedEvent;
+  "shield:approveAndWrap": ShieldSubmittedEvent;
+  transfer: TransferSubmittedEvent;
+  transferFrom: TransferFromSubmittedEvent;
+  unwrap: UnwrapSubmittedEvent;
+  unwrapAll: UnwrapSubmittedEvent;
+};
+
+type TransactionOperationMetadata = {
+  readonly [O in TransactionOperation]: {
+    readonly submittedEvent: (
+      txHash: Hex,
+    ) => Omit<SubmittedEventByOperation[O], "timestamp" | "tokenAddress">;
+  };
+};
+
+/**
+ * SDK transaction operations that emit submitted/error lifecycle events.
+ *
+ * Operation strings encode the execution-path discriminator for flows that have
+ * one (`shield:transferAndCall` vs. `shield:approveAndWrap`), routing both error
+ * and success events on a single field — see {@link transactionOperationMetadata}.
+ */
+export type TransactionOperation = keyof SubmittedEventByOperation;
+
+/**
+ * Single source of truth for each transaction operation's submitted-event payload.
+ * The `satisfies` check keeps the table exhaustive and preserves the specific
+ * operation → event pairing.
+ */
+export const transactionOperationMetadata = {
+  approveUnderlying: {
+    submittedEvent: (txHash) => ({
+      type: ZamaSDKEvents.ApproveUnderlyingSubmitted,
+      txHash,
+      step: "approve",
+    }),
+  },
+  "approveUnderlying:reset": {
+    submittedEvent: (txHash) => ({
+      type: ZamaSDKEvents.ApproveUnderlyingSubmitted,
+      txHash,
+      step: "reset",
+    }),
+  },
+  delegateDecryption: {
+    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.DelegationSubmitted, txHash }),
+  },
+  finalizeUnwrap: {
+    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.FinalizeUnwrapSubmitted, txHash }),
+  },
+  revokeDelegation: {
+    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.RevokeDelegationSubmitted, txHash }),
+  },
+  setOperator: {
+    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.SetOperatorSubmitted, txHash }),
+  },
+  "shield:transferAndCall": {
+    submittedEvent: (txHash) => ({
+      type: ZamaSDKEvents.ShieldSubmitted,
+      txHash,
+      shieldPath: "transferAndCall",
+    }),
+  },
+  "shield:approveAndWrap": {
+    submittedEvent: (txHash) => ({
+      type: ZamaSDKEvents.ShieldSubmitted,
+      txHash,
+      shieldPath: "approveAndWrap",
+    }),
+  },
+  transfer: {
+    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.TransferSubmitted, txHash }),
+  },
+  transferFrom: {
+    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.TransferFromSubmitted, txHash }),
+  },
+  unwrap: {
+    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }),
+  },
+  unwrapAll: {
+    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }),
+  },
+} satisfies TransactionOperationMetadata;

--- a/packages/sdk/src/events/sdk-events.ts
+++ b/packages/sdk/src/events/sdk-events.ts
@@ -193,28 +193,70 @@ export type ZamaSDKEventInput = ZamaSDKEvent extends infer E
     : never
   : never;
 
-type SubmittedEventByOperation = {
-  approveUnderlying: ApproveUnderlyingSubmittedEvent;
-  "approveUnderlying:reset": ApproveUnderlyingSubmittedEvent;
-  delegateDecryption: DelegationSubmittedEvent;
-  finalizeUnwrap: FinalizeUnwrapSubmittedEvent;
-  revokeDelegation: RevokeDelegationSubmittedEvent;
-  setOperator: SetOperatorSubmittedEvent;
-  "shield:transferAndCall": ShieldSubmittedEvent;
-  "shield:approveAndWrap": ShieldSubmittedEvent;
-  transfer: TransferSubmittedEvent;
-  transferFrom: TransferFromSubmittedEvent;
-  unwrap: UnwrapSubmittedEvent;
-  unwrapAll: UnwrapSubmittedEvent;
-};
-
-type TransactionOperationMetadata = {
-  readonly [O in TransactionOperation]: {
-    readonly submittedEvent: (
-      txHash: Hex,
-    ) => Omit<SubmittedEventByOperation[O], "timestamp" | "tokenAddress">;
-  };
-};
+/**
+ * Single source of truth for each transaction operation's submitted-event payload.
+ *
+ * Adding a write op = adding one entry here. `TransactionOperation` is then
+ * `keyof typeof transactionOperationMetadata`, so the dispatch table and the
+ * operation union cannot drift.
+ *
+ * The `satisfies` check enforces that every entry produces a valid
+ * {@link ZamaSDKEventInput}.
+ */
+export const transactionOperationMetadata = {
+  approveUnderlying: {
+    submittedEvent: (txHash: Hex) => ({
+      type: ZamaSDKEvents.ApproveUnderlyingSubmitted,
+      txHash,
+      step: "approve" as const,
+    }),
+  },
+  "approveUnderlying:reset": {
+    submittedEvent: (txHash: Hex) => ({
+      type: ZamaSDKEvents.ApproveUnderlyingSubmitted,
+      txHash,
+      step: "reset" as const,
+    }),
+  },
+  delegateDecryption: {
+    submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.DelegationSubmitted, txHash }),
+  },
+  finalizeUnwrap: {
+    submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.FinalizeUnwrapSubmitted, txHash }),
+  },
+  revokeDelegation: {
+    submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.RevokeDelegationSubmitted, txHash }),
+  },
+  setOperator: {
+    submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.SetOperatorSubmitted, txHash }),
+  },
+  "shield:transferAndCall": {
+    submittedEvent: (txHash: Hex) => ({
+      type: ZamaSDKEvents.ShieldSubmitted,
+      txHash,
+      shieldPath: "transferAndCall" as const,
+    }),
+  },
+  "shield:approveAndWrap": {
+    submittedEvent: (txHash: Hex) => ({
+      type: ZamaSDKEvents.ShieldSubmitted,
+      txHash,
+      shieldPath: "approveAndWrap" as const,
+    }),
+  },
+  transfer: {
+    submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.TransferSubmitted, txHash }),
+  },
+  transferFrom: {
+    submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.TransferFromSubmitted, txHash }),
+  },
+  unwrap: {
+    submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }),
+  },
+  unwrapAll: {
+    submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }),
+  },
+} satisfies Record<string, { submittedEvent: (txHash: Hex) => ZamaSDKEventInput }>;
 
 /**
  * SDK transaction operations that emit submitted/error lifecycle events.
@@ -223,64 +265,4 @@ type TransactionOperationMetadata = {
  * one (`shield:transferAndCall` vs. `shield:approveAndWrap`), routing both error
  * and success events on a single field — see {@link transactionOperationMetadata}.
  */
-export type TransactionOperation = keyof SubmittedEventByOperation;
-
-/**
- * Single source of truth for each transaction operation's submitted-event payload.
- * The `satisfies` check keeps the table exhaustive and preserves the specific
- * operation → event pairing.
- */
-export const transactionOperationMetadata = {
-  approveUnderlying: {
-    submittedEvent: (txHash) => ({
-      type: ZamaSDKEvents.ApproveUnderlyingSubmitted,
-      txHash,
-      step: "approve",
-    }),
-  },
-  "approveUnderlying:reset": {
-    submittedEvent: (txHash) => ({
-      type: ZamaSDKEvents.ApproveUnderlyingSubmitted,
-      txHash,
-      step: "reset",
-    }),
-  },
-  delegateDecryption: {
-    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.DelegationSubmitted, txHash }),
-  },
-  finalizeUnwrap: {
-    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.FinalizeUnwrapSubmitted, txHash }),
-  },
-  revokeDelegation: {
-    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.RevokeDelegationSubmitted, txHash }),
-  },
-  setOperator: {
-    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.SetOperatorSubmitted, txHash }),
-  },
-  "shield:transferAndCall": {
-    submittedEvent: (txHash) => ({
-      type: ZamaSDKEvents.ShieldSubmitted,
-      txHash,
-      shieldPath: "transferAndCall",
-    }),
-  },
-  "shield:approveAndWrap": {
-    submittedEvent: (txHash) => ({
-      type: ZamaSDKEvents.ShieldSubmitted,
-      txHash,
-      shieldPath: "approveAndWrap",
-    }),
-  },
-  transfer: {
-    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.TransferSubmitted, txHash }),
-  },
-  transferFrom: {
-    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.TransferFromSubmitted, txHash }),
-  },
-  unwrap: {
-    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }),
-  },
-  unwrapAll: {
-    submittedEvent: (txHash) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }),
-  },
-} satisfies TransactionOperationMetadata;
+export type TransactionOperation = keyof typeof transactionOperationMetadata;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -154,7 +154,6 @@ export {
   SigningFailedError,
   EncryptionFailedError,
   DecryptionFailedError,
-  ApprovalFailedError,
   TransactionRevertedError,
   KeypairExpiredError,
   InvalidKeypairError,
@@ -182,7 +181,6 @@ export {
   DelegationExpirationTooSoonError,
   DelegationNotPropagatedError,
   matchZamaError,
-  matchAclRevert,
 } from "./errors";
 export { BaseSigner } from "./signer/base-signer";
 export { createWalletAccountStore, MutableWalletAccountStore } from "./signer/wallet-account-store";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -137,7 +137,7 @@ export type {
   UnshieldPhase2StartedEvent,
   UnshieldPhase2SubmittedEvent,
   TransactionErrorEvent,
-  TransactionErrorOperation,
+  TransactionOperation,
   EncryptStartEvent,
   EncryptEndEvent,
   EncryptErrorEvent,

--- a/packages/sdk/src/query/index.ts
+++ b/packages/sdk/src/query/index.ts
@@ -186,7 +186,7 @@ export type {
   FinalizeUnwrapSubmittedEvent,
   ShieldSubmittedEvent,
   TransactionErrorEvent,
-  TransactionErrorOperation,
+  TransactionOperation,
   TransferFromSubmittedEvent,
   TransferSubmittedEvent,
   UnshieldPhase1SubmittedEvent,

--- a/packages/sdk/src/services/__tests__/delegation-service.test.ts
+++ b/packages/sdk/src/services/__tests__/delegation-service.test.ts
@@ -1,5 +1,6 @@
 import { getAddress, type Address } from "viem";
 import { MAX_UINT64 } from "../../contracts";
+import { DelegationCooldownError, TransactionRevertedError } from "../../errors";
 import { describe, expect, test, vi } from "../../test-fixtures";
 
 const CONTRACT = getAddress("0x3333333333333333333333333333333333333333") as Address;
@@ -228,16 +229,20 @@ describe("DelegationService", () => {
     delegateAddress,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(MAX_UINT64);
-    vi.mocked(signer.writeContract).mockRejectedValue(
-      new Error("AlreadyDelegatedOrRevokedInSameBlock"),
-    );
+    const rootCause = new Error("AlreadyDelegatedOrRevokedInSameBlock");
+    vi.mocked(signer.writeContract).mockRejectedValue(rootCause);
 
-    await expect(
-      delegationService.revokeDelegation(signer, {
+    const thrown = await delegationService
+      .revokeDelegation(signer, {
         contractAddress: CONTRACT,
         delegatorAddress: userAddress,
         delegateAddress,
-      }),
-    ).rejects.toMatchObject({ code: "DELEGATION_COOLDOWN" });
+      })
+      .catch((error: Error) => error);
+
+    expect(thrown).toBeInstanceOf(DelegationCooldownError);
+    expect(thrown).toMatchObject({ code: "DELEGATION_COOLDOWN" });
+    expect(thrown.cause).toBeInstanceOf(TransactionRevertedError);
+    expect((thrown.cause as Error).cause).toBe(rootCause);
   });
 });

--- a/packages/sdk/src/services/delegation-service.ts
+++ b/packages/sdk/src/services/delegation-service.ts
@@ -12,12 +12,23 @@ import {
   DelegationExpiryUnchangedError,
   DelegationNotFoundError,
   DelegationSelfNotAllowedError,
-  matchAclRevert,
+  TransactionRevertedError,
 } from "../errors";
-import type { ZamaSDKEventInput } from "../events/sdk-events";
+import { matchAclRevert } from "../errors/acl-revert";
+import type { TransactionOperation, ZamaSDKEventInput } from "../events/sdk-events";
 import type { RelayerDispatcher } from "../relayer/relayer-dispatcher";
-import type { GenericProvider, GenericSigner, TransactionResult } from "../types";
-import { submitTransaction as submitSdkTransaction } from "../utils/submit-transaction";
+import type {
+  GenericProvider,
+  GenericSigner,
+  TransactionResult,
+  WriteContractConfig,
+} from "../types";
+import { submitTransaction } from "../utils/submit-transaction";
+
+type AclTransactionOperation = Extract<
+  TransactionOperation,
+  "delegateDecryption" | "revokeDelegation"
+>;
 
 export class DelegationService {
   readonly #provider: GenericProvider;
@@ -96,18 +107,16 @@ export class DelegationService {
       );
     }
 
-    return submitSdkTransaction({
+    return this.#submitAclTransaction({
       operation: "delegateDecryption",
       signer,
-      provider: this.#provider,
+      contractAddress,
       config: delegateForUserDecryptionContract(
         acl,
         normalizedDelegate,
         normalizedContract,
         expDate,
       ),
-      emit: (input) => this.#emitEvent(input, contractAddress),
-      mapError: matchAclRevert,
     });
   }
 
@@ -145,13 +154,11 @@ export class DelegationService {
       );
     }
 
-    return submitSdkTransaction({
+    return this.#submitAclTransaction({
       operation: "revokeDelegation",
       signer,
-      provider: this.#provider,
+      contractAddress,
       config: revokeDelegationContract(acl, normalizedDelegate, normalizedContract),
-      emit: (input) => this.#emitEvent(input, contractAddress),
-      mapError: matchAclRevert,
     });
   }
 
@@ -189,6 +196,41 @@ export class DelegationService {
         getAddress(contractAddress),
       ),
     );
+  }
+
+  async #submitAclTransaction({
+    operation,
+    signer,
+    contractAddress,
+    config,
+  }: {
+    operation: AclTransactionOperation;
+    signer: GenericSigner;
+    contractAddress: Address;
+    config: WriteContractConfig;
+  }): Promise<TransactionResult> {
+    try {
+      return await submitTransaction({
+        operation,
+        signer,
+        provider: this.#provider,
+        config,
+        emit: (input) => this.#emitEvent(input, contractAddress),
+      });
+    } catch (error) {
+      this.#throwAclRevertIfMatched(error);
+      throw error;
+    }
+  }
+
+  #throwAclRevertIfMatched(error: unknown): void {
+    if (!(error instanceof TransactionRevertedError)) {
+      return;
+    }
+    const mapped = matchAclRevert(error.cause ?? error, error);
+    if (mapped) {
+      throw mapped;
+    }
   }
 
   async findInactiveDelegations(

--- a/packages/sdk/src/services/delegation-service.ts
+++ b/packages/sdk/src/services/delegation-service.ts
@@ -99,7 +99,6 @@ export class DelegationService {
     return this.#executeAclTx(
       signer,
       delegateForUserDecryptionContract(acl, normalizedDelegate, normalizedContract, expDate),
-      "Delegation transaction failed",
       "delegateDecryption",
       normalizedContract,
     );
@@ -142,7 +141,6 @@ export class DelegationService {
     return this.#executeAclTx(
       signer,
       revokeDelegationContract(acl, normalizedDelegate, normalizedContract),
-      "Revoke delegation transaction failed",
       "revokeDelegation",
       normalizedContract,
     );
@@ -238,7 +236,6 @@ export class DelegationService {
   async #executeAclTx(
     signer: GenericSigner,
     call: Parameters<GenericSigner["writeContract"]>[0],
-    failureMessage: string,
     operation: Extract<TransactionOperation, "delegateDecryption" | "revokeDelegation">,
     contractAddress: Address,
   ): Promise<TransactionResult> {
@@ -249,7 +246,6 @@ export class DelegationService {
       config: call,
       emit: (input) => this.#emitEvent(input, contractAddress),
       mapError: matchAclRevert,
-      failureMessage,
     });
   }
 }

--- a/packages/sdk/src/services/delegation-service.ts
+++ b/packages/sdk/src/services/delegation-service.ts
@@ -14,7 +14,7 @@ import {
   DelegationSelfNotAllowedError,
   matchAclRevert,
 } from "../errors";
-import type { TransactionOperation, ZamaSDKEventInput } from "../events/sdk-events";
+import type { ZamaSDKEventInput } from "../events/sdk-events";
 import type { RelayerDispatcher } from "../relayer/relayer-dispatcher";
 import type { GenericProvider, GenericSigner, TransactionResult } from "../types";
 import { submitTransaction as submitSdkTransaction } from "../utils/submit-transaction";
@@ -96,12 +96,19 @@ export class DelegationService {
       );
     }
 
-    return this.#executeAclTx(
+    return submitSdkTransaction({
+      operation: "delegateDecryption",
       signer,
-      delegateForUserDecryptionContract(acl, normalizedDelegate, normalizedContract, expDate),
-      "delegateDecryption",
-      normalizedContract,
-    );
+      provider: this.#provider,
+      config: delegateForUserDecryptionContract(
+        acl,
+        normalizedDelegate,
+        normalizedContract,
+        expDate,
+      ),
+      emit: (input) => this.#emitEvent(input, contractAddress),
+      mapError: matchAclRevert,
+    });
   }
 
   async revokeDelegation(
@@ -138,12 +145,14 @@ export class DelegationService {
       );
     }
 
-    return this.#executeAclTx(
+    return submitSdkTransaction({
+      operation: "revokeDelegation",
       signer,
-      revokeDelegationContract(acl, normalizedDelegate, normalizedContract),
-      "revokeDelegation",
-      normalizedContract,
-    );
+      provider: this.#provider,
+      config: revokeDelegationContract(acl, normalizedDelegate, normalizedContract),
+      emit: (input) => this.#emitEvent(input, contractAddress),
+      mapError: matchAclRevert,
+    });
   }
 
   async isDelegated(params: {
@@ -231,21 +240,5 @@ export class DelegationService {
         );
       }
     }
-  }
-
-  async #executeAclTx(
-    signer: GenericSigner,
-    call: Parameters<GenericSigner["writeContract"]>[0],
-    operation: Extract<TransactionOperation, "delegateDecryption" | "revokeDelegation">,
-    contractAddress: Address,
-  ): Promise<TransactionResult> {
-    return submitSdkTransaction({
-      operation,
-      signer,
-      provider: this.#provider,
-      config: call,
-      emit: (input) => this.#emitEvent(input, contractAddress),
-      mapError: matchAclRevert,
-    });
   }
 }

--- a/packages/sdk/src/services/delegation-service.ts
+++ b/packages/sdk/src/services/delegation-service.ts
@@ -12,14 +12,12 @@ import {
   DelegationExpiryUnchangedError,
   DelegationNotFoundError,
   DelegationSelfNotAllowedError,
-  TransactionRevertedError,
   matchAclRevert,
-  ZamaError,
 } from "../errors";
-import type { ZamaSDKEventInput } from "../events/sdk-events";
-import { ZamaSDKEvents } from "../events/sdk-events";
+import type { TransactionOperation, ZamaSDKEventInput } from "../events/sdk-events";
 import type { RelayerDispatcher } from "../relayer/relayer-dispatcher";
 import type { GenericProvider, GenericSigner, TransactionResult } from "../types";
+import { submitTransaction as submitSdkTransaction } from "../utils/submit-transaction";
 
 export class DelegationService {
   readonly #provider: GenericProvider;
@@ -102,7 +100,7 @@ export class DelegationService {
       signer,
       delegateForUserDecryptionContract(acl, normalizedDelegate, normalizedContract, expDate),
       "Delegation transaction failed",
-      ZamaSDKEvents.DelegationSubmitted,
+      "delegateDecryption",
       normalizedContract,
     );
   }
@@ -145,7 +143,7 @@ export class DelegationService {
       signer,
       revokeDelegationContract(acl, normalizedDelegate, normalizedContract),
       "Revoke delegation transaction failed",
-      ZamaSDKEvents.RevokeDelegationSubmitted,
+      "revokeDelegation",
       normalizedContract,
     );
   }
@@ -241,29 +239,17 @@ export class DelegationService {
     signer: GenericSigner,
     call: Parameters<GenericSigner["writeContract"]>[0],
     failureMessage: string,
-    submittedType:
-      | typeof ZamaSDKEvents.DelegationSubmitted
-      | typeof ZamaSDKEvents.RevokeDelegationSubmitted,
+    operation: Extract<TransactionOperation, "delegateDecryption" | "revokeDelegation">,
     contractAddress: Address,
   ): Promise<TransactionResult> {
-    try {
-      const txHash = await signer.writeContract(call);
-      if (submittedType === ZamaSDKEvents.DelegationSubmitted) {
-        this.#emitEvent({ type: ZamaSDKEvents.DelegationSubmitted, txHash }, contractAddress);
-      } else {
-        this.#emitEvent({ type: ZamaSDKEvents.RevokeDelegationSubmitted, txHash }, contractAddress);
-      }
-      const receipt = await this.#provider.waitForTransactionReceipt(txHash);
-      return { txHash, receipt };
-    } catch (error) {
-      if (error instanceof ZamaError) {
-        throw error;
-      }
-      const mapped = matchAclRevert(error);
-      if (mapped) {
-        throw mapped;
-      }
-      throw new TransactionRevertedError(failureMessage, { cause: error });
-    }
+    return submitSdkTransaction({
+      operation,
+      signer,
+      provider: this.#provider,
+      config: call,
+      emit: (input) => this.#emitEvent(input, contractAddress),
+      mapError: matchAclRevert,
+      failureMessage,
+    });
   }
 }

--- a/packages/sdk/src/token/__tests__/events.test.ts
+++ b/packages/sdk/src/token/__tests__/events.test.ts
@@ -16,6 +16,7 @@ import {
   type ZamaSDKEventListener,
   ZamaSDKEvents,
 } from "../../events/sdk-events";
+import { TransactionRevertedError } from "../../errors";
 import type { RelayerSDK } from "../../relayer/relayer-sdk";
 import { ZamaSDK } from "../../zama-sdk";
 import type { ZamaConfig } from "../../config/types";
@@ -417,7 +418,12 @@ describe("Token event emissions", () => {
       const txError = events.find((e) => e.type === ZamaSDKEvents.TransactionError);
       expect(txError).toBeDefined();
       expect("operation" in txError! && txError.operation).toBe("transfer");
-      expect("error" in txError! && txError.error.message).toBe("tx reverted");
+      expect("error" in txError! && txError.error).toBeInstanceOf(TransactionRevertedError);
+      expect("error" in txError! && txError.error.message).toBe(
+        "Transaction failed during transfer",
+      );
+      expect("error" in txError! && txError.error.cause).toBeInstanceOf(Error);
+      expect("error" in txError! && (txError.error.cause as Error).message).toBe("tx reverted");
     });
   });
 

--- a/packages/sdk/src/token/__tests__/events.test.ts
+++ b/packages/sdk/src/token/__tests__/events.test.ts
@@ -583,16 +583,16 @@ describe("Token event emissions", () => {
   });
 
   describe("approveUnderlying events", () => {
-    it("emits ApproveUnderlyingSubmitted", async ({
+    it("emits ApproveUnderlyingSubmitted with approve step", async ({
       relayer,
       signer,
       tokenAddress,
       storage,
       provider,
     }) => {
-      vi.mocked(provider.readContract).mockResolvedValue(
-        "0x9C9c9c9c9c9c9C9c9c9C9C9c9c9C9c9c9c9c9C9c",
-      );
+      vi.mocked(provider.readContract)
+        .mockResolvedValueOnce("0x9C9c9c9c9c9c9C9c9c9C9C9c9c9C9c9c9c9c9C9c")
+        .mockResolvedValueOnce(0n);
       const { token, events } = setupSdkWithEvents({
         relayer,
         signer,
@@ -604,6 +604,34 @@ describe("Token event emissions", () => {
 
       const types = events.map((e) => e.type);
       expect(types).toContain(ZamaSDKEvents.ApproveUnderlyingSubmitted);
+      const submitted = events.find((e) => e.type === ZamaSDKEvents.ApproveUnderlyingSubmitted);
+      expect(submitted).toMatchObject({ step: "approve" });
+    });
+
+    it("distinguishes reset and approve submissions", async ({
+      relayer,
+      signer,
+      tokenAddress,
+      storage,
+      provider,
+    }) => {
+      vi.mocked(provider.readContract)
+        .mockResolvedValueOnce("0x9C9c9c9c9c9c9C9c9c9C9C9c9c9C9c9c9c9c9C9c")
+        .mockResolvedValueOnce(50n);
+      const { token, events } = setupSdkWithEvents({
+        relayer,
+        signer,
+        provider,
+        storage,
+        tokenAddress,
+      });
+      await token.approveUnderlying(100n);
+
+      expect(
+        events
+          .filter((e) => e.type === ZamaSDKEvents.ApproveUnderlyingSubmitted)
+          .map((e) => e.step),
+      ).toEqual(["reset", "approve"]);
     });
   });
 

--- a/packages/sdk/src/token/__tests__/shield.test.ts
+++ b/packages/sdk/src/token/__tests__/shield.test.ts
@@ -1,6 +1,7 @@
 import { type Address, getAddress } from "viem";
 import { describe, expect, it, vi } from "../../test-fixtures";
 import { ZamaSDKEvents } from "../../events/sdk-events";
+import { ZamaErrorCode } from "../../errors";
 
 const UNDERLYING = "0x9C9c9c9c9c9c9C9c9c9C9C9c9c9C9c9c9c9c9C9c" as Address;
 const OTHER_RECIPIENT = "0x8b8b8b8b8B8B8b8B8B8b8b8b8b8B8B8B8B8b8B8b" as Address;
@@ -233,7 +234,9 @@ describe("WrappedToken.shield", () => {
 
       vi.mocked(signer.writeContract).mockRejectedValueOnce(new Error("transferAndCall reverted"));
 
-      await expect(token.shield(100n)).rejects.toThrow("TransferAndCall shield transaction failed");
+      await expect(token.shield(100n)).rejects.toMatchObject({
+        code: ZamaErrorCode.TransactionReverted,
+      });
       expect(signer.writeContract).toHaveBeenCalledOnce();
     });
 
@@ -251,7 +254,9 @@ describe("WrappedToken.shield", () => {
       // rejection or RPC failure where falling back would be hostile UX.
       vi.mocked(signer.writeContract).mockRejectedValueOnce(new Error("User rejected the request"));
 
-      await expect(token.shield(100n)).rejects.toThrow("TransferAndCall shield transaction failed");
+      await expect(token.shield(100n)).rejects.toMatchObject({
+        code: ZamaErrorCode.TransactionReverted,
+      });
       expect(signer.writeContract).toHaveBeenCalledOnce();
     });
 
@@ -270,7 +275,9 @@ describe("WrappedToken.shield", () => {
         new Error("network dropped"),
       );
 
-      await expect(token.shield(100n)).rejects.toThrow("TransferAndCall shield transaction failed");
+      await expect(token.shield(100n)).rejects.toMatchObject({
+        code: ZamaErrorCode.TransactionReverted,
+      });
       // Submission happened exactly once — no second wallet popup.
       expect(signer.writeContract).toHaveBeenCalledOnce();
     });

--- a/packages/sdk/src/token/__tests__/token.test.ts
+++ b/packages/sdk/src/token/__tests__/token.test.ts
@@ -1,5 +1,10 @@
 import { getAddress, type Address } from "viem";
-import { DecryptionFailedError, ZamaError, ZamaErrorCode } from "../../errors";
+import {
+  DecryptionFailedError,
+  TransactionRevertedError,
+  ZamaError,
+  ZamaErrorCode,
+} from "../../errors";
 import { ZERO_HANDLE } from "../../utils/handles";
 import { describe, expect, it, vi } from "../../test-fixtures";
 
@@ -252,18 +257,21 @@ describe("Token", () => {
       expect(result.txHash).toBe("0xtxhash");
     });
 
-    it("wraps error in ApprovalFailed", async ({ signer, token }) => {
-      vi.mocked(signer.writeContract).mockRejectedValueOnce(new Error("tx failed"));
+    it("wraps error in TransactionReverted", async ({ signer, token }) => {
+      const rootCause = new Error("tx failed");
+      vi.mocked(signer.writeContract).mockRejectedValueOnce(rootCause);
 
-      await expect(
-        token.setOperator("0x3C3C3C3C3c3C3c3C3C3C3C3C3c3c3c3c3c3c3c3C" as Address),
-      ).rejects.toMatchObject({
-        code: ZamaErrorCode.ApprovalFailed,
-      });
+      const thrown = await token
+        .setOperator("0x3C3C3C3C3c3C3c3C3C3C3C3C3c3c3c3c3c3c3c3C" as Address)
+        .catch((error: Error) => error);
+
+      expect(thrown).toBeInstanceOf(TransactionRevertedError);
+      expect(thrown).toMatchObject({ code: ZamaErrorCode.TransactionReverted });
+      expect(thrown.cause).toBe(rootCause);
     });
 
     it("re-throws ZamaError from writeContract as-is", async ({ signer, token }) => {
-      const original = new ZamaError(ZamaErrorCode.ApprovalFailed, "already wrapped");
+      const original = new ZamaError(ZamaErrorCode.TransactionReverted, "already wrapped");
       vi.mocked(signer.writeContract).mockRejectedValueOnce(original);
 
       await expect(

--- a/packages/sdk/src/token/__tests__/token.test.ts
+++ b/packages/sdk/src/token/__tests__/token.test.ts
@@ -192,7 +192,6 @@ describe("Token", () => {
         }),
       ).rejects.toMatchObject({
         code: ZamaErrorCode.TransactionReverted,
-        message: "Transfer transaction failed",
       });
     });
   });
@@ -234,7 +233,6 @@ describe("Token", () => {
         ),
       ).rejects.toMatchObject({
         code: ZamaErrorCode.TransactionReverted,
-        message: "TransferFrom transaction failed",
       });
     });
   });
@@ -259,12 +257,8 @@ describe("Token", () => {
 
       await expect(
         token.setOperator("0x3C3C3C3C3c3C3c3C3C3C3C3C3c3c3c3c3c3c3c3C" as Address),
-      ).rejects.toSatisfy((err: ZamaError) => {
-        return (
-          err instanceof ZamaError &&
-          err.code === ZamaErrorCode.ApprovalFailed &&
-          err.message === "Operator approval failed"
-        );
+      ).rejects.toMatchObject({
+        code: ZamaErrorCode.ApprovalFailed,
       });
     });
 

--- a/packages/sdk/src/token/__tests__/wrapped-token.test.ts
+++ b/packages/sdk/src/token/__tests__/wrapped-token.test.ts
@@ -190,7 +190,6 @@ describe("WrappedToken", () => {
 
       await expect(wrappedToken.shield(100n, { approvalStrategy: "skip" })).rejects.toMatchObject({
         code: ZamaErrorCode.TransactionReverted,
-        message: "ApproveAndWrap shield transaction failed",
       });
     });
   });
@@ -338,7 +337,6 @@ describe("WrappedToken", () => {
 
       await expect(wrappedToken.finalizeUnwrap("0xburn" as Address)).rejects.toMatchObject({
         code: ZamaErrorCode.TransactionReverted,
-        message: "Failed to finalize unshield",
       });
     });
   });

--- a/packages/sdk/src/token/__tests__/wrapped-token.test.ts
+++ b/packages/sdk/src/token/__tests__/wrapped-token.test.ts
@@ -1,6 +1,11 @@
 import type { Address } from "viem";
 import { Topics } from "../../events";
-import { DecryptionFailedError, ZamaError, ZamaErrorCode } from "../../errors";
+import {
+  DecryptionFailedError,
+  TransactionRevertedError,
+  ZamaError,
+  ZamaErrorCode,
+} from "../../errors";
 import { ZERO_HANDLE } from "../../utils/handles";
 import { describe, expect, it, vi } from "../../test-fixtures";
 
@@ -234,13 +239,16 @@ describe("WrappedToken", () => {
       );
     });
 
-    it("wraps error in ApprovalFailed", async ({ signer, wrappedToken, provider }) => {
+    it("wraps error in TransactionReverted", async ({ signer, wrappedToken, provider }) => {
       vi.mocked(provider.readContract).mockResolvedValueOnce(UNDERLYING).mockResolvedValueOnce(0n);
-      vi.mocked(signer.writeContract).mockRejectedValueOnce(new Error("approve failed"));
+      const rootCause = new Error("approve failed");
+      vi.mocked(signer.writeContract).mockRejectedValueOnce(rootCause);
 
-      await expect(wrappedToken.approveUnderlying()).rejects.toMatchObject({
-        code: ZamaErrorCode.ApprovalFailed,
-      });
+      const thrown = await wrappedToken.approveUnderlying().catch((error: Error) => error);
+
+      expect(thrown).toBeInstanceOf(TransactionRevertedError);
+      expect(thrown).toMatchObject({ code: ZamaErrorCode.TransactionReverted });
+      expect(thrown.cause).toBe(rootCause);
     });
   });
 
@@ -539,7 +547,7 @@ describe("WrappedToken", () => {
         .mockResolvedValueOnce(false) // supportsInterface (ERC-1363)
         .mockResolvedValueOnce(1000n)
         .mockResolvedValueOnce(0n);
-      const original = new ZamaError(ZamaErrorCode.ApprovalFailed, "already wrapped");
+      const original = new ZamaError(ZamaErrorCode.TransactionReverted, "already wrapped");
       vi.mocked(signer.writeContract).mockRejectedValueOnce(original);
 
       await expect(wrappedToken.shield(100n)).rejects.toBe(original);

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -1,4 +1,4 @@
-import { type Address, getAddress } from "viem";
+import { type Address, getAddress, type Hex } from "viem";
 import {
   confidentialBalanceOfContract,
   confidentialTransferContract,
@@ -21,19 +21,26 @@ import {
   EncryptionFailedError,
   InsufficientConfidentialBalanceError,
   isFatalBatchError,
-  TransactionRevertedError,
   ZamaError,
 } from "../errors";
-import type { ZamaSDKEventInput } from "../events/sdk-events";
-import { ZamaSDKEvents } from "../events/sdk-events";
+import type { TransactionOperation, ZamaSDKEventInput } from "../events/sdk-events";
 import type { ClearValueType, Handle } from "../relayer/relayer-sdk.types";
 import { toError } from "../utils";
 import { requireAlignedWalletAccount, requireChainAlignment } from "../utils/alignment";
 import { assertBigint } from "../utils/assertions";
 import { pLimit } from "../utils/concurrency";
 import { isZeroHandle } from "../utils/handles";
+import {
+  submitTransaction as submitSdkTransaction,
+  type ZamaErrorClass,
+} from "../utils/submit-transaction";
 import { swallow } from "../utils/swallow";
-import type { TransactionResult, TransferCallbacks, TransferOptions } from "../types";
+import type {
+  TransactionResult,
+  TransferCallbacks,
+  TransferOptions,
+  WriteContractConfig,
+} from "../types";
 import type { ZamaSDK } from "../zama-sdk";
 
 /** Options for {@link Token.batchDecryptBalancesAs}. */
@@ -519,7 +526,6 @@ export class Token {
     amount: bigint,
     options?: TransferOptions,
   ): Promise<TransactionResult> {
-    const signer = this.sdk.requireSigner("confidentialTransfer");
     const account = await requireAlignedWalletAccount(
       "confidentialTransfer",
       this.sdk.signer,
@@ -544,27 +550,11 @@ export class Token {
       throw new EncryptionFailedError("Encryption returned no handles");
     }
 
-    try {
-      const txHash = await signer.writeContract(
-        confidentialTransferContract(this.address, normalizedTo, handles[0]!, inputProof),
-      );
-      this.emit({ type: ZamaSDKEvents.TransferSubmitted, txHash });
-      void swallow("transfer: onTransferSubmitted", () => onTransferSubmitted?.(txHash));
-      const receipt = await this.sdk.provider.waitForTransactionReceipt(txHash);
-      return { txHash, receipt };
-    } catch (error) {
-      this.emit({
-        type: ZamaSDKEvents.TransactionError,
-        operation: "transfer",
-        error: toError(error),
-      });
-      if (error instanceof ZamaError) {
-        throw error;
-      }
-      throw new TransactionRevertedError("Transfer transaction failed", {
-        cause: error,
-      });
-    }
+    return this.submitTransaction({
+      operation: "transfer",
+      config: confidentialTransferContract(this.address, normalizedTo, handles[0]!, inputProof),
+      onSubmitted: onTransferSubmitted,
+    });
   }
 
   /**
@@ -587,7 +577,6 @@ export class Token {
     amount: bigint,
     callbacks?: TransferCallbacks,
   ): Promise<TransactionResult> {
-    const signer = this.sdk.requireSigner("confidentialTransferFrom");
     await requireAlignedWalletAccount(
       "confidentialTransferFrom",
       this.sdk.signer,
@@ -607,35 +596,17 @@ export class Token {
       throw new EncryptionFailedError("Encryption returned no handles");
     }
 
-    try {
-      const txHash = await signer.writeContract(
-        confidentialTransferFromContract(
-          this.address,
-          normalizedFrom,
-          normalizedTo,
-          handles[0]!,
-          inputProof,
-        ),
-      );
-      this.emit({ type: ZamaSDKEvents.TransferFromSubmitted, txHash });
-      void swallow("transferFrom: onTransferSubmitted", () =>
-        callbacks?.onTransferSubmitted?.(txHash),
-      );
-      const receipt = await this.sdk.provider.waitForTransactionReceipt(txHash);
-      return { txHash, receipt };
-    } catch (error) {
-      this.emit({
-        type: ZamaSDKEvents.TransactionError,
-        operation: "transferFrom",
-        error: toError(error),
-      });
-      if (error instanceof ZamaError) {
-        throw error;
-      }
-      throw new TransactionRevertedError("TransferFrom transaction failed", {
-        cause: error,
-      });
-    }
+    return this.submitTransaction({
+      operation: "transferFrom",
+      config: confidentialTransferFromContract(
+        this.address,
+        normalizedFrom,
+        normalizedTo,
+        handles[0]!,
+        inputProof,
+      ),
+      onSubmitted: callbacks?.onTransferSubmitted,
+    });
   }
 
   // OPERATOR APPROVAL
@@ -654,29 +625,13 @@ export class Token {
    * ```
    */
   async setOperator(operator: Address, until?: number): Promise<TransactionResult> {
-    const signer = this.sdk.requireSigner("setOperator");
     await requireChainAlignment("setOperator", this.sdk.signer, this.sdk.provider);
     const normalizedOperator = getAddress(operator);
-    try {
-      const txHash = await signer.writeContract(
-        setOperatorContract(this.address, normalizedOperator, until),
-      );
-      this.emit({ type: ZamaSDKEvents.SetOperatorSubmitted, txHash });
-      const receipt = await this.sdk.provider.waitForTransactionReceipt(txHash);
-      return { txHash, receipt };
-    } catch (error) {
-      this.emit({
-        type: ZamaSDKEvents.TransactionError,
-        operation: "setOperator",
-        error: toError(error),
-      });
-      if (error instanceof ZamaError) {
-        throw error;
-      }
-      throw new ApprovalFailedError("Operator approval failed", {
-        cause: error,
-      });
-    }
+    return this.submitTransaction({
+      operation: "setOperator",
+      config: setOperatorContract(this.address, normalizedOperator, until),
+      errorClass: ApprovalFailedError,
+    });
   }
 
   /**
@@ -756,6 +711,32 @@ export class Token {
    */
   protected emit(input: ZamaSDKEventInput): void {
     this.sdk.emitEvent(input, this.address);
+  }
+
+  /**
+   * Submit a token-scoped write transaction through the shared SDK transaction
+   * pipeline. Callers keep pre-flight and operation-specific work local.
+   *
+   * @internal
+   */
+  protected async submitTransaction(params: {
+    operation: TransactionOperation;
+    config: WriteContractConfig;
+    onSubmitted?: (txHash: Hex) => void;
+    errorClass?: ZamaErrorClass;
+  }): Promise<TransactionResult> {
+    const { operation, config, onSubmitted, errorClass } = params;
+    const signerOperation =
+      operation === "approveUnderlying:reset" ? "approveUnderlying" : operation;
+    return submitSdkTransaction({
+      operation,
+      signer: this.sdk.requireSigner(signerOperation),
+      provider: this.sdk.provider,
+      config,
+      emit: (input) => this.emit(input),
+      onSubmitted,
+      errorClass,
+    });
   }
 
   /** Verify all tokens share the same SDK instance and return it. */

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -14,7 +14,6 @@ import {
   symbolContract,
 } from "../contracts";
 import {
-  ApprovalFailedError,
   BalanceCheckUnavailableError,
   ConfigurationError,
   DecryptionFailedError,
@@ -30,10 +29,7 @@ import { requireAlignedWalletAccount, requireChainAlignment } from "../utils/ali
 import { assertBigint } from "../utils/assertions";
 import { pLimit } from "../utils/concurrency";
 import { isZeroHandle } from "../utils/handles";
-import {
-  submitTransaction as submitSdkTransaction,
-  type ZamaErrorClass,
-} from "../utils/submit-transaction";
+import { submitTransaction as submitSdkTransaction } from "../utils/submit-transaction";
 import { swallow } from "../utils/swallow";
 import type {
   TransactionResult,
@@ -630,7 +626,6 @@ export class Token {
     return this.submitTransaction({
       operation: "setOperator",
       config: setOperatorContract(this.address, normalizedOperator, until),
-      errorClass: ApprovalFailedError,
     });
   }
 
@@ -723,19 +718,15 @@ export class Token {
     operation: TransactionOperation;
     config: WriteContractConfig;
     onSubmitted?: (txHash: Hex) => void;
-    errorClass?: ZamaErrorClass;
   }): Promise<TransactionResult> {
-    const { operation, config, onSubmitted, errorClass } = params;
-    const signerOperation =
-      operation === "approveUnderlying:reset" ? "approveUnderlying" : operation;
+    const { operation, config, onSubmitted } = params;
     return submitSdkTransaction({
       operation,
-      signer: this.sdk.requireSigner(signerOperation),
+      signer: this.sdk.requireSigner(operation),
       provider: this.sdk.provider,
       config,
       emit: (input) => this.emit(input),
       onSubmitted,
-      errorClass,
     });
   }
 

--- a/packages/sdk/src/token/wrapped-token.ts
+++ b/packages/sdk/src/token/wrapped-token.ts
@@ -15,7 +15,6 @@ import { findUnwrapRequested } from "../events/onchain-events";
 import { ZamaSDKEvents } from "../events/sdk-events";
 import type { Handle } from "../relayer/relayer-sdk.types";
 import {
-  ApprovalFailedError,
   DecryptionFailedError,
   ERC20ReadFailedError,
   EncryptionFailedError,
@@ -121,8 +120,7 @@ export class WrappedToken extends Token {
    * @returns The transaction hash and mined receipt.
    * @throws {@link ChainMismatchError} if signer and provider are on different chains.
    * @throws {@link InsufficientERC20BalanceError} if the ERC-20 balance is less than `amount`.
-   * @throws {@link ApprovalFailedError} if the ERC-20 approval step fails (approveAndWrap path).
-   * @throws {@link TransactionRevertedError} if the shield transaction reverts.
+   * @throws {@link TransactionRevertedError} if the ERC-20 approval or shield transaction reverts.
    *
    * @example
    * ```ts
@@ -235,7 +233,6 @@ export class WrappedToken extends Token {
         await this.submitTransaction({
           operation: "approveUnderlying:reset",
           config: approveContract(underlying, this.address, 0n),
-          errorClass: ApprovalFailedError,
         });
       }
     }
@@ -243,7 +240,6 @@ export class WrappedToken extends Token {
     return this.submitTransaction({
       operation: "approveUnderlying",
       config: approveContract(underlying, this.address, approvalAmount),
-      errorClass: ApprovalFailedError,
     });
   }
 
@@ -519,7 +515,6 @@ export class WrappedToken extends Token {
       await this.submitTransaction({
         operation: "approveUnderlying:reset",
         config: approveContract(underlying, this.address, 0n),
-        errorClass: ApprovalFailedError,
       });
     }
 
@@ -529,7 +524,6 @@ export class WrappedToken extends Token {
       operation: "approveUnderlying",
       config: approveContract(underlying, this.address, approvalAmount),
       onSubmitted: callbacks?.onApprovalSubmitted,
-      errorClass: ApprovalFailedError,
     });
   }
 }

--- a/packages/sdk/src/token/wrapped-token.ts
+++ b/packages/sdk/src/token/wrapped-token.ts
@@ -170,7 +170,6 @@ export class WrappedToken extends Token {
     userAddress: Address,
     options?: ShieldOptions,
   ): Promise<TransactionResult> {
-    const signer = this.sdk.requireSigner("shield");
     const recipient = options?.to ? getAddress(options.to) : userAddress;
     // ERC7984ERC20Wrapper.onTransferReceived decodes the recipient via
     // `address(bytes20(data))` — i.e. the first 20 bytes of `data`. We pass
@@ -178,31 +177,11 @@ export class WrappedToken extends Token {
     // for self-shield so the wrapper falls back to `from`.
     const data: Hex = recipient === userAddress ? "0x" : recipient;
 
-    try {
-      const txHash = await signer.writeContract(
-        transferAndCallContract(underlying, this.address, amount, data),
-      );
-      this.emit({
-        type: ZamaSDKEvents.ShieldSubmitted,
-        txHash,
-        shieldPath: "transferAndCall",
-      });
-      void swallow("shield: onShieldSubmitted", () => options?.onShieldSubmitted?.(txHash));
-      const receipt = await this.sdk.provider.waitForTransactionReceipt(txHash);
-      return { txHash, receipt };
-    } catch (error) {
-      this.emit({
-        type: ZamaSDKEvents.TransactionError,
-        operation: "shield:transferAndCall",
-        error: toError(error),
-      });
-      if (error instanceof ZamaError) {
-        throw error;
-      }
-      throw new TransactionRevertedError("TransferAndCall shield transaction failed", {
-        cause: error,
-      });
-    }
+    return this.submitTransaction({
+      operation: "shield:transferAndCall",
+      config: transferAndCallContract(underlying, this.address, amount, data),
+      onSubmitted: options?.onShieldSubmitted,
+    });
   }
 
   async #shieldViaApproveAndWrap(
@@ -210,36 +189,16 @@ export class WrappedToken extends Token {
     userAddress: Address,
     options?: ShieldOptions,
   ): Promise<TransactionResult> {
-    const signer = this.sdk.requireSigner("shield");
     const strategy = options?.approvalStrategy ?? "exact";
     if (strategy !== "skip") {
       await this.#ensureAllowance(amount, strategy === "max", options);
     }
-
-    try {
-      const recipient = options?.to ? getAddress(options.to) : userAddress;
-      const txHash = await signer.writeContract(wrapContract(this.address, recipient, amount));
-      this.emit({
-        type: ZamaSDKEvents.ShieldSubmitted,
-        txHash,
-        shieldPath: "approveAndWrap",
-      });
-      void swallow("shield: onShieldSubmitted", () => options?.onShieldSubmitted?.(txHash));
-      const receipt = await this.sdk.provider.waitForTransactionReceipt(txHash);
-      return { txHash, receipt };
-    } catch (error) {
-      this.emit({
-        type: ZamaSDKEvents.TransactionError,
-        operation: "shield:approveAndWrap",
-        error: toError(error),
-      });
-      if (error instanceof ZamaError) {
-        throw error;
-      }
-      throw new TransactionRevertedError("ApproveAndWrap shield transaction failed", {
-        cause: error,
-      });
-    }
+    const recipient = options?.to ? getAddress(options.to) : userAddress;
+    return this.submitTransaction({
+      operation: "shield:approveAndWrap",
+      config: wrapContract(this.address, recipient, amount),
+      onSubmitted: options?.onShieldSubmitted,
+    });
   }
 
   /**
@@ -257,7 +216,6 @@ export class WrappedToken extends Token {
    * ```
    */
   async approveUnderlying(amount?: bigint): Promise<TransactionResult> {
-    const signer = this.sdk.requireSigner("approveUnderlying");
     const account = await requireAlignedWalletAccount(
       "approveUnderlying",
       this.sdk.signer,
@@ -268,36 +226,25 @@ export class WrappedToken extends Token {
 
     const approvalAmount = amount ?? 2n ** 256n - 1n;
 
-    try {
-      if (approvalAmount > 0n) {
-        const currentAllowance = await this.sdk.provider.readContract(
-          allowanceContract(underlying, userAddress, this.address),
-        );
-
-        if (currentAllowance > 0n) {
-          await signer.writeContract(approveContract(underlying, this.address, 0n));
-        }
-      }
-
-      const txHash = await signer.writeContract(
-        approveContract(underlying, this.address, approvalAmount),
+    if (approvalAmount > 0n) {
+      const currentAllowance = await this.sdk.provider.readContract(
+        allowanceContract(underlying, userAddress, this.address),
       );
-      this.emit({ type: ZamaSDKEvents.ApproveUnderlyingSubmitted, txHash });
-      const receipt = await this.sdk.provider.waitForTransactionReceipt(txHash);
-      return { txHash, receipt };
-    } catch (error) {
-      this.emit({
-        type: ZamaSDKEvents.TransactionError,
-        operation: "approveUnderlying",
-        error: toError(error),
-      });
-      if (error instanceof ZamaError) {
-        throw error;
+
+      if (currentAllowance > 0n) {
+        await this.submitTransaction({
+          operation: "approveUnderlying:reset",
+          config: approveContract(underlying, this.address, 0n),
+          errorClass: ApprovalFailedError,
+        });
       }
-      throw new ApprovalFailedError("ERC-20 approval failed", {
-        cause: error,
-      });
     }
+
+    return this.submitTransaction({
+      operation: "approveUnderlying",
+      config: approveContract(underlying, this.address, approvalAmount),
+      errorClass: ApprovalFailedError,
+    });
   }
 
   // UNSHIELD (confidential → ERC-20)
@@ -398,7 +345,6 @@ export class WrappedToken extends Token {
    * ```
    */
   async unwrap(amount: bigint): Promise<TransactionResult> {
-    const signer = this.sdk.requireSigner("unwrap");
     const account = await requireAlignedWalletAccount("unwrap", this.sdk.signer, this.sdk.provider);
     const userAddress = getAddress(account.address);
 
@@ -413,26 +359,10 @@ export class WrappedToken extends Token {
       throw new EncryptionFailedError("Encryption returned no handles");
     }
 
-    try {
-      const txHash = await signer.writeContract(
-        unwrapContract(this.address, userAddress, userAddress, handle, inputProof),
-      );
-      this.emit({ type: ZamaSDKEvents.UnwrapSubmitted, txHash });
-      const receipt = await this.sdk.provider.waitForTransactionReceipt(txHash);
-      return { txHash, receipt };
-    } catch (error) {
-      this.emit({
-        type: ZamaSDKEvents.TransactionError,
-        operation: "unwrap",
-        error: toError(error),
-      });
-      if (error instanceof ZamaError) {
-        throw error;
-      }
-      throw new TransactionRevertedError("Unwrap transaction failed", {
-        cause: error,
-      });
-    }
+    return this.submitTransaction({
+      operation: "unwrap",
+      config: unwrapContract(this.address, userAddress, userAddress, handle, inputProof),
+    });
   }
 
   /**
@@ -449,7 +379,6 @@ export class WrappedToken extends Token {
    * ```
    */
   async unwrapAll(): Promise<TransactionResult> {
-    const signer = this.sdk.requireSigner("unwrapAll");
     const account = await requireAlignedWalletAccount(
       "unwrapAll",
       this.sdk.signer,
@@ -462,26 +391,10 @@ export class WrappedToken extends Token {
       throw new DecryptionFailedError("Cannot unshield: balance is zero");
     }
 
-    try {
-      const txHash = await signer.writeContract(
-        unwrapFromBalanceContract(this.address, userAddress, userAddress, handle),
-      );
-      this.emit({ type: ZamaSDKEvents.UnwrapSubmitted, txHash });
-      const receipt = await this.sdk.provider.waitForTransactionReceipt(txHash);
-      return { txHash, receipt };
-    } catch (error) {
-      this.emit({
-        type: ZamaSDKEvents.TransactionError,
-        operation: "unwrap",
-        error: toError(error),
-      });
-      if (error instanceof ZamaError) {
-        throw error;
-      }
-      throw new TransactionRevertedError("UnwrapAll transaction failed", {
-        cause: error,
-      });
-    }
+    return this.submitTransaction({
+      operation: "unwrapAll",
+      config: unwrapFromBalanceContract(this.address, userAddress, userAddress, handle),
+    });
   }
 
   /**
@@ -501,36 +414,19 @@ export class WrappedToken extends Token {
    * ```
    */
   async finalizeUnwrap(unwrapRequestIdOrAmount: Handle): Promise<TransactionResult> {
-    const signer = this.sdk.requireSigner("finalizeUnwrap");
     await requireChainAlignment("finalizeUnwrap", this.sdk.signer, this.sdk.provider);
     const result = await this.sdk.publicDecrypt([unwrapRequestIdOrAmount]);
     const clearValue = result.clearValues[unwrapRequestIdOrAmount];
     assertBigint(clearValue, "finalizeUnwrap: clearValue");
-    try {
-      const txHash = await signer.writeContract(
-        finalizeUnwrapContract(
-          this.address,
-          unwrapRequestIdOrAmount,
-          clearValue,
-          result.decryptionProof,
-        ),
-      );
-      this.emit({ type: ZamaSDKEvents.FinalizeUnwrapSubmitted, txHash });
-      const receipt = await this.sdk.provider.waitForTransactionReceipt(txHash);
-      return { txHash, receipt };
-    } catch (error) {
-      this.emit({
-        type: ZamaSDKEvents.TransactionError,
-        operation: "finalizeUnwrap",
-        error: toError(error),
-      });
-      if (error instanceof ZamaError) {
-        throw error;
-      }
-      throw new TransactionRevertedError("Failed to finalize unshield", {
-        cause: error,
-      });
-    }
+    return this.submitTransaction({
+      operation: "finalizeUnwrap",
+      config: finalizeUnwrapContract(
+        this.address,
+        unwrapRequestIdOrAmount,
+        clearValue,
+        result.decryptionProof,
+      ),
+    });
   }
 
   // PRIVATE HELPERS
@@ -601,7 +497,6 @@ export class WrappedToken extends Token {
     maxApproval: boolean,
     callbacks?: ShieldCallbacks,
   ): Promise<void> {
-    const signer = this.sdk.requireSigner("approveUnderlying");
     const underlying = await this.#getUnderlying();
     const account = await requireAlignedWalletAccount(
       "approveUnderlying",
@@ -617,30 +512,24 @@ export class WrappedToken extends Token {
       return;
     }
 
-    try {
-      // Reset to zero first when there's an existing non-zero allowance.
-      // Required by non-standard tokens like USDT, and also mitigates the
-      // ERC-20 approve race condition for all tokens.
-      if (allowance > 0n) {
-        const resetHash = await signer.writeContract(approveContract(underlying, this.address, 0n));
-        await this.sdk.provider.waitForTransactionReceipt(resetHash);
-      }
-
-      const approvalAmount = maxApproval ? 2n ** 256n - 1n : amount;
-
-      const txHash = await signer.writeContract(
-        approveContract(underlying, this.address, approvalAmount),
-      );
-      this.emit({ type: ZamaSDKEvents.ApproveUnderlyingSubmitted, txHash });
-      void swallow("shield: onApprovalSubmitted", () => callbacks?.onApprovalSubmitted?.(txHash));
-      await this.sdk.provider.waitForTransactionReceipt(txHash);
-    } catch (error) {
-      if (error instanceof ZamaError) {
-        throw error;
-      }
-      throw new ApprovalFailedError("ERC-20 approval failed", {
-        cause: error,
+    // Reset to zero first when there's an existing non-zero allowance.
+    // Required by non-standard tokens like USDT, and also mitigates the
+    // ERC-20 approve race condition for all tokens.
+    if (allowance > 0n) {
+      await this.submitTransaction({
+        operation: "approveUnderlying:reset",
+        config: approveContract(underlying, this.address, 0n),
+        errorClass: ApprovalFailedError,
       });
     }
+
+    const approvalAmount = maxApproval ? 2n ** 256n - 1n : amount;
+
+    await this.submitTransaction({
+      operation: "approveUnderlying",
+      config: approveContract(underlying, this.address, approvalAmount),
+      onSubmitted: callbacks?.onApprovalSubmitted,
+      errorClass: ApprovalFailedError,
+    });
   }
 }

--- a/packages/sdk/src/utils/submit-transaction.ts
+++ b/packages/sdk/src/utils/submit-transaction.ts
@@ -8,11 +8,7 @@ import type {
   TransactionResult,
   WriteContractConfig,
 } from "../types";
-import { toError } from "./error";
 import { swallow } from "./swallow";
-
-/** Constructor of a {@link ZamaError} subclass with the standard message/options signature. */
-export type ZamaErrorClass = new (message: string, options?: ErrorOptions) => ZamaError;
 
 /**
  * Shared write-transaction pipeline used by every SDK call that submits a tx.
@@ -21,15 +17,10 @@ export type ZamaErrorClass = new (message: string, options?: ErrorOptions) => Za
  * {@link transactionOperationMetadata}, fires `onSubmitted`, waits for the
  * receipt, and returns `{ txHash, receipt }`.
  *
- * On failure: always emits a {@link ZamaSDKEvents.TransactionError} event
- * (including for `ZamaError` causes), then throws according to this precedence:
- *
- * 1. `ZamaError` instances are rethrown as-is.
- * 2. `mapError(error)` is consulted next; if it returns a `ZamaError`, that
- *    is thrown (used for revert-data → typed-error mapping).
- * 3. Otherwise wraps in `errorClass ?? TransactionRevertedError` with a
- *    generic `"Transaction failed during ${operation}"` message and the
- *    original error as `cause`.
+ * On failure: emits a {@link ZamaSDKEvents.TransactionError} event with the
+ * transaction-level error it will throw, then throws it. Existing `ZamaError`
+ * instances are rethrown as-is; all other failures are wrapped in
+ * `TransactionRevertedError` with the original error as `cause`.
  */
 export async function submitTransaction(params: {
   operation: TransactionOperation;
@@ -38,10 +29,8 @@ export async function submitTransaction(params: {
   config: WriteContractConfig;
   emit: (input: ZamaSDKEventInput) => void;
   onSubmitted?: (txHash: Hex) => void;
-  errorClass?: ZamaErrorClass;
-  mapError?: (error: unknown) => ZamaError | null | undefined;
 }): Promise<TransactionResult> {
-  const { operation, signer, provider, config, emit, onSubmitted, errorClass, mapError } = params;
+  const { operation, signer, provider, config, emit, onSubmitted } = params;
   const metadata = transactionOperationMetadata[operation];
 
   try {
@@ -51,21 +40,18 @@ export async function submitTransaction(params: {
     const receipt = await provider.waitForTransactionReceipt(txHash);
     return { txHash, receipt };
   } catch (error) {
+    const failure =
+      error instanceof ZamaError
+        ? error
+        : new TransactionRevertedError(`Transaction failed during ${operation}`, {
+            cause: error,
+          });
+
     emit({
       type: ZamaSDKEvents.TransactionError,
       operation,
-      error: toError(error),
+      error: failure,
     });
-    if (error instanceof ZamaError) {
-      throw error;
-    }
-    const mapped = mapError?.(error);
-    if (mapped) {
-      throw mapped;
-    }
-    const ErrorCtor = errorClass ?? TransactionRevertedError;
-    throw new ErrorCtor(`Transaction failed during ${operation}`, {
-      cause: error,
-    });
+    throw failure;
   }
 }

--- a/packages/sdk/src/utils/submit-transaction.ts
+++ b/packages/sdk/src/utils/submit-transaction.ts
@@ -1,0 +1,65 @@
+import type { Hex } from "viem";
+import { TransactionRevertedError, ZamaError } from "../errors";
+import type { TransactionOperation, ZamaSDKEventInput } from "../events/sdk-events";
+import { transactionOperationMetadata, ZamaSDKEvents } from "../events/sdk-events";
+import type {
+  GenericProvider,
+  GenericSigner,
+  TransactionResult,
+  WriteContractConfig,
+} from "../types";
+import { toError } from "./error";
+import { swallow } from "./swallow";
+
+/** Constructor of a {@link ZamaError} subclass with the standard message/options signature. */
+export type ZamaErrorClass = new (message: string, options?: ErrorOptions) => ZamaError;
+
+export async function submitTransaction(params: {
+  operation: TransactionOperation;
+  signer: GenericSigner;
+  provider: GenericProvider;
+  config: WriteContractConfig;
+  emit: (input: ZamaSDKEventInput) => void;
+  onSubmitted?: (txHash: Hex) => void;
+  errorClass?: ZamaErrorClass;
+  mapError?: (error: unknown) => ZamaError | null | undefined;
+  failureMessage?: string;
+}): Promise<TransactionResult> {
+  const {
+    operation,
+    signer,
+    provider,
+    config,
+    emit,
+    onSubmitted,
+    errorClass,
+    mapError,
+    failureMessage,
+  } = params;
+  const metadata = transactionOperationMetadata[operation];
+
+  try {
+    const txHash = await signer.writeContract(config);
+    emit(metadata.submittedEvent(txHash));
+    void swallow(`${operation}: onSubmitted`, () => onSubmitted?.(txHash));
+    const receipt = await provider.waitForTransactionReceipt(txHash);
+    return { txHash, receipt };
+  } catch (error) {
+    emit({
+      type: ZamaSDKEvents.TransactionError,
+      operation,
+      error: toError(error),
+    });
+    if (error instanceof ZamaError) {
+      throw error;
+    }
+    const mapped = mapError?.(error);
+    if (mapped) {
+      throw mapped;
+    }
+    const ErrorCtor = errorClass ?? TransactionRevertedError;
+    throw new ErrorCtor(failureMessage ?? `Transaction failed during ${operation}`, {
+      cause: error,
+    });
+  }
+}

--- a/packages/sdk/src/utils/submit-transaction.ts
+++ b/packages/sdk/src/utils/submit-transaction.ts
@@ -14,6 +14,23 @@ import { swallow } from "./swallow";
 /** Constructor of a {@link ZamaError} subclass with the standard message/options signature. */
 export type ZamaErrorClass = new (message: string, options?: ErrorOptions) => ZamaError;
 
+/**
+ * Shared write-transaction pipeline used by every SDK call that submits a tx.
+ *
+ * On success: writes the tx, emits the per-operation submitted event from
+ * {@link transactionOperationMetadata}, fires `onSubmitted`, waits for the
+ * receipt, and returns `{ txHash, receipt }`.
+ *
+ * On failure: always emits a {@link ZamaSDKEvents.TransactionError} event
+ * (including for `ZamaError` causes), then throws according to this precedence:
+ *
+ * 1. `ZamaError` instances are rethrown as-is.
+ * 2. `mapError(error)` is consulted next; if it returns a `ZamaError`, that
+ *    is thrown (used for revert-data → typed-error mapping).
+ * 3. Otherwise wraps in `errorClass ?? TransactionRevertedError` with a
+ *    generic `"Transaction failed during ${operation}"` message and the
+ *    original error as `cause`.
+ */
 export async function submitTransaction(params: {
   operation: TransactionOperation;
   signer: GenericSigner;
@@ -23,19 +40,8 @@ export async function submitTransaction(params: {
   onSubmitted?: (txHash: Hex) => void;
   errorClass?: ZamaErrorClass;
   mapError?: (error: unknown) => ZamaError | null | undefined;
-  failureMessage?: string;
 }): Promise<TransactionResult> {
-  const {
-    operation,
-    signer,
-    provider,
-    config,
-    emit,
-    onSubmitted,
-    errorClass,
-    mapError,
-    failureMessage,
-  } = params;
+  const { operation, signer, provider, config, emit, onSubmitted, errorClass, mapError } = params;
   const metadata = transactionOperationMetadata[operation];
 
   try {
@@ -58,7 +64,7 @@ export async function submitTransaction(params: {
       throw mapped;
     }
     const ErrorCtor = errorClass ?? TransactionRevertedError;
-    throw new ErrorCtor(failureMessage ?? `Transaction failed during ${operation}`, {
+    throw new ErrorCtor(`Transaction failed during ${operation}`, {
       cause: error,
     });
   }


### PR DESCRIPTION
## Context

Every SDK call that submits an on-chain write followed the same pattern: `requireSigner` → `writeContract` → emit `<Op>Submitted` → wait for receipt, with a `try/catch` that emits `TransactionError` and rethrows as a typed `ZamaError`. That block was duplicated across `Token`, `WrappedToken`, and `DelegationService`, and the operation-string → submitted-event-type mapping lived inline at each call site.

## Motivation

Centralize this pipeline so:
- The submitted/error event contract is enforced in one place (impossible to forget the `TransactionError` emit, or get the event payload shape wrong).
- The set of valid `TransactionOperation` strings is derived from the dispatch table — no hand-maintained union that can drift from the actual call sites.
- Adding a new write operation is a one-row change in a single table, not five edits across three files.

## High-level overview

- **New `utils/submit-transaction.ts` helper** owns the entire submit pipeline: write → emit submitted → wait for receipt, or emit `TransactionError` and rethrow. Precedence on failure is documented in its JSDoc: `ZamaError` rethrown as-is → `mapError` → `errorClass ?? TransactionRevertedError` with a single generic `"Transaction failed during ${operation}"` message.
- **Single source of truth for operation → submitted-event payloads.** `transactionOperationMetadata` (in `events/sdk-events.ts`) maps every `TransactionOperation` to the exact event shape it produces, guarded by `satisfies` for exhaustiveness. `TransactionOperation` itself is derived from this table via `keyof`, replacing the old hand-maintained `TransactionErrorOperation` union.
- **Token / WrappedToken / DelegationService** now route every write through the helper. Token exposes a thin protected `submitTransaction` wrapper so subclasses (e.g. `WrappedToken`) can call it without re-importing the free function.
- **Observable behavior changes** (worth noting since events are public API; SDK is alpha so all acceptable):
  - `DelegationService` now emits `TransactionError` on delegate/revoke failures (was previously silent — the `try/catch` only rethrew). Brings delegation in line with every other write path.
  - `unwrapAll` error events now carry `operation: "unwrapAll"` instead of the previous `"unwrap"` (the success path was already distinct; this aligns the error path).
  - New `operation` discriminator `"approveUnderlying:reset"` is publicly visible on both `TransactionErrorEvent.operation` and as `step: "reset"` on `ApproveUnderlyingSubmittedEvent`. The pre-flight allowance-reset transaction was previously silent; it now emits like any other approval, with `step: "reset" | "approve"` distinguishing the two.
  - `TransactionErrorOperation` is renamed to `TransactionOperation` and broadened with `"approveUnderlying:reset"` and `"unwrapAll"`. Exhaustive-switch consumers must add those cases.
- **Tests** updated to match: error-message-coupled assertions relaxed to `code` matches (the per-operation strings are gone), and new coverage added for the `step: "reset" | "approve"` discriminator on `ApproveUnderlyingSubmitted` events.
