### PR TITLE
ci(license-compat): silence safe-chain stdout to keep JSON output clean

### DIFF
--- a/.github/workflows/license-compat.yml
+++ b/.github/workflows/license-compat.yml
@@ -46,6 +46,8 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Generate license inventory
+        env:
+          SAFE_CHAIN_LOGGING: silent
         run: |
           mkdir -p artifacts/license
           pnpm --filter @zama-fhe/sdk licenses list --json --prod > artifacts/license/licenses-sdk.json


### PR DESCRIPTION
## Summary
- Set `SAFE_CHAIN_LOGGING=silent` on the `Generate license inventory` step so Aikido Safe-chain stops printing banners onto stdout and contaminating `pnpm licenses list --json` output.
- Replaces the previous `grep -v '^ℹ Safe-chain:'` filter, which only stripped the first banner line and let continuation lines (e.g. `   To disable this check, use: --safe-chain-skip-minimum-package-age`) slip through and break `JSON.parse`.

## Why
Most recent failure on PR #360: https://github.com/zama-ai/sdk/actions/runs/26085110527/job/76696121939?pr=360

```
SyntaxError: Unexpected non-whitespace character after JSON at position 16233 (line 504 column 3)
```

Suppressing safe-chain output at the source is more robust than chasing banner shapes with grep.

## Test plan
- [ ] License Compatibility workflow passes on this PR
- [ ] After merge, re-run CI on PR #360 (or rebase it onto prerelease) and confirm the `Generate license inventory` step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)