### PR TITLE
docs(sdk): swap @throws condition and {@link} so links render

### DIFF
--- a/claude-setup/skills/jsdoc/SKILL.md
+++ b/claude-setup/skills/jsdoc/SKILL.md
@@ -51,9 +51,10 @@ Full JSDoc. These feed typedoc and appear in generated API reference pages.
  * @param amount - Plaintext amount to transfer.
  * @param options - Transfer options.
  * @returns The transaction hash and mined receipt.
- * @throws {@link InsufficientConfidentialBalanceError} if balance is less than `amount`.
- * @throws {@link EncryptionFailedError} if FHE encryption fails.
- * @throws {@link TransactionRevertedError} if the on-chain transfer reverts.
+ *
+ * @throws if balance is less than `amount`. {@link InsufficientConfidentialBalanceError}
+ * @throws if FHE encryption fails. {@link EncryptionFailedError}
+ * @throws if the on-chain transfer reverts. {@link TransactionRevertedError}
  *
  * @example
  * ```ts
@@ -101,7 +102,8 @@ Hooks are public exports and follow the same full JSDoc rule. However, `@param` 
  * Read the connected wallet's confidential token balance, polling at regular intervals.
  *
  * @returns Query result with `data` as the decrypted balance in base units (bigint).
- * @throws {@link DecryptionFailedError} if FHE decryption fails.
+ *
+ * @throws if FHE decryption fails. {@link DecryptionFailedError}
  *
  * @example
  * ```tsx
@@ -141,7 +143,7 @@ This rule also applies to **`protected` methods on abstract base classes** — t
 /**
  * Ensure ERC-20 allowance is sufficient for the shield amount.
  *
- * @throws {@link ApprovalFailedError} if the approval transaction fails.
+ * @throws if the approval transaction fails. {@link ApprovalFailedError}
  */
 async #ensureAllowance(amount: bigint, maxApproval: boolean, callbacks?: ShieldCallbacks): Promise<void> {
 
@@ -150,8 +152,8 @@ async #ensureAllowance(amount: bigint, maxApproval: boolean, callbacks?: ShieldC
  * Resolve credentials for the given contracts, creating fresh ones if none are cached.
  * Deduplicates concurrent creation calls.
  *
