### PR TITLE
feat(sdk): introduce clear signing intents

### DIFF
--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -82,6 +82,57 @@ export type BatchDecryptBalancesAsParams = BatchDecryptAsOptions;
 // @public
 export function clearCredentialsMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.clearCredentials"], void, void>;
 
+// @public
+export interface ClearSigningCallbacks {
+    onClearSigningIntent?: (intent: ClearSigningIntent) => Promise<void> | void;
+}
+
+// @public
+export interface ClearSigningContractContext {
+    chainId?: number;
+    contractAddress?: Address;
+    functionName?: string;
+}
+
+// @public
+export interface ClearSigningField {
+    description?: string;
+    displayValue?: string;
+    label: string;
+    redacted?: boolean;
+    value?: ClearSigningFieldValue;
+    visibility: ClearSigningVisibility;
+}
+
+// @public
+export type ClearSigningFieldValue = string | number | bigint | boolean | null | readonly ClearSigningFieldValue[] | {
+    readonly [key: string]: ClearSigningFieldValue;
+};
+
+// @public
+export interface ClearSigningIntent {
+    contractContext?: ClearSigningContractContext;
+    fields: ClearSigningField[];
+    kind: ClearSigningIntentKind;
+    rawContext?: ClearSigningRawContext;
+    summary: string;
+    title: string;
+}
+
+// @public
+export type ClearSigningIntentKind = "allow" | "allowAs" | "delegateDecryption" | "confidentialTransfer" | "confidentialTransferFrom" | "shield" | "unwrap" | "unwrapAll" | "finalizeUnwrap";
+
+// @public
+export interface ClearSigningRawContext {
+    contractCall?: unknown;
+    contractCalls?: readonly unknown[];
+    sdkInput?: unknown;
+    typedData?: unknown;
+}
+
+// @public
+export type ClearSigningVisibility = "public" | "encrypted" | "derived" | "internal";
+
 export { ClearValueType }
 
 // @public (undocumented)
