### PR TITLE
ci: install Aikido Safe Chain before every pnpm install step

### DIFF
--- a/.github/workflows/api-report.yml
+++ b/.github/workflows/api-report.yml
@@ -41,6 +41,9 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,9 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/license-compat.yml
+++ b/.github/workflows/license-compat.yml
@@ -39,6 +39,9 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,9 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -88,6 +88,9 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -219,6 +222,9 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -333,6 +339,9 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -75,6 +75,9 @@ jobs:
           echo "npm $(npm --version)"
           [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]
 
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,9 @@ jobs:
           echo "npm $(npm --version)"
           [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]
 
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
@@ -231,6 +234,9 @@ jobs:
           fi
           echo "npm $(npm --version)"
           [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]
+
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -41,6 +41,9 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- Add an `Install Aikido Safe Chain` step before every `pnpm install` in the GitHub Actions workflows.
- Covers all 12 install steps across docs, api-report, lint, license-compat, playwright (×3), release (×2), release-preview, and vitest.
- Uses the official `install-safe-chain.sh` installer with `--ci`, which sets up PATH shims for pnpm/npm/yarn/etc. so the subsequent install routes through Safe Chain's local proxy.

## Why
[Aikido Safe Chain](https://github.com/AikidoSec/safe-chain) intercepts package downloads from npm and blocks any package flagged as malicious before it reaches the runner — guards against supply-chain attacks on the CI install path.

## Test plan
- [ ] Watch the next CI run on this PR — expect a new `Install Aikido Safe Chain` step preceding each `Install dependencies` step
- [ ] Confirm `pnpm install --frozen-lockfile` still completes in each workflow (the shim is transparent for clean deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)