- * @throws {@link SigningRejectedError} if the user rejects the wallet signature prompt.
- * @throws {@link SigningFailedError} if signing fails for any other reason.
+ * @throws if the user rejects the wallet signature prompt. {@link SigningRejectedError}
+ * @throws if signing fails for any other reason. {@link SigningFailedError}
  */
 protected async resolveCredentials(...): Promise<TCreds> {
 
@@ -163,7 +165,8 @@ protected async resolveCredentials(...): Promise<TCreds> {
  * @param maxApproval - Whether to approve max uint256.
  * @param callbacks - Optional shield callbacks.
  * @returns Resolves when allowance is sufficient.
- * @throws {@link ApprovalFailedError} if the approval transaction fails.
+ *
+ * @throws if the approval transaction fails. {@link ApprovalFailedError}
  */
 
 // BAD — protected method reduced to just @internal (loses error contract)
@@ -316,10 +319,19 @@ One per function. Compact. Show the primary use case, plus one variant if it dem
 
 Keep everywhere — public and private. This is the only place error contracts are documented. TypeScript has no `throws` clause, thus, the information is conveyed via JSDoc.
 
+Put the condition first and the `{@link X}` at the end of the description. When `{@link X}` sits immediately after `@throws ` (whether the description follows on the same line or the next), renderers (TypeScript hover, typedoc) treat the braces as the JSDoc type-annotation slot and emit the link as literal text instead of a clickable link. Moving the link to the description's tail keeps it in description position.
+
 ```ts
-// Always document @throws, even on private methods
+// GOOD — condition first, {@link} at the end of the description
+@throws if no active delegation exists. {@link DelegationNotFoundError}
+@throws if the delegation has expired. {@link DelegationExpiredError}
+
+// BAD — {@link} immediately after @throws sits in the type slot, doesn't render
 @throws {@link DelegationNotFoundError} if no active delegation exists.
-@throws {@link DelegationExpiredError} if the delegation has expired.
+
+// BAD — same problem on two lines: link still sits right after `@throws `
+@throws {@link DelegationNotFoundError}
+if no active delegation exists.
 ```
 
 ### 8. `{@link}` References
@@ -389,7 +401,7 @@ Use `@remarks` for:
  * Call {@link allow} first to pre-authorize and control when the prompt appears.
  *
  * @returns The decrypted plaintext balance as a bigint.
- * @throws {@link SigningRejectedError} if the user rejects the wallet prompt.
+ * @throws if the user rejects the wallet prompt. {@link SigningRejectedError}
  */
 
 // GOOD — data caveat on a utility

--- a/packages/react-sdk/src/authorization/use-is-allowed.ts
+++ b/packages/react-sdk/src/authorization/use-is-allowed.ts
@@ -20,8 +20,8 @@ export interface UseIsAllowedConfig {
  * @returns Query result with `data: boolean` — `true` if a stored permit covers
  *   every entry in `contractAddresses`. The query auto-disables when no signer is configured
  *   (`data` stays `undefined`, `status` stays `"pending"`).
- * @throws {@link SignerNotConfiguredError} if the query runs without a signer configured
- *   (the `enabled` guard normally prevents this; only reachable if the caller forces `query: { enabled: true }`).
+ * @throws if the query runs without a signer configured (the `enabled` guard normally
+ *   prevents this; only reachable if the caller forces `query: { enabled: true }`). {@link SignerNotConfiguredError}
  *
  * @example
  * ```tsx

--- a/packages/react-sdk/src/wagmi/wagmi-provider.ts
+++ b/packages/react-sdk/src/wagmi/wagmi-provider.ts
@@ -57,8 +57,8 @@ export class WagmiProvider implements GenericProvider {
    *
    * @param hash - The transaction hash to wait for.
    * @returns The transaction receipt.
-   * @throws {@link TransactionRevertedError} if the transaction hash cannot be found (e.g.
-   *   an ERC-4337 bundler returned a `UserOperation` hash instead of a transaction hash).
+   * @throws if the transaction hash cannot be found (e.g. an ERC-4337 bundler
+   *   returned a `UserOperation` hash instead of a transaction hash). {@link TransactionRevertedError}
    */
   async waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt> {
     try {

--- a/packages/sdk/src/credentials/credential-service.ts
+++ b/packages/sdk/src/credentials/credential-service.ts
@@ -70,8 +70,8 @@ export class CredentialService {
    * when best-effort persistence fails.
    *
    * @returns The resolved keypair and permits covering the requested contracts.
-   * @throws {@link SigningRejectedError} if the user rejects a wallet signature prompt.
-   * @throws {@link SigningFailedError} if signing fails for any other reason.
+   * @throws if the user rejects a wallet signature prompt. {@link SigningRejectedError}
+   * @throws if signing fails for any other reason. {@link SigningFailedError}
    */
   async allow(contracts: readonly Address[], delegator?: Address): Promise<CredentialBundle> {
     const account = this.#signer.requireWalletAccount("allow");
@@ -140,7 +140,7 @@ export class CredentialService {
    *   (current chain) whose immutable payload touches any listed address is
    *   removed. Delegated permits are not touched in this mode.
    *
-   * @throws {@link SigningFailedError} if reading the signer address fails.
+   * @throws if reading the signer address fails. {@link SigningFailedError}
    */
   async revokePermits(contracts?: readonly Address[]): Promise<void> {
     const account = this.#signer.requireWalletAccount("revokePermits");
@@ -164,7 +164,7 @@ export class CredentialService {
    * Wipe the keypair for the current signer and cascade-delete every
    * permission referencing it across all chains and delegators.
    *
-   * @throws {@link SigningFailedError} if reading the signer address fails.
+   * @throws if reading the signer address fails. {@link SigningFailedError}
    */
   async clearCredentials(): Promise<void> {
     const account = this.#signer.requireWalletAccount("clearCredentials");

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -145,7 +145,7 @@ export class Token {
    *
    * @param owner - Balance owner address.
    * @returns The decrypted plaintext balance as a bigint.
-   * @throws {@link DecryptionFailedError} if FHE decryption fails.
+   * @throws if FHE decryption fails. {@link DecryptionFailedError}
    *
    * @example
    * ```ts
@@ -193,9 +193,9 @@ export class Token {
    * @param accountAddress - The account whose on-chain balance to read. Defaults
    *   to the delegator address.
    * @returns The decrypted plaintext balance as a bigint.
-   * @throws {@link DelegationNotFoundError} if no active delegation exists.
-   * @throws {@link DelegationExpiredError} if the delegation has expired.
-   * @throws {@link DecryptionFailedError} if delegated decryption fails.
+   * @throws if no active delegation exists. {@link DelegationNotFoundError}
+   * @throws if the delegation has expired. {@link DelegationExpiredError}
+   * @throws if delegated decryption fails. {@link DecryptionFailedError}
    *
    * @example
    * ```ts
@@ -328,9 +328,9 @@ export class Token {
    * @param tokens - Array of Token instances to decrypt balances for.
    * @param options - Delegated decryption configuration.
    * @returns A Map from token address to decrypted balance.
-   * @throws {@link DelegationNotFoundError} if no active delegation exists.
-   * @throws {@link DelegationExpiredError} if the delegation has expired.
-   * @throws {@link DecryptionFailedError} if any decryption fails and no `onError` is provided.
+   * @throws if no active delegation exists. {@link DelegationNotFoundError}
+   * @throws if the delegation has expired. {@link DelegationExpiredError}
+   * @throws if any decryption fails and no `onError` is provided. {@link DecryptionFailedError}
    *
    * @example
    * ```ts
@@ -503,11 +503,11 @@ export class Token {
    * @param amount - Plaintext amount to transfer (encrypted automatically via FHE).
    * @param options - Optional: `skipBalanceCheck` (default `false`).
    * @returns The transaction hash and mined receipt.
-   * @throws {@link ChainMismatchError} if signer and provider are on different chains.
-   * @throws {@link InsufficientConfidentialBalanceError} if the balance is less than `amount`.
-   * @throws {@link BalanceCheckUnavailableError} if balance validation requires decryption that is not possible.
-   * @throws {@link EncryptionFailedError} if FHE encryption fails.
-   * @throws {@link TransactionRevertedError} if the on-chain transfer reverts.
+   * @throws if signer and provider are on different chains. {@link ChainMismatchError}
+   * @throws if the balance is less than `amount`. {@link InsufficientConfidentialBalanceError}
+   * @throws if balance validation requires decryption that is not possible. {@link BalanceCheckUnavailableError}
+   * @throws if FHE encryption fails. {@link EncryptionFailedError}
+   * @throws if the on-chain transfer reverts. {@link TransactionRevertedError}
    *
    * @example
    * ```ts

--- a/packages/sdk/src/token/wrapped-token.ts
+++ b/packages/sdk/src/token/wrapped-token.ts
@@ -119,10 +119,10 @@ export class WrappedToken extends Token {
    * @param amount - The plaintext amount to shield.
    * @param options - Optional: `approvalStrategy`, `to`, callbacks.
    * @returns The transaction hash and mined receipt.
-   * @throws {@link ChainMismatchError} if signer and provider are on different chains.
-   * @throws {@link InsufficientERC20BalanceError} if the ERC-20 balance is less than `amount`.
-   * @throws {@link ApprovalFailedError} if the ERC-20 approval step fails (approveAndWrap path).
-   * @throws {@link TransactionRevertedError} if the shield transaction reverts.
+   * @throws if signer and provider are on different chains. {@link ChainMismatchError}
+   * @throws if the ERC-20 balance is less than `amount`. {@link InsufficientERC20BalanceError}
+   * @throws if the ERC-20 approval step fails (approveAndWrap path). {@link ApprovalFailedError}
+   * @throws if the shield transaction reverts. {@link TransactionRevertedError}
    *
    * @example
    * ```ts
@@ -346,7 +346,7 @@ export class WrappedToken extends Token {
    *
    * @param callbacks - Optional progress callbacks for each phase.
    * @returns The finalize transaction hash and mined receipt.
-   * @throws {@link DecryptionFailedError} if the balance is zero.
+   * @throws if the balance is zero. {@link DecryptionFailedError}
    *
    * @example
    * ```ts
@@ -441,7 +441,7 @@ export class WrappedToken extends Token {
    * Throws if the balance is zero.
    *
    * @returns The transaction hash and mined receipt.
-   * @throws {@link DecryptionFailedError} if the balance is zero.
+   * @throws if the balance is zero. {@link DecryptionFailedError}
    *
    * @example
    * ```ts

--- a/packages/sdk/src/wrappers-registry.ts
+++ b/packages/sdk/src/wrappers-registry.ts
@@ -192,7 +192,7 @@ export class WrappersRegistry {
    * Priority: `registryAddresses[chainId]` \> built-in default.
    *
    * @returns The registry contract address for the connected chain.
-   * @throws {@link ConfigurationError} if no address is configured for the chain.
+   * @throws if no address is configured for the chain. {@link ConfigurationError}
    */
   async getRegistryAddress(): Promise<Address> {
     const chainId = await this.provider.getChainId();

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -114,7 +114,7 @@ export class ZamaSDK {
   /**
    * Return the configured signer or throw {@link SignerNotConfiguredError}.
    *
-   * @throws {@link SignerNotConfiguredError} if no signer is configured.
+   * @throws if no signer is configured. {@link SignerNotConfiguredError}
    */
   requireSigner(operation: string): GenericSigner {
     if (!this.signer) {
@@ -298,13 +298,13 @@ export class ZamaSDK {
    * @param delegateAddress - Address to delegate decryption rights to.
    * @param expirationDate - Optional expiration date (defaults to permanent delegation via `uint64.max`).
    * @returns The transaction hash and mined receipt.
-   * @throws {@link SignerNotConfiguredError} if no signer is configured.
-   * @throws {@link ChainMismatchError} if signer and provider are on different chains.
-   * @throws {@link DelegationExpirationTooSoonError} if `expirationDate` is less than 1 hour in the future.
-   * @throws {@link DelegationSelfNotAllowedError} if the delegate equals the connected wallet.
-   * @throws {@link DelegationDelegateEqualsContractError} if the delegate equals the contract address.
-   * @throws {@link DelegationExpiryUnchangedError} if the new expiry equals the current one.
-   * @throws {@link TransactionRevertedError} if the delegation transaction reverts.
+   * @throws if no signer is configured. {@link SignerNotConfiguredError}
+   * @throws if signer and provider are on different chains. {@link ChainMismatchError}
+   * @throws if `expirationDate` is less than 1 hour in the future. {@link DelegationExpirationTooSoonError}
+   * @throws if the delegate equals the connected wallet. {@link DelegationSelfNotAllowedError}
+   * @throws if the delegate equals the contract address. {@link DelegationDelegateEqualsContractError}
+   * @throws if the new expiry equals the current one. {@link DelegationExpiryUnchangedError}
+   * @throws if the delegation transaction reverts. {@link TransactionRevertedError}
    */
   async delegateDecryption({
     contractAddress,
@@ -336,10 +336,10 @@ export class ZamaSDK {
    * @param contractAddress - The confidential contract address to revoke delegation on.
    * @param delegateAddress - Address to revoke delegation from.
    * @returns The transaction hash and mined receipt.
-   * @throws {@link SignerNotConfiguredError} if no signer is configured.
-   * @throws {@link ChainMismatchError} if signer and provider are on different chains.
-   * @throws {@link DelegationNotFoundError} if no delegation exists for this (delegator, delegate, contract) tuple.
-   * @throws {@link TransactionRevertedError} if the revocation transaction reverts.
+   * @throws if no signer is configured. {@link SignerNotConfiguredError}
+   * @throws if signer and provider are on different chains. {@link ChainMismatchError}
+   * @throws if no delegation exists for this (delegator, delegate, contract) tuple. {@link DelegationNotFoundError}
+   * @throws if the revocation transaction reverts. {@link TransactionRevertedError}
    */
   async revokeDelegation({
     contractAddress,
@@ -411,8 +411,8 @@ export class ZamaSDK {
    *
    * @param handles - Handles to decrypt, each paired with its contract address.
    * @returns A record mapping each handle to its decrypted clear-text value.
-   * @throws {@link SignerNotConfiguredError} if no signer is configured.
-   * @throws {@link ChainMismatchError} if signer and provider are on different chains.
+   * @throws if no signer is configured. {@link SignerNotConfiguredError}
+   * @throws if signer and provider are on different chains. {@link ChainMismatchError}
    *
    * @example
    * ```ts
@@ -529,7 +529,7 @@ export class ZamaSDK {
    *
    * @param params - Typed FHE inputs, the target contract address, and the user address.
    * @returns Encrypted handles and the input proof for on-chain submission.
-   * @throws {@link EncryptionFailedError} if FHE encryption fails.
+   * @throws if FHE encryption fails. {@link EncryptionFailedError}
    *
    * @example
    * ```ts
@@ -555,7 +555,7 @@ export class ZamaSDK {
    *   removed. May also drop coverage for other contracts that shared the same
    *   permit. Delegated permits are not touched in this mode.
    *
-   * @throws {@link SignerNotConfiguredError} if no signer is configured.
+   * @throws if no signer is configured. {@link SignerNotConfiguredError}
    */
   async revokePermits(contracts?: Address[]): Promise<void> {
     const service = this.#requireCredentialService("revokePermits");
@@ -572,7 +572,7 @@ export class ZamaSDK {
    * Wipe the keypair for the current signer and cascade-delete every permit
    * (across chains and delegators) referencing it.
    *
-   * @throws {@link SignerNotConfiguredError} if no signer is configured.
+   * @throws if no signer is configured. {@link SignerNotConfiguredError}
    */
   async clearCredentials(): Promise<void> {
     const service = this.#requireCredentialService("clearCredentials");


### PR DESCRIPTION
## Summary

`{@link X}` immediately after `@throws ` lands in the JSDoc type-annotation slot. TypeScript hover, typedoc, and other renderers emit it as literal text — `@link` shows up as a block tag in italics and the class name sits as plain text, not a navigable link. Moving the link to the end of the description keeps it in description position where inline tags render correctly.

All 42 `@throws` blocks across `packages/sdk/src` and `packages/react-sdk/src` swapped from:

```
@throws {@link ErrorClass} if condition.
```

to:

```
@throws if condition. {@link ErrorClass}
```

The jsdoc skill (section 7) now documents the convention and flags the broken forms (single-line and TSDoc multi-line) as anti-patterns.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] Visually verify the rendered docs site shows `{@link}` as a clickable link on a `@throws` line
- [ ] Hover one of the touched methods in VSCode and confirm the link is navigable

🤖 Generated with [Claude Code](https://claude.com/claude-code)