### PR TITLE
feat(examples): example-ingen — T-Rex InGen cleartext demo [SDK-184]

### DIFF
--- a/examples/example-ingen/.env.example
+++ b/examples/example-ingen/.env.example
@@ -1,0 +1,2 @@
+# Optional: override the default InGen RPC (https://rpc.ingen.t-rex.network)
+# NEXT_PUBLIC_INGEN_RPC_URL=https://your-private-endpoint.example.com

--- a/examples/example-ingen/README.md
+++ b/examples/example-ingen/README.md
@@ -1,0 +1,70 @@
+# InGen Confidential Token Quickstart — react-ethers
+
+Next.js 16 example app demonstrating `@zama-fhe/react-sdk` integration with
+[ethers v6](https://docs.ethers.org/v6/) on the **T-Rex InGen** private testnet
+(chain ID `364301`), backed by the cleartext fhEVM stack deployed in SDK-184.
+
+Forked from `examples/react-ethers` (Sepolia + real relayer) and adapted to use
+the `cleartext()` relayer transport against InGen.
+
+Covers: connect wallet, shield ERC-20 → confidential, confidential transfer,
+unshield, grant/revoke/use delegation, pending unshield recovery.
+
+## Stack
+
+- **Next.js 16** (App Router, Webpack)
+- **React 19** + **ethers v6**
+- **TanStack Query v5**
+- **@zama-fhe/react-sdk@3.0.0-alpha.41** — `ZamaProvider`, `useShield`, `useConfidentialBalance`, `useUnshield`, `useDelegateDecryption`, etc.
+- **@zama-fhe/sdk/ethers** — `createConfig` wires ethers-compatible provider/signer adapters
+- **`cleartext()` transport** — no relayer/KMS network, signatures verified by mock keys baked into the SDK
+
+## Setup
+
+```bash
+cp .env.example .env.local   # optional — defaults work out of the box
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) and connect MetaMask (or any
+EIP-1193 wallet). The app will prompt you to add and switch to the InGen network
+on first connection.
+
+## Getting TREX (native gas token)
+
+Use the [InGen faucet](https://faucet.ingen.gateway.fm/) to fund your wallet
+with TREX before interacting with the app.
+
+## Network details
+
+| Field           | Value                                |
+| --------------- | ------------------------------------ |
+| Network name    | InGen                                |
+| Chain ID        | `364301`                             |
+| RPC URL         | `https://rpc.ingen.t-rex.network`    |
+| Explorer        | `https://explorer.ingen.t-rex.network` |
+| Native symbol   | `TREX`                               |
+
+## Environment variables
+
+| Variable                     | Required | Description                                                                  |
+| ---------------------------- | -------- | ---------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_INGEN_RPC_URL`  | No       | InGen RPC override. Defaults to `https://rpc.ingen.t-rex.network`.           |
+
+## Deployed contracts on InGen
+
+See `/tmp/sdk-184/deployment-notes.md` for the full address record. The chain
+config in `src/providers.tsx` already wires them in — no manual setup needed.
+
+| Contract                     | Address                                      |
+| ---------------------------- | -------------------------------------------- |
+| ACL                          | `0x09a4710BfBe7B557cD5CFE88BB31e9b5b85C419b` |
+| CleartextFHEVMExecutor       | `0x1B05DE5b67b8f8363DC04E3a5996a616f11f8C7B` |
+| KMSVerifier                  | `0xd885DEa6a924785fCcdf9CE993FEe27EA11832e6` |
+| InputVerifier                | `0x90f05B10db153365D8cB143EA17f5E5714D0bCD5` |
+| WrappersRegistry             | `0x7FC3D79EF9d01fA318CF2Aa5D91dDC492383Be0F` |
+| USDCMock                     | `0xBBdABB33Cf7Bb427dA1c76f1C59a0786E90EB00b` |
+| USDT mock                    | `0x7CC6EB5E82f5ae84BC08cC58734E6aD2c2510068` |
+| cUSDC                        | `0x1D0480a22d9ff7DF4dcf94bB70D9B761C358A8a8` |
+| cUSDT                        | `0x604fFb6b71bfEe1B155B4093bdCF19a7c7029Efd` |

--- a/examples/example-ingen/README.md
+++ b/examples/example-ingen/README.md
@@ -54,8 +54,8 @@ with TREX before interacting with the app.
 
 ## Deployed contracts on InGen
 
-See `/tmp/sdk-184/deployment-notes.md` for the full address record. The chain
-config in `src/providers.tsx` already wires them in — no manual setup needed.
+The chain config in `src/providers.tsx` already wires these addresses in — no
+manual setup needed. They are reproduced here for reference.
 
 | Contract               | Address                                      |
 | ---------------------- | -------------------------------------------- |

--- a/examples/example-ingen/README.md
+++ b/examples/example-ingen/README.md
@@ -38,33 +38,33 @@ with TREX before interacting with the app.
 
 ## Network details
 
-| Field           | Value                                |
-| --------------- | ------------------------------------ |
-| Network name    | InGen                                |
-| Chain ID        | `364301`                             |
-| RPC URL         | `https://rpc.ingen.t-rex.network`    |
-| Explorer        | `https://explorer.ingen.t-rex.network` |
-| Native symbol   | `TREX`                               |
+| Field         | Value                                  |
+| ------------- | -------------------------------------- |
+| Network name  | InGen                                  |
+| Chain ID      | `364301`                               |
+| RPC URL       | `https://rpc.ingen.t-rex.network`      |
+| Explorer      | `https://explorer.ingen.t-rex.network` |
+| Native symbol | `TREX`                                 |
 
 ## Environment variables
 
-| Variable                     | Required | Description                                                                  |
-| ---------------------------- | -------- | ---------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_INGEN_RPC_URL`  | No       | InGen RPC override. Defaults to `https://rpc.ingen.t-rex.network`.           |
+| Variable                    | Required | Description                                                        |
+| --------------------------- | -------- | ------------------------------------------------------------------ |
+| `NEXT_PUBLIC_INGEN_RPC_URL` | No       | InGen RPC override. Defaults to `https://rpc.ingen.t-rex.network`. |
 
 ## Deployed contracts on InGen
 
 See `/tmp/sdk-184/deployment-notes.md` for the full address record. The chain
 config in `src/providers.tsx` already wires them in — no manual setup needed.
 
-| Contract                     | Address                                      |
-| ---------------------------- | -------------------------------------------- |
-| ACL                          | `0x09a4710BfBe7B557cD5CFE88BB31e9b5b85C419b` |
-| CleartextFHEVMExecutor       | `0x1B05DE5b67b8f8363DC04E3a5996a616f11f8C7B` |
-| KMSVerifier                  | `0xd885DEa6a924785fCcdf9CE993FEe27EA11832e6` |
-| InputVerifier                | `0x90f05B10db153365D8cB143EA17f5E5714D0bCD5` |
-| WrappersRegistry             | `0x7FC3D79EF9d01fA318CF2Aa5D91dDC492383Be0F` |
-| USDCMock                     | `0xBBdABB33Cf7Bb427dA1c76f1C59a0786E90EB00b` |
-| USDT mock                    | `0x7CC6EB5E82f5ae84BC08cC58734E6aD2c2510068` |
-| cUSDC                        | `0x1D0480a22d9ff7DF4dcf94bB70D9B761C358A8a8` |
-| cUSDT                        | `0x604fFb6b71bfEe1B155B4093bdCF19a7c7029Efd` |
+| Contract               | Address                                      |
+| ---------------------- | -------------------------------------------- |
+| ACL                    | `0x09a4710BfBe7B557cD5CFE88BB31e9b5b85C419b` |
+| CleartextFHEVMExecutor | `0x1B05DE5b67b8f8363DC04E3a5996a616f11f8C7B` |
+| KMSVerifier            | `0xd885DEa6a924785fCcdf9CE993FEe27EA11832e6` |
+| InputVerifier          | `0x90f05B10db153365D8cB143EA17f5E5714D0bCD5` |
+| WrappersRegistry       | `0x7FC3D79EF9d01fA318CF2Aa5D91dDC492383Be0F` |
+| USDCMock               | `0xBBdABB33Cf7Bb427dA1c76f1C59a0786E90EB00b` |
+| USDT mock              | `0x7CC6EB5E82f5ae84BC08cC58734E6aD2c2510068` |
+| cUSDC                  | `0x1D0480a22d9ff7DF4dcf94bB70D9B761C358A8a8` |
+| cUSDT                  | `0x604fFb6b71bfEe1B155B4093bdCF19a7c7029Efd` |

--- a/examples/example-ingen/next-env.d.ts
+++ b/examples/example-ingen/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/example-ingen/next.config.ts
+++ b/examples/example-ingen/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/examples/example-ingen/package-lock.json
+++ b/examples/example-ingen/package-lock.json
@@ -1,0 +1,1626 @@
+{
+  "name": "example-ingen",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "example-ingen",
+      "dependencies": {
+        "@tanstack/react-query": "^5.90.0",
+        "@zama-fhe/react-sdk": "3.0.0-alpha.34",
+        "@zama-fhe/sdk": "3.0.0-alpha.34",
+        "ethers": "^6.13.0",
+        "next": "^16.2.5",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.0",
+        "typescript": "^5.8.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.11.tgz",
+      "integrity": "sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.11.tgz",
+      "integrity": "sha512-J0f9s5x3LE1450nNNfYx+e/n0DMa0uOBdFJUy5r0RvmsXd4nB/n0rbHtHI1vYXhikNFan+wf51p6Tmp4c8ucrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.11"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@zama-fhe/react-sdk": {
+      "version": "3.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.0.0-alpha.34.tgz",
+      "integrity": "sha512-htEbAF7tdBxwGFrEPSigr6OfyL8JTHzlgyE+FoJLu5lfLQIIgYwunM6kNcZ+X8tzYMYpqljxCQ2mrW3/AzPKSQ==",
+      "license": "BSD-3-Clause-Clear",
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": ">=5",
+        "@zama-fhe/sdk": "^3.0.0-alpha.34",
+        "react": ">=18",
+        "viem": "^2.47.0",
+        "wagmi": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "wagmi": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@zama-fhe/relayer-sdk": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.4.3.tgz",
+      "integrity": "sha512-/Lz+yBda4vppMx3FiCnqjRmBWxxEzGrcyOLeFQg1fqadnCWPU5GCmx7pSBQXesJHQz7MJ5hD07ERv2gdNjxv3w==",
+      "license": "BSD-3-Clause-Clear",
+      "dependencies": {
+        "commander": "^14.0.0",
+        "ethers": "^6.15.0",
+        "fetch-retry": "^6.0.0",
+        "keccak": "^3.0.4",
+        "node-tfhe": "1.4.0-alpha.3",
+        "node-tkms": "^0.12.0",
+        "tfhe": "1.4.0-alpha.3",
+        "tkms": "^0.12.0",
+        "wasm-feature-detect": "^1.8.0"
+      },
+      "bin": {
+        "relayer": "bin/relayer.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@zama-fhe/sdk": {
+      "version": "3.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.0.0-alpha.34.tgz",
+      "integrity": "sha512-AHOaSC60sUUc9XltfdLvuf1aBswrGCCUPHsy2lfqJKDezTbV0WidTDFtyQeJTNOWa8AqHn6dvCua/ylCfb33sA==",
+      "license": "BSD-3-Clause-Clear",
+      "dependencies": {
+        "@zama-fhe/relayer-sdk": "~0.4.2",
+        "viem": ">=2",
+        "zod": ">=4"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@tanstack/query-core": ">=5",
+        "ethers": ">=6",
+        "viem": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "@tanstack/query-core": {
+          "optional": true
+        },
+        "ethers": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/keccak": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.6",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-tfhe": {
+      "version": "1.4.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/node-tfhe/-/node-tfhe-1.4.0-alpha.3.tgz",
+      "integrity": "sha512-oTcWL0OFA6t6BhScmDiGQ3VA8tU8T3EXCzIzpNxQxcuJDgQtiUF5CV6dgJLOrpWck4KCp1Bo/xLhv07uwn3q6Q==",
+      "license": "BSD-3-Clause-Clear"
+    },
+    "node_modules/node-tkms": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.12.8.tgz",
+      "integrity": "sha512-4erFxgbSVm1HCohIN2qijDfQL2GoIGaBve7SDeIKTu2bNBZZdTRKatcW+ExwHZF5MC6CzGDTvJQhEnG9LD7T3w==",
+      "license": "BSD-3-Clause-Clear"
+    },
+    "node_modules/ox": {
+      "version": "0.14.22",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.22.tgz",
+      "integrity": "sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tfhe": {
+      "version": "1.4.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/tfhe/-/tfhe-1.4.0-alpha.3.tgz",
+      "integrity": "sha512-xdla7hi2WzLFIdAx2/ihRZ/bKlKcgDDabTJGtoqp1E5oqhLM1PzTXsJE0p7tW8+ebrvxiMGfbgMAWnU3f2ZAIQ==",
+      "license": "BSD-3-Clause-Clear"
+    },
+    "node_modules/tkms": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.12.8.tgz",
+      "integrity": "sha512-iXS8wxz3jhx3JlKVJiBZUOibGtP69lC2H9I120EfhAI5amc/4xW/HCM7tmMtBJEuqdCoN5ssnHvfGog8gZ6UKg==",
+      "license": "BSD-3-Clause-Clear"
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/viem": {
+      "version": "2.50.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.50.4.tgz",
+      "integrity": "sha512-rf98F4s3Vlb+uJZEKfay3IbBw3CNCbVtx5Y3UIljlO2tSX420g/J0WQSYsjzBSasUFgxgsXabji14O9kGbiqgg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.22",
+        "ws": "8.20.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/example-ingen/package.json
+++ b/examples/example-ingen/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "example-ingen",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --webpack",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.90.0",
+    "@zama-fhe/react-sdk": "3.0.0-alpha.34",
+    "@zama-fhe/sdk": "3.0.0-alpha.34",
+    "ethers": "^6.13.0",
+    "next": "^16.2.5",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/examples/example-ingen/package.json
+++ b/examples/example-ingen/package.json
@@ -2,7 +2,7 @@
   "name": "example-ingen",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/examples/example-ingen/src/app/client-providers.tsx
+++ b/examples/example-ingen/src/app/client-providers.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { ReactNode } from "react";
+
+// Providers accesses window.ethereum which is unavailable server-side.
+// next/dynamic with ssr:false must be declared inside a "use client" component,
+// which is why this thin wrapper exists — layout.tsx is a Server Component.
+const Providers = dynamic(() => import("../providers").then((m) => ({ default: m.Providers })), {
+  ssr: false,
+});
+
+export function ClientProviders({ children }: { children: ReactNode }) {
+  return <Providers>{children}</Providers>;
+}

--- a/examples/example-ingen/src/app/globals.css
+++ b/examples/example-ingen/src/app/globals.css
@@ -1,0 +1,260 @@
+/* Reset */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  background: #f8fafc;
+  color: #0f172a;
+  line-height: 1.5;
+}
+
+/* Layout */
+.app-container {
+  max-width: 580px;
+  margin: 0 auto;
+  padding: 40px 20px;
+}
+
+/* Header */
+.app-header {
+  margin-bottom: 28px;
+}
+.app-header h1 {
+  font-size: 22px;
+  font-weight: 700;
+}
+.app-header .connected-address {
+  font-size: 12px;
+  color: #64748b;
+  margin-top: 4px;
+  font-family: monospace;
+  word-break: break-all;
+}
+
+/* Connect screen */
+.connect-screen {
+  text-align: center;
+  padding: 80px 24px;
+}
+.connect-screen h1 {
+  font-size: 26px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.connect-screen .subtitle {
+  color: #64748b;
+  margin-bottom: 28px;
+  font-size: 15px;
+}
+
+/* Card */
+.card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin-bottom: 12px;
+}
+.card-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+  margin-bottom: 14px;
+}
+
+/* Balance rows */
+.balance-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+}
+.balance-row + .balance-row {
+  border-top: 1px solid #f1f5f9;
+}
+.balance-label {
+  color: #64748b;
+  font-size: 14px;
+}
+.balance-label-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.balance-value {
+  font-size: 15px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.balance-value.loading {
+  color: #94a3b8;
+  font-weight: 400;
+}
+
+/* Buttons */
+.btn {
+  border: none;
+  border-radius: 8px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    opacity 0.12s;
+  white-space: nowrap;
+}
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.btn-full {
+  width: 100%;
+}
+.btn-sm {
+  padding: 3px 10px;
+  font-size: 12px;
+  border-radius: 6px;
+}
+.btn-primary {
+  background: #2563eb;
+  color: #fff;
+}
+.btn-primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+.btn-secondary {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+.btn-secondary:hover:not(:disabled) {
+  background: #e2e8f0;
+}
+
+/* Input */
+.input {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 14px;
+  width: 100%;
+  outline: none;
+  background: #fff;
+}
+.input:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+.input-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.input-unit {
+  font-size: 14px;
+  font-weight: 500;
+  color: #64748b;
+  min-width: 32px;
+}
+
+/* Token metadata hint */
+.token-meta {
+  font-size: 13px;
+  color: #94a3b8;
+  margin-top: 8px;
+}
+.token-meta-error {
+  color: #991b1b;
+}
+
+/* Select */
+.select {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 14px;
+  background: #fff;
+  cursor: pointer;
+}
+
+/* Alerts */
+.alert {
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-size: 14px;
+  margin-bottom: 12px;
+}
+.alert-error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+}
+.alert-success {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #166534;
+}
+.alert a {
+  color: inherit;
+  font-weight: 600;
+}
+
+/* Spacing helpers for action cards */
+.card-gap {
+  margin-bottom: 10px;
+}
+.card-status {
+  margin-top: 10px;
+}
+
+/* Checkbox label */
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+/* Delegation status indicator (DecryptAsCard) */
+.delegation-status {
+  font-size: 13px;
+}
+.delegation-status-active {
+  color: #166534;
+}
+.delegation-status-none,
+.delegation-status-checking {
+  color: #94a3b8;
+}
+
+/* Section label — centered text with a line on each side */
+.section-label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+  margin: 16px 0 12px;
+}
+.section-label::before,
+.section-label::after {
+  content: "";
+  flex: 1;
+  border-top: 1px solid #e2e8f0;
+}

--- a/examples/example-ingen/src/app/layout.tsx
+++ b/examples/example-ingen/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+import { ClientProviders } from "./client-providers";
+import "./globals.css";
+
+export const metadata = {
+  title: "InGen Confidential Token Quickstart",
+  description:
+    "Quickstart demo for ERC-7984 confidential tokens on the T-Rex InGen testnet (cleartext fhEVM) using the Zama FHE SDK.",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ClientProviders>{children}</ClientProviders>
+      </body>
+    </html>
+  );
+}

--- a/examples/example-ingen/src/app/page.tsx
+++ b/examples/example-ingen/src/app/page.tsx
@@ -200,6 +200,7 @@ function SelectedTokenPanel({
       <ShieldCard
         key={`shield-${address}-${token.confidentialTokenAddress}`}
         tokenAddress={token.confidentialTokenAddress}
+        underlyingAddress={token.tokenAddress}
         decimals={erc20Decimals}
         symbol={erc20Symbol}
         disabled={actionsDisabled}

--- a/examples/example-ingen/src/app/page.tsx
+++ b/examples/example-ingen/src/app/page.tsx
@@ -1,0 +1,483 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { formatEther, formatUnits, parseUnits, JsonRpcProvider } from "ethers";
+import {
+  useConfidentialBalance,
+  useIsAllowed,
+  useAllow,
+  useListPairs,
+  useZamaSDK,
+} from "@zama-fhe/react-sdk";
+import { balanceOfContract } from "@zama-fhe/sdk";
+import type { TokenWrapperPair, TokenWrapperPairWithMetadata, Address } from "@zama-fhe/sdk";
+import { zamaQueryKeys } from "@zama-fhe/sdk/query";
+import { BalancesCard } from "@/components/BalancesCard";
+import { ShieldCard } from "@/components/ShieldCard";
+import { TransferCard } from "@/components/TransferCard";
+import { UnshieldCard } from "@/components/UnshieldCard";
+import { PendingUnshieldCard } from "@/components/PendingUnshieldCard";
+import { DelegateDecryptionCard } from "@/components/DelegateDecryptionCard";
+import { RevokeDelegationCard } from "@/components/RevokeDelegationCard";
+import { DecryptAsCard } from "@/components/DecryptAsCard";
+import {
+  INGEN_CHAIN_ID,
+  INGEN_CHAIN_ID_HEX,
+  INGEN_EXPLORER_URL,
+  INGEN_RPC_URL,
+} from "@/lib/config";
+import { getEthereumProvider } from "@/lib/ethereum";
+
+// mint(address, uint256) is not part of the ERC-20 standard — it is a convenience
+// function added to both test tokens for easy balance top-ups during development.
+const MINT_ABI = ["function mint(address to, uint256 amount)"];
+
+// useListPairs through ethers can return objects backed by ethers Result, where named
+// ABI fields are non-enumerable. Read named fields first and fall back to tuple indexes.
+function normalizePair(
+  raw: TokenWrapperPair | TokenWrapperPairWithMetadata,
+): TokenWrapperPairWithMetadata | null {
+  if (!("underlying" in raw)) return null;
+  const t = raw as unknown as readonly [Address, Address, boolean];
+  return {
+    tokenAddress: raw.tokenAddress ?? t[0],
+    confidentialTokenAddress: raw.confidentialTokenAddress ?? t[1],
+    isValid: raw.isValid ?? t[2],
+    underlying: (raw as TokenWrapperPairWithMetadata).underlying,
+    confidential: (raw as TokenWrapperPairWithMetadata).confidential,
+  };
+}
+
+// Routes TREX balance reads through the direct InGen RPC so polling is fast
+// and independent of the injected wallet's own RPC endpoint.
+const rpcProvider = new JsonRpcProvider(INGEN_RPC_URL);
+
+// Attempt to switch to InGen. If the network is unknown to the wallet (error 4902),
+// prompt to add it. Errors from wallet_switchEthereumChain (including 4001 user rejection)
+// are swallowed — the caller re-reads the current chainId to determine the outcome.
+// Errors from wallet_addEthereumChain propagate to the caller.
+async function switchToIngen(ethereum: NonNullable<ReturnType<typeof getEthereumProvider>>) {
+  try {
+    await ethereum.request({
+      method: "wallet_switchEthereumChain",
+      params: [{ chainId: INGEN_CHAIN_ID_HEX }],
+    });
+  } catch (err: unknown) {
+    if ((err as { code: number }).code === 4902) {
+      await ethereum.request({
+        method: "wallet_addEthereumChain",
+        params: [
+          {
+            chainId: INGEN_CHAIN_ID_HEX,
+            chainName: "InGen",
+            nativeCurrency: { name: "T-REX", symbol: "TREX", decimals: 18 },
+            rpcUrls: [INGEN_RPC_URL],
+            blockExplorerUrls: [INGEN_EXPLORER_URL],
+          },
+        ],
+      });
+    }
+  }
+}
+
+interface SelectedTokenPanelProps {
+  address: Address;
+  token: TokenWrapperPairWithMetadata;
+  validPairs: TokenWrapperPairWithMetadata[];
+  isIngen: boolean;
+  ethBalanceKey: readonly unknown[];
+}
+
+function SelectedTokenPanel({
+  address,
+  token,
+  validPairs,
+  isIngen,
+  ethBalanceKey,
+}: SelectedTokenPanelProps) {
+  const queryClient = useQueryClient();
+  const sdk = useZamaSDK();
+
+  const { data: isAllowed } = useIsAllowed({
+    contractAddresses: [token.confidentialTokenAddress],
+  });
+
+  const decimals = token.confidential.decimals;
+  const erc20Decimals = token.underlying.decimals;
+  const confidentialSymbol = token.confidential.symbol;
+  const erc20Symbol = token.underlying.symbol;
+
+  const allowTokens = useAllow();
+  function handleDecrypt() {
+    if (validPairs.length === 0) return;
+    allowTokens.mutate(validPairs.map((p) => p.confidentialTokenAddress));
+  }
+
+  const erc20BalanceKey = ["erc20-balance", token.tokenAddress, address] as const;
+  const { data: erc20Balance } = useQuery({
+    queryKey: erc20BalanceKey,
+    queryFn: async () => {
+      const result = await sdk.provider.readContract(
+        balanceOfContract(token.tokenAddress, address),
+      );
+      return result as bigint;
+    },
+    enabled: isIngen,
+  });
+
+  const refreshBalances = () => {
+    queryClient.invalidateQueries({ queryKey: erc20BalanceKey });
+    queryClient.invalidateQueries({ queryKey: ethBalanceKey });
+    queryClient.invalidateQueries({
+      queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
+    });
+  };
+
+  const balance = useConfidentialBalance(
+    { tokenAddress: token.confidentialTokenAddress, account: address },
+    { enabled: isIngen && !!isAllowed },
+  );
+
+  const mint = useMutation({
+    mutationFn: async () => {
+      const signer = sdk.requireSigner("mint");
+      const txHash = await signer.writeContract({
+        address: token.tokenAddress,
+        abi: MINT_ABI,
+        functionName: "mint",
+        args: [address, parseUnits("10", erc20Decimals)],
+      });
+      await sdk.provider.waitForTransactionReceipt(txHash);
+      return txHash;
+    },
+    onSuccess: refreshBalances,
+  });
+
+  useEffect(() => {
+    mint.reset();
+    allowTokens.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [address, token.confidentialTokenAddress]);
+
+  const formattedErc20 =
+    erc20Balance !== undefined ? `${formatUnits(erc20Balance, erc20Decimals)} ${erc20Symbol}` : "—";
+  const formattedConfidential =
+    balance.data !== undefined
+      ? `${formatUnits(balance.data, decimals)} ${confidentialSymbol}`
+      : "—";
+  const actionsDisabled = !isIngen;
+
+  return (
+    <>
+      <BalancesCard
+        formattedErc20={formattedErc20}
+        formattedConfidential={formattedConfidential}
+        isLoadingConfidential={balance.isLoading || balance.isFetching}
+        erc20Symbol={erc20Symbol}
+        onMint={() => mint.mutate()}
+        isMinting={mint.isPending}
+        mintDisabled={actionsDisabled}
+        mintError={mint.isError ? (mint.error?.message ?? null) : null}
+        mintTxHash={mint.isSuccess && mint.data ? mint.data : null}
+        isAllowed={!!isAllowed}
+        onDecrypt={handleDecrypt}
+        isDecrypting={allowTokens.isPending}
+        decryptError={allowTokens.isError ? (allowTokens.error?.message ?? "Signing failed") : null}
+      />
+
+      {validPairs.map((pair) => (
+        <PendingUnshieldCard
+          key={`${pair.confidentialTokenAddress}-${address}`}
+          tokenAddress={pair.confidentialTokenAddress}
+          label={pair.underlying.symbol}
+          onSuccess={refreshBalances}
+        />
+      ))}
+
+      <div className="section-label">Operations</div>
+
+      <ShieldCard
+        key={`shield-${address}-${token.confidentialTokenAddress}`}
+        tokenAddress={token.confidentialTokenAddress}
+        decimals={erc20Decimals}
+        symbol={erc20Symbol}
+        disabled={actionsDisabled}
+        onSuccess={refreshBalances}
+      />
+
+      <TransferCard
+        key={`transfer-${address}-${token.confidentialTokenAddress}`}
+        tokenAddress={token.confidentialTokenAddress}
+        decimals={decimals}
+        symbol={confidentialSymbol}
+        disabled={actionsDisabled}
+        balanceDecryptRequired={!isAllowed}
+        onSuccess={refreshBalances}
+      />
+
+      <UnshieldCard
+        key={`unshield-${address}-${token.confidentialTokenAddress}`}
+        tokenAddress={token.confidentialTokenAddress}
+        decimals={decimals}
+        symbol={confidentialSymbol}
+        disabled={actionsDisabled}
+        balanceDecryptRequired={!isAllowed}
+        onSuccess={refreshBalances}
+      />
+
+      <div className="section-label">Delegation — as owner</div>
+
+      <DelegateDecryptionCard
+        key={`grant-delegation-${address}-${token.confidentialTokenAddress}`}
+        tokenAddress={token.confidentialTokenAddress}
+        disabled={actionsDisabled}
+      />
+
+      <RevokeDelegationCard
+        key={`revoke-delegation-${address}-${token.confidentialTokenAddress}`}
+        tokenAddress={token.confidentialTokenAddress}
+        disabled={actionsDisabled}
+      />
+
+      <div className="section-label">Delegation — as delegate</div>
+
+      <DecryptAsCard
+        key={`decrypt-as-${address}-${token.confidentialTokenAddress}`}
+        tokenAddress={token.confidentialTokenAddress}
+        decimals={decimals}
+        symbol={confidentialSymbol}
+        disabled={actionsDisabled}
+        connectedAddress={address}
+      />
+    </>
+  );
+}
+
+export default function Home() {
+  const [isInitializing, setIsInitializing] = useState(true);
+  const [address, setAddress] = useState<string | null>(null);
+  const [chainId, setChainId] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isSwitching, setIsSwitching] = useState(false);
+  const [switchFailed, setSwitchFailed] = useState(false);
+  const [selectedTokenAddress, setSelectedTokenAddress] = useState<Address | null>(null);
+  const [connectError, setConnectError] = useState<string | null>(null);
+
+  // Case-insensitive: some wallets return uppercase hex.
+  const isIngen = chainId?.toLowerCase() === INGEN_CHAIN_ID_HEX;
+
+  const queryClient = useQueryClient();
+
+  // Registry address is resolved automatically from the connected chain via the
+  // chain config we passed to createConfig (registryAddress: 0x7FC3D79E…).
+  const {
+    data: pairsData,
+    isPending: isRegistryPending,
+    isError: isRegistryError,
+  } = useListPairs({ metadata: true });
+
+  const validPairs = useMemo(
+    () =>
+      (pairsData?.items ?? [])
+        .map(normalizePair)
+        .filter((p): p is TokenWrapperPairWithMetadata => p !== null && p.isValid),
+    [pairsData],
+  );
+
+  useEffect(() => {
+    if (validPairs.length > 0 && selectedTokenAddress === null) {
+      setSelectedTokenAddress(validPairs[0].confidentialTokenAddress);
+    }
+  }, [validPairs, selectedTokenAddress]);
+
+  const token = validPairs.find((p) => p.confidentialTokenAddress === selectedTokenAddress);
+
+  async function handleSwitchToIngen() {
+    const ethereum = getEthereumProvider();
+    if (!ethereum) return;
+    setIsSwitching(true);
+    setSwitchFailed(false);
+    try {
+      await switchToIngen(ethereum);
+    } catch (err) {
+      console.error("Failed to switch to InGen:", err);
+    } finally {
+      const current = (await ethereum.request({ method: "eth_chainId" })) as string;
+      setChainId(current);
+      setIsSwitching(false);
+      setSwitchFailed(current.toLowerCase() !== INGEN_CHAIN_ID_HEX);
+    }
+  }
+
+  useEffect(() => {
+    const ethereum = getEthereumProvider();
+    if (!ethereum) {
+      setIsInitializing(false);
+      return;
+    }
+
+    Promise.all([
+      ethereum.request({ method: "eth_accounts" }) as Promise<string[]>,
+      ethereum.request({ method: "eth_chainId" }) as Promise<string>,
+    ])
+      .then(([accounts, currentChainId]) => {
+        setAddress(accounts[0] ?? null);
+        setChainId(currentChainId);
+      })
+      .catch((err) => console.error("Failed to detect wallet state:", err))
+      .finally(() => setIsInitializing(false));
+
+    const handleAccountsChanged = (accounts: unknown) => {
+      setAddress((accounts as string[])[0] ?? null);
+      (ethereum.request({ method: "eth_chainId" }) as Promise<string>)
+        .then(setChainId)
+        .catch((err) => console.error("[chainId refresh] eth_chainId failed:", err));
+      queryClient.invalidateQueries({ queryKey: ["eth-balance"] });
+      queryClient.invalidateQueries({ queryKey: ["erc20-balance"] });
+    };
+    const handleChainChanged = (chainId: unknown) => setChainId(chainId as string);
+
+    ethereum.on("accountsChanged", handleAccountsChanged);
+    ethereum.on("chainChanged", handleChainChanged);
+    return () => {
+      ethereum.removeListener("accountsChanged", handleAccountsChanged);
+      ethereum.removeListener("chainChanged", handleChainChanged);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function connect() {
+    const ethereum = getEthereumProvider();
+    if (!ethereum) {
+      setConnectError(
+        "No Ethereum wallet found. Please install an EIP-1193 browser wallet (e.g. Rabby, MetaMask, or Phantom).",
+      );
+      return;
+    }
+
+    setConnectError(null);
+    setIsConnecting(true);
+    try {
+      const accounts = (await ethereum.request({
+        method: "eth_requestAccounts",
+      })) as string[];
+
+      await handleSwitchToIngen();
+      setAddress(accounts[0] ?? null);
+    } catch (err) {
+      console.error("Failed to connect wallet:", err);
+      setConnectError(err instanceof Error ? err.message : "Failed to connect wallet");
+    } finally {
+      setIsConnecting(false);
+    }
+  }
+
+  const ethBalanceKey = ["eth-balance", address];
+  const { data: ethBalance } = useQuery({
+    queryKey: ethBalanceKey,
+    queryFn: () => rpcProvider.getBalance(address!).then(formatEther),
+    enabled: !!address && isIngen,
+  });
+
+  // ── Screen 0: Initializing ────────────────────────────────────────────────
+  if (isInitializing) {
+    return (
+      <div className="app-container connect-screen">
+        <h1>InGen Confidential Token Quickstart</h1>
+      </div>
+    );
+  }
+
+  // ── Screen 1: No wallet connected ─────────────────────────────────────────
+  if (!address) {
+    return (
+      <div className="app-container connect-screen">
+        <h1>InGen Confidential Token Quickstart</h1>
+        <p className="subtitle">
+          Connect your wallet to interact with ERC-7984 tokens on the T-Rex InGen testnet (cleartext fhEVM).
+        </p>
+        <button type="button" className="btn btn-primary" onClick={connect} disabled={isConnecting}>
+          {isConnecting ? "Connecting…" : "Connect Wallet"}
+        </button>
+        {connectError && <div className="alert alert-error card-status">{connectError}</div>}
+      </div>
+    );
+  }
+
+  // ── Screen 2: Wrong network ────────────────────────────────────────────────
+  if (!isIngen) {
+    return (
+      <div className="app-container connect-screen">
+        <h1>InGen Network Required</h1>
+        <p className="subtitle">
+          This app only works on the T-Rex InGen testnet (chain ID {INGEN_CHAIN_ID}).
+        </p>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={handleSwitchToIngen}
+          disabled={isSwitching}
+        >
+          {isSwitching ? "Switching…" : "Switch to InGen"}
+        </button>
+        {switchFailed && (
+          <div className="alert alert-error card-status">
+            Could not switch to InGen. Please switch manually in your wallet.
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // ── Screen 3: Connected on InGen — main UI ─────────────────────────────────
+  return (
+    <div className="app-container">
+      <div className="app-header">
+        <h1>InGen Confidential Token Quickstart</h1>
+        <div className="connected-address">Connected: {address}</div>
+        <div className="connected-address">
+          TREX: {ethBalance !== undefined ? Number(ethBalance).toFixed(4) : "—"}
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-title">Token</div>
+        <select
+          className="select"
+          value={selectedTokenAddress ?? ""}
+          onChange={(e) => setSelectedTokenAddress(e.target.value as Address)}
+          disabled={isRegistryPending || isRegistryError || validPairs.length === 0}
+        >
+          {(isRegistryPending || selectedTokenAddress === null) && (
+            <option value="" disabled>
+              {isRegistryPending || validPairs.length > 0 ? "Loading…" : "No tokens available"}
+            </option>
+          )}
+          {validPairs.map((pair) => (
+            <option key={pair.confidentialTokenAddress} value={pair.confidentialTokenAddress}>
+              {pair.underlying.symbol}
+            </option>
+          ))}
+        </select>
+        {isRegistryPending && <p className="token-meta">Loading tokens from registry…</p>}
+        {!isRegistryPending && isRegistryError && (
+          <p className="token-meta">Failed to load tokens from registry.</p>
+        )}
+        {!isRegistryPending && !isRegistryError && validPairs.length === 0 && (
+          <p className="token-meta">No tokens available.</p>
+        )}
+      </div>
+
+      {token && (
+        <SelectedTokenPanel
+          key={`${address}-${token.confidentialTokenAddress}`}
+          address={address as Address}
+          token={token}
+          validPairs={validPairs}
+          isIngen={isIngen}
+          ethBalanceKey={ethBalanceKey}
+        />
+      )}
+    </div>
+  );
+}

--- a/examples/example-ingen/src/app/page.tsx
+++ b/examples/example-ingen/src/app/page.tsx
@@ -394,7 +394,8 @@ export default function Home() {
       <div className="app-container connect-screen">
         <h1>InGen Confidential Token Quickstart</h1>
         <p className="subtitle">
-          Connect your wallet to interact with ERC-7984 tokens on the T-Rex InGen testnet (cleartext fhEVM).
+          Connect your wallet to interact with ERC-7984 tokens on the T-Rex InGen testnet (cleartext
+          fhEVM).
         </p>
         <button type="button" className="btn btn-primary" onClick={connect} disabled={isConnecting}>
           {isConnecting ? "Connecting…" : "Connect Wallet"}

--- a/examples/example-ingen/src/components/BalancesCard.tsx
+++ b/examples/example-ingen/src/components/BalancesCard.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { INGEN_EXPLORER_URL } from "@/lib/config";
+
+interface BalancesCardProps {
+  formattedErc20: string;
+  formattedConfidential: string;
+  isLoadingConfidential: boolean;
+  erc20Symbol: string;
+  onMint: () => void;
+  isMinting: boolean;
+  mintDisabled: boolean;
+  mintError?: string | null;
+  mintTxHash?: string | null;
+  isAllowed: boolean;
+  onDecrypt: () => void;
+  isDecrypting: boolean;
+  decryptError?: string | null;
+}
+
+export function BalancesCard({
+  formattedErc20,
+  formattedConfidential,
+  isLoadingConfidential,
+  erc20Symbol,
+  onMint,
+  isMinting,
+  mintDisabled,
+  mintError,
+  mintTxHash,
+  isAllowed,
+  onDecrypt,
+  isDecrypting,
+  decryptError,
+}: BalancesCardProps) {
+  return (
+    <div className="card">
+      <div className="card-title">Balances</div>
+      <div className="balance-row">
+        <span className="balance-label-group">
+          <span className="balance-label">ERC-20 (public)</span>
+          <button
+            type="button"
+            className="btn btn-sm btn-secondary"
+            onClick={onMint}
+            disabled={mintDisabled || isMinting}
+          >
+            {isMinting ? "Minting…" : `Mint ${erc20Symbol}`}
+          </button>
+        </span>
+        <span className="balance-value">{formattedErc20}</span>
+      </div>
+      <div className="balance-row">
+        <span className="balance-label">Confidential (private)</span>
+        {!isAllowed ? (
+          <button
+            type="button"
+            className="btn btn-sm btn-secondary"
+            onClick={onDecrypt}
+            disabled={isDecrypting}
+          >
+            {isDecrypting ? "Signing…" : "Decrypt Balance"}
+          </button>
+        ) : (
+          <span className={`balance-value${isLoadingConfidential ? " loading" : ""}`}>
+            {isLoadingConfidential ? <i>Decrypting…</i> : formattedConfidential}
+          </span>
+        )}
+      </div>
+      {decryptError && <div className="alert alert-error card-status">{decryptError}</div>}
+      {mintError && <div className="alert alert-error card-status">{mintError}</div>}
+      {mintTxHash && (
+        <div className="alert alert-success card-status">
+          Minted!{" "}
+          <a href={`${INGEN_EXPLORER_URL}/tx/${mintTxHash}`} target="_blank" rel="noreferrer">
+            {mintTxHash.slice(0, 10)}…
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-ingen/src/components/DecryptAsCard.tsx
+++ b/examples/example-ingen/src/components/DecryptAsCard.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+import { isAddress, formatUnits } from "ethers";
+import { useDelegationStatus, useDecryptBalanceAs } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
+import { DelegationNotFoundError, DelegationExpiredError } from "@zama-fhe/sdk";
+
+// Sentinel value used by the ACL contract to represent permanent (no-expiry) delegations.
+// The SDK sends this on-chain when expirationDate is undefined. Not exported by the SDK —
+// if this value changes in a future SDK version, formatExpiry will silently display wrong dates.
+// Track: https://github.com/zama-ai/sdk/issues (search PERMANENT_DELEGATION) for a public export.
+const PERMANENT_DELEGATION = 2n ** 64n - 1n;
+
+interface DecryptAsCardProps {
+  tokenAddress: Address;
+  decimals: number;
+  symbol: string;
+  disabled: boolean;
+  connectedAddress: Address;
+}
+
+function formatExpiry(expiryTimestamp: bigint): string {
+  if (expiryTimestamp === PERMANENT_DELEGATION) return "Permanent";
+  return new Date(Number(expiryTimestamp) * 1000).toLocaleString();
+}
+
+function delegationErrorMessage(error: Error): string {
+  if (error instanceof DelegationNotFoundError)
+    return "No delegation found — ask the owner to grant you access first.";
+  if (error instanceof DelegationExpiredError)
+    return "Delegation has expired — ask the owner to renew it.";
+  return error.message;
+}
+
+export function DecryptAsCard({
+  tokenAddress,
+  decimals,
+  symbol,
+  disabled,
+  connectedAddress,
+}: DecryptAsCardProps) {
+  const [ownerAddress, setOwnerAddress] = useState("");
+
+  const ownerIsValid = isAddress(ownerAddress);
+
+  // Live delegation status query — only fires when a valid owner address is entered.
+  // delegatorAddress = the owner who granted the delegation.
+  // delegateAddress  = the connected wallet (us).
+  const delegationStatus = useDelegationStatus({
+    tokenAddress,
+    delegatorAddress: ownerIsValid ? (ownerAddress as Address) : undefined,
+    delegateAddress: connectedAddress,
+  });
+
+  // Note: useDecryptBalanceAs takes a positional tokenAddress argument, unlike
+  // useDelegateDecryption / useRevokeDelegation which use a config object { tokenAddress }.
+  // This asymmetry is a current SDK API design decision.
+  const decryptAs = useDecryptBalanceAs(tokenAddress);
+
+  function handleDecrypt() {
+    decryptAs.mutate({ delegatorAddress: ownerAddress as Address });
+  }
+
+  return (
+    <div className="card">
+      <div className="card-title">Decrypt Balance On Behalf Of</div>
+      <input
+        className="input card-gap"
+        type="text"
+        value={ownerAddress}
+        onChange={(e) => {
+          setOwnerAddress(e.target.value);
+          decryptAs.reset();
+        }}
+        placeholder="Owner address (0x…)"
+      />
+
+      {/* Live delegation status — shown as soon as a valid address is entered */}
+      {ownerIsValid && (
+        <div className="delegation-status card-gap">
+          {delegationStatus.isPending && (
+            <span className="delegation-status-checking">Checking delegation status…</span>
+          )}
+          {delegationStatus.isError && (
+            <span className="delegation-status-none">
+              Unable to check delegation status: {delegationStatus.error?.message}
+            </span>
+          )}
+          {delegationStatus.data?.isDelegated && (
+            <span className="delegation-status-active">
+              ✓ Delegated · {formatExpiry(delegationStatus.data.expiryTimestamp)}
+            </span>
+          )}
+          {delegationStatus.data && !delegationStatus.data.isDelegated && (
+            <span className="delegation-status-none">No active delegation for this token</span>
+          )}
+        </div>
+      )}
+
+      <button
+        type="button"
+        className="btn btn-primary btn-full"
+        onClick={handleDecrypt}
+        disabled={disabled || !ownerIsValid || decryptAs.isPending}
+      >
+        {decryptAs.isPending ? "Decrypting…" : "Decrypt Balance"}
+      </button>
+      {decryptAs.isError && (
+        <div className="alert alert-error card-status">
+          {delegationErrorMessage(decryptAs.error)}
+        </div>
+      )}
+      {decryptAs.isSuccess && decryptAs.data !== undefined && (
+        <div className="alert alert-success card-status">
+          {formatUnits(decryptAs.data, decimals)} {symbol}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-ingen/src/components/DelegateDecryptionCard.tsx
+++ b/examples/example-ingen/src/components/DelegateDecryptionCard.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import { isAddress } from "ethers";
+import { useDelegateDecryption } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
+import { INGEN_EXPLORER_URL } from "@/lib/config";
+
+interface DelegateDecryptionCardProps {
+  tokenAddress: Address;
+  disabled?: boolean;
+}
+
+export function DelegateDecryptionCard({
+  tokenAddress,
+  disabled = false,
+}: DelegateDecryptionCardProps) {
+  const [delegateAddress, setDelegateAddress] = useState("");
+  // Checked by default so a developer can grant access in one click during testing.
+  const [noExpiry, setNoExpiry] = useState(true);
+  const [expirationInput, setExpirationInput] = useState("");
+
+  const delegate = useDelegateDecryption(
+    { tokenAddress },
+    {
+      onSuccess: () => {
+        setDelegateAddress("");
+        setNoExpiry(true);
+        setExpirationInput("");
+      },
+    },
+  );
+
+  // ACL contract enforces a minimum of 1 hour — reject anything shorter at the UI level.
+  const isExpiryValid =
+    noExpiry ||
+    (!!expirationInput && new Date(expirationInput) > new Date(Date.now() + 60 * 60 * 1000));
+  const canSubmit = isAddress(delegateAddress) && isExpiryValid;
+
+  function handleGrant() {
+    delegate.mutate({
+      delegateAddress: delegateAddress as Address,
+      // undefined → SDK sends PERMANENT_DELEGATION on-chain (permanent, no expiry).
+      expirationDate: noExpiry ? undefined : new Date(expirationInput),
+    });
+  }
+
+  return (
+    <div className="card">
+      <div className="card-title">Grant Decryption Access</div>
+      <input
+        className="input card-gap"
+        type="text"
+        value={delegateAddress}
+        onChange={(e) => setDelegateAddress(e.target.value)}
+        placeholder="Delegate address (0x…)"
+      />
+      <div className="input-row card-gap">
+        <input
+          className="input"
+          type="datetime-local"
+          value={expirationInput}
+          onChange={(e) => setExpirationInput(e.target.value)}
+          disabled={noExpiry}
+        />
+        <label className="checkbox-label">
+          <input
+            type="checkbox"
+            checked={noExpiry}
+            onChange={(e) => setNoExpiry(e.target.checked)}
+          />
+          No expiration
+        </label>
+      </div>
+      {!noExpiry && !expirationInput && (
+        <p className="token-meta card-gap">
+          Select an expiration date and time (ACL contract requires at least 1 hour from now).
+        </p>
+      )}
+      {!noExpiry && expirationInput && !isExpiryValid && (
+        <p className="token-meta token-meta-error card-gap">
+          Date must be at least 1 hour from now (ACL minimum).
+        </p>
+      )}
+      <button
+        type="button"
+        className="btn btn-primary btn-full"
+        onClick={handleGrant}
+        disabled={disabled || !canSubmit || delegate.isPending}
+      >
+        {delegate.isPending ? "Granting…" : "Grant Access"}
+      </button>
+      {delegate.isError && (
+        <div className="alert alert-error card-status">{delegate.error?.message}</div>
+      )}
+      {delegate.isSuccess && delegate.data?.txHash && (
+        <div className="alert alert-success card-status">
+          Access granted!{" "}
+          <a
+            href={`${INGEN_EXPLORER_URL}/tx/${delegate.data.txHash}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {delegate.data.txHash.slice(0, 10)}…
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-ingen/src/components/PendingUnshieldCard.tsx
+++ b/examples/example-ingen/src/components/PendingUnshieldCard.tsx
@@ -65,11 +65,7 @@ export function PendingUnshieldCard({ tokenAddress, label, onSuccess }: PendingU
         <div className="balance-row">
           <span className="balance-label">
             Unwrap confirmed, finalization pending —{" "}
-            <a
-              href={`${INGEN_EXPLORER_URL}/tx/${pendingTxHash}`}
-              target="_blank"
-              rel="noreferrer"
-            >
+            <a href={`${INGEN_EXPLORER_URL}/tx/${pendingTxHash}`} target="_blank" rel="noreferrer">
               {pendingTxHash.slice(0, 10)}…
             </a>
           </span>

--- a/examples/example-ingen/src/components/PendingUnshieldCard.tsx
+++ b/examples/example-ingen/src/components/PendingUnshieldCard.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useZamaSDK, useResumeUnshield } from "@zama-fhe/react-sdk";
+import { loadPendingUnshield, clearPendingUnshield } from "@zama-fhe/sdk";
+import type { Address, Hex } from "@zama-fhe/sdk";
+import { INGEN_EXPLORER_URL } from "@/lib/config";
+
+interface PendingUnshieldCardProps {
+  tokenAddress: Address;
+  label: string;
+  onSuccess?: () => void;
+}
+
+export function PendingUnshieldCard({ tokenAddress, label, onSuccess }: PendingUnshieldCardProps) {
+  const { storage } = useZamaSDK();
+  const [pendingTxHash, setPendingTxHash] = useState<Hex | null>(null);
+  const [loadError, setLoadError] = useState(false);
+
+  useEffect(() => {
+    loadPendingUnshield(storage, tokenAddress)
+      .then(setPendingTxHash)
+      .catch((err) => {
+        console.error("[PendingUnshieldCard] loadPendingUnshield failed:", err);
+        setLoadError(true);
+      });
+  }, [storage, tokenAddress]);
+
+  const resume = useResumeUnshield(
+    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
+    { tokenAddress, wrapperAddress: tokenAddress },
+    {
+      onSuccess: () => {
+        clearPendingUnshield(storage, tokenAddress).catch((err) =>
+          console.error("[PendingUnshieldCard] Failed to clear pending unshield:", err),
+        );
+        setPendingTxHash(null);
+        onSuccess?.();
+      },
+    },
+  );
+
+  if (loadError) {
+    return (
+      <div className="card">
+        <div className="card-title">Pending Unshield — {label}</div>
+        <div className="alert alert-error card-status">
+          Unable to load pending unshield state. If you have an interrupted unshield, check your
+          browser&apos;s storage settings.
+        </div>
+      </div>
+    );
+  }
+
+  // Keep the card mounted when resume.isSuccess so the "Unshielded!" alert is
+  // visible. React 18 batches setPendingTxHash(null) with the mutation's isSuccess
+  // state change — without this guard, the null check would unmount the card on
+  // the very same render that sets isSuccess, hiding the success message.
+  if (!pendingTxHash && !resume.isSuccess) return null;
+
+  return (
+    <div className="card">
+      <div className="card-title">Pending Unshield — {label}</div>
+      {pendingTxHash && (
+        <div className="balance-row">
+          <span className="balance-label">
+            Unwrap confirmed, finalization pending —{" "}
+            <a
+              href={`${INGEN_EXPLORER_URL}/tx/${pendingTxHash}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {pendingTxHash.slice(0, 10)}…
+            </a>
+          </span>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => resume.mutate({ unwrapTxHash: pendingTxHash })}
+            disabled={resume.isPending}
+          >
+            {resume.isPending ? "Finalizing…" : "Finalize"}
+          </button>
+        </div>
+      )}
+      {resume.isError && (
+        <div className="alert alert-error card-status">{resume.error?.message}</div>
+      )}
+      {resume.isSuccess && resume.data?.txHash && (
+        <div className="alert alert-success card-status">
+          Unshielded!{" "}
+          <a
+            href={`${INGEN_EXPLORER_URL}/tx/${resume.data.txHash}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {resume.data.txHash.slice(0, 10)}…
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-ingen/src/components/RevokeDelegationCard.tsx
+++ b/examples/example-ingen/src/components/RevokeDelegationCard.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { isAddress } from "ethers";
+import { useRevokeDelegation } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
+import { INGEN_EXPLORER_URL } from "@/lib/config";
+
+interface RevokeDelegationCardProps {
+  tokenAddress: Address;
+  disabled?: boolean;
+}
+
+export function RevokeDelegationCard({
+  tokenAddress,
+  disabled = false,
+}: RevokeDelegationCardProps) {
+  const [delegateAddress, setDelegateAddress] = useState("");
+
+  const revoke = useRevokeDelegation(
+    { tokenAddress },
+    {
+      onSuccess: () => setDelegateAddress(""),
+    },
+  );
+
+  function handleRevoke() {
+    revoke.mutate({ delegateAddress: delegateAddress as Address });
+  }
+
+  return (
+    <div className="card">
+      <div className="card-title">Revoke Decryption Access</div>
+      <input
+        className="input card-gap"
+        type="text"
+        value={delegateAddress}
+        onChange={(e) => setDelegateAddress(e.target.value)}
+        placeholder="Delegate address (0x…)"
+      />
+      <button
+        type="button"
+        className="btn btn-primary btn-full"
+        onClick={handleRevoke}
+        disabled={disabled || !isAddress(delegateAddress) || revoke.isPending}
+      >
+        {revoke.isPending ? "Revoking…" : "Revoke Access"}
+      </button>
+      {revoke.isError && (
+        <div className="alert alert-error card-status">{revoke.error?.message}</div>
+      )}
+      {revoke.isSuccess && revoke.data?.txHash && (
+        <div className="alert alert-success card-status">
+          Access revoked!{" "}
+          <a
+            href={`${INGEN_EXPLORER_URL}/tx/${revoke.data.txHash}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {revoke.data.txHash.slice(0, 10)}…
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-ingen/src/components/ShieldCard.tsx
+++ b/examples/example-ingen/src/components/ShieldCard.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import { useShield } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
+import { parseAmount } from "@/lib/parseAmount";
+import { INGEN_EXPLORER_URL } from "@/lib/config";
+
+interface ShieldCardProps {
+  tokenAddress: Address;
+  decimals: number;
+  symbol: string;
+  disabled: boolean;
+  onSuccess?: () => void;
+}
+
+export function ShieldCard({
+  tokenAddress,
+  decimals,
+  symbol,
+  disabled,
+  onSuccess,
+}: ShieldCardProps) {
+  const [amount, setAmount] = useState("");
+  const [phase, setPhase] = useState<"shield" | "approve" | "submit">("shield");
+
+  const parsedAmount = parseAmount(amount, decimals);
+  const pendingLabel =
+    phase === "approve"
+      ? "Shielding… (approval)"
+      : phase === "submit"
+        ? "Shielding… (submitting)"
+        : "Shielding…";
+
+  const shield = useShield({ tokenAddress, wrapperAddress: tokenAddress }, { onSuccess });
+
+  function handleShield() {
+    setPhase("shield");
+    shield.mutate({
+      amount: parsedAmount,
+      approvalStrategy: "max",
+      onApprovalSubmitted: () => setPhase("approve"),
+      onShieldSubmitted: () => setPhase("submit"),
+    });
+  }
+
+  return (
+    <div className="card">
+      <div className="card-title">Shield — ERC-20 → Confidential</div>
+      <div className="input-row card-gap">
+        <input
+          className="input"
+          type="text"
+          inputMode="decimal"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="0.00"
+        />
+        <span className="input-unit">{symbol}</span>
+      </div>
+      <button
+        type="button"
+        className="btn btn-primary btn-full"
+        onClick={handleShield}
+        disabled={disabled || parsedAmount === 0n || shield.isPending}
+      >
+        {shield.isPending ? pendingLabel : "Shield"}
+      </button>
+      {shield.isError && (
+        <div className="alert alert-error card-status">{shield.error?.message}</div>
+      )}
+      {shield.isSuccess && shield.data?.txHash && (
+        <div className="alert alert-success card-status">
+          Shielded!{" "}
+          <a
+            href={`${INGEN_EXPLORER_URL}/tx/${shield.data.txHash}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {shield.data.txHash.slice(0, 10)}…
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-ingen/src/components/ShieldCard.tsx
+++ b/examples/example-ingen/src/components/ShieldCard.tsx
@@ -1,13 +1,19 @@
 "use client";
 
 import { useState } from "react";
-import { useShield } from "@zama-fhe/react-sdk";
+import { useMutation } from "@tanstack/react-query";
+import { isError } from "ethers";
+import { useZamaSDK } from "@zama-fhe/react-sdk";
+import { allowanceContract, approveContract, balanceOfContract } from "@zama-fhe/sdk";
 import type { Address } from "@zama-fhe/sdk";
 import { parseAmount } from "@/lib/parseAmount";
 import { INGEN_EXPLORER_URL } from "@/lib/config";
 
 interface ShieldCardProps {
+  /** Confidential wrapper address (the shield destination). */
   tokenAddress: Address;
+  /** ERC-20 address of the underlying token (the `erc20` side of the pair). */
+  underlyingAddress: Address;
   decimals: number;
   symbol: string;
   disabled: boolean;
@@ -16,32 +22,105 @@ interface ShieldCardProps {
 
 export function ShieldCard({
   tokenAddress,
+  underlyingAddress,
   decimals,
   symbol,
   disabled,
   onSuccess,
 }: ShieldCardProps) {
   const [amount, setAmount] = useState("");
-  const [phase, setPhase] = useState<"shield" | "approve" | "submit">("shield");
+  // "wrap"               = checking allowance or waiting for the wrap tx (no approval in progress)
+  // "approve"            = waiting for the ERC-20 approval transaction
+  // "wrap-after-approve" = approval confirmed, waiting for the wrap transaction
+  const [phase, setPhase] = useState<"wrap" | "approve" | "wrap-after-approve">("wrap");
+
+  const sdk = useZamaSDK();
 
   const parsedAmount = parseAmount(amount, decimals);
   const pendingLabel =
     phase === "approve"
-      ? "Shielding… (approval)"
-      : phase === "submit"
-        ? "Shielding… (submitting)"
+      ? "Shielding… (1/2 approve)"
+      : phase === "wrap-after-approve"
+        ? "Shielding… (2/2 wrap)"
         : "Shielding…";
 
-  const shield = useShield({ tokenAddress, wrapperAddress: tokenAddress }, { onSuccess });
+  // Spend cap strategy: approve for the user's full ERC-20 balance at approval time
+  // (not the exact shield amount, and not MaxUint256). This avoids re-approval on every
+  // shield within the remaining cap — subsequent shields need only the wrap transaction
+  // (1 wallet confirmation) — while keeping the popup readable for the user (a sane
+  // number derived from their balance, not 1.15e77).
+  //
+  // USDT-style detection (non-zero insufficient allowance case):
+  // We try approve(fullBalance) directly via writeContract. writeContract uses the signer,
+  // so eth_estimateGas is called with from=userAddress. For USDT-style tokens, the allowance
+  // check (_allowances[userAddress][spender] > 0) causes the estimation to revert before the
+  // wallet is ever prompted. We catch this and fall back to reset(0) + approve(fullBalance).
+  // User rejections (ACTION_REJECTED) are re-thrown immediately — we never silently fall back
+  // to the reset path when the user said no.
+  const shield = useMutation({
+    mutationFn: async (amount: bigint) => {
+      const signer = sdk.requireSigner("shield");
+      const token = sdk.createToken(tokenAddress);
+      const userAddress = signer.requireWalletAccount("shield").address;
+
+      // Read the current ERC-20 allowance granted to the wrapper.
+      const currentAllowance = (await sdk.provider.readContract(
+        allowanceContract(underlyingAddress, userAddress, tokenAddress),
+      )) as bigint;
+
+      if (currentAllowance < amount) {
+        // Fetch the user's full ERC-20 balance to use as the new spend cap.
+        const erc20Balance = (await sdk.provider.readContract(
+          balanceOfContract(underlyingAddress, userAddress),
+        )) as bigint;
+
+        setPhase("approve");
+
+        if (currentAllowance > 0n) {
+          // Non-zero insufficient allowance: try direct overwrite first.
+          // - Standard ERC-20: eth_estimateGas succeeds → wallet prompted → 1 confirmation.
+          // - USDT-style: eth_estimateGas reverts → caught below → reset path (2 confirmations).
+          let needsReset = false;
+          try {
+            const approveTxHash = await signer.writeContract(
+              approveContract(underlyingAddress, tokenAddress, erc20Balance),
+            );
+            await sdk.provider.waitForTransactionReceipt(approveTxHash);
+          } catch (err) {
+            if (isError(err, "ACTION_REJECTED")) throw err; // user rejected — stop here
+            needsReset = true; // eth_estimateGas reverted → USDT-style token
+          }
+
+          if (needsReset) {
+            const resetTxHash = await signer.writeContract(
+              approveContract(underlyingAddress, tokenAddress, 0n),
+            );
+            await sdk.provider.waitForTransactionReceipt(resetTxHash);
+            const approveTxHash = await signer.writeContract(
+              approveContract(underlyingAddress, tokenAddress, erc20Balance),
+            );
+            await sdk.provider.waitForTransactionReceipt(approveTxHash);
+          }
+        } else {
+          // Zero allowance: simple approve — no reset needed for any token.
+          const approveTxHash = await signer.writeContract(
+            approveContract(underlyingAddress, tokenAddress, erc20Balance),
+          );
+          await sdk.provider.waitForTransactionReceipt(approveTxHash);
+        }
+
+        setPhase("wrap-after-approve");
+      }
+
+      // approvalStrategy: 'skip' — allowance is confirmed above (or was already sufficient).
+      return token.shield(amount, { approvalStrategy: "skip" });
+    },
+    onSuccess,
+  });
 
   function handleShield() {
-    setPhase("shield");
-    shield.mutate({
-      amount: parsedAmount,
-      approvalStrategy: "max",
-      onApprovalSubmitted: () => setPhase("approve"),
-      onShieldSubmitted: () => setPhase("submit"),
-    });
+    setPhase("wrap"); // reset to default; updated to "approve" inside mutation if needed
+    shield.mutate(parsedAmount);
   }
 
   return (

--- a/examples/example-ingen/src/components/TransferCard.tsx
+++ b/examples/example-ingen/src/components/TransferCard.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { isAddress } from "ethers";
+import { useConfidentialTransfer } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
+import { parseAmount } from "@/lib/parseAmount";
+import { INGEN_EXPLORER_URL } from "@/lib/config";
+
+interface TransferCardProps {
+  tokenAddress: Address;
+  decimals: number;
+  symbol: string;
+  disabled: boolean;
+  balanceDecryptRequired: boolean;
+  onSuccess?: () => void;
+}
+
+export function TransferCard({
+  tokenAddress,
+  decimals,
+  symbol,
+  disabled,
+  balanceDecryptRequired,
+  onSuccess,
+}: TransferCardProps) {
+  const [amount, setAmount] = useState("");
+  const [recipient, setRecipient] = useState("");
+  const [step, setStep] = useState<1 | 2>(1);
+
+  const transfer = useConfidentialTransfer({ tokenAddress }, { onSuccess });
+
+  const parsedAmount = parseAmount(amount, decimals);
+  const pendingLabel = step === 2 ? "Submitting…" : "Encrypting…";
+
+  function handleTransfer() {
+    setStep(1);
+    transfer.mutate({
+      to: recipient as Address,
+      amount: parsedAmount,
+      onEncryptComplete: () => setStep(2),
+    });
+  }
+
+  return (
+    <div className="card">
+      <div className="card-title">Confidential Transfer</div>
+      <div className="input-row card-gap">
+        <input
+          className="input"
+          type="text"
+          inputMode="decimal"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="0.00"
+        />
+        <span className="input-unit">{symbol}</span>
+      </div>
+      <input
+        className="input card-gap"
+        type="text"
+        value={recipient}
+        onChange={(e) => setRecipient(e.target.value)}
+        placeholder="0x…"
+      />
+      <button
+        type="button"
+        className="btn btn-primary btn-full"
+        onClick={handleTransfer}
+        disabled={
+          disabled ||
+          balanceDecryptRequired ||
+          parsedAmount === 0n ||
+          !isAddress(recipient) ||
+          transfer.isPending
+        }
+      >
+        {transfer.isPending ? pendingLabel : "Transfer"}
+      </button>
+      {balanceDecryptRequired && !disabled && (
+        <p className="token-meta">Decrypt your balance first to enable transfers.</p>
+      )}
+      {transfer.isError && (
+        <div className="alert alert-error card-status">{transfer.error?.message}</div>
+      )}
+      {transfer.isSuccess && transfer.data?.txHash && (
+        <div className="alert alert-success card-status">
+          Transferred!{" "}
+          <a
+            href={`${INGEN_EXPLORER_URL}/tx/${transfer.data.txHash}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {transfer.data.txHash.slice(0, 10)}…
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-ingen/src/components/UnshieldCard.tsx
+++ b/examples/example-ingen/src/components/UnshieldCard.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { useUnshield, useZamaSDK } from "@zama-fhe/react-sdk";
+import { clearPendingUnshield } from "@zama-fhe/sdk";
+import type { Address } from "@zama-fhe/sdk";
+import { parseAmount } from "@/lib/parseAmount";
+import { INGEN_EXPLORER_URL } from "@/lib/config";
+import { setActiveUnshieldToken } from "@/lib/activeUnshield";
+
+interface UnshieldCardProps {
+  tokenAddress: Address;
+  decimals: number;
+  symbol: string;
+  disabled: boolean;
+  balanceDecryptRequired: boolean;
+  onSuccess?: () => void;
+}
+
+export function UnshieldCard({
+  tokenAddress,
+  decimals,
+  symbol,
+  disabled,
+  balanceDecryptRequired,
+  onSuccess,
+}: UnshieldCardProps) {
+  const [amount, setAmount] = useState("");
+  const [step, setStep] = useState<1 | 2>(1);
+
+  const { storage } = useZamaSDK();
+
+  const unshield = useUnshield(
+    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
+    { tokenAddress, wrapperAddress: tokenAddress },
+    {
+      onSuccess: () => {
+        clearPendingUnshield(storage, tokenAddress).catch((err) =>
+          console.error("[UnshieldCard] Failed to clear pending unshield:", err),
+        );
+        onSuccess?.();
+      },
+      // Clear the active token ref on failure so a stale address is never used by the
+      // onEvent handler in ZamaProvider if a subsequent UnshieldPhase1Submitted fires.
+      onError: () => setActiveUnshieldToken(null),
+    },
+  );
+
+  const parsedAmount = parseAmount(amount, decimals);
+  const pendingLabel = step === 2 ? "Unshielding… (2/2)" : "Unshielding… (1/2)";
+
+  function handleUnshield() {
+    setStep(1);
+    // Register the active token before mutate() so the onEvent handler in ZamaProvider
+    // can associate the txHash (from ZamaSDKEvents.UnshieldPhase1Submitted) with this wrapperAddress.
+    // savePendingUnshield is called there — after Phase 1 is mined but before Phase 2
+    // completes — so closing the tab between phases still leaves recoverable state.
+    setActiveUnshieldToken(tokenAddress);
+    unshield.mutate({
+      amount: parsedAmount,
+      // onFinalizing fires between the two on-chain transactions, marking step 2.
+      onFinalizing: () => setStep(2),
+    });
+  }
+
+  return (
+    <div className="card">
+      <div className="card-title">Unshield — Confidential → ERC-20</div>
+      <div className="input-row card-gap">
+        <input
+          className="input"
+          type="text"
+          inputMode="decimal"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="0.00"
+        />
+        <span className="input-unit">{symbol}</span>
+      </div>
+      <button
+        type="button"
+        className="btn btn-primary btn-full"
+        onClick={handleUnshield}
+        disabled={disabled || balanceDecryptRequired || parsedAmount === 0n || unshield.isPending}
+      >
+        {unshield.isPending ? pendingLabel : "Unshield"}
+      </button>
+      {balanceDecryptRequired && !disabled && (
+        <p className="token-meta">Decrypt your balance first to enable unshielding.</p>
+      )}
+      {unshield.isError && (
+        <div className="alert alert-error card-status">{unshield.error?.message}</div>
+      )}
+      {unshield.isSuccess && unshield.data?.txHash && (
+        <div className="alert alert-success card-status">
+          Unshielded!{" "}
+          <a
+            href={`${INGEN_EXPLORER_URL}/tx/${unshield.data.txHash}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {unshield.data.txHash.slice(0, 10)}…
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-ingen/src/global.d.ts
+++ b/examples/example-ingen/src/global.d.ts
@@ -1,0 +1,7 @@
+interface Window {
+  ethereum?: {
+    request(args: { method: string; params?: unknown[] }): Promise<unknown>;
+    on(event: string, handler: (...args: unknown[]) => void): void;
+    removeListener(event: string, handler: (...args: unknown[]) => void): void;
+  };
+}

--- a/examples/example-ingen/src/lib/activeUnshield.ts
+++ b/examples/example-ingen/src/lib/activeUnshield.ts
@@ -1,0 +1,21 @@
+import type { Address } from "@zama-fhe/sdk";
+
+/**
+ * Module-level bridge used to associate an in-flight unwrap transaction hash
+ * (received via ZamaSDKEvents.UnshieldPhase1Submitted, which carries no token address)
+ * with the correct wrapperAddress so providers.tsx can call savePendingUnshield
+ * after Phase 1 is mined but before Phase 2 completes.
+ *
+ * Set by UnshieldCard just before mutate() is called; read by the onEvent handler
+ * in ZamaProvider. A module-level variable is intentional here — only one unshield
+ * can be in flight at a time per browser tab.
+ */
+let _wrapperAddress: Address | null = null;
+
+export function setActiveUnshieldToken(addr: Address | null): void {
+  _wrapperAddress = addr;
+}
+
+export function getActiveUnshieldToken(): Address | null {
+  return _wrapperAddress;
+}

--- a/examples/example-ingen/src/lib/config.ts
+++ b/examples/example-ingen/src/lib/config.ts
@@ -1,0 +1,11 @@
+// ─── InGen network configuration ──────────────────────────────────────────────
+// T-Rex InGen private testnet (chain 364301, OP stack) — cleartext fhEVM
+// deployment from SDK-184. Edit these values to target a different network.
+
+export const INGEN_CHAIN_ID = 364301;
+export const INGEN_CHAIN_ID_HEX = `0x${INGEN_CHAIN_ID.toString(16)}`; // "0x58f0d"
+export const INGEN_EXPLORER_URL = "https://explorer.ingen.t-rex.network";
+const INGEN_RPC_DEFAULT = "https://rpc.ingen.t-rex.network";
+// Use || not ?? — Next.js replaces unset NEXT_PUBLIC_* with "" (empty string) at build time,
+// not undefined. "" is not nullish, so ?? would use the empty string as the URL.
+export const INGEN_RPC_URL = process.env.NEXT_PUBLIC_INGEN_RPC_URL || INGEN_RPC_DEFAULT;

--- a/examples/example-ingen/src/lib/ethereum.ts
+++ b/examples/example-ingen/src/lib/ethereum.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns the injected EIP-1193 provider (MetaMask, Rabby, etc.).
+ * Uses window.ethereum directly — the standard injection point for EVM wallets.
+ */
+export function getEthereumProvider() {
+  if (typeof window === "undefined") return undefined;
+  return window.ethereum;
+}

--- a/examples/example-ingen/src/lib/parseAmount.ts
+++ b/examples/example-ingen/src/lib/parseAmount.ts
@@ -1,0 +1,14 @@
+import { parseUnits } from "ethers";
+
+/**
+ * Parse a human-readable amount string into a raw BigInt, using the token's
+ * decimal precision. Returns BigInt(0) on empty input or invalid values (e.g. too
+ * many decimal places for the given precision).
+ */
+export function parseAmount(value: string, decimals: number): bigint {
+  try {
+    return value ? parseUnits(value, decimals) : 0n;
+  } catch {
+    return 0n;
+  }
+}

--- a/examples/example-ingen/src/providers.tsx
+++ b/examples/example-ingen/src/providers.tsx
@@ -45,7 +45,6 @@ import { getEthereumProvider } from "@/lib/ethereum";
 const permitDBStorage = new IndexedDBStorage("PermitStore");
 
 // Inline InGen chain config (SDK-184 deployment).
-// See /tmp/sdk-184/deployment-notes.md for these addresses.
 const zamaIngen = {
   id: 364301,
   gatewayChainId: 10901,

--- a/examples/example-ingen/src/providers.tsx
+++ b/examples/example-ingen/src/providers.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, useEffect, useMemo, useRef, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  ZamaSDKEvents,
+  IndexedDBStorage,
+  indexedDBStorage,
+  savePendingUnshield,
+  cleartext,
+} from "@zama-fhe/sdk";
+import { createConfig } from "@zama-fhe/sdk/ethers";
+import type { EIP1193Provider } from "@zama-fhe/sdk/ethers";
+import { ZamaProvider } from "@zama-fhe/react-sdk";
+import { JsonRpcProvider } from "ethers";
+import { INGEN_RPC_URL } from "@/lib/config";
+import { getActiveUnshieldToken, setActiveUnshieldToken } from "@/lib/activeUnshield";
+import { getEthereumProvider } from "@/lib/ethereum";
+
+// ── What this file does ────────────────────────────────────────────────────────
+//
+// Wires the three SDK primitives every integration needs:
+//
+//   const config = createConfig({ chains, ethereum, provider, relayers, storage, permitStorage });
+//   <ZamaProvider config={config}>
+//
+// The InGen chain config is inlined below (no shipped preset yet for chain 364301).
+// The cleartext relayer transport (`cleartext()`) is used because InGen runs the
+// cleartext fhEVM host stack — there is no real relayer/KMS network to call.
+//
+// SDK reads use a JsonRpcProvider pointed at INGEN_RPC_URL. Wallet writes and EIP-712
+// signing use the injected EIP-1193 provider through the ethers adapter.
+//
+// Two extra layers handle wallet reactivity:
+//
+// 1. Separate IndexedDB instances for storage and permitStorage — distinct SDK
+//    persistence responsibilities, must not overwrite each other.
+//
+// 2. walletKey + refSeededRef — remounts ZamaProvider on wallet switch with fresh
+//    ethers adapter state bound to the new account, while ignoring spurious
+//    accountsChanged events some wallets emit before eth_accounts resolves.
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Separate DB from indexedDBStorage — see block comment above for the reason.
+const permitDBStorage = new IndexedDBStorage("PermitStore");
+
+// Inline InGen chain config (SDK-184 deployment).
+// See /tmp/sdk-184/deployment-notes.md for these addresses.
+const zamaIngen = {
+  id: 364301,
+  gatewayChainId: 10901,
+  relayerUrl: "",
+  network: INGEN_RPC_URL,
+  aclContractAddress: "0x09a4710BfBe7B557cD5CFE88BB31e9b5b85C419b",
+  kmsContractAddress: "0xd885DEa6a924785fCcdf9CE993FEe27EA11832e6",
+  inputVerifierContractAddress: "0x90f05B10db153365D8cB143EA17f5E5714D0bCD5",
+  verifyingContractAddressDecryption: "0x5ffdaAB0373E62E2ea2944776209aEf29E631A64",
+  verifyingContractAddressInputVerification: "0x812b06e1CDCE800494b79fFE4f925A504a9A9810",
+  registryAddress: "0x7FC3D79EF9d01fA318CF2Aa5D91dDC492383Be0F",
+  executorAddress: "0x1B05DE5b67b8f8363DC04E3a5996a616f11f8C7B",
+} as const;
+
+export function Providers({ children }: { children: ReactNode }) {
+  // Created once per Providers mount — avoids sharing the QueryClient across
+  // SSR requests and React Strict Mode double-invocations.
+  const [queryClient] = useState(() => new QueryClient());
+
+  // Updated synchronously in accountsChanged (before setWalletKey re-renders) so the
+  // next ethers adapter config sees the correct accounts immediately.
+  const liveAccountsRef = useRef<readonly string[]>([]);
+
+  // Becomes true once the initial eth_accounts call resolves. accountsChanged events
+  // that arrive before that point are ignored — some wallets (Phantom, certain MetaMask
+  // versions) fire accountsChanged on page load before the async seed completes, which
+  // would cause a spurious ZamaProvider remount and force the user to re-sign.
+  const refSeededRef = useRef(false);
+
+  // Incremented on wallet switch to remount ZamaProvider with fresh ethers adapter state
+  // bound to the new account.
+  const [walletKey, setWalletKey] = useState(0);
+
+  useEffect(() => {
+    const ethereum = getEthereumProvider();
+    if (!ethereum) return;
+    // Seed the ref for already-connected wallets on page load.
+    (ethereum.request({ method: "eth_accounts" }) as Promise<string[]>).then(
+      (accounts) => {
+        liveAccountsRef.current = accounts;
+        refSeededRef.current = true;
+      },
+      (err) => {
+        console.error("[Providers] Failed to seed accounts:", err);
+        refSeededRef.current = true;
+      },
+    );
+    const handleAccountsChanged = (accounts: unknown) => {
+      const newAccounts = accounts as string[];
+      const prevAddress = liveAccountsRef.current[0];
+      liveAccountsRef.current = newAccounts;
+      if (!refSeededRef.current) return;
+      if (newAccounts[0] !== prevAddress) {
+        setWalletKey((k) => k + 1);
+      }
+    };
+    const handleChainChanged = () => {
+      setWalletKey((k) => k + 1);
+      queryClient.invalidateQueries();
+    };
+    ethereum.on("accountsChanged", handleAccountsChanged);
+    ethereum.on("chainChanged", handleChainChanged);
+    return () => {
+      ethereum.removeListener("accountsChanged", handleAccountsChanged);
+      ethereum.removeListener("chainChanged", handleChainChanged);
+    };
+  }, [queryClient]);
+
+  const zamaConfig = useMemo(() => {
+    const ethereum = (getEthereumProvider() ?? {
+      request: async ({ method }: { method: string }) => {
+        if (method === "eth_accounts") return [];
+        if (method === "eth_chainId") return `0x${zamaIngen.id.toString(16)}`;
+        throw new Error("No Ethereum wallet detected. Connect a wallet to use this app.");
+      },
+      on: () => {},
+      removeListener: () => {},
+    }) as EIP1193Provider;
+    const provider = new JsonRpcProvider(INGEN_RPC_URL);
+
+    return createConfig({
+      chains: [zamaIngen],
+      ethereum,
+      provider,
+      storage: indexedDBStorage,
+      permitStorage: permitDBStorage,
+      relayers: { [zamaIngen.id]: cleartext() },
+      onEvent: (event) => {
+        if (event.type === ZamaSDKEvents.UnshieldPhase1Submitted) {
+          const wrapperAddress = getActiveUnshieldToken();
+          if (wrapperAddress) {
+            savePendingUnshield(indexedDBStorage, wrapperAddress, event.txHash).catch((err) =>
+              console.error("[Providers] Failed to persist pending unshield:", event.txHash, err),
+            );
+            setActiveUnshieldToken(null);
+          }
+        }
+      },
+    });
+  }, [walletKey]);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ZamaProvider key={walletKey} config={zamaConfig}>
+        {children}
+      </ZamaProvider>
+    </QueryClientProvider>
+  );
+}

--- a/examples/example-ingen/tsconfig.json
+++ b/examples/example-ingen/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "target": "ES2020",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Adds `examples/example-ingen`, a Next.js + ethers demo app targeting the **T-Rex InGen** private testnet (chain ID `364301`) and the **cleartext fhEVM** host stack deployed as part of [SDK-184](https://linear.app/zama/issue/SDK-184).

Forked from `examples/react-ethers` (Sepolia + real relayer) with three substantive changes:
- Relayer transport swapped from `web()` → `cleartext()` (`packages/sdk/src/relayer/cleartext`).
- Chain preset inlined for InGen — no shipped `@zama-fhe/sdk/chains` preset for chain 364301 yet.
- Sepolia network UX (chain ID, RPC, explorer, currency symbol) replaced with InGen equivalents throughout.

Lets Tokeny / Apex integrate against confidential token primitives on their own testnet ahead of the full Zama Protocol rollout (queued for Q2 with the protocol division), without needing to stand up a relayer or KMS network.

## Context: the cleartext stack deployed for this ticket

The host stack and tokens below were deployed off-repo (forge-fhevm + protocol-apps). This PR ships only the SDK-side demo — it consumes those contracts via the inlined chain config in `src/providers.tsx`. Decision per the ticket was to **match Hoodi exactly** (no unified cleartext stack, no Alex B. changes — explicit product call by Mathieu).

### Network

| Field | Value |
| --- | --- |
| Name | InGen |
| Chain ID | `364301` |
| RPC URL | `https://rpc.ingen.t-rex.network` |
| Explorer | `https://explorer.ingen.t-rex.network` (Blockscout v8.1.2) |
| Native gas token | TREX |
| Faucet | `https://faucet.ingen.gateway.fm/` |
| L1 bridge (on Sepolia) | `0xca20897f47769bc96ee016569699b697f79ab07b` |

### Cleartext fhEVM host stack (forge-fhevm)

Deployer: `0xfD967634817Ce7BEF604f2558784a745c771E258` (fresh wallet, 1Password T-Rex vault).
EIP-712 gateway domain constants reused verbatim from Hoodi (`0x5ffdaAB0…` decryption, `0x812b06e1…` input verification, gateway chain id `10901`). Mock KMS / coprocessor signer keys reused verbatim from `forge-fhevm/.env.example` — these are the same constants baked into `RelayerCleartext` (`packages/sdk/src/relayer/cleartext/constants.ts`), so the relayer reconciles automatically with the deployed contracts.

| Contract | Address | Role |
| --- | --- | --- |
| ACL (UUPS proxy) | `0x09a4710BfBe7B557cD5CFE88BB31e9b5b85C419b` | Access control for FHE handles |
| CleartextFHEVMExecutor (UUPS proxy) | `0x1B05DE5b67b8f8363DC04E3a5996a616f11f8C7B` | Mock executor — stores plaintexts on-chain instead of running FHE |
| KMSVerifier (UUPS proxy) | `0xd885DEa6a924785fCcdf9CE993FEe27EA11832e6` | Verifies decryption signatures from the mock KMS signer |
| InputVerifier (UUPS proxy) | `0x90f05B10db153365D8cB143EA17f5E5714D0bCD5` | Verifies encrypted inputs from the mock coprocessor signer |
| HCULimit (UUPS proxy) | `0xbde86f7bB31Fc0a295CC7Bc585f004a802d97D9d` | Per-tx homomorphic cost limit (unused on cleartext) |
| PauserSet | `0x2fdF18BF542292f27D75C05e6258590Def6F3346` | Pauser registry |

### ERC-20 mocks (protocol-apps/confidential-token-wrappers-registry)

Both expose a public `mint(address,uint256)` so any wallet can self-mint for testing — wired into the app's `BalancesCard`.

| Token | Address | `name()` | `symbol()` | Decimals |
| --- | --- | --- | --- | --- |
| USDCMock | `0xBBdABB33Cf7Bb427dA1c76f1C59a0786E90EB00b` | "USD Coin (Mock)" | `USDCMock` | 6 |
| USDTMock | `0x7CC6EB5E82f5ae84BC08cC58734E6aD2c2510068` | "Tether USD (Mock)" | `USDTMock` | 6 |

The USDTMock contract is the standard mock that ships with `protocol-apps` — symbol hardcoded, includes the USDT "approve-to-zero-first" quirk for realistic ERC-20 edge-case testing. USDCMock was redeployed mid-flight to give it the `Mock` suffix for naming parity in the UI (`task:deployERC20Mock --symbol USDCMock`).

### Confidential wrappers registry (protocol-apps/confidential-token-wrappers-registry)

| Contract | Address |
| --- | --- |
| ConfidentialTokenWrappersRegistry (UUPS proxy) | `0x7FC3D79EF9d01fA318CF2Aa5D91dDC492383Be0F` |
| ConfidentialTokenWrappersRegistry (impl) | `0xfF3dAABfFaa3094DF6e512CfCb6250D91Daf30e8` |

Initial owner = deployer. The SDK's `WrappersRegistry` resolves this address automatically from the chain config (`registryAddress` field on the inlined InGen preset), so the app's BalancesCard / token dropdown fetch the active pairs without any hardcoded list.

### Confidential wrappers (protocol-apps/confidential-wrapper)

| Wrapper | Proxy | Underlying |
| --- | --- | --- |
| cUSDC (`Confidential USDC`) | `0x1D0480a22d9ff7DF4dcf94bB70D9B761C358A8a8` | USDCMock |
| cUSDT (`Confidential USDT`) | `0x604fFb6b71bfEe1B155B4093bdCF19a7c7029Efd` | USDT mock |

Both UUPS proxies share implementation `0xE435DbeD40D6998fD314566d428A32E6739F40B7` (OZ upgrades reuses impl across wrappers). Both registered in the registry with `isValid = true`.

### Registry pair state

| Underlying | Confidential | `isValid` |
| --- | --- | --- |
| USDCMock `0xBBdABB33…` | cUSDC `0x1D0480a2…` | ✓ |
| USDT `0x7CC6EB5E…` | cUSDT `0x604fFb6b…` | ✓ |
| ~~USDC `0x9affdEEF…`~~ | ~~cUSDC `0x1f855c3c…`~~ | ✗ revoked (superseded by USDCMock) |

The app filters on `isValid` via `useListPairs()`, so the revoked pair is invisible in the UI.

## E2E functional validation (off-PR)

A pre-merge node script (`@zama-fhe/sdk@3.0.0-alpha.41`, `cleartext()` transport, two fresh wallets) was run against the deployment before opening this PR. Full flow passed:

- Mint 1000 USDT → A
- Shield 100 → A holds 100 cUSDT, 900 USDT
- Confidential transfer 10 A→B (encrypted handle on-chain)
- A holds 90 cUSDT, B holds 10 cUSDT
- Unshield 50 cUSDT → A holds 40 cUSDT, 950 USDT
- Delegate decryption A→B, B decrypts A's balance, revoke

TX hashes (verifiable on the InGen explorer):
- Mint: `0x691fb168db4bcf5fe2fdb8b6d73bdc7295f2629dcc038f9156fb36b2927dc65e`
- Shield (approve + wrap): `0x9c1d15ce…0c5cf667fe97f08ec945437a5dd36a07201c0ff6ab110` + `0x50a60002255172681cb9fe4c3eea0f7798a56def5899f32d038e4acc39ac64d1`
- Confidential transfer: `0xa8229960830e07d0f0207de2e354e04e3a2ea321ba39ee8b035626e06686f7f0`
- Unshield (unwrap + finalize): `0xda69cfdc25a84688f9c4149160effb80ed8b9779908e7f3409737a81beaad424` + `0x653af2112498417cd47001e16e500a3efee6edbad524feef742cdf5814811aed`

## Caveats / runbook gaps surfaced during this work

Filed for follow-up against the Notion runbook (not blockers for SDK-184):

1. **`ZamaConfig.sol` patch required for any new chain.** `ConfidentialWrapper.initialize()` calls `FHE.setCoprocessor(ZamaConfig.getEthereumCoprocessorConfig())`, which is a chain-id switch in `@fhevm/solidity@0.10` that reverts for any chain other than 1 / 11155111 / 31337. The protocol-apps deploy step on a new chain therefore requires patching `node_modules/@fhevm/solidity/config/ZamaConfig.sol` to add a branch returning the just-deployed host stack addresses. Upstream fix suggestion: take `CoprocessorConfig` as an initializer parameter.
2. **Registry deploy step missing from the runbook.** `task:deployConfidentialTokenWrappersRegistry` exists with `INITIAL_OWNER` env var, but the runbook only documents *registering* wrappers, not standing up the registry itself.
3. **Verification path assumes Etherscan.** InGen's explorer is Blockscout v8 — the existing `hardhat-verify` config in `protocol-apps` would need a `customChains` entry. Skipped for this private testnet (not in success criteria).
4. **`ETHERSCAN_API_KEY` is hard-required** by `protocol-apps/contracts/*/hardhat.config.ts` (non-null assertion) — set `ETHERSCAN_API_KEY=dummy` in `.env` even when no verification is run.

## What this PR is NOT

- It does **not** add an `ingen` preset to `packages/sdk/src/chains/configs.ts`. The chain config is intentionally inlined in `src/providers.tsx` for now — promoting it to a preset is a follow-up decision once the InGen deployment stabilises.
- It does **not** ship a `WALKTHROUGH.md` (the Sepolia version did not survive the cleartext / chain rewrite cleanly; the README covers setup).
- It does **not** include Playwright e2e tests (the Sepolia-flavoured ones in `examples/react-ethers/e2e/` mock the real relayer flow and don't map onto cleartext).

## Test plan

- [ ] `cd examples/example-ingen && npm install && npm run dev`
- [ ] Open `http://localhost:3000` (or 3001 if 3000 is in use)
- [ ] Create a fresh MetaMask account; claim TREX at `https://faucet.ingen.gateway.fm/`
- [ ] Connect wallet → MetaMask prompts `wallet_addEthereumChain` for InGen, then `wallet_switchEthereumChain`
- [ ] Token dropdown lists `USDCMock` and `USDTMock` (resolved from registry on-chain)
- [ ] Mint 10 USDTMock; sign EIP-712 decrypt permit; balance shown
- [ ] Shield 5 (approve + wrap, 2 popups); confidential balance → 5
- [ ] Confidential transfer 1 to a second wallet; encrypted handle visible on-chain, plaintext invisible
- [ ] Unshield 2 (unwrap + finalize, finalize phase instantaneous on cleartext); ERC-20 balance ticks back up
- [ ] Delegate decryption to a second wallet; switch wallet; "Decrypt Balance On Behalf Of" returns the delegator's plaintext balance; revoke works

🤖 Generated with [Claude Code](https://claude.com/claude-code)