### PR TITLE
docs: migrate README package links to docs.zama.org

### DIFF
--- a/docs/gitbook/src/concepts/security-model.md
+++ b/docs/gitbook/src/concepts/security-model.md
@@ -196,4 +196,4 @@ The token is refreshed before each encrypt/decrypt call. Only POST, PUT, DELETE,
 
 ## Reporting vulnerabilities
 
-If you discover a security vulnerability in the SDK, report it to **security@zama.ai**. Do not open a public GitHub issue for security reports. See the [Security Policy](https://github.com/zama-ai/token-sdk/blob/main/SECURITY.md) for full details.
+If you discover a security vulnerability in the SDK, report it to **security@zama.ai**. Do not open a public GitHub issue for security reports. See the [Security Policy](https://github.com/zama-ai/sdk/blob/main/SECURITY.md) for full details.

--- a/docs/gitbook/src/overview.md
+++ b/docs/gitbook/src/overview.md
@@ -15,7 +15,7 @@ This is the new default SDK for building on the Zama Protocol. The legacy `@zama
 
 ## Where to go next
 
-If you're new to the Zama Protocol, start with the [Litepaper](https://docs.zama.ai/protocol/zama-protocol-litepaper) or the [Protocol Overview](https://docs.zama.ai/protocol) to understand the foundations.
+If you're new to the Zama Protocol, start with the [Litepaper](https://docs.zama.org/protocol/zama-protocol-litepaper) or the [Protocol Overview](https://docs.zama.org/protocol) to understand the foundations.
 
 Otherwise:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -38,7 +38,7 @@ API reports are intentionally excluded from this file. They remain available in 
 
 ## Where to go next
 
-If you're new to the Zama Protocol, start with the [Litepaper](https://docs.zama.ai/protocol/zama-protocol-litepaper) or the [Protocol Overview](https://docs.zama.ai/protocol) to understand the foundations.
+If you're new to the Zama Protocol, start with the [Litepaper](https://docs.zama.org/protocol/zama-protocol-litepaper) or the [Protocol Overview](https://docs.zama.org/protocol) to understand the foundations.
 
 Otherwise:
 
@@ -14994,7 +14994,7 @@ The token is refreshed before each encrypt/decrypt call. Only POST, PUT, DELETE,
 
 ## Reporting vulnerabilities
 
-If you discover a security vulnerability in the SDK, report it to **security@zama.ai**. Do not open a public GitHub issue for security reports. See the [Security Policy](https://github.com/zama-ai/token-sdk/blob/main/SECURITY.md) for full details.
+If you discover a security vulnerability in the SDK, report it to **security@zama.ai**. Do not open a public GitHub issue for security reports. See the [Security Policy](https://github.com/zama-ai/sdk/blob/main/SECURITY.md) for full details.
 
 ## Official Examples
 


### PR DESCRIPTION
## Summary

Rebased onto `prerelease`. The original premise of this PR (migrate package-README links to `docs.zama.org/protocol/sdk/*`) was built on a base that predated #385 by 76 commits. #385 already handled the package-README links — pointing them at **specific in-repo pages via absolute GitHub-blob URLs** and deleting the orphaned section READMEs (`guides/README.md`, `tutorials/README.md`, `concepts/README.md`) that Yuxi's flat `## Section` SUMMARY format made non-clickable.

After rebasing and resolving to prerelease's structure, the net change is two genuine breakage fixes that prerelease did **not** already contain:

- **`docs/gitbook/src/concepts/security-model.md`** — Security Policy link pointed at the stale `zama-ai/token-sdk` repo path → `zama-ai/sdk`.
- **`docs/gitbook/src/overview.md`** — Litepaper / Protocol Overview links used `docs.zama.ai` (301-redirects to `docs.zama.org`) → canonical `docs.zama.org`. Cross-repo, so they stay absolute.
- **`llms-full.txt`** — regenerated via `pnpm llm:build` so embedded content matches. `llms.txt` and `corpus-manifest.json` unchanged.

## What was dropped vs the earlier version of this PR

- The `docs.zama.org/protocol/sdk/*` hosted-doc links — superseded by #385's GitHub-blob-to-specific-page links.
- The relative-link rewrite — prerelease standardized on absolute GitHub-blob URLs; kept that convention.
- Edits to the three section READMEs — those files are deleted on prerelease (#385); accepted the deletion.

## Link convention (confirmed against prerelease)

- In-repo docs → absolute GitHub-blob URLs to **specific pages** (never section READMEs). Already correct on prerelease.
- Cross-repo (`docs.zama.org/protocol`, Litepaper) → absolute.

## Validation

- `pnpm format:check` clean.
- Net diff vs `prerelease` is 3 files (2 doc fixes + regenerated `llms-full.txt`).
- No references to deleted section READMEs; no `docs.zama.ai` or `token-sdk` left in docs or artifacts.