@@ -363,6 +414,9 @@ export function filterQueryOptions<TOptions extends Record<string, unknown>>(opt
 export function finalizeUnwrapMutationOptions(token: WrappedToken): MutationFactoryOptions<readonly ["zama.finalizeUnwrap", Address], FinalizeUnwrapParams, TransactionResult>;
 
 // @public
+export type FinalizeUnwrapOptions = ClearSigningCallbacks;
+
+// @public
 export type FinalizeUnwrapParams = /** Preferred input from upgraded `UnwrapRequested` events. */{
     unwrapRequestId: Handle;
     burnAmountHandle?: never;
@@ -596,7 +650,7 @@ export interface SetOperatorSubmittedEvent extends BaseEvent {
 }
 
 // @public
-export interface ShieldCallbacks {
+export interface ShieldCallbacks extends ClearSigningCallbacks {
     onApprovalSubmitted?: (txHash: Hex) => void;
     onShieldSubmitted?: (txHash: Hex) => void;
 }
@@ -644,6 +698,7 @@ export class Token {
     confidentialBalanceOf(owner: Address): Promise<Handle>;
     confidentialTransfer(to: Address, amount: bigint, options?: TransferOptions): Promise<TransactionResult>;
     confidentialTransferFrom(from: Address, to: Address, amount: bigint, callbacks?: TransferCallbacks): Promise<TransactionResult>;
+    createConfidentialTransferClearSigningIntent(to: Address, amount: bigint): Promise<ClearSigningIntent>;
     decimals(): Promise<number>;
     decryptBalanceAs(input: {
         delegatorAddress: Address;
@@ -757,7 +812,7 @@ export interface TransactionResult {
 }
 
 // @public
-export interface TransferCallbacks {
+export interface TransferCallbacks extends ClearSigningCallbacks {
     onEncryptComplete?: () => void;
     onTransferSubmitted?: (txHash: Hex) => void;
 }
@@ -801,7 +856,7 @@ export function unshieldAllMutationOptions(token: WrappedToken): MutationFactory
 export interface UnshieldAllParams extends UnshieldCallbacks {}
 
 // @public
-export interface UnshieldCallbacks {
+export interface UnshieldCallbacks extends ClearSigningCallbacks {
     onFinalizeSubmitted?: (txHash: Hex) => void;
     onFinalizing?: () => void;
     onUnwrapSubmitted?: (txHash: Hex) => void;
@@ -847,6 +902,9 @@ export interface UnshieldPhase2SubmittedEvent extends BaseEvent {
 export function unwrapAllMutationOptions(token: WrappedToken): MutationFactoryOptions<readonly ["zama.unwrapAll", Address], void, TransactionResult>;
 
 // @public
+export type UnwrapAllOptions = ClearSigningCallbacks;
+
+// @public
 export interface UnwrapFinalizedEvent {
     readonly cleartextAmount: bigint;
     readonly encryptedAmount: Handle;
@@ -858,6 +916,9 @@ export interface UnwrapFinalizedEvent {
 
 // @public (undocumented)
 export function unwrapMutationOptions(token: WrappedToken): MutationFactoryOptions<readonly ["zama.unwrap", Address], UnwrapParams, TransactionResult>;
+
+// @public
+export type UnwrapOptions = ClearSigningCallbacks;
 
 // @public
 export interface UnwrapParams {
@@ -971,15 +1032,19 @@ export interface WrappedEvent {
 export class WrappedToken extends Token {
     allowance(owner: Address): Promise<bigint>;
     approveUnderlying(amount?: bigint): Promise<TransactionResult>;
-    finalizeUnwrap(unwrapRequestIdOrAmount: Handle): Promise<TransactionResult>;
+    createFinalizeUnwrapClearSigningIntent(unwrapRequestIdOrAmount: Handle, clearAmount?: bigint): Promise<ClearSigningIntent>;
+    createShieldClearSigningIntent(amount: bigint, options?: ShieldOptions): Promise<ClearSigningIntent>;
+    createUnwrapAllClearSigningIntent(): Promise<ClearSigningIntent>;
+    createUnwrapClearSigningIntent(amount: bigint): Promise<ClearSigningIntent>;
+    finalizeUnwrap(unwrapRequestIdOrAmount: Handle, options?: FinalizeUnwrapOptions): Promise<TransactionResult>;
     isPayable(): Promise<boolean>;
     resumeUnshield(unwrapTxHash: Hex, callbacks?: UnshieldCallbacks): Promise<TransactionResult>;
     shield(amount: bigint, options?: ShieldOptions): Promise<TransactionResult>;
     underlying(): Promise<Address>;
     unshield(amount: bigint, options?: UnshieldOptions): Promise<TransactionResult>;
     unshieldAll(callbacks?: UnshieldCallbacks): Promise<TransactionResult>;
-    unwrap(amount: bigint): Promise<TransactionResult>;
-    unwrapAll(): Promise<TransactionResult>;
+    unwrap(amount: bigint, options?: UnwrapOptions): Promise<TransactionResult>;
+    unwrapAll(options?: UnwrapAllOptions): Promise<TransactionResult>;
 }
 
 // @public (undocumented)
@@ -1270,9 +1335,9 @@ export const ZamaSDKEvents: {
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/types-C-OHT8i4.d.ts:652:3 - (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
-// dist/esm/types-C-OHT8i4.d.ts:653:3 - (ae-forgotten-export) The symbol "RelayerDispatcher" needs to be exported by the entry point index.d.ts
-// dist/esm/types-C-OHT8i4.d.ts:654:3 - (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts
+// dist/esm/types-4s4G1DA_.d.ts:653:3 - (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
+// dist/esm/types-4s4G1DA_.d.ts:654:3 - (ae-forgotten-export) The symbol "RelayerDispatcher" needs to be exported by the entry point index.d.ts
+// dist/esm/types-4s4G1DA_.d.ts:655:3 - (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -361,6 +361,9 @@ export interface ApproveUnderlyingSubmittedEvent extends BaseEvent {
 }
 
 // @public
+export function assertClearSigningIntentSafe(intent: ClearSigningIntent): void;
+
+// @public
 export type AtLeastOneChain = readonly [FheChain, ...FheChain[]];
 
 // @public
@@ -582,6 +585,144 @@ export interface BatchDecryptHandlesResult {
 }
 
 // @public
+export function buildAllowAsIntent(input: BuildAllowAsIntentParams): ClearSigningIntent;
+
+// @public
+export function buildAllowAsIntentFromEIP712(typedData: KmsDelegatedUserDecryptEIP712Type): ClearSigningIntent;
+
+// @public
+export interface BuildAllowAsIntentParams extends BuildAllowIntentParams {
+    delegatorAddress: Address;
+}
+
+// @public
+export function buildAllowIntent(input: BuildAllowIntentParams): ClearSigningIntent;
+
+// @public
+export function buildAllowIntentFromEIP712(typedData: KmsUserDecryptEIP712Type): ClearSigningIntent;
+
+// @public
+export interface BuildAllowIntentParams {
+    chainId?: number;
+    contractAddresses: readonly Address[];
+    durationDays?: number | bigint;
+    startTimestamp?: number | bigint;
+    typedData?: unknown;
+    verifyingContract?: Address;
+}
+
+// @public
+export function buildConfidentialTransferFromIntent(input: BuildConfidentialTransferFromIntentParams): ClearSigningIntent;
+
+// @public
+export interface BuildConfidentialTransferFromIntentParams extends Omit<BuildConfidentialTransferIntentParams, "senderAddress"> {
+    operatorAddress: Address;
+    sourceAddress: Address;
+}
+
+// @public
+export function buildConfidentialTransferIntent(input: BuildConfidentialTransferIntentParams): ClearSigningIntent;
+
+// @public
+export interface BuildConfidentialTransferIntentParams {
+    amount?: bigint;
+    chainId?: number;
+    contractCall?: unknown;
+    encryptedAmount?: ClearSigningEncryptedValue;
+    hasInputProof?: boolean;
+    recipientAddress: Address;
+    senderAddress?: Address;
+    tokenAddress: Address;
+}
+
+// @public
+export function buildDelegateDecryptionIntent(input: BuildDelegateDecryptionIntentParams): ClearSigningIntent;
+
+// @public
+export interface BuildDelegateDecryptionIntentParams {
+    aclAddress?: Address;
+    chainId?: number;
+    contractAddress: Address;
+    contractCall?: unknown;
+    delegateAddress: Address;
+    delegatorAddress?: Address;
+    expirationTimestamp?: number | bigint;
+    permanent?: boolean;
+}
+
+// @public
+export function buildFinalizeUnwrapIntent(input: BuildFinalizeUnwrapIntentParams): ClearSigningIntent;
+
+// @public
+export interface BuildFinalizeUnwrapIntentParams {
+    chainId?: number;
+    clearAmount?: bigint;
+    contractCall?: unknown;
+    hasDecryptionProof?: boolean;
+    legacyEncryptedAmount?: ClearSigningEncryptedValue;
+    unwrapRequestId?: string;
+    wrapperAddress: Address;
+}
+
+// @public
+export interface BuildShieldIntentBaseParams {
+    amount: bigint;
+    chainId?: number;
+    recipientAddress: Address;
+    senderAddress?: Address;
+    underlyingTokenAddress: Address;
+    wrapperAddress: Address;
+}
+
+// @public
+export function buildShieldViaTransferAndCallIntent(input: BuildShieldViaTransferAndCallIntentParams): ClearSigningIntent;
+
+// @public
+export interface BuildShieldViaTransferAndCallIntentParams extends BuildShieldIntentBaseParams {
+    contractCall?: unknown;
+}
+
+// @public
+export function buildShieldViaWrapIntent(input: BuildShieldViaWrapIntentParams): ClearSigningIntent;
+
+// @public
+export interface BuildShieldViaWrapIntentParams extends BuildShieldIntentBaseParams {
+    approvalAmount?: bigint;
+    approvalContractCall?: unknown;
+    approvalResetContractCall?: unknown;
+    maxApproval?: boolean;
+    wrapContractCall?: unknown;
+}
+
+// @public
+export function buildUnwrapAllIntent(input: BuildUnwrapAllIntentParams): ClearSigningIntent;
+
+// @public
+export interface BuildUnwrapAllIntentParams {
+    chainId?: number;
+    contractCall?: unknown;
+    encryptedBalance?: ClearSigningEncryptedValue;
+    fromAddress: Address;
+    recipientAddress: Address;
+    wrapperAddress: Address;
+}
+
+// @public
+export function buildUnwrapIntent(input: BuildUnwrapIntentParams): ClearSigningIntent;
+
+// @public
+export interface BuildUnwrapIntentParams {
+    amount?: bigint;
+    chainId?: number;
+    contractCall?: unknown;
+    encryptedAmount?: ClearSigningEncryptedValue;
+    fromAddress: Address;
+    hasInputProof?: boolean;
+    recipientAddress: Address;
+    wrapperAddress: Address;
+}
+
+// @public
 export class ChainMismatchError extends ZamaError {
     constructor(input: {
         operation: string;
@@ -614,6 +755,76 @@ export const chromeSessionStorage: ChromeSessionStorage;
 
 // @public
 export function clearPendingUnshield(storage: GenericStorage, wrapperAddress: Address): Promise<void>;
+
+// @public
+export interface ClearSigningCallbacks {
+    onClearSigningIntent?: (intent: ClearSigningIntent) => Promise<void> | void;
+}
+
+// @public
+export interface ClearSigningContractContext {
+    chainId?: number;
+    contractAddress?: Address;
+    functionName?: string;
+}
+
+// @public
+export interface ClearSigningEncryptedValue {
+    displayValue?: string;
+    value?: string;
+}
+
+// @public
+export interface ClearSigningField {
+    description?: string;
+    displayValue?: string;
+    label: string;
+    redacted?: boolean;
+    value?: ClearSigningFieldValue;
+    visibility: ClearSigningVisibility;
+}
+
+// @public
+export type ClearSigningFieldValue = string | number | bigint | boolean | null | readonly ClearSigningFieldValue[] | {
+    readonly [key: string]: ClearSigningFieldValue;
+};
+
+// @public
+export interface ClearSigningIntent {
+    contractContext?: ClearSigningContractContext;
+    fields: ClearSigningField[];
+    kind: ClearSigningIntentKind;
+    rawContext?: ClearSigningRawContext;
+    summary: string;
+    title: string;
+}
+
+// @public
+export type ClearSigningIntentKind = "allow" | "allowAs" | "delegateDecryption" | "confidentialTransfer" | "confidentialTransferFrom" | "shield" | "unwrap" | "unwrapAll" | "finalizeUnwrap";
+
+// @public
+export interface ClearSigningRawContext {
+    contractCall?: unknown;
+    contractCalls?: readonly unknown[];
+    sdkInput?: unknown;
+    typedData?: unknown;
+}
+
+// @public
+export interface ClearSigningValidationIssue {
+    code: "missing-title" | "missing-summary" | "missing-fields" | "invalid-kind" | "missing-field-label" | "missing-field-visibility" | "encrypted-field-missing-safe-display" | "internal-field-not-redacted" | "internal-field-has-value";
+    fieldIndex?: number;
+    message: string;
+}
+
+// @public
+export interface ClearSigningValidationResult {
+    issues: ClearSigningValidationIssue[];
+    valid: boolean;
+}
+
+// @public
+export type ClearSigningVisibility = "public" | "encrypted" | "derived" | "internal";
 
 // @public
 export function cleartext(): CleartextRelayerConfig;
@@ -6359,13 +6570,19 @@ export class Delegations {
     constructor(opts: {
         signer: GenericSigner | undefined;
         provider: GenericProvider;
+        relayer: RelayerDispatcher;
         delegationService: DelegationService;
     });
+    createDelegateDecryptionClearSigningIntent(input: {
+        contractAddress: Address;
+        delegateAddress: Address;
+        expirationDate?: Date;
+    }): Promise<ClearSigningIntent>;
     delegateDecryption(input: {
         contractAddress: Address;
         delegateAddress: Address;
         expirationDate?: Date;
-    }): Promise<TransactionResult>;
+    } & ClearSigningCallbacks): Promise<TransactionResult>;
     getExpiry(params: {
         contractAddress: Address;
         delegatorAddress: Address;
@@ -7524,6 +7741,9 @@ export function finalizeUnwrapContract(wrapper: Address, unwrapRequestIdOrAmount
     readonly functionName: "finalizeUnwrap";
     readonly args: readonly [`0x${string}`, bigint, `0x${string}`];
 };
+
+// @public
+export type FinalizeUnwrapOptions = ClearSigningCallbacks;
 
 // @public (undocumented)
 export interface FinalizeUnwrapSubmittedEvent extends BaseEvent {
@@ -11768,8 +11988,10 @@ export class Permits {
         credentialService: CredentialService | undefined;
     });
     clear(): Promise<void>;
-    grantDelegationPermit(delegator: Address, contracts: Address[]): Promise<void>;
-    grantPermit(contracts: Address[]): Promise<void>;
+    createAllowAsClearSigningIntent(delegator: Address, contracts: Address[]): Promise<ClearSigningIntent>;
+    createAllowClearSigningIntent(contracts: Address[]): Promise<ClearSigningIntent>;
+    grantDelegationPermit(delegator: Address, contracts: Address[], options?: ClearSigningCallbacks): Promise<void>;
+    grantPermit(contracts: Address[], options?: ClearSigningCallbacks): Promise<void>;
     hasDelegationPermit(delegator: Address, contracts: Address[]): Promise<boolean>;
     hasPermit(contracts: Address[]): Promise<boolean>;
     revokePermits(contracts?: Address[]): Promise<void>;
@@ -13194,6 +13416,29 @@ export interface RelayerSDK extends FheOperations {
 
 // @public
 export type RelayerSDKStatus = "idle" | "initializing" | "ready" | "error";
+
+// @public
+export function renderClearSigningIntent(intent: ClearSigningIntent, options?: RenderClearSigningIntentOptions): RenderedClearSigningIntent;
+
+// @public
+export interface RenderClearSigningIntentOptions {
+    includeInternal?: boolean;
+}
+
+// @public
+export interface RenderedClearSigningField {
+    label: string;
+    value: string;
+    visibility: ClearSigningField["visibility"];
+}
+
+// @public
+export interface RenderedClearSigningIntent {
+    fields: RenderedClearSigningField[];
+    kind: ClearSigningIntent["kind"];
+    summary: string;
+    title: string;
+}
 
 // @public (undocumented)
 export function resolveChainRelayers(chains: readonly FheChain[], relayers: Readonly<Record<number, RelayerConfig>>): Map<number, ResolvedChainRelayer>;
@@ -14666,7 +14911,7 @@ export interface SetOperatorSubmittedEvent extends BaseEvent {
 }
 
 // @public
-export interface ShieldCallbacks {
+export interface ShieldCallbacks extends ClearSigningCallbacks {
     onApprovalSubmitted?: (txHash: Hex) => void;
     onShieldSubmitted?: (txHash: Hex) => void;
 }
@@ -14893,6 +15138,7 @@ export class Token {
     confidentialBalanceOf(owner: Address): Promise<Handle>;
     confidentialTransfer(to: Address, amount: bigint, options?: TransferOptions): Promise<TransactionResult>;
     confidentialTransferFrom(from: Address, to: Address, amount: bigint, callbacks?: TransferCallbacks): Promise<TransactionResult>;
+    createConfidentialTransferClearSigningIntent(to: Address, amount: bigint): Promise<ClearSigningIntent>;
     decimals(): Promise<number>;
     decryptBalanceAs(input: {
         delegatorAddress: Address;
@@ -15034,7 +15280,7 @@ export function transferAndCallContract(tokenAddress: Address, to: Address, amou
 };
 
 // @public
-export interface TransferCallbacks {
+export interface TransferCallbacks extends ClearSigningCallbacks {
     onEncryptComplete?: () => void;
     onTransferSubmitted?: (txHash: Hex) => void;
 }
@@ -16088,7 +16334,7 @@ export function underlyingContract(wrapperAddress: Address): {
 };
 
 // @public
-export interface UnshieldCallbacks {
+export interface UnshieldCallbacks extends ClearSigningCallbacks {
     onFinalizeSubmitted?: (txHash: Hex) => void;
     onFinalizing?: () => void;
     onUnwrapSubmitted?: (txHash: Hex) => void;
@@ -16120,6 +16366,9 @@ export interface UnshieldPhase2SubmittedEvent extends BaseEvent {
     // (undocumented)
     type: typeof ZamaSDKEvents.UnshieldPhase2Submitted;
 }
+
+// @public
+export type UnwrapAllOptions = ClearSigningCallbacks;
 
 // @public
 export function unwrapContract(encryptedErc20: Address, from: Address, to: Address, encryptedAmount: Uint8Array, inputProof: Uint8Array): {
@@ -18773,6 +19022,9 @@ export function unwrapFromBalanceContract(encryptedErc20: Address, from: Address
     readonly args: readonly [`0x${string}`, `0x${string}`, `0x${string}`];
 };
 
+// @public
+export type UnwrapOptions = ClearSigningCallbacks;
+
 // @public @deprecated (undocumented)
 export interface UnwrappedFinalizedEvent {
     // (undocumented)
@@ -18838,6 +19090,9 @@ export interface UserDecryptParams {
     // (undocumented)
     startTimestamp: number;
 }
+
+// @public
+export function validateClearSigningIntent(intent: ClearSigningIntent): ClearSigningValidationResult;
 
 // @public
 export interface WalletAccount {
@@ -19920,15 +20175,19 @@ export interface WrappedEvent {
 export class WrappedToken extends Token {
     allowance(owner: Address): Promise<bigint>;
     approveUnderlying(amount?: bigint): Promise<TransactionResult>;
-    finalizeUnwrap(unwrapRequestIdOrAmount: Handle): Promise<TransactionResult>;
+    createFinalizeUnwrapClearSigningIntent(unwrapRequestIdOrAmount: Handle, clearAmount?: bigint): Promise<ClearSigningIntent>;
+    createShieldClearSigningIntent(amount: bigint, options?: ShieldOptions): Promise<ClearSigningIntent>;
+    createUnwrapAllClearSigningIntent(): Promise<ClearSigningIntent>;
+    createUnwrapClearSigningIntent(amount: bigint): Promise<ClearSigningIntent>;
+    finalizeUnwrap(unwrapRequestIdOrAmount: Handle, options?: FinalizeUnwrapOptions): Promise<TransactionResult>;
     isPayable(): Promise<boolean>;
     resumeUnshield(unwrapTxHash: Hex, callbacks?: UnshieldCallbacks): Promise<TransactionResult>;
     shield(amount: bigint, options?: ShieldOptions): Promise<TransactionResult>;
     underlying(): Promise<Address>;
     unshield(amount: bigint, options?: UnshieldOptions): Promise<TransactionResult>;
     unshieldAll(callbacks?: UnshieldCallbacks): Promise<TransactionResult>;
-    unwrap(amount: bigint): Promise<TransactionResult>;
-    unwrapAll(): Promise<TransactionResult>;
+    unwrap(amount: bigint, options?: UnwrapOptions): Promise<TransactionResult>;
+    unwrapAll(options?: UnwrapAllOptions): Promise<TransactionResult>;
 }
 
 // @public
@@ -20156,10 +20415,10 @@ export { ZKProofLike }
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/index-DE4MHZtQ.d.ts:20449:5 - (ae-forgotten-export) The symbol "DecryptionService" needs to be exported by the entry point index.d.ts
-// dist/esm/index-DE4MHZtQ.d.ts:20578:5 - (ae-forgotten-export) The symbol "DelegationService" needs to be exported by the entry point index.d.ts
-// dist/esm/index-DE4MHZtQ.d.ts:20680:5 - (ae-forgotten-export) The symbol "CachingService" needs to be exported by the entry point index.d.ts
-// dist/esm/index-DE4MHZtQ.d.ts:20681:5 - (ae-forgotten-export) The symbol "CredentialService" needs to be exported by the entry point index.d.ts
+// dist/esm/index-2UXC3lE7.d.ts:20449:5 - (ae-forgotten-export) The symbol "DecryptionService" needs to be exported by the entry point index.d.ts
+// dist/esm/index-2UXC3lE7.d.ts:20579:5 - (ae-forgotten-export) The symbol "DelegationService" needs to be exported by the entry point index.d.ts
+// dist/esm/index-2UXC3lE7.d.ts:20692:5 - (ae-forgotten-export) The symbol "CachingService" needs to be exported by the entry point index.d.ts
+// dist/esm/index-2UXC3lE7.d.ts:20693:5 - (ae-forgotten-export) The symbol "CredentialService" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -35,6 +35,17 @@
       },
       "default": "./dist/esm/cleartext/index.js"
     },
+    "./clear-signing": {
+      "import": {
+        "types": "./dist/esm/clear-signing/index.d.ts",
+        "default": "./dist/esm/clear-signing/index.js"
+      },
+      "require": {
+        "types": "./dist/esm/clear-signing/index.d.ts",
+        "default": "./dist/cjs/clear-signing/index.cjs"
+      },
+      "default": "./dist/esm/clear-signing/index.js"
+    },
     "./query": {
       "import": {
         "types": "./dist/esm/query/index.d.ts",
@@ -103,6 +114,9 @@
   },
   "typesVersions": {
     "*": {
+      "clear-signing": [
+        "./dist/esm/clear-signing/index.d.ts"
+      ],
       "cleartext": [
         "./dist/esm/cleartext/index.d.ts"
       ],

--- a/packages/sdk/rolldown.config.ts
+++ b/packages/sdk/rolldown.config.ts
@@ -13,6 +13,7 @@ const shared = {
 const entryPoints = {
   index: "src/index.ts",
   "chains/index": "src/chains/index.ts",
+  "clear-signing/index": "src/clear-signing/index.ts",
   "cleartext/index": "src/relayer/cleartext/index.ts",
   "query/index": "src/query/index.ts",
   "web/index": "src/web/index.ts",

--- a/packages/sdk/src/clear-signing/__tests__/__snapshots__/builders.test.ts.snap
+++ b/packages/sdk/src/clear-signing/__tests__/__snapshots__/builders.test.ts.snap
@@ -1,0 +1,592 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`clear signing intent builders > buildAllowAsIntentFromEIP712 maps delegated decrypt typed data 1`] = `
+{
+  "contractContext": {
+    "chainId": 1,
+    "contractAddress": "0x2222222222222222222222222222222222222222",
+  },
+  "fields": [
+    {
+      "label": "Authorized contracts",
+      "value": [
+        "0x1111111111111111111111111111111111111111",
+      ],
+      "visibility": "public",
+    },
+    {
+      "label": "Delegator wallet",
+      "value": "0x4444444444444444444444444444444444444444",
+      "visibility": "public",
+    },
+    {
+      "displayValue": "2023-11-14T22:13:20.000Z",
+      "label": "Starts at",
+      "value": "1700000000",
+      "visibility": "public",
+    },
+    {
+      "label": "Duration",
+      "value": "30",
+      "visibility": "public",
+    },
+    {
+      "displayValue": "Protocol data (hidden)",
+      "label": "FHE public key",
+      "redacted": true,
+      "visibility": "internal",
+    },
+    {
+      "displayValue": "Protocol data (hidden)",
+      "label": "Protocol extra data",
+      "redacted": true,
+      "visibility": "internal",
+    },
+  ],
+  "kind": "allowAs",
+  "rawContext": {
+    "typedData": {
+      "domain": {
+        "chainId": 1n,
+        "name": "Decryption",
+        "verifyingContract": "0x2222222222222222222222222222222222222222",
+        "version": "1",
+      },
+      "message": {
+        "contractAddresses": [
+          "0x1111111111111111111111111111111111111111",
+        ],
+        "delegatorAddress": "0x4444444444444444444444444444444444444444",
+        "durationDays": "30",
+        "extraData": "0x00",
+        "publicKey": "0xpublic",
+        "startTimestamp": "1700000000",
+      },
+      "primaryType": "DelegatedUserDecryptRequestVerification",
+      "types": {
+        "DelegatedUserDecryptRequestVerification": [],
+        "EIP712Domain": [],
+      },
+    },
+  },
+  "summary": "Allow this wallet to decrypt delegated confidential values for selected contracts.",
+  "title": "Authorize delegated confidential data decryption",
+}
+`;
+
+exports[`clear signing intent builders > buildAllowIntent snapshots user decrypt authorization 1`] = `
+{
+  "contractContext": {
+    "chainId": 1,
+  },
+  "fields": [
+    {
+      "label": "Authorized contracts",
+      "value": [
+        "0x1111111111111111111111111111111111111111",
+        "0x2222222222222222222222222222222222222222",
+      ],
+      "visibility": "public",
+    },
+    {
+      "displayValue": "2023-11-14T22:13:20.000Z",
+      "label": "Starts at",
+      "value": "1700000000",
+      "visibility": "public",
+    },
+    {
+      "label": "Duration",
+      "value": "30",
+      "visibility": "public",
+    },
+    {
+      "displayValue": "Protocol data (hidden)",
+      "label": "FHE public key",
+      "redacted": true,
+      "visibility": "internal",
+    },
+    {
+      "displayValue": "Protocol data (hidden)",
+      "label": "Protocol extra data",
+      "redacted": true,
+      "visibility": "internal",
+    },
+  ],
+  "kind": "allow",
+  "rawContext": {
+    "typedData": {
+      "primaryType": "UserDecryptRequestVerification",
+    },
+  },
+  "summary": "Allow this wallet to decrypt confidential values for selected contracts.",
+  "title": "Authorize confidential data decryption",
+}
+`;
+
+exports[`clear signing intent builders > buildAllowIntentFromEIP712 maps direct decrypt typed data 1`] = `
+{
+  "contractContext": {
+    "chainId": 1,
+    "contractAddress": "0x2222222222222222222222222222222222222222",
+  },
+  "fields": [
+    {
+      "label": "Authorized contracts",
+      "value": [
+        "0x1111111111111111111111111111111111111111",
+      ],
+      "visibility": "public",
+    },
+    {
+      "displayValue": "2023-11-14T22:13:20.000Z",
+      "label": "Starts at",
+      "value": "1700000000",
+      "visibility": "public",
+    },
+    {
+      "label": "Duration",
+      "value": "30",
+      "visibility": "public",
+    },
+    {
+      "displayValue": "Protocol data (hidden)",
+      "label": "FHE public key",
+      "redacted": true,
+      "visibility": "internal",
+    },
+    {
+      "displayValue": "Protocol data (hidden)",
+      "label": "Protocol extra data",
+      "redacted": true,
+      "visibility": "internal",
+    },
+  ],
+  "kind": "allow",
+  "rawContext": {
+    "typedData": {
+      "domain": {
+        "chainId": 1n,
+        "name": "Decryption",
+        "verifyingContract": "0x2222222222222222222222222222222222222222",
+        "version": "1",
+      },
+      "message": {
+        "contractAddresses": [
+          "0x1111111111111111111111111111111111111111",
+        ],
+        "durationDays": "30",
+        "extraData": "0x00",
+        "publicKey": "0xpublic",
+        "startTimestamp": "1700000000",
+      },
+      "primaryType": "UserDecryptRequestVerification",
+      "types": {
+        "EIP712Domain": [],
+        "UserDecryptRequestVerification": [],
+      },
+    },
+  },
+  "summary": "Allow this wallet to decrypt confidential values for selected contracts.",
+  "title": "Authorize confidential data decryption",
+}
+`;
+
+exports[`clear signing intent builders > buildConfidentialTransferFromIntent snapshots operator context 1`] = `
+{
+  "contractContext": {
+    "chainId": 1,
+    "contractAddress": "0x1111111111111111111111111111111111111111",
+    "functionName": "confidentialTransferFrom",
+  },
+  "fields": [
+    {
+      "label": "Confidential token",
+      "value": "0x1111111111111111111111111111111111111111",
+      "visibility": "public",
+    },
+    {
+      "label": "Granting wallet",
+      "value": "0x4444444444444444444444444444444444444444",
+      "visibility": "public",
+    },
+    {
+      "label": "Operator wallet",
+      "value": "0x6666666666666666666666666666666666666666",
+      "visibility": "public",
+    },
+    {
+      "label": "Recipient",
+      "value": "0x5555555555555555555555555555555555555555",
+      "visibility": "public",
+    },
+    {
+      "label": "Amount",
+      "value": 100n,
+      "visibility": "public",
+    },
+    {
+      "displayValue": "Hidden encrypted amount",
+      "label": "Encrypted amount",
+      "value": "0xabababababababababababababababababababababababababababababababab",
+      "visibility": "encrypted",
+    },
+    {
+      "displayValue": "Protocol proof (hidden)",
+      "label": "Input proof",
+      "redacted": true,
+      "visibility": "internal",
+    },
+  ],
+  "kind": "confidentialTransferFrom",
+  "rawContext": {
+    "contractCall": {
+      "functionName": "confidentialTransferFrom",
+    },
+    "sdkInput": {
+      "amount": 100n,
+    },
+  },
+  "summary": "Transfer an encrypted token amount from another wallet to a public recipient.",
+  "title": "Send confidential tokens as operator",
+}
+`;
+
+exports[`clear signing intent builders > buildConfidentialTransferIntent snapshots encrypted amount separation 1`] = `
+{
+  "contractContext": {
+    "chainId": 1,
+    "contractAddress": "0x1111111111111111111111111111111111111111",
+    "functionName": "confidentialTransfer",
+  },
+  "fields": [
+    {
+      "label": "Confidential token",
+      "value": "0x1111111111111111111111111111111111111111",
+      "visibility": "public",
+    },
+    {
+      "label": "Granting wallet",
+      "value": "0x4444444444444444444444444444444444444444",
+      "visibility": "public",
+    },
+    {
+      "label": "Recipient",
+      "value": "0x5555555555555555555555555555555555555555",
+      "visibility": "public",
+    },
+    {
+      "label": "Amount",
+      "value": 100n,
+      "visibility": "public",
+    },
+    {
+      "displayValue": "Hidden encrypted amount",
+      "label": "Encrypted amount",
+      "value": "0xabababababababababababababababababababababababababababababababab",
+      "visibility": "encrypted",
+    },
+    {
+      "displayValue": "Protocol proof (hidden)",
+      "label": "Input proof",
+      "redacted": true,
+      "visibility": "internal",
+    },
+  ],
+  "kind": "confidentialTransfer",
+  "rawContext": {
+    "contractCall": {
+      "functionName": "confidentialTransfer",
+    },
+    "sdkInput": {
+      "amount": 100n,
+    },
+  },
+  "summary": "Transfer an encrypted token amount to a public recipient.",
+  "title": "Send confidential tokens",
+}
+`;
+
+exports[`clear signing intent builders > buildDelegateDecryptionIntent snapshots delegated decrypt semantics 1`] = `
+{
+  "contractContext": {
+    "chainId": 1,
+    "contractAddress": "0x7777777777777777777777777777777777777777",
+    "functionName": "delegateForUserDecryption",
+  },
+  "fields": [
+    {
+      "label": "Confidential contract",
+      "value": "0x1111111111111111111111111111111111111111",
+      "visibility": "public",
+    },
+    {
+      "label": "Wallet allowed to view",
+      "value": "0x6666666666666666666666666666666666666666",
+      "visibility": "public",
+    },
+    {
+      "label": "Granting wallet",
+      "value": "0x4444444444444444444444444444444444444444",
+      "visibility": "public",
+    },
+    {
+      "label": "ACL contract",
+      "value": "0x7777777777777777777777777777777777777777",
+      "visibility": "public",
+    },
+    {
+      "label": "Access expires",
+      "value": "Access remains active until revoked",
+      "visibility": "public",
+    },
+  ],
+  "kind": "delegateDecryption",
+  "rawContext": {
+    "contractCall": {
+      "functionName": "delegateForUserDecryption",
+    },
+  },
+  "summary": "Grant decryption access for one confidential contract.",
+  "title": "Allow another wallet to view confidential data",
+}
+`;
+
+exports[`clear signing intent builders > buildFinalizeUnwrapIntent snapshots public finalization amount 1`] = `
+{
+  "contractContext": {
+    "chainId": 1,
+    "contractAddress": "0x2222222222222222222222222222222222222222",
+    "functionName": "finalizeUnwrap",
+  },
+  "fields": [
+    {
+      "label": "Confidential wrapper",
+      "value": "0x2222222222222222222222222222222222222222",
+      "visibility": "public",
+    },
+    {
+      "label": "Pending unshield request",
+      "value": "0xabababababababababababababababababababababababababababababababab",
+      "visibility": "public",
+    },
+    {
+      "label": "Public amount",
+      "value": 50n,
+      "visibility": "public",
+    },
+    {
+      "displayValue": "Protocol proof (hidden)",
+      "label": "Decryption proof",
+      "redacted": true,
+      "visibility": "internal",
+    },
+  ],
+  "kind": "finalizeUnwrap",
+  "rawContext": {
+    "contractCall": {
+      "functionName": "finalizeUnwrap",
+    },
+  },
+  "summary": "Complete a pending unshield and receive public tokens.",
+  "title": "Finalize unshield",
+}
+`;
+
+exports[`clear signing intent builders > buildShieldViaTransferAndCallIntent snapshots single transaction shield 1`] = `
+{
+  "contractContext": {
+    "chainId": 1,
+    "contractAddress": "0x2222222222222222222222222222222222222222",
+  },
+  "fields": [
+    {
+      "label": "Public token",
+      "value": "0x3333333333333333333333333333333333333333",
+      "visibility": "public",
+    },
+    {
+      "label": "Confidential wrapper",
+      "value": "0x2222222222222222222222222222222222222222",
+      "visibility": "public",
+    },
+    {
+      "label": "Granting wallet",
+      "value": "0x4444444444444444444444444444444444444444",
+      "visibility": "public",
+    },
+    {
+      "label": "Public amount",
+      "value": 500n,
+      "visibility": "public",
+    },
+    {
+      "label": "Recipient",
+      "value": "0x4444444444444444444444444444444444444444",
+      "visibility": "public",
+    },
+  ],
+  "kind": "shield",
+  "rawContext": {
+    "contractCall": {
+      "functionName": "transferAndCall",
+    },
+  },
+  "summary": "Convert public ERC-20 tokens into a confidential balance.",
+  "title": "Shield public tokens",
+}
+`;
+
+exports[`clear signing intent builders > buildShieldViaWrapIntent snapshots approval and wrap shield 1`] = `
+{
+  "contractContext": {
+    "chainId": 1,
+    "contractAddress": "0x2222222222222222222222222222222222222222",
+  },
+  "fields": [
+    {
+      "label": "Public token",
+      "value": "0x3333333333333333333333333333333333333333",
+      "visibility": "public",
+    },
+    {
+      "label": "Confidential wrapper",
+      "value": "0x2222222222222222222222222222222222222222",
+      "visibility": "public",
+    },
+    {
+      "label": "Granting wallet",
+      "value": "0x4444444444444444444444444444444444444444",
+      "visibility": "public",
+    },
+    {
+      "label": "Public amount",
+      "value": 500n,
+      "visibility": "public",
+    },
+    {
+      "label": "Recipient",
+      "value": "0x5555555555555555555555555555555555555555",
+      "visibility": "public",
+    },
+    {
+      "label": "Approval amount",
+      "value": 115792089237316195423570985008687907853269984665640564039457584007913129639935n,
+      "visibility": "public",
+    },
+  ],
+  "kind": "shield",
+  "rawContext": {
+    "contractCalls": [
+      {
+        "functionName": "approve",
+      },
+      {
+        "functionName": "wrap",
+      },
+    ],
+  },
+  "summary": "Convert public ERC-20 tokens into a confidential balance.",
+  "title": "Shield public tokens",
+}
+`;
+
+exports[`clear signing intent builders > buildUnwrapAllIntent snapshots entire balance semantics 1`] = `
+{
+  "contractContext": {
+    "chainId": 1,
+    "contractAddress": "0x2222222222222222222222222222222222222222",
+    "functionName": "unwrap",
+  },
+  "fields": [
+    {
+      "label": "Confidential wrapper",
+      "value": "0x2222222222222222222222222222222222222222",
+      "visibility": "public",
+    },
+    {
+      "label": "Granting wallet",
+      "value": "0x4444444444444444444444444444444444444444",
+      "visibility": "public",
+    },
+    {
+      "label": "Public token recipient",
+      "value": "0x4444444444444444444444444444444444444444",
+      "visibility": "public",
+    },
+    {
+      "label": "Amount",
+      "value": "Entire confidential balance",
+      "visibility": "derived",
+    },
+    {
+      "displayValue": "Hidden encrypted balance",
+      "label": "Encrypted balance",
+      "value": "0xabababababababababababababababababababababababababababababababab",
+      "visibility": "encrypted",
+    },
+  ],
+  "kind": "unwrapAll",
+  "rawContext": {
+    "contractCall": {
+      "functionName": "unwrap",
+    },
+  },
+  "summary": "Start converting your entire confidential balance into public tokens.",
+  "title": "Request unshield of entire confidential balance",
+}
+`;
+
+exports[`clear signing intent builders > buildUnwrapIntent snapshots first phase unshield 1`] = `
+{
+  "contractContext": {
+    "chainId": 1,
+    "contractAddress": "0x2222222222222222222222222222222222222222",
+    "functionName": "unwrap",
+  },
+  "fields": [
+    {
+      "label": "Confidential wrapper",
+      "value": "0x2222222222222222222222222222222222222222",
+      "visibility": "public",
+    },
+    {
+      "label": "Granting wallet",
+      "value": "0x4444444444444444444444444444444444444444",
+      "visibility": "public",
+    },
+    {
+      "label": "Public token recipient",
+      "value": "0x4444444444444444444444444444444444444444",
+      "visibility": "public",
+    },
+    {
+      "label": "Amount",
+      "value": 50n,
+      "visibility": "public",
+    },
+    {
+      "displayValue": "Hidden encrypted amount",
+      "label": "Encrypted amount",
+      "value": "0xabababababababababababababababababababababababababababababababab",
+      "visibility": "encrypted",
+    },
+    {
+      "displayValue": "Protocol proof (hidden)",
+      "label": "Input proof",
+      "redacted": true,
+      "visibility": "internal",
+    },
+  ],
+  "kind": "unwrap",
+  "rawContext": {
+    "contractCall": {
+      "functionName": "unwrap",
+    },
+    "sdkInput": {
+      "amount": 50n,
+    },
+  },
+  "summary": "Start converting a confidential amount into public tokens.",
+  "title": "Request unshield",
+}
+`;

--- a/packages/sdk/src/clear-signing/__tests__/__snapshots__/render.test.ts.snap
+++ b/packages/sdk/src/clear-signing/__tests__/__snapshots__/render.test.ts.snap
@@ -1,0 +1,56 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderClearSigningIntent > can include internal fields for advanced displays 1`] = `
+{
+  "fields": [
+    {
+      "label": "Recipient",
+      "value": "0x1111111111111111111111111111111111111111",
+      "visibility": "public",
+    },
+    {
+      "label": "Amount",
+      "value": "100",
+      "visibility": "public",
+    },
+    {
+      "label": "Encrypted amount",
+      "value": "Hidden encrypted amount",
+      "visibility": "encrypted",
+    },
+    {
+      "label": "Input proof",
+      "value": "Protocol proof (hidden)",
+      "visibility": "internal",
+    },
+  ],
+  "kind": "confidentialTransfer",
+  "summary": "Transfer an encrypted token amount to a public recipient.",
+  "title": "Send confidential tokens",
+}
+`;
+
+exports[`renderClearSigningIntent > renders a safe user-facing intent by default 1`] = `
+{
+  "fields": [
+    {
+      "label": "Recipient",
+      "value": "0x1111111111111111111111111111111111111111",
+      "visibility": "public",
+    },
+    {
+      "label": "Amount",
+      "value": "100",
+      "visibility": "public",
+    },
+    {
+      "label": "Encrypted amount",
+      "value": "Hidden encrypted amount",
+      "visibility": "encrypted",
+    },
+  ],
+  "kind": "confidentialTransfer",
+  "summary": "Transfer an encrypted token amount to a public recipient.",
+  "title": "Send confidential tokens",
+}
+`;

--- a/packages/sdk/src/clear-signing/__tests__/builders.test.ts
+++ b/packages/sdk/src/clear-signing/__tests__/builders.test.ts
@@ -1,0 +1,357 @@
+import type { Address } from "viem";
+import { describe, expect, test } from "../../test-fixtures";
+import {
+  buildAllowIntent,
+  buildAllowAsIntentFromEIP712,
+  buildConfidentialTransferFromIntent,
+  buildAllowIntentFromEIP712,
+  buildConfidentialTransferIntent,
+  buildDelegateDecryptionIntent,
+  buildFinalizeUnwrapIntent,
+  buildShieldViaTransferAndCallIntent,
+  buildShieldViaWrapIntent,
+  buildUnwrapAllIntent,
+  buildUnwrapIntent,
+} from "../builders";
+
+const TOKEN = "0x1111111111111111111111111111111111111111" as Address;
+const WRAPPER = "0x2222222222222222222222222222222222222222" as Address;
+const UNDERLYING = "0x3333333333333333333333333333333333333333" as Address;
+const USER = "0x4444444444444444444444444444444444444444" as Address;
+const RECIPIENT = "0x5555555555555555555555555555555555555555" as Address;
+const DELEGATE = "0x6666666666666666666666666666666666666666" as Address;
+const ACL = "0x7777777777777777777777777777777777777777" as Address;
+const HANDLE = `0x${"ab".repeat(32)}`;
+
+describe("clear signing intent builders", () => {
+  test("buildAllowIntent snapshots user decrypt authorization", () => {
+    expect(
+      buildAllowIntent({
+        contractAddresses: [TOKEN, WRAPPER],
+        startTimestamp: 1_700_000_000,
+        durationDays: 30,
+        chainId: 1,
+        typedData: { primaryType: "UserDecryptRequestVerification" },
+      }),
+    ).toMatchSnapshot();
+  });
+
+  test("buildAllowIntentFromEIP712 maps direct decrypt typed data", () => {
+    const intent = buildAllowIntentFromEIP712({
+      domain: {
+        name: "Decryption",
+        version: "1",
+        chainId: 1n,
+        verifyingContract: WRAPPER,
+      },
+      types: {
+        EIP712Domain: [],
+        UserDecryptRequestVerification: [],
+      },
+      primaryType: "UserDecryptRequestVerification",
+      message: {
+        publicKey: "0xpublic",
+        contractAddresses: [TOKEN],
+        startTimestamp: "1700000000",
+        durationDays: "30",
+        extraData: "0x00",
+      },
+    });
+
+    expect(intent).toMatchSnapshot();
+    expect(intent.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Authorized contracts", visibility: "public" }),
+        expect.objectContaining({ label: "FHE public key", visibility: "internal" }),
+      ]),
+    );
+  });
+
+  test("buildAllowAsIntentFromEIP712 maps delegated decrypt typed data", () => {
+    const intent = buildAllowAsIntentFromEIP712({
+      domain: {
+        name: "Decryption",
+        version: "1",
+        chainId: 1n,
+        verifyingContract: WRAPPER,
+      },
+      types: {
+        EIP712Domain: [],
+        DelegatedUserDecryptRequestVerification: [],
+      },
+      primaryType: "DelegatedUserDecryptRequestVerification",
+      message: {
+        publicKey: "0xpublic",
+        contractAddresses: [TOKEN],
+        delegatorAddress: USER,
+        startTimestamp: "1700000000",
+        durationDays: "30",
+        extraData: "0x00",
+      },
+    });
+
+    expect(intent).toMatchSnapshot();
+    expect(intent.kind).toBe("allowAs");
+  });
+
+  test("buildDelegateDecryptionIntent snapshots delegated decrypt semantics", () => {
+    const intent = buildDelegateDecryptionIntent({
+      contractAddress: TOKEN,
+      delegateAddress: DELEGATE,
+      delegatorAddress: USER,
+      aclAddress: ACL,
+      permanent: true,
+      chainId: 1,
+      contractCall: { functionName: "delegateForUserDecryption" },
+    });
+
+    expect(intent).toMatchSnapshot();
+  });
+
+  test("buildConfidentialTransferIntent snapshots encrypted amount separation", () => {
+    const intent = buildConfidentialTransferIntent({
+      tokenAddress: TOKEN,
+      senderAddress: USER,
+      recipientAddress: RECIPIENT,
+      amount: 100n,
+      encryptedAmount: { value: HANDLE },
+      hasInputProof: true,
+      chainId: 1,
+      contractCall: { functionName: "confidentialTransfer" },
+    });
+
+    expect(intent).toMatchSnapshot();
+    expect(intent.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Amount", visibility: "public", value: 100n }),
+        expect.objectContaining({
+          label: "Encrypted amount",
+          visibility: "encrypted",
+          displayValue: "Hidden encrypted amount",
+        }),
+        expect.objectContaining({ label: "Input proof", visibility: "internal", redacted: true }),
+      ]),
+    );
+  });
+
+  test("buildConfidentialTransferFromIntent snapshots operator context", () => {
+    const intent = buildConfidentialTransferFromIntent({
+      tokenAddress: TOKEN,
+      sourceAddress: USER,
+      operatorAddress: DELEGATE,
+      recipientAddress: RECIPIENT,
+      amount: 100n,
+      encryptedAmount: { value: HANDLE },
+      hasInputProof: true,
+      chainId: 1,
+      contractCall: { functionName: "confidentialTransferFrom" },
+    });
+
+    expect(intent).toMatchSnapshot();
+    expect(intent.kind).toBe("confidentialTransferFrom");
+    expect(intent.contractContext?.functionName).toBe("confidentialTransferFrom");
+    expect(intent.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Granting wallet", value: USER }),
+        expect.objectContaining({ label: "Operator wallet", value: DELEGATE }),
+      ]),
+    );
+  });
+
+  test("buildShieldViaTransferAndCallIntent snapshots single transaction shield", () => {
+    expect(
+      buildShieldViaTransferAndCallIntent({
+        underlyingTokenAddress: UNDERLYING,
+        wrapperAddress: WRAPPER,
+        senderAddress: USER,
+        recipientAddress: USER,
+        amount: 500n,
+        chainId: 1,
+        contractCall: { functionName: "transferAndCall" },
+      }),
+    ).toMatchSnapshot();
+  });
+
+  test("buildShieldViaWrapIntent snapshots approval and wrap shield", () => {
+    const intent = buildShieldViaWrapIntent({
+      underlyingTokenAddress: UNDERLYING,
+      wrapperAddress: WRAPPER,
+      senderAddress: USER,
+      recipientAddress: RECIPIENT,
+      amount: 500n,
+      approvalAmount: 2n ** 256n - 1n,
+      maxApproval: true,
+      chainId: 1,
+      approvalContractCall: { functionName: "approve" },
+      wrapContractCall: { functionName: "wrap" },
+    });
+
+    expect(intent).toMatchSnapshot();
+    expect(intent.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Approval amount", value: 2n ** 256n - 1n }),
+      ]),
+    );
+  });
+
+  test("buildShieldViaWrapIntent omits approval amount when no approval is shown", () => {
+    const intent = buildShieldViaWrapIntent({
+      underlyingTokenAddress: UNDERLYING,
+      wrapperAddress: WRAPPER,
+      senderAddress: USER,
+      recipientAddress: RECIPIENT,
+      amount: 500n,
+      maxApproval: true,
+      chainId: 1,
+      wrapContractCall: { functionName: "wrap" },
+    });
+
+    expect(intent.fields).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ label: "Approval amount" })]),
+    );
+  });
+
+  test("buildUnwrapIntent snapshots first phase unshield", () => {
+    const intent = buildUnwrapIntent({
+      wrapperAddress: WRAPPER,
+      fromAddress: USER,
+      recipientAddress: USER,
+      amount: 50n,
+      encryptedAmount: { value: HANDLE },
+      hasInputProof: true,
+      chainId: 1,
+      contractCall: { functionName: "unwrap" },
+    });
+
+    expect(intent).toMatchSnapshot();
+  });
+
+  test("buildUnwrapAllIntent snapshots entire balance semantics", () => {
+    const intent = buildUnwrapAllIntent({
+      wrapperAddress: WRAPPER,
+      fromAddress: USER,
+      recipientAddress: USER,
+      encryptedBalance: { value: HANDLE },
+      chainId: 1,
+      contractCall: { functionName: "unwrap" },
+    });
+
+    expect(intent).toMatchSnapshot();
+    expect(intent.title).toContain("entire confidential balance");
+    expect(intent.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Amount",
+          visibility: "derived",
+          value: "Entire confidential balance",
+        }),
+        expect.objectContaining({
+          label: "Encrypted balance",
+          visibility: "encrypted",
+          displayValue: "Hidden encrypted balance",
+        }),
+      ]),
+    );
+  });
+
+  test("buildFinalizeUnwrapIntent snapshots public finalization amount", () => {
+    const intent = buildFinalizeUnwrapIntent({
+      wrapperAddress: WRAPPER,
+      unwrapRequestId: HANDLE,
+      clearAmount: 50n,
+      hasDecryptionProof: true,
+      chainId: 1,
+      contractCall: { functionName: "finalizeUnwrap" },
+    });
+
+    expect(intent).toMatchSnapshot();
+    expect(intent.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Public amount", visibility: "public", value: 50n }),
+        expect.objectContaining({
+          label: "Decryption proof",
+          visibility: "internal",
+          redacted: true,
+        }),
+      ]),
+    );
+  });
+
+  test("encrypted fields never use plaintext amount display labels", () => {
+    const intents = [
+      buildConfidentialTransferIntent({
+        tokenAddress: TOKEN,
+        recipientAddress: RECIPIENT,
+        amount: 100n,
+        encryptedAmount: { value: HANDLE },
+      }),
+      buildUnwrapIntent({
+        wrapperAddress: WRAPPER,
+        fromAddress: USER,
+        recipientAddress: USER,
+        amount: 100n,
+        encryptedAmount: { value: HANDLE },
+      }),
+      buildUnwrapAllIntent({
+        wrapperAddress: WRAPPER,
+        fromAddress: USER,
+        recipientAddress: USER,
+        encryptedBalance: { value: HANDLE },
+      }),
+    ];
+
+    for (const intent of intents) {
+      for (const field of intent.fields.filter((item) => item.visibility === "encrypted")) {
+        expect(field.displayValue).not.toBe("100");
+        expect(field.label.toLowerCase()).toContain("encrypted");
+      }
+    }
+  });
+
+  test("large timestamps fall back to raw display instead of throwing", () => {
+    const largeTimestamp = 2n ** 64n - 1n;
+
+    const allowIntent = buildAllowIntent({
+      contractAddresses: [TOKEN],
+      startTimestamp: largeTimestamp,
+      durationDays: 30,
+    });
+    const delegationIntent = buildDelegateDecryptionIntent({
+      contractAddress: TOKEN,
+      delegateAddress: DELEGATE,
+      expirationTimestamp: largeTimestamp,
+    });
+
+    expect(allowIntent.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Starts at",
+          displayValue: largeTimestamp.toString(),
+        }),
+      ]),
+    );
+    expect(delegationIntent.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Access expires",
+          value: largeTimestamp.toString(),
+        }),
+      ]),
+    );
+  });
+
+  test("builders omit optional undefined properties", () => {
+    const allowIntent = buildAllowIntent({ contractAddresses: [TOKEN] });
+    const shieldIntent = buildShieldViaWrapIntent({
+      underlyingTokenAddress: UNDERLYING,
+      wrapperAddress: WRAPPER,
+      recipientAddress: USER,
+      amount: 100n,
+    });
+
+    expect(allowIntent.contractContext).toBeUndefined();
+    expect(allowIntent.rawContext).toBeUndefined();
+    expect(allowIntent.fields[0]).not.toHaveProperty("displayValue");
+    expect(shieldIntent.rawContext).toBeUndefined();
+  });
+});

--- a/packages/sdk/src/clear-signing/__tests__/render.test.ts
+++ b/packages/sdk/src/clear-signing/__tests__/render.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "../../test-fixtures";
+import { renderClearSigningIntent } from "../render";
+import type { ClearSigningIntent } from "../types";
+
+const intent: ClearSigningIntent = {
+  kind: "confidentialTransfer",
+  title: "Send confidential tokens",
+  summary: "Transfer an encrypted token amount to a public recipient.",
+  fields: [
+    {
+      label: "Recipient",
+      visibility: "public",
+      value: "0x1111111111111111111111111111111111111111",
+    },
+    {
+      label: "Amount",
+      visibility: "public",
+      value: 100n,
+    },
+    {
+      label: "Encrypted amount",
+      visibility: "encrypted",
+      value: "0xhidden",
+      displayValue: "Hidden encrypted amount",
+    },
+    {
+      label: "Input proof",
+      visibility: "internal",
+      displayValue: "Protocol proof (hidden)",
+      redacted: true,
+    },
+  ],
+};
+
+describe("renderClearSigningIntent", () => {
+  test("renders a safe user-facing intent by default", () => {
+    const rendered = renderClearSigningIntent(intent);
+
+    expect(rendered).toMatchSnapshot();
+    expect(rendered.fields).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ label: "Input proof" })]),
+    );
+    expect(rendered.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Encrypted amount",
+          value: "Hidden encrypted amount",
+          visibility: "encrypted",
+        }),
+      ]),
+    );
+  });
+
+  test("can include internal fields for advanced displays", () => {
+    const rendered = renderClearSigningIntent(intent, { includeInternal: true });
+
+    expect(rendered).toMatchSnapshot();
+    expect(rendered.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Input proof",
+          value: "Protocol proof (hidden)",
+          visibility: "internal",
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/sdk/src/clear-signing/__tests__/validation.test.ts
+++ b/packages/sdk/src/clear-signing/__tests__/validation.test.ts
@@ -1,0 +1,240 @@
+import type { Address } from "viem";
+import { describe, expect, test } from "../../test-fixtures";
+import {
+  buildAllowAsIntent,
+  buildAllowIntent,
+  buildConfidentialTransferIntent,
+  buildDelegateDecryptionIntent,
+  buildFinalizeUnwrapIntent,
+  buildShieldViaTransferAndCallIntent,
+  buildShieldViaWrapIntent,
+  buildUnwrapAllIntent,
+  buildUnwrapIntent,
+} from "../builders";
+import { assertClearSigningIntentSafe, validateClearSigningIntent } from "../validation";
+import type { ClearSigningIntent } from "../types";
+
+const TOKEN = "0x1111111111111111111111111111111111111111" as Address;
+const WRAPPER = "0x2222222222222222222222222222222222222222" as Address;
+const UNDERLYING = "0x3333333333333333333333333333333333333333" as Address;
+const USER = "0x4444444444444444444444444444444444444444" as Address;
+const RECIPIENT = "0x5555555555555555555555555555555555555555" as Address;
+const DELEGATE = "0x6666666666666666666666666666666666666666" as Address;
+const ACL = "0x7777777777777777777777777777777777777777" as Address;
+const HANDLE = `0x${"ab".repeat(32)}`;
+
+describe("validateClearSigningIntent", () => {
+  test("accepts every generated builder intent", () => {
+    const intents = [
+      buildAllowIntent({
+        contractAddresses: [TOKEN],
+        startTimestamp: 1_700_000_000,
+        durationDays: 30,
+      }),
+      buildAllowAsIntent({
+        contractAddresses: [TOKEN],
+        delegatorAddress: USER,
+        startTimestamp: 1_700_000_000,
+        durationDays: 30,
+      }),
+      buildDelegateDecryptionIntent({
+        contractAddress: TOKEN,
+        delegateAddress: DELEGATE,
+        delegatorAddress: USER,
+        aclAddress: ACL,
+      }),
+      buildConfidentialTransferIntent({
+        tokenAddress: TOKEN,
+        recipientAddress: RECIPIENT,
+        amount: 100n,
+        encryptedAmount: { value: HANDLE },
+        hasInputProof: true,
+      }),
+      buildShieldViaTransferAndCallIntent({
+        underlyingTokenAddress: UNDERLYING,
+        wrapperAddress: WRAPPER,
+        senderAddress: USER,
+        recipientAddress: RECIPIENT,
+        amount: 100n,
+      }),
+      buildShieldViaWrapIntent({
+        underlyingTokenAddress: UNDERLYING,
+        wrapperAddress: WRAPPER,
+        senderAddress: USER,
+        recipientAddress: RECIPIENT,
+        amount: 100n,
+      }),
+      buildUnwrapIntent({
+        wrapperAddress: WRAPPER,
+        fromAddress: USER,
+        recipientAddress: RECIPIENT,
+        amount: 100n,
+        encryptedAmount: { value: HANDLE },
+        hasInputProof: true,
+      }),
+      buildUnwrapAllIntent({
+        wrapperAddress: WRAPPER,
+        fromAddress: USER,
+        recipientAddress: RECIPIENT,
+        encryptedBalance: { value: HANDLE },
+      }),
+      buildFinalizeUnwrapIntent({
+        wrapperAddress: WRAPPER,
+        unwrapRequestId: HANDLE,
+        clearAmount: 100n,
+        hasDecryptionProof: true,
+      }),
+    ];
+
+    for (const intent of intents) {
+      expect(validateClearSigningIntent(intent), intent.kind).toEqual({ valid: true, issues: [] });
+      expect(() => assertClearSigningIntentSafe(intent), intent.kind).not.toThrow();
+    }
+  });
+
+  test("rejects encrypted fields without safe display values", () => {
+    const intent: ClearSigningIntent = {
+      kind: "confidentialTransfer",
+      title: "Send confidential tokens",
+      summary: "Transfer an encrypted token amount to a public recipient.",
+      fields: [
+        {
+          label: "Encrypted amount",
+          visibility: "encrypted",
+          value: "0xencrypted",
+        },
+      ],
+    };
+
+    expect(validateClearSigningIntent(intent)).toMatchInlineSnapshot(`
+      {
+        "issues": [
+          {
+            "code": "encrypted-field-missing-safe-display",
+            "fieldIndex": 0,
+            "message": "Encrypted fields must provide a safe display value.",
+          },
+        ],
+        "valid": false,
+      }
+    `);
+    expect(() => assertClearSigningIntentSafe(intent)).toThrow(
+      "Unsafe clear-signing intent: encrypted-field-missing-safe-display at field 0",
+    );
+  });
+
+  test("rejects internal fields that are not redacted", () => {
+    const intent: ClearSigningIntent = {
+      kind: "unwrap",
+      title: "Request unshield",
+      summary: "Start converting a confidential amount into public tokens.",
+      fields: [
+        {
+          label: "Input proof",
+          visibility: "internal",
+          displayValue: "Protocol proof (hidden)",
+        },
+      ],
+    };
+
+    expect(validateClearSigningIntent(intent)).toMatchInlineSnapshot(`
+      {
+        "issues": [
+          {
+            "code": "internal-field-not-redacted",
+            "fieldIndex": 0,
+            "message": "Internal fields must be marked as redacted.",
+          },
+        ],
+        "valid": false,
+      }
+    `);
+  });
+
+  test("rejects internal fields that expose raw values", () => {
+    const intent: ClearSigningIntent = {
+      kind: "unwrap",
+      title: "Request unshield",
+      summary: "Start converting a confidential amount into public tokens.",
+      fields: [
+        {
+          label: "Input proof",
+          visibility: "internal",
+          value: "0xproof",
+          displayValue: "Protocol proof (hidden)",
+          redacted: true,
+        },
+      ],
+    };
+
+    expect(validateClearSigningIntent(intent)).toMatchInlineSnapshot(`
+      {
+        "issues": [
+          {
+            "code": "internal-field-has-value",
+            "fieldIndex": 0,
+            "message": "Internal fields must not expose raw values.",
+          },
+        ],
+        "valid": false,
+      }
+    `);
+  });
+
+  test("rejects unsupported intent kinds at runtime", () => {
+    const intent = {
+      kind: "transfer",
+      title: "Send tokens",
+      summary: "Unsupported kind.",
+      fields: [{ label: "Recipient", visibility: "public", value: RECIPIENT }],
+    } as unknown as ClearSigningIntent;
+
+    expect(validateClearSigningIntent(intent)).toMatchInlineSnapshot(`
+      {
+        "issues": [
+          {
+            "code": "invalid-kind",
+            "message": "Intent kind is not supported.",
+          },
+        ],
+        "valid": false,
+      }
+    `);
+  });
+
+  test("rejects empty title, summary, and field labels", () => {
+    const intent: ClearSigningIntent = {
+      kind: "allow",
+      title: "",
+      summary: "",
+      fields: [{ label: "", visibility: "public", value: "0xcontract" }],
+    };
+
+    expect(validateClearSigningIntent(intent).issues.map((issue) => issue.code)).toEqual([
+      "missing-title",
+      "missing-summary",
+      "missing-field-label",
+    ]);
+  });
+
+  test("rejects intents without fields", () => {
+    const intent: ClearSigningIntent = {
+      kind: "shield",
+      title: "Shield public tokens",
+      summary: "Convert public ERC-20 tokens into a confidential balance.",
+      fields: [],
+    };
+
+    expect(validateClearSigningIntent(intent)).toMatchInlineSnapshot(`
+      {
+        "issues": [
+          {
+            "code": "missing-fields",
+            "message": "Intent must include at least one field.",
+          },
+        ],
+        "valid": false,
+      }
+    `);
+  });
+});

--- a/packages/sdk/src/clear-signing/builders/allow.ts
+++ b/packages/sdk/src/clear-signing/builders/allow.ts
@@ -1,0 +1,123 @@
+import type { Address } from "viem";
+import type {
+  KmsDelegatedUserDecryptEIP712Type,
+  KmsUserDecryptEIP712Type,
+} from "../../relayer/relayer-sdk.types";
+import type { ClearSigningIntent } from "../types";
+import { clearSigningWording } from "../wording";
+import {
+  dateDisplay,
+  internalField,
+  optionalContractContext,
+  optionalFields,
+  optionalRawContext,
+  publicField,
+  safeIntent,
+} from "./helpers";
+
+/** Parameters for building a direct decrypt authorization clear-signing intent. */
+export interface BuildAllowIntentParams {
+  /** Confidential contract addresses covered by the decrypt permit. */
+  contractAddresses: readonly Address[];
+  /** Permit start timestamp in seconds. */
+  startTimestamp?: number | bigint;
+  /** Permit duration in days. */
+  durationDays?: number | bigint;
+  /** Chain ID associated with the EIP-712 authorization. */
+  chainId?: number;
+  /** EIP-712 verifying contract, when available. */
+  verifyingContract?: Address;
+  /** Raw EIP-712 typed data payload. */
+  typedData?: unknown;
+}
+
+/** Parameters for building a delegated decrypt credential clear-signing intent. */
+export interface BuildAllowAsIntentParams extends BuildAllowIntentParams {
+  /** Wallet whose confidential values may be decrypted through an existing delegation. */
+  delegatorAddress: Address;
+}
+
+/** Build a clear-signing intent for direct decrypt authorization. */
+export function buildAllowIntent({
+  contractAddresses,
+  startTimestamp,
+  durationDays,
+  chainId,
+  verifyingContract,
+  typedData,
+}: BuildAllowIntentParams): ClearSigningIntent {
+  const labels = clearSigningWording.labels;
+  return safeIntent({
+    kind: "allow",
+    title: clearSigningWording.allow.title,
+    summary: clearSigningWording.allow.summary,
+    fields: optionalFields([
+      publicField(labels.authorizedContracts, [...contractAddresses]),
+      startTimestamp !== undefined &&
+        publicField(labels.startsAt, String(startTimestamp), dateDisplay(startTimestamp)),
+      durationDays !== undefined && publicField(labels.duration, String(durationDays)),
+      internalField(labels.fhePublicKey),
+      internalField(labels.protocolExtraData),
+    ]),
+    contractContext: optionalContractContext({ chainId, contractAddress: verifyingContract }),
+    rawContext: optionalRawContext({ typedData }),
+  });
+}
+
+/** Build a clear-signing intent for delegated decrypt credential authorization. */
+export function buildAllowAsIntent({
+  contractAddresses,
+  delegatorAddress,
+  startTimestamp,
+  durationDays,
+  chainId,
+  verifyingContract,
+  typedData,
+}: BuildAllowAsIntentParams): ClearSigningIntent {
+  const labels = clearSigningWording.labels;
+  return safeIntent({
+    kind: "allowAs",
+    title: clearSigningWording.allowAs.title,
+    summary: clearSigningWording.allowAs.summary,
+    fields: optionalFields([
+      publicField(labels.authorizedContracts, [...contractAddresses]),
+      publicField(labels.delegatorWallet, delegatorAddress),
+      startTimestamp !== undefined &&
+        publicField(labels.startsAt, String(startTimestamp), dateDisplay(startTimestamp)),
+      durationDays !== undefined && publicField(labels.duration, String(durationDays)),
+      internalField(labels.fhePublicKey),
+      internalField(labels.protocolExtraData),
+    ]),
+    contractContext: optionalContractContext({ chainId, contractAddress: verifyingContract }),
+    rawContext: optionalRawContext({ typedData }),
+  });
+}
+
+/** Build a direct decrypt authorization intent from the SDK's EIP-712 payload. */
+export function buildAllowIntentFromEIP712(
+  typedData: KmsUserDecryptEIP712Type,
+): ClearSigningIntent {
+  return buildAllowIntent({
+    contractAddresses: typedData.message.contractAddresses,
+    startTimestamp: BigInt(typedData.message.startTimestamp),
+    durationDays: BigInt(typedData.message.durationDays),
+    chainId: Number(typedData.domain.chainId),
+    verifyingContract: typedData.domain.verifyingContract,
+    typedData,
+  });
+}
+
+/** Build a delegated decrypt credential intent from the SDK's EIP-712 payload. */
+export function buildAllowAsIntentFromEIP712(
+  typedData: KmsDelegatedUserDecryptEIP712Type,
+): ClearSigningIntent {
+  return buildAllowAsIntent({
+    contractAddresses: typedData.message.contractAddresses,
+    delegatorAddress: typedData.message.delegatorAddress,
+    startTimestamp: BigInt(typedData.message.startTimestamp),
+    durationDays: BigInt(typedData.message.durationDays),
+    chainId: Number(typedData.domain.chainId),
+    verifyingContract: typedData.domain.verifyingContract,
+    typedData,
+  });
+}

--- a/packages/sdk/src/clear-signing/builders/confidential-transfer.ts
+++ b/packages/sdk/src/clear-signing/builders/confidential-transfer.ts
@@ -1,0 +1,119 @@
+import type { Address } from "viem";
+import type { ClearSigningEncryptedValue, ClearSigningIntent } from "../types";
+import { clearSigningWording } from "../wording";
+import {
+  encryptedField,
+  internalField,
+  optionalContractContext,
+  optionalFields,
+  optionalRawContext,
+  publicField,
+  safeIntent,
+} from "./helpers";
+
+/** Parameters for building a confidential transfer clear-signing intent. */
+export interface BuildConfidentialTransferIntentParams {
+  /** Confidential token contract address. */
+  tokenAddress: Address;
+  /** Public recipient address. */
+  recipientAddress: Address;
+  /** Sender wallet address, when known. */
+  senderAddress?: Address;
+  /** Plaintext SDK input amount before encryption, when available. */
+  amount?: bigint;
+  /** Opaque encrypted amount handle submitted on-chain. */
+  encryptedAmount?: ClearSigningEncryptedValue;
+  /** Whether the contract call includes an input proof. */
+  hasInputProof?: boolean;
+  /** Chain ID associated with the transfer. */
+  chainId?: number;
+  /** Raw confidential transfer contract call config. */
+  contractCall?: unknown;
+}
+
+/** Parameters for building an operator confidential transfer clear-signing intent. */
+export interface BuildConfidentialTransferFromIntentParams extends Omit<
+  BuildConfidentialTransferIntentParams,
+  "senderAddress"
+> {
+  /** Wallet whose confidential balance is being transferred by the operator. */
+  sourceAddress: Address;
+  /** Operator wallet submitting the transferFrom transaction. */
+  operatorAddress: Address;
+}
+
+/** Build a clear-signing intent for a confidential token transfer. */
+export function buildConfidentialTransferIntent({
+  tokenAddress,
+  recipientAddress,
+  senderAddress,
+  amount,
+  encryptedAmount,
+  hasInputProof,
+  chainId,
+  contractCall,
+}: BuildConfidentialTransferIntentParams): ClearSigningIntent {
+  const labels = clearSigningWording.labels;
+  return safeIntent({
+    kind: "confidentialTransfer",
+    title: clearSigningWording.confidentialTransfer.title,
+    summary: clearSigningWording.confidentialTransfer.summary,
+    fields: optionalFields([
+      publicField(labels.confidentialToken, tokenAddress),
+      senderAddress && publicField(labels.grantingWallet, senderAddress),
+      publicField(labels.recipient, recipientAddress),
+      amount !== undefined && publicField(labels.amount, amount),
+      encryptedField(labels.encryptedAmount, encryptedAmount),
+      hasInputProof &&
+        internalField(labels.inputProof, clearSigningWording.values.protocolProofHidden),
+    ]),
+    contractContext: optionalContractContext({
+      chainId,
+      contractAddress: tokenAddress,
+      functionName: "confidentialTransfer",
+    }),
+    rawContext: optionalRawContext({
+      contractCall,
+      sdkInput: amount === undefined ? undefined : { amount },
+    }),
+  });
+}
+
+/** Build a clear-signing intent for an operator confidential token transfer. */
+export function buildConfidentialTransferFromIntent({
+  tokenAddress,
+  sourceAddress,
+  operatorAddress,
+  recipientAddress,
+  amount,
+  encryptedAmount,
+  hasInputProof,
+  chainId,
+  contractCall,
+}: BuildConfidentialTransferFromIntentParams): ClearSigningIntent {
+  const labels = clearSigningWording.labels;
+  return safeIntent({
+    kind: "confidentialTransferFrom",
+    title: clearSigningWording.confidentialTransferFrom.title,
+    summary: clearSigningWording.confidentialTransferFrom.summary,
+    fields: optionalFields([
+      publicField(labels.confidentialToken, tokenAddress),
+      publicField(labels.grantingWallet, sourceAddress),
+      publicField(labels.operatorWallet, operatorAddress),
+      publicField(labels.recipient, recipientAddress),
+      amount !== undefined && publicField(labels.amount, amount),
+      encryptedField(labels.encryptedAmount, encryptedAmount),
+      hasInputProof &&
+        internalField(labels.inputProof, clearSigningWording.values.protocolProofHidden),
+    ]),
+    contractContext: optionalContractContext({
+      chainId,
+      contractAddress: tokenAddress,
+      functionName: "confidentialTransferFrom",
+    }),
+    rawContext: optionalRawContext({
+      contractCall,
+      sdkInput: amount === undefined ? undefined : { amount },
+    }),
+  });
+}

--- a/packages/sdk/src/clear-signing/builders/delegate-decryption.ts
+++ b/packages/sdk/src/clear-signing/builders/delegate-decryption.ts
@@ -1,0 +1,70 @@
+import type { Address } from "viem";
+import type { ClearSigningIntent } from "../types";
+import { clearSigningWording } from "../wording";
+import {
+  dateDisplay,
+  optionalContractContext,
+  optionalFields,
+  optionalRawContext,
+  publicField,
+  safeIntent,
+} from "./helpers";
+
+/** Parameters for building a decryption delegation clear-signing intent. */
+export interface BuildDelegateDecryptionIntentParams {
+  /** Confidential contract whose values may be decrypted by the delegate. */
+  contractAddress: Address;
+  /** Wallet receiving decryption rights. */
+  delegateAddress: Address;
+  /** Wallet granting decryption rights. */
+  delegatorAddress?: Address;
+  /** ACL contract that receives the delegation transaction. */
+  aclAddress?: Address;
+  /** Expiration timestamp in seconds, when the delegation is time-limited. */
+  expirationTimestamp?: number | bigint;
+  /** Whether the delegation remains active until revoked. */
+  permanent?: boolean;
+  /** Chain ID associated with the delegation transaction. */
+  chainId?: number;
+  /** Raw ACL contract call config. */
+  contractCall?: unknown;
+}
+
+/** Build a clear-signing intent for decryption delegation. */
+export function buildDelegateDecryptionIntent({
+  contractAddress,
+  delegateAddress,
+  delegatorAddress,
+  aclAddress,
+  expirationTimestamp,
+  permanent,
+  chainId,
+  contractCall,
+}: BuildDelegateDecryptionIntentParams): ClearSigningIntent {
+  const labels = clearSigningWording.labels;
+  const expirationValue =
+    permanent === true
+      ? clearSigningWording.values.untilRevoked
+      : expirationTimestamp === undefined
+        ? undefined
+        : dateDisplay(expirationTimestamp);
+
+  return safeIntent({
+    kind: "delegateDecryption",
+    title: clearSigningWording.delegateDecryption.title,
+    summary: clearSigningWording.delegateDecryption.summary,
+    fields: optionalFields([
+      publicField(labels.confidentialContract, contractAddress),
+      publicField(labels.walletAllowedToView, delegateAddress),
+      delegatorAddress ? publicField(labels.grantingWallet, delegatorAddress) : undefined,
+      aclAddress ? publicField(labels.aclContract, aclAddress) : undefined,
+      expirationValue ? publicField(labels.accessExpires, expirationValue) : undefined,
+    ]),
+    contractContext: optionalContractContext({
+      chainId,
+      contractAddress: aclAddress,
+      functionName: "delegateForUserDecryption",
+    }),
+    rawContext: optionalRawContext({ contractCall }),
+  });
+}

--- a/packages/sdk/src/clear-signing/builders/finalize-unwrap.ts
+++ b/packages/sdk/src/clear-signing/builders/finalize-unwrap.ts
@@ -1,0 +1,64 @@
+import type { Address } from "viem";
+import type { ClearSigningEncryptedValue, ClearSigningIntent } from "../types";
+import { clearSigningWording } from "../wording";
+import {
+  encryptedField,
+  internalField,
+  optionalContractContext,
+  optionalFields,
+  optionalRawContext,
+  publicField,
+  safeIntent,
+} from "./helpers";
+
+/** Parameters for building a finalize-unshield clear-signing intent. */
+export interface BuildFinalizeUnwrapIntentParams {
+  /** Confidential wrapper contract address. */
+  wrapperAddress: Address;
+  /** Pending unwrap request identifier from upgraded wrappers. */
+  unwrapRequestId?: string;
+  /** Legacy encrypted amount handle used by older wrappers. */
+  legacyEncryptedAmount?: ClearSigningEncryptedValue;
+  /** Public amount submitted during finalization, when known. */
+  clearAmount?: bigint;
+  /** Whether the contract call includes a public decryption proof. */
+  hasDecryptionProof?: boolean;
+  /** Chain ID associated with finalization. */
+  chainId?: number;
+  /** Raw finalizeUnwrap contract call config. */
+  contractCall?: unknown;
+}
+
+/** Build a clear-signing intent for finalizing a pending unshield. */
+export function buildFinalizeUnwrapIntent({
+  wrapperAddress,
+  unwrapRequestId,
+  legacyEncryptedAmount,
+  clearAmount,
+  hasDecryptionProof,
+  chainId,
+  contractCall,
+}: BuildFinalizeUnwrapIntentParams): ClearSigningIntent {
+  const labels = clearSigningWording.labels;
+  return safeIntent({
+    kind: "finalizeUnwrap",
+    title: clearSigningWording.finalizeUnwrap.title,
+    summary: clearSigningWording.finalizeUnwrap.summary,
+    fields: optionalFields([
+      publicField(labels.confidentialWrapper, wrapperAddress),
+      unwrapRequestId ? publicField(labels.pendingUnshieldRequest, unwrapRequestId) : undefined,
+      legacyEncryptedAmount
+        ? encryptedField(labels.encryptedAmount, legacyEncryptedAmount)
+        : undefined,
+      clearAmount !== undefined && publicField(labels.publicAmount, clearAmount),
+      hasDecryptionProof &&
+        internalField(labels.decryptionProof, clearSigningWording.values.protocolProofHidden),
+    ]),
+    contractContext: optionalContractContext({
+      chainId,
+      contractAddress: wrapperAddress,
+      functionName: "finalizeUnwrap",
+    }),
+    rawContext: optionalRawContext({ contractCall }),
+  });
+}

--- a/packages/sdk/src/clear-signing/builders/helpers.ts
+++ b/packages/sdk/src/clear-signing/builders/helpers.ts
@@ -1,0 +1,117 @@
+import type {
+  ClearSigningContractContext,
+  ClearSigningEncryptedValue,
+  ClearSigningField,
+  ClearSigningFieldValue,
+  ClearSigningIntent,
+  ClearSigningRawContext,
+} from "../types";
+import { assertClearSigningIntentSafe } from "../validation";
+import { clearSigningWording } from "../wording";
+
+export function publicField(
+  label: string,
+  value: ClearSigningFieldValue,
+  displayValue?: string,
+): ClearSigningField {
+  const field: ClearSigningField = { label, visibility: "public", value };
+  if (displayValue !== undefined) {
+    field.displayValue = displayValue;
+  }
+  return field;
+}
+
+export function derivedField(
+  label: string,
+  value: ClearSigningFieldValue,
+  displayValue?: string,
+): ClearSigningField {
+  const field: ClearSigningField = { label, visibility: "derived", value };
+  if (displayValue !== undefined) {
+    field.displayValue = displayValue;
+  }
+  return field;
+}
+
+export function encryptedField(
+  label: string,
+  encrypted?: ClearSigningEncryptedValue,
+): ClearSigningField {
+  const field: ClearSigningField = {
+    label,
+    visibility: "encrypted",
+    displayValue: encrypted?.displayValue ?? clearSigningWording.values.hiddenEncryptedAmount,
+  };
+  if (encrypted?.value !== undefined) {
+    field.value = encrypted.value;
+  }
+  return field;
+}
+
+export function internalField(label: string, displayValue?: string): ClearSigningField {
+  return {
+    label,
+    visibility: "internal",
+    displayValue: displayValue ?? clearSigningWording.values.protocolDataHidden,
+    redacted: true,
+  };
+}
+
+export function optionalFields(
+  fields: readonly (ClearSigningField | undefined | false)[],
+): ClearSigningField[] {
+  return fields.filter((field): field is ClearSigningField => Boolean(field));
+}
+
+export function dateDisplay(timestampSeconds: number | bigint): string {
+  const millis = Number(timestampSeconds) * 1000;
+  if (!Number.isFinite(millis)) {
+    return String(timestampSeconds);
+  }
+  const date = new Date(millis);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) {
+    return String(timestampSeconds);
+  }
+  return date.toISOString();
+}
+
+export function optionalContractContext(
+  context: ClearSigningContractContext,
+): ClearSigningContractContext | undefined {
+  const output: ClearSigningContractContext = {};
+  if (context.chainId !== undefined) {
+    output.chainId = context.chainId;
+  }
+  if (context.contractAddress !== undefined) {
+    output.contractAddress = context.contractAddress;
+  }
+  if (context.functionName !== undefined) {
+    output.functionName = context.functionName;
+  }
+  return Object.keys(output).length === 0 ? undefined : output;
+}
+
+export function optionalRawContext(
+  context: ClearSigningRawContext,
+): ClearSigningRawContext | undefined {
+  const output: ClearSigningRawContext = {};
+  if (context.contractCall !== undefined) {
+    output.contractCall = context.contractCall;
+  }
+  if (context.contractCalls !== undefined && context.contractCalls.length > 0) {
+    output.contractCalls = context.contractCalls;
+  }
+  if (context.typedData !== undefined) {
+    output.typedData = context.typedData;
+  }
+  if (context.sdkInput !== undefined) {
+    output.sdkInput = context.sdkInput;
+  }
+  return Object.keys(output).length === 0 ? undefined : output;
+}
+
+export function safeIntent(intent: ClearSigningIntent): ClearSigningIntent {
+  assertClearSigningIntentSafe(intent);
+  return intent;
+}

--- a/packages/sdk/src/clear-signing/builders/index.ts
+++ b/packages/sdk/src/clear-signing/builders/index.ts
@@ -1,0 +1,28 @@
+export {
+  buildAllowAsIntent,
+  buildAllowAsIntentFromEIP712,
+  buildAllowIntent,
+  buildAllowIntentFromEIP712,
+  type BuildAllowAsIntentParams,
+  type BuildAllowIntentParams,
+} from "./allow";
+export {
+  buildDelegateDecryptionIntent,
+  type BuildDelegateDecryptionIntentParams,
+} from "./delegate-decryption";
+export {
+  buildConfidentialTransferIntent,
+  buildConfidentialTransferFromIntent,
+  type BuildConfidentialTransferFromIntentParams,
+  type BuildConfidentialTransferIntentParams,
+} from "./confidential-transfer";
+export {
+  buildShieldViaTransferAndCallIntent,
+  buildShieldViaWrapIntent,
+  type BuildShieldIntentBaseParams,
+  type BuildShieldViaTransferAndCallIntentParams,
+  type BuildShieldViaWrapIntentParams,
+} from "./shield";
+export { buildUnwrapIntent, type BuildUnwrapIntentParams } from "./unwrap";
+export { buildUnwrapAllIntent, type BuildUnwrapAllIntentParams } from "./unwrap-all";
+export { buildFinalizeUnwrapIntent, type BuildFinalizeUnwrapIntentParams } from "./finalize-unwrap";

--- a/packages/sdk/src/clear-signing/builders/shield.ts
+++ b/packages/sdk/src/clear-signing/builders/shield.ts
@@ -1,0 +1,132 @@
+import type { Address } from "viem";
+import type { ClearSigningIntent } from "../types";
+import { clearSigningWording } from "../wording";
+import {
+  optionalContractContext,
+  optionalFields,
+  optionalRawContext,
+  publicField,
+  safeIntent,
+} from "./helpers";
+
+/** Common parameters for shield clear-signing intents. */
+export interface BuildShieldIntentBaseParams {
+  /** Public ERC-20 token being shielded. */
+  underlyingTokenAddress: Address;
+  /** Confidential wrapper contract receiving or wrapping the public tokens. */
+  wrapperAddress: Address;
+  /** Public ERC-20 amount being shielded. */
+  amount: bigint;
+  /** Recipient of the resulting confidential balance. */
+  recipientAddress: Address;
+  /** Wallet sending the public ERC-20 tokens, when known. */
+  senderAddress?: Address;
+  /** Chain ID associated with the shield transaction. */
+  chainId?: number;
+}
+
+/** Parameters for building a single-transaction ERC-1363 shield intent. */
+export interface BuildShieldViaTransferAndCallIntentParams extends BuildShieldIntentBaseParams {
+  /** Raw ERC-1363 transferAndCall contract call config. */
+  contractCall?: unknown;
+}
+
+/** Parameters for building an approval-backed wrap shield intent. */
+export interface BuildShieldViaWrapIntentParams extends BuildShieldIntentBaseParams {
+  /** ERC-20 approval amount submitted before wrapping, when applicable. */
+  approvalAmount?: bigint;
+  /** Whether the approval amount is a max approval. */
+  maxApproval?: boolean;
+  /** Raw ERC-20 approval contract call config. */
+  approvalContractCall?: unknown;
+  /** Raw ERC-20 approval reset-to-zero contract call config, when needed. */
+  approvalResetContractCall?: unknown;
+  /** Raw wrapper wrap contract call config. */
+  wrapContractCall?: unknown;
+}
+
+/** Build a clear-signing intent for single-transaction ERC-1363 shield. */
+export function buildShieldViaTransferAndCallIntent({
+  underlyingTokenAddress,
+  wrapperAddress,
+  amount,
+  recipientAddress,
+  senderAddress,
+  chainId,
+  contractCall,
+}: BuildShieldViaTransferAndCallIntentParams): ClearSigningIntent {
+  return buildShieldIntent({
+    underlyingTokenAddress,
+    wrapperAddress,
+    amount,
+    recipientAddress,
+    senderAddress,
+    chainId,
+    rawContext: optionalRawContext({ contractCall }),
+  });
+}
+
+/** Build a clear-signing intent for approval-backed wrap shield. */
+export function buildShieldViaWrapIntent({
+  underlyingTokenAddress,
+  wrapperAddress,
+  amount,
+  recipientAddress,
+  senderAddress,
+  approvalAmount,
+  maxApproval: _maxApproval,
+  chainId,
+  approvalContractCall,
+  approvalResetContractCall,
+  wrapContractCall,
+}: BuildShieldViaWrapIntentParams): ClearSigningIntent {
+  const labels = clearSigningWording.labels;
+
+  return buildShieldIntent({
+    underlyingTokenAddress,
+    wrapperAddress,
+    amount,
+    recipientAddress,
+    senderAddress,
+    chainId,
+    extraFields: optionalFields([
+      approvalAmount !== undefined && publicField(labels.approvalAmount, approvalAmount),
+    ]),
+    rawContext: optionalRawContext({
+      contractCalls: [approvalResetContractCall, approvalContractCall, wrapContractCall].filter(
+        Boolean,
+      ),
+    }),
+  });
+}
+
+function buildShieldIntent({
+  underlyingTokenAddress,
+  wrapperAddress,
+  amount,
+  recipientAddress,
+  senderAddress,
+  chainId,
+  extraFields,
+  rawContext,
+}: BuildShieldIntentBaseParams & {
+  extraFields?: ReturnType<typeof optionalFields>;
+  rawContext: ClearSigningIntent["rawContext"];
+}): ClearSigningIntent {
+  const labels = clearSigningWording.labels;
+  return safeIntent({
+    kind: "shield",
+    title: clearSigningWording.shield.title,
+    summary: clearSigningWording.shield.summary,
+    fields: optionalFields([
+      publicField(labels.publicToken, underlyingTokenAddress),
+      publicField(labels.confidentialWrapper, wrapperAddress),
+      senderAddress && publicField(labels.grantingWallet, senderAddress),
+      publicField(labels.publicAmount, amount),
+      publicField(labels.recipient, recipientAddress),
+      ...(extraFields ?? []),
+    ]),
+    contractContext: optionalContractContext({ chainId, contractAddress: wrapperAddress }),
+    rawContext,
+  });
+}

--- a/packages/sdk/src/clear-signing/builders/unwrap-all.ts
+++ b/packages/sdk/src/clear-signing/builders/unwrap-all.ts
@@ -1,0 +1,62 @@
+import type { Address } from "viem";
+import type { ClearSigningEncryptedValue, ClearSigningIntent } from "../types";
+import { clearSigningWording } from "../wording";
+import {
+  derivedField,
+  encryptedField,
+  optionalContractContext,
+  optionalFields,
+  optionalRawContext,
+  publicField,
+  safeIntent,
+} from "./helpers";
+
+/** Parameters for building a first-phase entire-balance unshield intent. */
+export interface BuildUnwrapAllIntentParams {
+  /** Confidential wrapper contract address. */
+  wrapperAddress: Address;
+  /** Wallet whose entire confidential balance is being unshielded. */
+  fromAddress: Address;
+  /** Public token recipient after finalization. */
+  recipientAddress: Address;
+  /** Existing encrypted balance handle used for unwrap-all. */
+  encryptedBalance?: ClearSigningEncryptedValue;
+  /** Chain ID associated with the unwrap-all request. */
+  chainId?: number;
+  /** Raw unwrap contract call config. */
+  contractCall?: unknown;
+}
+
+/** Build a clear-signing intent for the first phase of an entire-balance unshield. */
+export function buildUnwrapAllIntent({
+  wrapperAddress,
+  fromAddress,
+  recipientAddress,
+  encryptedBalance,
+  chainId,
+  contractCall,
+}: BuildUnwrapAllIntentParams): ClearSigningIntent {
+  const labels = clearSigningWording.labels;
+  return safeIntent({
+    kind: "unwrapAll",
+    title: clearSigningWording.unwrapAll.title,
+    summary: clearSigningWording.unwrapAll.summary,
+    fields: optionalFields([
+      publicField(labels.confidentialWrapper, wrapperAddress),
+      publicField(labels.grantingWallet, fromAddress),
+      publicField(labels.publicTokenRecipient, recipientAddress),
+      derivedField(labels.amount, clearSigningWording.values.entireConfidentialBalance),
+      encryptedField(labels.encryptedBalance, {
+        ...encryptedBalance,
+        displayValue:
+          encryptedBalance?.displayValue ?? clearSigningWording.values.hiddenEncryptedBalance,
+      }),
+    ]),
+    contractContext: optionalContractContext({
+      chainId,
+      contractAddress: wrapperAddress,
+      functionName: "unwrap",
+    }),
+    rawContext: optionalRawContext({ contractCall }),
+  });
+}

--- a/packages/sdk/src/clear-signing/builders/unwrap.ts
+++ b/packages/sdk/src/clear-signing/builders/unwrap.ts
@@ -1,0 +1,69 @@
+import type { Address } from "viem";
+import type { ClearSigningEncryptedValue, ClearSigningIntent } from "../types";
+import { clearSigningWording } from "../wording";
+import {
+  encryptedField,
+  internalField,
+  optionalContractContext,
+  optionalFields,
+  optionalRawContext,
+  publicField,
+  safeIntent,
+} from "./helpers";
+
+/** Parameters for building a first-phase specific-amount unshield intent. */
+export interface BuildUnwrapIntentParams {
+  /** Confidential wrapper contract address. */
+  wrapperAddress: Address;
+  /** Wallet whose confidential balance is being unshielded. */
+  fromAddress: Address;
+  /** Public token recipient after finalization. */
+  recipientAddress: Address;
+  /** Plaintext SDK input amount before encryption, when available. */
+  amount?: bigint;
+  /** Opaque encrypted amount handle submitted on-chain. */
+  encryptedAmount?: ClearSigningEncryptedValue;
+  /** Whether the contract call includes an input proof. */
+  hasInputProof?: boolean;
+  /** Chain ID associated with the unwrap request. */
+  chainId?: number;
+  /** Raw unwrap contract call config. */
+  contractCall?: unknown;
+}
+
+/** Build a clear-signing intent for the first phase of a specific-amount unshield. */
+export function buildUnwrapIntent({
+  wrapperAddress,
+  fromAddress,
+  recipientAddress,
+  amount,
+  encryptedAmount,
+  hasInputProof,
+  chainId,
+  contractCall,
+}: BuildUnwrapIntentParams): ClearSigningIntent {
+  const labels = clearSigningWording.labels;
+  return safeIntent({
+    kind: "unwrap",
+    title: clearSigningWording.unwrap.title,
+    summary: clearSigningWording.unwrap.summary,
+    fields: optionalFields([
+      publicField(labels.confidentialWrapper, wrapperAddress),
+      publicField(labels.grantingWallet, fromAddress),
+      publicField(labels.publicTokenRecipient, recipientAddress),
+      amount !== undefined && publicField(labels.amount, amount),
+      encryptedField(labels.encryptedAmount, encryptedAmount),
+      hasInputProof &&
+        internalField(labels.inputProof, clearSigningWording.values.protocolProofHidden),
+    ]),
+    contractContext: optionalContractContext({
+      chainId,
+      contractAddress: wrapperAddress,
+      functionName: "unwrap",
+    }),
+    rawContext: optionalRawContext({
+      contractCall,
+      sdkInput: amount === undefined ? undefined : { amount },
+    }),
+  });
+}

--- a/packages/sdk/src/clear-signing/index.ts
+++ b/packages/sdk/src/clear-signing/index.ts
@@ -1,0 +1,49 @@
+export type {
+  ClearSigningContractContext,
+  ClearSigningEncryptedValue,
+  ClearSigningField,
+  ClearSigningFieldValue,
+  ClearSigningIntent,
+  ClearSigningIntentKind,
+  ClearSigningRawContext,
+  ClearSigningVisibility,
+} from "./types";
+export {
+  renderClearSigningIntent,
+  type RenderClearSigningIntentOptions,
+  type RenderedClearSigningField,
+  type RenderedClearSigningIntent,
+} from "./render";
+export {
+  assertClearSigningIntentSafe,
+  validateClearSigningIntent,
+  type ClearSigningValidationIssue,
+  type ClearSigningValidationResult,
+} from "./validation";
+export {
+  buildAllowIntent,
+  buildAllowIntentFromEIP712,
+  buildAllowAsIntent,
+  buildAllowAsIntentFromEIP712,
+  buildDelegateDecryptionIntent,
+  buildConfidentialTransferIntent,
+  buildConfidentialTransferFromIntent,
+  buildShieldViaTransferAndCallIntent,
+  buildShieldViaWrapIntent,
+  buildUnwrapIntent,
+  buildUnwrapAllIntent,
+  buildFinalizeUnwrapIntent,
+} from "./builders";
+export type {
+  BuildAllowIntentParams,
+  BuildAllowAsIntentParams,
+  BuildDelegateDecryptionIntentParams,
+  BuildConfidentialTransferIntentParams,
+  BuildConfidentialTransferFromIntentParams,
+  BuildShieldIntentBaseParams,
+  BuildShieldViaTransferAndCallIntentParams,
+  BuildShieldViaWrapIntentParams,
+  BuildUnwrapIntentParams,
+  BuildUnwrapAllIntentParams,
+  BuildFinalizeUnwrapIntentParams,
+} from "./builders";

--- a/packages/sdk/src/clear-signing/render.ts
+++ b/packages/sdk/src/clear-signing/render.ts
@@ -1,0 +1,83 @@
+import type { ClearSigningField, ClearSigningFieldValue, ClearSigningIntent } from "./types";
+
+/** Field rendered with safe display semantics applied. */
+export interface RenderedClearSigningField {
+  /** Original field label. */
+  label: string;
+  /** Safe user-facing value. */
+  value: string;
+  /** Original field visibility. */
+  visibility: ClearSigningField["visibility"];
+}
+
+/** Minimal user-facing representation of a clear-signing intent. */
+export interface RenderedClearSigningIntent {
+  /** Intent kind. */
+  kind: ClearSigningIntent["kind"];
+  /** User-facing title. */
+  title: string;
+  /** User-facing summary. */
+  summary: string;
+  /** Rendered fields after visibility rules are applied. */
+  fields: RenderedClearSigningField[];
+}
+
+/** Options controlling conservative intent rendering. */
+export interface RenderClearSigningIntentOptions {
+  /** Include internal fields in the rendered output. Defaults to false. */
+  includeInternal?: boolean;
+}
+
+/** Render an intent into a conservative wallet-readable shape. */
+export function renderClearSigningIntent(
+  intent: ClearSigningIntent,
+  options: RenderClearSigningIntentOptions = {},
+): RenderedClearSigningIntent {
+  return {
+    kind: intent.kind,
+    title: intent.title,
+    summary: intent.summary,
+    fields: intent.fields
+      .filter((field) => options.includeInternal === true || field.visibility !== "internal")
+      .map(renderField),
+  };
+}
+
+function renderField(field: ClearSigningField): RenderedClearSigningField {
+  return {
+    label: field.label,
+    value: renderFieldValue(field),
+    visibility: field.visibility,
+  };
+}
+
+function renderFieldValue(field: ClearSigningField): string {
+  if (field.visibility === "internal") {
+    return field.displayValue ?? "Internal protocol data";
+  }
+  if (field.visibility === "encrypted") {
+    return field.displayValue ?? "Hidden encrypted value";
+  }
+  if (field.displayValue !== undefined) {
+    return field.displayValue;
+  }
+  return stringifyFieldValue(field.value);
+}
+
+function stringifyFieldValue(value: ClearSigningFieldValue | undefined): string {
+  if (value === undefined) {
+    return "";
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => stringifyFieldValue(item)).join(", ");
+  }
+  if (typeof value === "object" && value !== null) {
+    return JSON.stringify(value, (_key, item) =>
+      typeof item === "bigint" ? item.toString() : item,
+    );
+  }
+  return String(value);
+}

--- a/packages/sdk/src/clear-signing/types.ts
+++ b/packages/sdk/src/clear-signing/types.ts
@@ -1,0 +1,88 @@
+import type { Address } from "viem";
+
+/** Visibility category for a field in a clear-signing intent. */
+export type ClearSigningVisibility = "public" | "encrypted" | "derived" | "internal";
+
+/** Supported clear-signing intent kinds. */
+export type ClearSigningIntentKind =
+  | "allow"
+  | "allowAs"
+  | "delegateDecryption"
+  | "confidentialTransfer"
+  | "confidentialTransferFrom"
+  | "shield"
+  | "unwrap"
+  | "unwrapAll"
+  | "finalizeUnwrap";
+
+/** JSON-like value that can be attached to a clear-signing field. */
+export type ClearSigningFieldValue =
+  | string
+  | number
+  | bigint
+  | boolean
+  | null
+  | readonly ClearSigningFieldValue[]
+  | { readonly [key: string]: ClearSigningFieldValue };
+
+/** Human-readable field with explicit visibility semantics. */
+export interface ClearSigningField {
+  /** User-facing field label. */
+  label: string;
+  /** Visibility classification that controls how the field can be rendered. */
+  visibility: ClearSigningVisibility;
+  /** Structured value for consumers that need machine-readable context. */
+  value?: ClearSigningFieldValue;
+  /** Conservative display value for user-facing rendering. */
+  displayValue?: string;
+  /** Optional explanation for advanced renderers. */
+  description?: string;
+  /** Whether the raw value is intentionally withheld from normal rendering. */
+  redacted?: boolean;
+}
+
+/** Contract-level context for a clear-signing intent. */
+export interface ClearSigningContractContext {
+  /** Chain ID associated with the intent, when known. */
+  chainId?: number;
+  /** Contract address most closely associated with the user-visible action. */
+  contractAddress?: Address;
+  /** Contract function name most closely associated with the user-visible action. */
+  functionName?: string;
+}
+
+/** Raw SDK context preserved for advanced consumers and descriptor generation. */
+export interface ClearSigningRawContext {
+  /** Single contract call config associated with the intent. */
+  contractCall?: unknown;
+  /** Multiple contract call configs associated with a multi-step intent. */
+  contractCalls?: readonly unknown[];
+  /** EIP-712 typed data associated with the intent. */
+  typedData?: unknown;
+  /** Original SDK inputs associated with the intent. */
+  sdkInput?: unknown;
+}
+
+/** Wallet-agnostic semantic description of a confidential SDK interaction. */
+export interface ClearSigningIntent {
+  /** Stable intent kind. */
+  kind: ClearSigningIntentKind;
+  /** Short user-facing title. */
+  title: string;
+  /** One-sentence user-facing summary. */
+  summary: string;
+  /** User-facing and advanced fields with explicit visibility semantics. */
+  fields: ClearSigningField[];
+  /** Contract-level context for wallet or descriptor integrations. */
+  contractContext?: ClearSigningContractContext;
+  /** Raw context that must remain available without becoming primary wording. */
+  rawContext?: ClearSigningRawContext;
+}
+
+/** Opaque encrypted value reference with an optional safe display label. */
+export interface ClearSigningEncryptedValue {
+  /** Opaque encrypted handle or identifier. */
+  value?: string;
+  /** Safe display string, for example "Hidden encrypted amount". */
+  displayValue?: string;
+}

--- a/packages/sdk/src/clear-signing/validation.ts
+++ b/packages/sdk/src/clear-signing/validation.ts
@@ -1,0 +1,137 @@
+import type { ClearSigningField, ClearSigningIntent } from "./types";
+
+/** Issue found while validating a clear-signing intent. */
+export interface ClearSigningValidationIssue {
+  /** Machine-readable issue code. */
+  code:
+    | "missing-title"
+    | "missing-summary"
+    | "missing-fields"
+    | "invalid-kind"
+    | "missing-field-label"
+    | "missing-field-visibility"
+    | "encrypted-field-missing-safe-display"
+    | "internal-field-not-redacted"
+    | "internal-field-has-value";
+  /** Human-readable issue message. */
+  message: string;
+  /** Optional field index where the issue was found. */
+  fieldIndex?: number;
+}
+
+/** Result of validating a clear-signing intent. */
+export interface ClearSigningValidationResult {
+  /** Whether the intent passed all validation checks. */
+  valid: boolean;
+  /** Validation issues, empty when `valid` is true. */
+  issues: ClearSigningValidationIssue[];
+}
+
+/** Validate structural and safety invariants for a clear-signing intent. */
+export function validateClearSigningIntent(
+  intent: ClearSigningIntent,
+): ClearSigningValidationResult {
+  const issues: ClearSigningValidationIssue[] = [];
+
+  if (intent.title.trim() === "") {
+    issues.push({ code: "missing-title", message: "Intent title must not be empty." });
+  }
+  if (intent.summary.trim() === "") {
+    issues.push({ code: "missing-summary", message: "Intent summary must not be empty." });
+  }
+  if (!isValidKind(intent.kind)) {
+    issues.push({
+      code: "invalid-kind",
+      message: "Intent kind is not supported.",
+    });
+  }
+  if (intent.fields.length === 0) {
+    issues.push({
+      code: "missing-fields",
+      message: "Intent must include at least one field.",
+    });
+  }
+
+  intent.fields.forEach((field, index) => {
+    issues.push(...validateField(field, index));
+  });
+
+  return { valid: issues.length === 0, issues };
+}
+
+function isValidKind(kind: ClearSigningIntent["kind"]): boolean {
+  return [
+    "allow",
+    "allowAs",
+    "delegateDecryption",
+    "confidentialTransfer",
+    "confidentialTransferFrom",
+    "shield",
+    "unwrap",
+    "unwrapAll",
+    "finalizeUnwrap",
+  ].includes(kind);
+}
+
+/** Assert structural and safety invariants for a clear-signing intent. */
+export function assertClearSigningIntentSafe(intent: ClearSigningIntent): void {
+  const result = validateClearSigningIntent(intent);
+  if (!result.valid) {
+    const details = result.issues
+      .map((issue) =>
+        issue.fieldIndex === undefined
+          ? `${issue.code}: ${issue.message}`
+          : `${issue.code} at field ${issue.fieldIndex}: ${issue.message}`,
+      )
+      .join("; ");
+    throw new Error(`Unsafe clear-signing intent: ${details}`);
+  }
+}
+
+function validateField(
+  field: ClearSigningField,
+  fieldIndex: number,
+): ClearSigningValidationIssue[] {
+  const issues: ClearSigningValidationIssue[] = [];
+
+  if (field.label.trim() === "") {
+    issues.push({
+      code: "missing-field-label",
+      message: "Field label must not be empty.",
+      fieldIndex,
+    });
+  }
+  if (!["public", "encrypted", "derived", "internal"].includes(field.visibility)) {
+    issues.push({
+      code: "missing-field-visibility",
+      message: "Field visibility must be public, encrypted, derived, or internal.",
+      fieldIndex,
+    });
+  }
+  if (field.visibility === "encrypted" && field.displayValue?.trim()) {
+    return issues;
+  }
+  if (field.visibility === "encrypted") {
+    issues.push({
+      code: "encrypted-field-missing-safe-display",
+      message: "Encrypted fields must provide a safe display value.",
+      fieldIndex,
+    });
+  }
+  if (field.visibility === "internal" && field.redacted !== true) {
+    issues.push({
+      code: "internal-field-not-redacted",
+      message: "Internal fields must be marked as redacted.",
+      fieldIndex,
+    });
+  }
+  if (field.visibility === "internal" && field.value !== undefined) {
+    issues.push({
+      code: "internal-field-has-value",
+      message: "Internal fields must not expose raw values.",
+      fieldIndex,
+    });
+  }
+
+  return issues;
+}

--- a/packages/sdk/src/clear-signing/wording.ts
+++ b/packages/sdk/src/clear-signing/wording.ts
@@ -1,0 +1,134 @@
+/** User-facing labels used by clear-signing builders and renderers. */
+export interface ClearSigningWordingLabels {
+  aclContract: string;
+  accessExpires: string;
+  amount: string;
+  approvalAmount: string;
+  authorizedContracts: string;
+  confidentialContract: string;
+  confidentialToken: string;
+  confidentialWrapper: string;
+  decryptionProof: string;
+  duration: string;
+  encryptedAmount: string;
+  encryptedBalance: string;
+  fhePublicKey: string;
+  grantingWallet: string;
+  inputProof: string;
+  operatorWallet: string;
+  pendingUnshieldRequest: string;
+  protocolExtraData: string;
+  publicAmount: string;
+  publicToken: string;
+  publicTokenRecipient: string;
+  recipient: string;
+  startsAt: string;
+  walletAllowedToView: string;
+  delegatorWallet: string;
+}
+
+/** Shared display values used by clear-signing builders and renderers. */
+export interface ClearSigningWordingValues {
+  hiddenEncryptedAmount: string;
+  hiddenEncryptedBalance: string;
+  entireConfidentialBalance: string;
+  protocolProofHidden: string;
+  protocolDataHidden: string;
+  untilRevoked: string;
+}
+
+/** User-facing title and summary for one clear-signing flow. */
+export interface ClearSigningFlowWording {
+  title: string;
+  summary: string;
+}
+
+/** User-facing wording registry for clear-signing intents. */
+export interface ClearSigningWording {
+  labels: ClearSigningWordingLabels;
+  values: ClearSigningWordingValues;
+  allow: ClearSigningFlowWording;
+  allowAs: ClearSigningFlowWording;
+  delegateDecryption: ClearSigningFlowWording;
+  confidentialTransfer: ClearSigningFlowWording;
+  confidentialTransferFrom: ClearSigningFlowWording;
+  shield: ClearSigningFlowWording;
+  unwrap: ClearSigningFlowWording;
+  unwrapAll: ClearSigningFlowWording;
+  finalizeUnwrap: ClearSigningFlowWording;
+}
+
+/** Centralized clear-signing wording registry. */
+export const clearSigningWording: ClearSigningWording = {
+  labels: {
+    aclContract: "ACL contract",
+    accessExpires: "Access expires",
+    amount: "Amount",
+    approvalAmount: "Approval amount",
+    authorizedContracts: "Authorized contracts",
+    confidentialContract: "Confidential contract",
+    confidentialToken: "Confidential token",
+    confidentialWrapper: "Confidential wrapper",
+    decryptionProof: "Decryption proof",
+    duration: "Duration",
+    encryptedAmount: "Encrypted amount",
+    encryptedBalance: "Encrypted balance",
+    fhePublicKey: "FHE public key",
+    grantingWallet: "Granting wallet",
+    inputProof: "Input proof",
+    operatorWallet: "Operator wallet",
+    pendingUnshieldRequest: "Pending unshield request",
+    protocolExtraData: "Protocol extra data",
+    publicAmount: "Public amount",
+    publicToken: "Public token",
+    publicTokenRecipient: "Public token recipient",
+    recipient: "Recipient",
+    startsAt: "Starts at",
+    walletAllowedToView: "Wallet allowed to view",
+    delegatorWallet: "Delegator wallet",
+  },
+  values: {
+    hiddenEncryptedAmount: "Hidden encrypted amount",
+    hiddenEncryptedBalance: "Hidden encrypted balance",
+    entireConfidentialBalance: "Entire confidential balance",
+    protocolProofHidden: "Protocol proof (hidden)",
+    protocolDataHidden: "Protocol data (hidden)",
+    untilRevoked: "Access remains active until revoked",
+  },
+  allow: {
+    title: "Authorize confidential data decryption",
+    summary: "Allow this wallet to decrypt confidential values for selected contracts.",
+  },
+  allowAs: {
+    title: "Authorize delegated confidential data decryption",
+    summary: "Allow this wallet to decrypt delegated confidential values for selected contracts.",
+  },
+  delegateDecryption: {
+    title: "Allow another wallet to view confidential data",
+    summary: "Grant decryption access for one confidential contract.",
+  },
+  confidentialTransfer: {
+    title: "Send confidential tokens",
+    summary: "Transfer an encrypted token amount to a public recipient.",
+  },
+  confidentialTransferFrom: {
+    title: "Send confidential tokens as operator",
+    summary: "Transfer an encrypted token amount from another wallet to a public recipient.",
+  },
+  shield: {
+    title: "Shield public tokens",
+    summary: "Convert public ERC-20 tokens into a confidential balance.",
+  },
+  unwrap: {
+    title: "Request unshield",
+    summary: "Start converting a confidential amount into public tokens.",
+  },
+  unwrapAll: {
+    title: "Request unshield of entire confidential balance",
+    summary: "Start converting your entire confidential balance into public tokens.",
+  },
+  finalizeUnwrap: {
+    title: "Finalize unshield",
+    summary: "Complete a pending unshield and receive public tokens.",
+  },
+};

--- a/packages/sdk/src/credentials/credential-service.ts
+++ b/packages/sdk/src/credentials/credential-service.ts
@@ -1,6 +1,11 @@
 import type { Address } from "viem";
-import type { GenericSigner, GenericStorage } from "../types";
+import type { ClearSigningCallbacks, GenericSigner, GenericStorage } from "../types";
+import { buildAllowAsIntentFromEIP712, buildAllowIntentFromEIP712 } from "../clear-signing";
 import type { RelayerDispatcher } from "../relayer/relayer-dispatcher";
+import type {
+  KmsDelegatedUserDecryptEIP712Type,
+  KmsUserDecryptEIP712Type,
+} from "../relayer/relayer-sdk.types";
 import { ZamaError } from "../errors/base";
 import { wrapSigningError } from "../errors/signing";
 import { swallow } from "../utils/swallow";
@@ -73,7 +78,11 @@ export class CredentialService {
    * @throws if the user rejects a wallet signature prompt. {@link SigningRejectedError}
    * @throws if signing fails for any other reason. {@link SigningFailedError}
    */
-  async grantPermit(contracts: readonly Address[], delegator?: Address): Promise<CredentialBundle> {
+  async grantPermit(
+    contracts: readonly Address[],
+    delegator?: Address,
+    callbacks?: ClearSigningCallbacks,
+  ): Promise<CredentialBundle> {
     const account = this.#signer.requireWalletAccount("grantPermit");
     const signerAddress = checksum(account.address);
     const requested = normalizeAddresses(contracts);
@@ -91,7 +100,7 @@ export class CredentialService {
     const permits = await this.#store.listUsableAndPrune(scope, keypair.publicKey);
 
     for (const chunk of chunkContracts(uncoveredContracts(permits, requested))) {
-      const permission = await this.#signPermit({ chunk, keypair, scope });
+      const permission = await this.#signPermit({ chunk, keypair, scope, callbacks });
       permits.push(permission);
       await swallow("persist permit", () => this.#store.append(scope, [permission]));
     }
@@ -206,8 +215,9 @@ export class CredentialService {
     chunk: ChecksummedAddress[];
     keypair: StoredKeypair;
     scope: PermissionScope;
+    callbacks?: ClearSigningCallbacks;
   }): Promise<Permission> {
-    const { chunk, keypair, scope } = input;
+    const { chunk, keypair, scope, callbacks } = input;
     const startTimestamp = nowSeconds();
     const isDelegated = scope.delegatorAddress !== scope.signerAddress;
 
@@ -226,6 +236,18 @@ export class CredentialService {
             startTimestamp,
             this.#permitTTL,
           );
+
+      await swallow(
+        isDelegated
+          ? "grantDelegationPermit: onClearSigningIntent"
+          : "grantPermit: onClearSigningIntent",
+        () =>
+          callbacks?.onClearSigningIntent?.(
+            isDelegated
+              ? buildAllowAsIntentFromEIP712(eip712 as KmsDelegatedUserDecryptEIP712Type)
+              : buildAllowIntentFromEIP712(eip712 as KmsUserDecryptEIP712Type),
+          ),
+      );
 
       const signature = await this.#signer.signTypedData(eip712);
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -111,6 +111,8 @@ export type {
   TransactionReceipt,
   TransactionResult,
   ApprovalStrategy,
+  ClearSigningCallbacks,
+  FinalizeUnwrapOptions,
   UnshieldCallbacks,
   UnshieldOptions,
   ShieldCallbacks,
@@ -118,6 +120,8 @@ export type {
   ShieldPath,
   TransferCallbacks,
   TransferOptions,
+  UnwrapAllOptions,
+  UnwrapOptions,
 } from "./types";
 export type { Address, Hex } from "viem";
 export { ZamaSDKEvents } from "./events";
@@ -185,6 +189,50 @@ export {
 } from "./errors";
 export { BaseSigner } from "./signer/base-signer";
 export { createWalletAccountStore, MutableWalletAccountStore } from "./signer/wallet-account-store";
+
+export {
+  buildAllowAsIntent,
+  buildAllowAsIntentFromEIP712,
+  buildAllowIntent,
+  buildAllowIntentFromEIP712,
+  buildConfidentialTransferFromIntent,
+  buildConfidentialTransferIntent,
+  buildDelegateDecryptionIntent,
+  buildFinalizeUnwrapIntent,
+  buildShieldViaTransferAndCallIntent,
+  buildShieldViaWrapIntent,
+  buildUnwrapAllIntent,
+  buildUnwrapIntent,
+  renderClearSigningIntent,
+  assertClearSigningIntentSafe,
+  validateClearSigningIntent,
+} from "./clear-signing";
+export type {
+  BuildAllowAsIntentParams,
+  BuildAllowIntentParams,
+  BuildConfidentialTransferFromIntentParams,
+  BuildConfidentialTransferIntentParams,
+  BuildDelegateDecryptionIntentParams,
+  BuildFinalizeUnwrapIntentParams,
+  BuildShieldIntentBaseParams,
+  BuildShieldViaTransferAndCallIntentParams,
+  BuildShieldViaWrapIntentParams,
+  BuildUnwrapAllIntentParams,
+  BuildUnwrapIntentParams,
+  ClearSigningContractContext,
+  ClearSigningEncryptedValue,
+  ClearSigningField,
+  ClearSigningFieldValue,
+  ClearSigningIntent,
+  ClearSigningIntentKind,
+  ClearSigningRawContext,
+  ClearSigningValidationIssue,
+  ClearSigningValidationResult,
+  ClearSigningVisibility,
+  RenderClearSigningIntentOptions,
+  RenderedClearSigningField,
+  RenderedClearSigningIntent,
+} from "./clear-signing";
 
 // Event decoders and types
 export type {

--- a/packages/sdk/src/namespaces/__tests__/delegations.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/delegations.test.ts
@@ -62,6 +62,37 @@ describe("Delegations", () => {
   });
 
   describe("delegator address resolution", () => {
+    test("createDelegateDecryptionClearSigningIntent describes delegation", async ({ sdk }) => {
+      const intent = await sdk.delegations.createDelegateDecryptionClearSigningIntent({
+        contractAddress: TOKEN,
+        delegateAddress: DELEGATE,
+      });
+
+      expect(intent.kind).toBe("delegateDecryption");
+      expect(intent.fields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ label: "Wallet allowed to view", value: DELEGATE }),
+          expect.objectContaining({ label: "Confidential contract", value: TOKEN }),
+        ]),
+      );
+    });
+
+    test("delegateDecryption emits a clear-signing intent", async ({ sdk, signer, provider }) => {
+      vi.mocked(provider.readContract).mockResolvedValue(0n);
+      vi.mocked(signer.writeContract).mockResolvedValue("0xtx");
+      const onClearSigningIntent = vi.fn();
+
+      await sdk.delegations.delegateDecryption({
+        contractAddress: TOKEN,
+        delegateAddress: DELEGATE,
+        onClearSigningIntent,
+      });
+
+      expect(onClearSigningIntent).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "delegateDecryption" }),
+      );
+    });
+
     test("delegateDecryption uses the wallet account address as delegator", async ({
       sdk,
       signer,

--- a/packages/sdk/src/namespaces/__tests__/permits.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/permits.test.ts
@@ -96,6 +96,54 @@ describe("Permits", () => {
   });
 
   describe("happy paths", () => {
+    test("createAllowClearSigningIntent describes direct decrypt authorization", async ({
+      sdk,
+    }) => {
+      const intent = await sdk.permits.createAllowClearSigningIntent([CONTRACT_A]);
+
+      expect(intent.kind).toBe("allow");
+      expect(intent.fields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ label: "Authorized contracts", visibility: "public" }),
+        ]),
+      );
+    });
+
+    test("grantPermit emits a clear-signing intent", async ({ sdk, signer }) => {
+      const onClearSigningIntent = vi.fn();
+
+      await sdk.permits.grantPermit([CONTRACT_A], { onClearSigningIntent });
+
+      expect(signer.signTypedData).toHaveBeenCalled();
+      expect(onClearSigningIntent).toHaveBeenCalledWith(expect.objectContaining({ kind: "allow" }));
+    });
+
+    test("createAllowAsClearSigningIntent describes delegated decrypt authorization", async ({
+      sdk,
+    }) => {
+      const intent = await sdk.permits.createAllowAsClearSigningIntent(DELEGATOR, [CONTRACT_A]);
+
+      expect(intent.kind).toBe("allowAs");
+      expect(intent.fields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ label: "Delegator wallet", value: DELEGATOR }),
+        ]),
+      );
+    });
+
+    test("grantDelegationPermit emits a clear-signing intent", async ({ sdk, signer }) => {
+      const onClearSigningIntent = vi.fn();
+
+      await sdk.permits.grantDelegationPermit(DELEGATOR, [CONTRACT_A], {
+        onClearSigningIntent,
+      });
+
+      expect(signer.signTypedData).toHaveBeenCalled();
+      expect(onClearSigningIntent).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "allowAs" }),
+      );
+    });
+
     test("grantPermit triggers a wallet signature for uncached contracts", async ({
       sdk,
       signer,

--- a/packages/sdk/src/namespaces/delegations.ts
+++ b/packages/sdk/src/namespaces/delegations.ts
@@ -1,6 +1,14 @@
-import type { Address } from "viem";
+import { getAddress, type Address } from "viem";
+import { buildDelegateDecryptionIntent, type ClearSigningIntent } from "../clear-signing";
+import type { RelayerDispatcher } from "../relayer/relayer-dispatcher";
 import type { DelegationService } from "../services/delegation-service";
-import type { GenericProvider, GenericSigner, TransactionResult } from "../types";
+import type {
+  ClearSigningCallbacks,
+  GenericProvider,
+  GenericSigner,
+  TransactionResult,
+} from "../types";
+import { swallow } from "../utils";
 import { requireAlignedWalletAccount } from "../utils/alignment";
 import { requireConfigured } from "../errors";
 
@@ -18,21 +26,52 @@ import { requireConfigured } from "../errors";
 export class Delegations {
   readonly #signer: GenericSigner | undefined;
   readonly #provider: GenericProvider;
+  readonly #relayer: RelayerDispatcher;
   readonly #delegationService: DelegationService;
 
   /** @internal */
   constructor(opts: {
     signer: GenericSigner | undefined;
     provider: GenericProvider;
+    relayer: RelayerDispatcher;
     delegationService: DelegationService;
   }) {
     this.#signer = opts.signer;
     this.#provider = opts.provider;
+    this.#relayer = opts.relayer;
     this.#delegationService = opts.delegationService;
   }
 
   #requireSigner(operation: string): GenericSigner {
     return requireConfigured(this.#signer, operation);
+  }
+
+  /** Build a clear-signing preview for granting delegated decryption rights. */
+  async createDelegateDecryptionClearSigningIntent({
+    contractAddress,
+    delegateAddress,
+    expirationDate,
+  }: {
+    contractAddress: Address;
+    delegateAddress: Address;
+    expirationDate?: Date;
+  }): Promise<ClearSigningIntent> {
+    const account = await requireAlignedWalletAccount(
+      "createDelegateDecryptionClearSigningIntent",
+      this.#signer,
+      this.#provider,
+    );
+    const aclAddress = await this.#relayer.getAclAddress();
+    return buildDelegateDecryptionIntent({
+      contractAddress: getAddress(contractAddress),
+      delegateAddress: getAddress(delegateAddress),
+      delegatorAddress: getAddress(account.address),
+      aclAddress,
+      expirationTimestamp:
+        expirationDate === undefined ? undefined : Math.floor(expirationDate.getTime() / 1000),
+      permanent: expirationDate === undefined,
+      chainId: await this.#provider.getChainId(),
+    });
   }
 
   /**
@@ -59,16 +98,32 @@ export class Delegations {
     contractAddress,
     delegateAddress,
     expirationDate,
+    onClearSigningIntent,
   }: {
     contractAddress: Address;
     delegateAddress: Address;
     expirationDate?: Date;
-  }): Promise<TransactionResult> {
+  } & ClearSigningCallbacks): Promise<TransactionResult> {
     const signer = this.#requireSigner("delegateDecryption");
     const account = await requireAlignedWalletAccount(
       "delegateDecryption",
       this.#signer,
       this.#provider,
+    );
+    const aclAddress = await this.#relayer.getAclAddress();
+    await swallow("delegateDecryption: onClearSigningIntent", () =>
+      onClearSigningIntent?.(
+        buildDelegateDecryptionIntent({
+          contractAddress: getAddress(contractAddress),
+          delegateAddress: getAddress(delegateAddress),
+          delegatorAddress: getAddress(account.address),
+          aclAddress,
+          expirationTimestamp:
+            expirationDate === undefined ? undefined : Math.floor(expirationDate.getTime() / 1000),
+          permanent: expirationDate === undefined,
+          chainId: account.chainId,
+        }),
+      ),
     );
     return this.#delegationService.delegateDecryption(signer, {
       contractAddress,

--- a/packages/sdk/src/namespaces/permits.ts
+++ b/packages/sdk/src/namespaces/permits.ts
@@ -1,8 +1,9 @@
 import { getAddress, type Address } from "viem";
+import { buildAllowAsIntent, buildAllowIntent, type ClearSigningIntent } from "../clear-signing";
 import type { CredentialService } from "../credentials/credential-service";
 import { requireConfigured } from "../errors";
 import type { CachingService } from "../services/caching-service";
-import type { GenericProvider, GenericSigner } from "../types";
+import type { ClearSigningCallbacks, GenericProvider, GenericSigner } from "../types";
 import { swallow } from "../utils";
 import { requireAlignedWalletAccount, requireChainAlignment } from "../utils/alignment";
 
@@ -42,6 +43,26 @@ export class Permits {
     return requireConfigured(this.#credentialService, operation);
   }
 
+  /** Build a clear-signing preview for direct decrypt authorization. */
+  async createAllowClearSigningIntent(contracts: Address[]): Promise<ClearSigningIntent> {
+    return buildAllowIntent({
+      contractAddresses: contracts.map((contract) => getAddress(contract)),
+      chainId: await this.#provider.getChainId(),
+    });
+  }
+
+  /** Build a clear-signing preview for delegated decrypt credential authorization. */
+  async createAllowAsClearSigningIntent(
+    delegator: Address,
+    contracts: Address[],
+  ): Promise<ClearSigningIntent> {
+    return buildAllowAsIntent({
+      delegatorAddress: getAddress(delegator),
+      contractAddresses: contracts.map((contract) => getAddress(contract)),
+      chainId: await this.#provider.getChainId(),
+    });
+  }
+
   /**
    * Sign and store an EIP-712 permit authorising direct decryption for the
    * given contract addresses.
@@ -54,13 +75,13 @@ export class Permits {
    *
    * @param contracts - Contract addresses to authorize.
    */
-  async grantPermit(contracts: Address[]): Promise<void> {
+  async grantPermit(contracts: Address[], options?: ClearSigningCallbacks): Promise<void> {
     if (contracts.length === 0) {
       return;
     }
     const service = this.#requireCredentialService("grantPermit");
     await requireChainAlignment("grantPermit", this.#signer, this.#provider);
-    await service.grantPermit(contracts);
+    await service.grantPermit(contracts, undefined, options);
   }
 
   /**
@@ -70,13 +91,17 @@ export class Permits {
    * @param delegator - The address that delegated decryption rights to the connected signer.
    * @param contracts - Contract addresses to authorize.
    */
-  async grantDelegationPermit(delegator: Address, contracts: Address[]): Promise<void> {
+  async grantDelegationPermit(
+    delegator: Address,
+    contracts: Address[],
+    options?: ClearSigningCallbacks,
+  ): Promise<void> {
     if (contracts.length === 0) {
       return;
     }
     const service = this.#requireCredentialService("grantDelegationPermit");
     await requireChainAlignment("grantDelegationPermit", this.#signer, this.#provider);
-    await service.grantPermit(contracts, delegator);
+    await service.grantPermit(contracts, delegator, options);
   }
 
   /**

--- a/packages/sdk/src/query/index.ts
+++ b/packages/sdk/src/query/index.ts
@@ -147,9 +147,20 @@ export type { ZamaSDK } from "../zama-sdk";
 export type { ZamaConfig } from "../config";
 export type { Keypair } from "../credentials";
 export type {
+  ClearSigningContractContext,
+  ClearSigningField,
+  ClearSigningFieldValue,
+  ClearSigningIntent,
+  ClearSigningIntentKind,
+  ClearSigningRawContext,
+  ClearSigningVisibility,
+} from "../clear-signing";
+export type {
   GenericSigner,
   GenericStorage,
   ApprovalStrategy,
+  ClearSigningCallbacks,
+  FinalizeUnwrapOptions,
   ShieldCallbacks,
   WalletAccount,
   WalletAccountChange,
@@ -162,6 +173,8 @@ export type {
   TransferOptions,
   UnshieldCallbacks,
   UnshieldOptions,
+  UnwrapAllOptions,
+  UnwrapOptions,
 } from "../types";
 export { ZamaSDKEvents } from "../events/sdk-events";
 export type {

--- a/packages/sdk/src/relayer/relayer-sdk.types.ts
+++ b/packages/sdk/src/relayer/relayer-sdk.types.ts
@@ -81,7 +81,7 @@ export type EncryptResult = InputProofBytesType;
 /** Canonical SDK type for encrypted ciphertext handles (`bytes32` values). Alias for {@link Bytes32Hex}. */
 export type Handle = Bytes32Hex;
 
-export type { ClearValueType };
+export type { ClearValueType, KmsDelegatedUserDecryptEIP712Type, KmsUserDecryptEIP712Type };
 
 /** A single value to encrypt with its FHE type. */
 export type EncryptInput =

--- a/packages/sdk/src/test-fixtures/relayer.ts
+++ b/packages/sdk/src/test-fixtures/relayer.ts
@@ -3,7 +3,7 @@
 import { vi } from "vitest";
 import type { RelayerSDK } from "../relayer/relayer-sdk";
 import type { FixturesOf } from "./types";
-import { ACL, TEST_PRIVATE_KEY, TEST_PUBLIC_KEY, TOKEN, VALID_HANDLE } from "./constants";
+import { ACL, TEST_PRIVATE_KEY, TEST_PUBLIC_KEY, VALID_HANDLE } from "./constants";
 
 export function createMockRelayer(overrides: Partial<RelayerSDK> = {}): RelayerSDK {
   return {
@@ -14,22 +14,26 @@ export function createMockRelayer(overrides: Partial<RelayerSDK> = {}): RelayerS
       publicKey: TEST_PUBLIC_KEY,
       privateKey: TEST_PRIVATE_KEY,
     }),
-    createEIP712: vi.fn().mockResolvedValue({
-      domain: {
-        name: "test",
-        version: "1",
-        chainId: 1,
-        verifyingContract: "0xkms",
-      },
-      types: { UserDecryptRequestVerification: [] },
-      message: {
-        publicKey: TEST_PUBLIC_KEY,
-        contractAddresses: [TOKEN],
-        startTimestamp: 1000n,
-        durationDays: 1n,
-        extraData: "0x",
-      },
-    }),
+    createEIP712: vi
+      .fn()
+      .mockImplementation((publicKey, contractAddresses, startTimestamp, durationDays) =>
+        Promise.resolve({
+          domain: {
+            name: "test",
+            version: "1",
+            chainId: 1,
+            verifyingContract: "0xkms",
+          },
+          types: { UserDecryptRequestVerification: [] },
+          message: {
+            publicKey,
+            contractAddresses,
+            startTimestamp,
+            durationDays,
+            extraData: "0x",
+          },
+        }),
+      ),
     encrypt: vi.fn().mockResolvedValue({
       handles: [new Uint8Array([1, 2, 3])],
       inputProof: new Uint8Array([4, 5, 6]),
@@ -48,16 +52,28 @@ export function createMockRelayer(overrides: Partial<RelayerSDK> = {}): RelayerS
         decryptionProof: "0xproof",
       });
     }),
-    createDelegatedUserDecryptEIP712: vi.fn().mockResolvedValue({
-      domain: {
-        name: "test",
-        version: "1",
-        chainId: 1,
-        verifyingContract: "0xkms",
-      },
-      types: { DelegatedUserDecryptRequestVerification: [] },
-      message: {},
-    }),
+    createDelegatedUserDecryptEIP712: vi
+      .fn()
+      .mockImplementation(
+        (publicKey, contractAddresses, delegatorAddress, startTimestamp, durationDays) =>
+          Promise.resolve({
+            domain: {
+              name: "test",
+              version: "1",
+              chainId: 1,
+              verifyingContract: "0xkms",
+            },
+            types: { DelegatedUserDecryptRequestVerification: [] },
+            message: {
+              publicKey,
+              contractAddresses,
+              delegatorAddress,
+              startTimestamp,
+              durationDays,
+              extraData: "0x",
+            },
+          }),
+      ),
     delegatedUserDecrypt: vi.fn().mockResolvedValue({
       [VALID_HANDLE as string]: 1000n,
     }),

--- a/packages/sdk/src/token/__tests__/callbacks.test.ts
+++ b/packages/sdk/src/token/__tests__/callbacks.test.ts
@@ -3,7 +3,7 @@ import { Topics } from "../../events";
 
 import { DecryptionFailedError, TransactionRevertedError } from "../../errors";
 import type { GenericProvider } from "../../types";
-import type { Address } from "viem";
+import { getAddress, type Address } from "viem";
 
 describe("Unshield callbacks (P4)", () => {
   function mockReceiptWithUnwrapRequested(provider: GenericProvider, userAddress: Address) {
@@ -212,6 +212,49 @@ describe("Transfer callbacks (SDK-19)", () => {
 
     expect(onEncryptComplete).toHaveBeenCalledOnce();
     expect(onTransferSubmitted).toHaveBeenCalledWith("0xtxhash");
+  });
+
+  test("fires onClearSigningIntent after encryption", async ({ token }) => {
+    const onClearSigningIntent = vi.fn();
+
+    await token.confidentialTransfer(
+      "0x8b8b8b8b8B8B8b8B8B8b8b8b8b8B8B8B8B8b8B8b" as Address,
+      100n,
+      { skipBalanceCheck: true, onClearSigningIntent },
+    );
+
+    expect(onClearSigningIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "confidentialTransfer",
+        fields: expect.arrayContaining([
+          expect.objectContaining({ label: "Amount", value: 100n }),
+          expect.objectContaining({ label: "Encrypted amount", visibility: "encrypted" }),
+        ]),
+      }),
+    );
+  });
+
+  test("fires operator clear-signing intent for confidentialTransferFrom", async ({ token }) => {
+    const onClearSigningIntent = vi.fn();
+    const source = "0x7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a" as Address;
+
+    await token.confidentialTransferFrom(
+      source,
+      "0x8b8b8b8B8B8b8b8B8B8B8b8B8B8b8B8B8B8b8B8b" as Address,
+      100n,
+      { onClearSigningIntent },
+    );
+
+    expect(onClearSigningIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "confidentialTransferFrom",
+        contractContext: expect.objectContaining({ functionName: "confidentialTransferFrom" }),
+        fields: expect.arrayContaining([
+          expect.objectContaining({ label: "Granting wallet", value: getAddress(source) }),
+          expect.objectContaining({ label: "Operator wallet" }),
+        ]),
+      }),
+    );
   });
 
   test("fires callbacks in correct order", async ({ token }) => {

--- a/packages/sdk/src/token/__tests__/wrapped-token.test.ts
+++ b/packages/sdk/src/token/__tests__/wrapped-token.test.ts
@@ -43,6 +43,40 @@ describe("WrappedToken", () => {
   });
 
   describe("shield", () => {
+    test("createShieldClearSigningIntent describes approve-and-wrap shield", async ({
+      wrappedToken,
+      provider,
+    }) => {
+      vi.mocked(provider.readContract)
+        .mockResolvedValueOnce(UNDERLYING)
+        .mockResolvedValueOnce(false);
+
+      const intent = await wrappedToken.createShieldClearSigningIntent(100n);
+
+      expect(intent).toMatchObject({
+        kind: "shield",
+        title: "Shield public tokens",
+      });
+      expect(intent.fields).toEqual(
+        expect.arrayContaining([expect.objectContaining({ label: "Public amount", value: 100n })]),
+      );
+    });
+
+    test("shield emits a clear-signing intent", async ({ wrappedToken, provider }) => {
+      vi.mocked(provider.readContract)
+        .mockResolvedValueOnce(UNDERLYING)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(1000n)
+        .mockResolvedValueOnce(200n);
+      const onClearSigningIntent = vi.fn();
+
+      await wrappedToken.shield(100n, { onClearSigningIntent });
+
+      expect(onClearSigningIntent).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "shield" }),
+      );
+    });
+
     test("checks allowance and shields", async ({ signer, wrappedToken, provider }) => {
       vi.mocked(provider.readContract)
         .mockResolvedValueOnce(UNDERLYING) // #getUnderlying

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -1,4 +1,10 @@
-import { type Address, getAddress, type Hex } from "viem";
+import { type Address, getAddress, type Hex, toHex } from "viem";
+import {
+  buildConfidentialTransferFromIntent,
+  buildConfidentialTransferIntent,
+  type ClearSigningEncryptedValue,
+  type ClearSigningIntent,
+} from "../clear-signing";
 import {
   confidentialBalanceOfContract,
   confidentialTransferContract,
@@ -89,6 +95,31 @@ export class Token {
   constructor(sdk: ZamaSDK, address: Address) {
     this.sdk = sdk;
     this.address = getAddress(address);
+  }
+
+  /**
+   * Build a clear-signing preview for a confidential transfer without
+   * submitting a transaction.
+   *
+   * The preview includes plaintext SDK inputs and wallet/chain context, but no
+   * encrypted handle because encryption happens during the actual transfer.
+   */
+  async createConfidentialTransferClearSigningIntent(
+    to: Address,
+    amount: bigint,
+  ): Promise<ClearSigningIntent> {
+    const account = await requireAlignedWalletAccount(
+      "createConfidentialTransferClearSigningIntent",
+      this.sdk.signer,
+      this.sdk.provider,
+    );
+    return buildConfidentialTransferIntent({
+      tokenAddress: this.address,
+      senderAddress: getAddress(account.address),
+      recipientAddress: getAddress(to),
+      amount,
+      chainId: await this.sdk.provider.getChainId(),
+    });
   }
 
   /** Resolve `sdk.signer` or throw {@link SignerNotConfiguredError} tagged with `operation`. */
@@ -558,9 +589,26 @@ export class Token {
       throw new EncryptionFailedError("Encryption returned no handles");
     }
 
+    const encryptedAmount = handles[0]!;
+    const encryptedAmountValue =
+      typeof encryptedAmount === "string" ? encryptedAmount : toHex(encryptedAmount);
+    await swallow("transfer: onClearSigningIntent", () =>
+      options?.onClearSigningIntent?.(
+        buildConfidentialTransferIntent({
+          tokenAddress: this.address,
+          senderAddress: getAddress(account.address),
+          recipientAddress: normalizedTo,
+          amount,
+          encryptedAmount: { value: encryptedAmountValue } satisfies ClearSigningEncryptedValue,
+          hasInputProof: true,
+          chainId: account.chainId,
+        }),
+      ),
+    );
+
     return this.submitTransaction({
       operation: "transfer",
-      config: confidentialTransferContract(this.address, normalizedTo, handles[0]!, inputProof),
+      config: confidentialTransferContract(this.address, normalizedTo, encryptedAmount, inputProof),
       onSubmitted: onTransferSubmitted,
     });
   }
@@ -586,7 +634,7 @@ export class Token {
     callbacks?: TransferCallbacks,
   ): Promise<TransactionResult> {
     this.#requireSigner("confidentialTransferFrom");
-    await requireAlignedWalletAccount(
+    const account = await requireAlignedWalletAccount(
       "confidentialTransferFrom",
       this.sdk.signer,
       this.sdk.provider,
@@ -605,13 +653,31 @@ export class Token {
       throw new EncryptionFailedError("Encryption returned no handles");
     }
 
+    const encryptedAmount = handles[0]!;
+    const encryptedAmountValue =
+      typeof encryptedAmount === "string" ? encryptedAmount : toHex(encryptedAmount);
+    await swallow("transferFrom: onClearSigningIntent", () =>
+      callbacks?.onClearSigningIntent?.(
+        buildConfidentialTransferFromIntent({
+          tokenAddress: this.address,
+          sourceAddress: normalizedFrom,
+          operatorAddress: getAddress(account.address),
+          recipientAddress: normalizedTo,
+          amount,
+          encryptedAmount: { value: encryptedAmountValue } satisfies ClearSigningEncryptedValue,
+          hasInputProof: true,
+          chainId: account.chainId,
+        }),
+      ),
+    );
+
     return this.submitTransaction({
       operation: "transferFrom",
       config: confidentialTransferFromContract(
         this.address,
         normalizedFrom,
         normalizedTo,
-        handles[0]!,
+        encryptedAmount,
         inputProof,
       ),
       onSubmitted: callbacks?.onTransferSubmitted,

--- a/packages/sdk/src/token/wrapped-token.ts
+++ b/packages/sdk/src/token/wrapped-token.ts
@@ -1,4 +1,13 @@
-import { type Address, getAddress, type Hex } from "viem";
+import { type Address, getAddress, type Hex, toHex } from "viem";
+import {
+  buildFinalizeUnwrapIntent,
+  buildShieldViaTransferAndCallIntent,
+  buildShieldViaWrapIntent,
+  buildUnwrapAllIntent,
+  buildUnwrapIntent,
+  type ClearSigningEncryptedValue,
+  type ClearSigningIntent,
+} from "../clear-signing";
 import {
   allowanceContract,
   approveContract,
@@ -31,9 +40,12 @@ import { swallow } from "../utils/swallow";
 import { Token } from "./token";
 import type {
   GenericSigner,
+  FinalizeUnwrapOptions,
   ShieldCallbacks,
   ShieldOptions,
   TransactionResult,
+  UnwrapAllOptions,
+  UnwrapOptions,
   UnshieldCallbacks,
   UnshieldOptions,
 } from "../types";
@@ -53,6 +65,102 @@ export class WrappedToken extends Token {
   #underlying: Address | undefined;
   #underlyingPromise: Promise<Address> | null = null;
   #isPayable: boolean | null = null;
+
+  /**
+   * Build a clear-signing preview for shielding public ERC-20 tokens into this
+   * confidential wrapper without submitting transactions.
+   */
+  async createShieldClearSigningIntent(
+    amount: bigint,
+    options?: ShieldOptions,
+  ): Promise<ClearSigningIntent> {
+    const account = await requireAlignedWalletAccount(
+      "createShieldClearSigningIntent",
+      this.sdk.signer,
+      this.sdk.provider,
+    );
+    const underlying = await this.#getUnderlying();
+    const userAddress = getAddress(account.address);
+    const recipient = options?.to ? getAddress(options.to) : userAddress;
+    const chainId = await this.sdk.provider.getChainId();
+    if (await this.isPayable()) {
+      return buildShieldViaTransferAndCallIntent({
+        underlyingTokenAddress: underlying,
+        wrapperAddress: this.address,
+        senderAddress: userAddress,
+        recipientAddress: recipient,
+        amount,
+        chainId,
+      });
+    }
+    const approvalStrategy = options?.approvalStrategy ?? "exact";
+    return buildShieldViaWrapIntent({
+      underlyingTokenAddress: underlying,
+      wrapperAddress: this.address,
+      senderAddress: userAddress,
+      recipientAddress: recipient,
+      amount,
+      approvalAmount:
+        approvalStrategy === "skip"
+          ? undefined
+          : approvalStrategy === "max"
+            ? 2n ** 256n - 1n
+            : amount,
+      maxApproval: approvalStrategy === "max",
+      chainId,
+    });
+  }
+
+  /** Build a clear-signing preview for the first phase of a specific-amount unshield. */
+  async createUnwrapClearSigningIntent(amount: bigint): Promise<ClearSigningIntent> {
+    const account = await requireAlignedWalletAccount(
+      "createUnwrapClearSigningIntent",
+      this.sdk.signer,
+      this.sdk.provider,
+    );
+    const userAddress = getAddress(account.address);
+    return buildUnwrapIntent({
+      wrapperAddress: this.address,
+      fromAddress: userAddress,
+      recipientAddress: userAddress,
+      amount,
+      chainId: await this.sdk.provider.getChainId(),
+    });
+  }
+
+  /** Build a clear-signing preview for unshielding the entire confidential balance. */
+  async createUnwrapAllClearSigningIntent(): Promise<ClearSigningIntent> {
+    const account = await requireAlignedWalletAccount(
+      "createUnwrapAllClearSigningIntent",
+      this.sdk.signer,
+      this.sdk.provider,
+    );
+    const userAddress = getAddress(account.address);
+    const handle = await this.readConfidentialBalanceOf(userAddress);
+    if (isZeroHandle(handle)) {
+      throw new DecryptionFailedError("Cannot unshield: balance is zero");
+    }
+    return buildUnwrapAllIntent({
+      wrapperAddress: this.address,
+      fromAddress: userAddress,
+      recipientAddress: userAddress,
+      encryptedBalance: { value: handle },
+      chainId: await this.sdk.provider.getChainId(),
+    });
+  }
+
+  /** Build a clear-signing preview for finalizing a pending unshield. */
+  async createFinalizeUnwrapClearSigningIntent(
+    unwrapRequestIdOrAmount: Handle,
+    clearAmount?: bigint,
+  ): Promise<ClearSigningIntent> {
+    return buildFinalizeUnwrapIntent({
+      wrapperAddress: this.address,
+      unwrapRequestId: unwrapRequestIdOrAmount,
+      clearAmount,
+      chainId: await this.sdk.provider.getChainId(),
+    });
+  }
 
   /** Resolve `sdk.signer` or throw {@link SignerNotConfiguredError} tagged with `operation`. */
   #requireSigner(operation: string): GenericSigner {
@@ -169,15 +277,22 @@ export class WrappedToken extends Token {
     }
 
     if (isPayableToken) {
-      return this.#shieldViaTransferAndCall(amount, underlying, userAddress, options);
+      return this.#shieldViaTransferAndCall(
+        amount,
+        underlying,
+        userAddress,
+        account.chainId,
+        options,
+      );
     }
-    return this.#shieldViaApproveAndWrap(amount, userAddress, options);
+    return this.#shieldViaApproveAndWrap(amount, userAddress, account.chainId, options);
   }
 
   async #shieldViaTransferAndCall(
     amount: bigint,
     underlying: Address,
     userAddress: Address,
+    chainId: number,
     options?: ShieldOptions,
   ): Promise<TransactionResult> {
     this.#requireSigner("shield");
@@ -187,6 +302,19 @@ export class WrappedToken extends Token {
     // the raw 20-byte address (not ABI-encoded), and the empty payload `0x`
     // for self-shield so the wrapper falls back to `from`.
     const data: Hex = recipient === userAddress ? "0x" : recipient;
+
+    await swallow("shield: onClearSigningIntent", () =>
+      options?.onClearSigningIntent?.(
+        buildShieldViaTransferAndCallIntent({
+          underlyingTokenAddress: underlying,
+          wrapperAddress: this.address,
+          senderAddress: userAddress,
+          recipientAddress: recipient,
+          amount,
+          chainId,
+        }),
+      ),
+    );
 
     return this.submitTransaction({
       operation: "shield:transferAndCall",
@@ -198,14 +326,31 @@ export class WrappedToken extends Token {
   async #shieldViaApproveAndWrap(
     amount: bigint,
     userAddress: Address,
+    chainId: number,
     options?: ShieldOptions,
   ): Promise<TransactionResult> {
     this.#requireSigner("shield");
     const strategy = options?.approvalStrategy ?? "exact";
+    const underlying = await this.#getUnderlying();
+    const recipient = options?.to ? getAddress(options.to) : userAddress;
+    await swallow("shield: onClearSigningIntent", () =>
+      options?.onClearSigningIntent?.(
+        buildShieldViaWrapIntent({
+          underlyingTokenAddress: underlying,
+          wrapperAddress: this.address,
+          senderAddress: userAddress,
+          recipientAddress: recipient,
+          amount,
+          approvalAmount:
+            strategy === "skip" ? undefined : strategy === "max" ? 2n ** 256n - 1n : amount,
+          maxApproval: strategy === "max",
+          chainId,
+        }),
+      ),
+    );
     if (strategy !== "skip") {
       await this.#ensureAllowance(amount, strategy === "max", options);
     }
-    const recipient = options?.to ? getAddress(options.to) : userAddress;
     return this.submitTransaction({
       operation: "shield:approveAndWrap",
       config: wrapContract(this.address, recipient, amount),
@@ -279,6 +424,7 @@ export class WrappedToken extends Token {
   async unshield(amount: bigint, options?: UnshieldOptions): Promise<TransactionResult> {
     const {
       skipBalanceCheck = false,
+      onClearSigningIntent,
       onUnwrapSubmitted,
       onFinalizing,
       onFinalizeSubmitted,
@@ -289,11 +435,12 @@ export class WrappedToken extends Token {
     }
 
     const callbacks: UnshieldCallbacks = {
+      onClearSigningIntent,
       onFinalizing,
       onFinalizeSubmitted,
     };
     const operationId = crypto.randomUUID();
-    const unwrapResult = await this.unwrap(amount);
+    const unwrapResult = await this.unwrap(amount, { onClearSigningIntent });
     void swallow("unshield: onUnwrapSubmitted", () => onUnwrapSubmitted?.(unwrapResult.txHash));
     return this.#waitAndFinalizeUnshield(unwrapResult.txHash, operationId, callbacks);
   }
@@ -313,7 +460,7 @@ export class WrappedToken extends Token {
    */
   async unshieldAll(callbacks?: UnshieldCallbacks): Promise<TransactionResult> {
     const operationId = crypto.randomUUID();
-    const unwrapResult = await this.unwrapAll();
+    const unwrapResult = await this.unwrapAll(callbacks);
     void swallow("unshieldAll: onUnwrapSubmitted", () =>
       callbacks?.onUnwrapSubmitted?.(unwrapResult.txHash),
     );
@@ -355,7 +502,7 @@ export class WrappedToken extends Token {
    * const txHash = await wrappedToken.unwrap(500n);
    * ```
    */
-  async unwrap(amount: bigint): Promise<TransactionResult> {
+  async unwrap(amount: bigint, options?: UnwrapOptions): Promise<TransactionResult> {
     this.#requireSigner("unwrap");
     const account = await requireAlignedWalletAccount("unwrap", this.sdk.signer, this.sdk.provider);
     const userAddress = getAddress(account.address);
@@ -370,6 +517,21 @@ export class WrappedToken extends Token {
     if (!handle) {
       throw new EncryptionFailedError("Encryption returned no handles");
     }
+    const encryptedAmountValue = typeof handle === "string" ? handle : toHex(handle);
+
+    await swallow("unwrap: onClearSigningIntent", () =>
+      options?.onClearSigningIntent?.(
+        buildUnwrapIntent({
+          wrapperAddress: this.address,
+          fromAddress: userAddress,
+          recipientAddress: userAddress,
+          amount,
+          encryptedAmount: { value: encryptedAmountValue } satisfies ClearSigningEncryptedValue,
+          hasInputProof: true,
+          chainId: account.chainId,
+        }),
+      ),
+    );
 
     return this.submitTransaction({
       operation: "unwrap",
@@ -390,7 +552,7 @@ export class WrappedToken extends Token {
    * const txHash = await wrappedToken.unwrapAll();
    * ```
    */
-  async unwrapAll(): Promise<TransactionResult> {
+  async unwrapAll(options?: UnwrapAllOptions): Promise<TransactionResult> {
     this.#requireSigner("unwrapAll");
     const account = await requireAlignedWalletAccount(
       "unwrapAll",
@@ -403,6 +565,18 @@ export class WrappedToken extends Token {
     if (isZeroHandle(handle)) {
       throw new DecryptionFailedError("Cannot unshield: balance is zero");
     }
+
+    await swallow("unwrapAll: onClearSigningIntent", () =>
+      options?.onClearSigningIntent?.(
+        buildUnwrapAllIntent({
+          wrapperAddress: this.address,
+          fromAddress: userAddress,
+          recipientAddress: userAddress,
+          encryptedBalance: { value: handle } satisfies ClearSigningEncryptedValue,
+          chainId: account.chainId,
+        }),
+      ),
+    );
 
     return this.submitTransaction({
       operation: "unwrapAll",
@@ -426,12 +600,27 @@ export class WrappedToken extends Token {
    * );
    * ```
    */
-  async finalizeUnwrap(unwrapRequestIdOrAmount: Handle): Promise<TransactionResult> {
+  async finalizeUnwrap(
+    unwrapRequestIdOrAmount: Handle,
+    options?: FinalizeUnwrapOptions,
+  ): Promise<TransactionResult> {
     this.#requireSigner("finalizeUnwrap");
     await requireChainAlignment("finalizeUnwrap", this.sdk.signer, this.sdk.provider);
+    const chainId = await this.sdk.provider.getChainId();
     const result = await this.sdk.decryption.publicDecrypt([unwrapRequestIdOrAmount]);
     const clearValue = result.clearValues[unwrapRequestIdOrAmount];
     assertBigint(clearValue, "finalizeUnwrap: clearValue");
+    await swallow("finalizeUnwrap: onClearSigningIntent", () =>
+      options?.onClearSigningIntent?.(
+        buildFinalizeUnwrapIntent({
+          wrapperAddress: this.address,
+          unwrapRequestId: unwrapRequestIdOrAmount,
+          clearAmount: clearValue,
+          hasDecryptionProof: true,
+          chainId,
+        }),
+      ),
+    );
     return this.submitTransaction({
       operation: "finalizeUnwrap",
       config: finalizeUnwrapContract(
@@ -494,6 +683,9 @@ export class WrappedToken extends Token {
     void swallow("unshield: onFinalizing", () => callbacks?.onFinalizing?.());
     const finalizeResult = await this.finalizeUnwrap(
       event.unwrapRequestId ?? event.encryptedAmount,
+      {
+        onClearSigningIntent: callbacks?.onClearSigningIntent,
+      },
     );
     this.emit({
       type: ZamaSDKEvents.UnshieldPhase2Submitted,

--- a/packages/sdk/src/types/callbacks.ts
+++ b/packages/sdk/src/types/callbacks.ts
@@ -1,7 +1,19 @@
 import type { Hex } from "viem";
+import type { ClearSigningIntent } from "../clear-signing";
+
+/** Callback for SDK-generated clear-signing intent previews. */
+export interface ClearSigningCallbacks {
+  /**
+   * Fired when the SDK can describe the next signature or transaction in
+   * user-facing terms. Callback errors are swallowed and never abort the SDK
+   * operation. The SDK awaits this callback before opening the corresponding
+   * wallet prompt, so UIs can render the intent first.
+   */
+  onClearSigningIntent?: (intent: ClearSigningIntent) => Promise<void> | void;
+}
 
 /** Progress callbacks for multi-step unshield operations. */
-export interface UnshieldCallbacks {
+export interface UnshieldCallbacks extends ClearSigningCallbacks {
   /** Fired after the unwrap transaction is submitted. */
   onUnwrapSubmitted?: (txHash: Hex) => void;
   /** Fired when the finalization step begins (receipt parsed, about to finalize). */
@@ -11,7 +23,7 @@ export interface UnshieldCallbacks {
 }
 
 /** Progress callbacks for multi-step shield operations. */
-export interface ShieldCallbacks {
+export interface ShieldCallbacks extends ClearSigningCallbacks {
   /** Fired after the ERC-20 approval transaction is submitted (skipped when `approvalStrategy: "skip"`). */
   onApprovalSubmitted?: (txHash: Hex) => void;
   /** Fired after the shield (wrap) transaction is submitted. */
@@ -19,7 +31,7 @@ export interface ShieldCallbacks {
 }
 
 /** Progress callbacks for multi-step confidential transfer operations. */
-export interface TransferCallbacks {
+export interface TransferCallbacks extends ClearSigningCallbacks {
   /** Fired after FHE encryption of the transfer amount completes. */
   onEncryptComplete?: () => void;
   /** Fired after the transfer transaction is submitted. */

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -18,11 +18,19 @@ export type {
 } from "./signer";
 export type { GenericProvider } from "./provider";
 export type { GenericStorage } from "./storage";
-export type { UnshieldCallbacks, ShieldCallbacks, TransferCallbacks } from "./callbacks";
+export type {
+  ClearSigningCallbacks,
+  UnshieldCallbacks,
+  ShieldCallbacks,
+  TransferCallbacks,
+} from "./callbacks";
 export type {
   ApprovalStrategy,
   TransferOptions,
   ShieldOptions,
   UnshieldOptions,
+  UnwrapOptions,
+  UnwrapAllOptions,
+  FinalizeUnwrapOptions,
   ShieldPath,
 } from "./token";

--- a/packages/sdk/src/types/token.ts
+++ b/packages/sdk/src/types/token.ts
@@ -1,5 +1,10 @@
 import type { Address } from "viem";
-import type { ShieldCallbacks, TransferCallbacks, UnshieldCallbacks } from "./callbacks";
+import type {
+  ClearSigningCallbacks,
+  ShieldCallbacks,
+  TransferCallbacks,
+  UnshieldCallbacks,
+} from "./callbacks";
 
 /** Options for {@link ConfidentialToken.confidentialTransfer}. */
 export interface TransferOptions extends TransferCallbacks {
@@ -41,3 +46,12 @@ export interface UnshieldOptions extends UnshieldCallbacks {
   /** Skip confidential balance validation (e.g. for smart wallets). Default: `false`. */
   skipBalanceCheck?: boolean;
 }
+
+/** Options for {@link WrappedToken.unwrap}. */
+export type UnwrapOptions = ClearSigningCallbacks;
+
+/** Options for {@link WrappedToken.unwrapAll}. */
+export type UnwrapAllOptions = ClearSigningCallbacks;
+
+/** Options for {@link WrappedToken.finalizeUnwrap}. */
+export type FinalizeUnwrapOptions = ClearSigningCallbacks;

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -118,6 +118,7 @@ export class ZamaSDK {
     this.delegations = new Delegations({
       signer: this.signer,
       provider: this.provider,
+      relayer: this.relayer,
       delegationService: this.#delegationService,
     });
     this.decryption = new Decryption({


### PR DESCRIPTION
## Summary
- Add the SDK clear-signing intent data model, builders, renderer, and validation helpers.
- Expose clear-signing helpers via the main SDK export and a dedicated `@zama-fhe/sdk/clear-signing` subpath.
- Emit clear-signing intents from token, shield/unshield, permit, and delegation flows, with preview builders and regression tests.

## Validation
- pnpm --filter @zama-fhe/sdk typecheck
- pnpm exec vitest run packages/sdk/src/clear-signing/__tests__ packages/sdk/src/token/__tests__/callbacks.test.ts packages/sdk/src/token/__tests__/wrapped-token.test.ts packages/sdk/src/namespaces/__tests__/permits.test.ts packages/sdk/src/namespaces/__tests__/delegations.test.ts
- pnpm lint
- pnpm format:check
- pnpm build:sdk
- pnpm api-report:sdk

Linear: SDK-174 (https://linear.app/zama/issue/SDK-174/introduce-sdk-clear-signing-intents)