### PR TITLE
fix(sdk-189): warm keypair through wallet chain, not chains[0]

### DIFF
--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -1260,9 +1260,9 @@ export const ZamaSDKEvents: {
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/types-CC0Mp18i.d.ts:637:3 - (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
-// dist/esm/types-CC0Mp18i.d.ts:638:3 - (ae-forgotten-export) The symbol "RelayerDispatcher" needs to be exported by the entry point index.d.ts
-// dist/esm/types-CC0Mp18i.d.ts:639:3 - (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts
+// dist/esm/types-CHE3pJ-P.d.ts:648:3 - (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
+// dist/esm/types-CHE3pJ-P.d.ts:649:3 - (ae-forgotten-export) The symbol "RelayerDispatcher" needs to be exported by the entry point index.d.ts
+// dist/esm/types-CHE3pJ-P.d.ts:650:3 - (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -13083,8 +13083,9 @@ export class RelayerDispatcher implements RelayerSDK, Disposable {
     delegatedUserDecrypt(params: DelegatedUserDecryptParams): Promise<Readonly<Record<EncryptedValue, ClearValue>>>;
     // (undocumented)
     encrypt(params: EncryptParams): Promise<EncryptResult>;
-    // (undocumented)
-    generateKeypair(): Promise<KeypairType<Hex>>;
+    generateKeypair(options?: {
+        chainId?: number;
+    }): Promise<KeypairType<Hex>>;
     // (undocumented)
     getAclAddress(): Promise<Address>;
     // (undocumented)
@@ -18737,6 +18738,11 @@ export interface WorkerLike {
 }
 
 // @public
+export class WorkerUnavailableError extends ZamaError {
+    constructor(message: string, options?: ErrorOptions);
+}
+
+// @public
 export function wrapContract(wrapperAddress: Address, to: Address, amount: bigint): {
     readonly address: `0x${string}`;
     readonly abi: readonly [{
@@ -19882,7 +19888,8 @@ export const ZamaErrorCode: {
     readonly InvalidKeypair: "INVALID_KEYPAIR"; /** No FHE ciphertext exists for this account (never shielded). */
     readonly NoCiphertext: "NO_CIPHERTEXT"; /** Relayer HTTP request failed. */
     readonly RelayerRequestFailed: "RELAYER_REQUEST_FAILED"; /** SDK configuration is invalid (e.g. forbidden chain ID, unsupported type). */
-    readonly Configuration: "CONFIGURATION"; /** Delegation cannot target self (delegate === msg.sender). */
+    readonly Configuration: "CONFIGURATION"; /** Web Worker runtime is not available (e.g. server-side rendering). */
+    readonly WorkerUnavailable: "WORKER_UNAVAILABLE"; /** Delegation cannot target self (delegate === msg.sender). */
     readonly DelegationSelfNotAllowed: "DELEGATION_SELF_NOT_ALLOWED"; /** Only one delegate/revoke per (delegator, delegate, contract) per block. */
     readonly DelegationCooldown: "DELEGATION_COOLDOWN"; /** No active delegation found for this (delegator, delegate, contract) tuple. */
     readonly DelegationNotFound: "DELEGATION_NOT_FOUND"; /** The delegation has expired. */
@@ -19976,10 +19983,10 @@ export { ZKProofLike }
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/index-CUTD_pS4.d.ts:19566:5 - (ae-forgotten-export) The symbol "DecryptionService" needs to be exported by the entry point index.d.ts
-// dist/esm/index-CUTD_pS4.d.ts:19695:5 - (ae-forgotten-export) The symbol "DelegationService" needs to be exported by the entry point index.d.ts
-// dist/esm/index-CUTD_pS4.d.ts:19797:5 - (ae-forgotten-export) The symbol "CachingService" needs to be exported by the entry point index.d.ts
-// dist/esm/index-CUTD_pS4.d.ts:19798:5 - (ae-forgotten-export) The symbol "CredentialService" needs to be exported by the entry point index.d.ts
+// dist/esm/index-DCESH9Fz.d.ts:19581:5 - (ae-forgotten-export) The symbol "DecryptionService" needs to be exported by the entry point index.d.ts
+// dist/esm/index-DCESH9Fz.d.ts:19710:5 - (ae-forgotten-export) The symbol "DelegationService" needs to be exported by the entry point index.d.ts
+// dist/esm/index-DCESH9Fz.d.ts:19812:5 - (ae-forgotten-export) The symbol "CachingService" needs to be exported by the entry point index.d.ts
+// dist/esm/index-DCESH9Fz.d.ts:19813:5 - (ae-forgotten-export) The symbol "CredentialService" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/src/credentials/__tests__/credential-service.test.ts
+++ b/packages/sdk/src/credentials/__tests__/credential-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "../../test-fixtures";
 import type { Address } from "viem";
+import { WorkerUnavailableError } from "../../errors";
 import { SigningRejectedError, SigningFailedError } from "../../errors/signing";
 
 const USER = "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B" as Address;
@@ -127,9 +128,67 @@ describe("CredentialService.handleWalletAccountChange", () => {
     await credentialService.grantPermit([A]);
     expect(await credentialService.hasPermit([A])).toBe(true);
 
-    await credentialService.handleWalletAccountChange({ address: USER }, { address: DELEGATOR });
+    await credentialService.handleWalletAccountChange(
+      { address: USER, chainId: 31337 },
+      { address: DELEGATOR, chainId: 31337 },
+    );
 
     expect(await credentialService.hasPermit([A])).toBe(false);
+  });
+
+  test("warmup routes keypair generation through next.chainId, not the dispatcher's active chain", async ({
+    createCredentialService,
+    relayer,
+  }) => {
+    // The dispatcher mock used by the fixture has #chainId === chains[0] === 31337.
+    // We warm up for a wallet connected to chain 1 (mainnet) and assert the
+    // generator was invoked with that chainId — proving the warmup is no longer
+    // tied to dispatcher state. This is the lock-in for the wrong-chain bug.
+    const credentialService = createCredentialService();
+    await credentialService.handleWalletAccountChange(undefined, {
+      address: DELEGATOR,
+      chainId: 1,
+    });
+    expect(relayer.generateKeypair).toHaveBeenCalledWith({ chainId: 1 });
+  });
+
+  test("WorkerUnavailableError from warmup is swallowed without warning (SSR-safe)", async ({
+    createCredentialService,
+    relayer,
+  }) => {
+    vi.mocked(relayer.generateKeypair).mockRejectedValueOnce(
+      new WorkerUnavailableError("Web Worker is not available in this environment."),
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const credentialService = createCredentialService();
+      await credentialService.handleWalletAccountChange(undefined, {
+        address: DELEGATOR,
+        chainId: 1,
+      });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("non-WorkerUnavailableError from warmup is logged as a warning", async ({
+    createCredentialService,
+    relayer,
+  }) => {
+    vi.mocked(relayer.generateKeypair).mockRejectedValueOnce(new Error("network down"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const credentialService = createCredentialService();
+      await credentialService.handleWalletAccountChange(undefined, {
+        address: DELEGATOR,
+        chainId: 1,
+      });
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0]?.[0]).toContain("warm keypair failed");
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/packages/sdk/src/credentials/__tests__/credential-service.test.ts
+++ b/packages/sdk/src/credentials/__tests__/credential-service.test.ts
@@ -140,10 +140,11 @@ describe("CredentialService.handleWalletAccountChange", () => {
     createCredentialService,
     relayer,
   }) => {
-    // The dispatcher mock used by the fixture has #chainId === chains[0] === 31337.
-    // We warm up for a wallet connected to chain 1 (mainnet) and assert the
-    // generator was invoked with that chainId — proving the warmup is no longer
-    // tied to dispatcher state. This is the lock-in for the wrong-chain bug.
+    // Invariant: the generator must be invoked with the connected wallet's
+    // chainId, independently of the dispatcher's active chain. The fixture's
+    // mock dispatcher has #chainId === 31337, so requesting a warmup for
+    // chainId 1 proves the routing is driven by the WalletAccount, not by
+    // dispatcher state.
     const credentialService = createCredentialService();
     await credentialService.handleWalletAccountChange(undefined, {
       address: DELEGATOR,

--- a/packages/sdk/src/credentials/credential-service.ts
+++ b/packages/sdk/src/credentials/credential-service.ts
@@ -1,7 +1,8 @@
 import type { Address } from "viem";
-import type { GenericSigner, GenericStorage } from "../types";
+import type { GenericSigner, GenericStorage, WalletAccount } from "../types";
 import type { RelayerDispatcher } from "../relayer/relayer-dispatcher";
 import { ZamaError } from "../errors/base";
+import { WorkerUnavailableError } from "../errors/relayer";
 import { wrapSigningError } from "../errors/signing";
 import { swallow } from "../utils/swallow";
 import { KeypairVault } from "./keypair-vault";
@@ -45,7 +46,7 @@ export class CredentialService {
 
   constructor(config: CredentialServiceConfig) {
     this.#vault = new KeypairVault({
-      generator: () => config.relayer.generateKeypair(),
+      generator: (chainId) => config.relayer.generateKeypair({ chainId }),
       storage: config.storage,
       ttl: config.keypairTTL,
     });
@@ -187,11 +188,15 @@ export class CredentialService {
    * on key generation. Chain-only changes keep credentials intact because
    * permits are chain-scoped already and stale decrypt plaintext is cleared by
    * `ZamaSDK`.
+   *
+   * Warmup routes generation through the connected account's `chainId` rather
+   * than the dispatcher's active chain — required so a wallet connected to
+   * (say) Anvil never hits the mainnet relayer just because mainnet is
+   * `chains[0]`. {@link WorkerUnavailableError} is treated as expected (e.g.
+   * Next.js SSR) and silenced; the SDK is reconstructed client-side and the
+   * first real decrypt will lazily generate the keypair.
    */
-  async handleWalletAccountChange(
-    prev?: { address: Address },
-    next?: { address: Address },
-  ): Promise<void> {
+  async handleWalletAccountChange(prev?: WalletAccount, next?: WalletAccount): Promise<void> {
     const prevAddr = prev ? checksum(prev.address) : undefined;
     const nextAddr = next ? checksum(next.address) : undefined;
     if (prevAddr === nextAddr) {
@@ -202,9 +207,15 @@ export class CredentialService {
       await this.#store.clearAllForSigner(prevAddr);
     }
     if (nextAddr) {
-      await swallow("warm keypair", async () => {
-        await this.#vault.getOrCreate(nextAddr);
-      });
+      try {
+        await this.#vault.getOrCreate(nextAddr, next?.chainId);
+      } catch (error) {
+        if (error instanceof WorkerUnavailableError) {
+          return;
+        }
+        // oxlint-disable-next-line no-console
+        console.warn("[zama-sdk] warm keypair failed:", error);
+      }
     }
   }
 

--- a/packages/sdk/src/credentials/credential-service.ts
+++ b/packages/sdk/src/credentials/credential-service.ts
@@ -206,9 +206,9 @@ export class CredentialService {
       await this.#vault.clear(prevAddr);
       await this.#store.clearAllForSigner(prevAddr);
     }
-    if (nextAddr) {
+    if (next && nextAddr) {
       try {
-        await this.#vault.getOrCreate(nextAddr, next?.chainId);
+        await this.#vault.getOrCreate(nextAddr, next.chainId);
       } catch (error) {
         if (error instanceof WorkerUnavailableError) {
           return;

--- a/packages/sdk/src/credentials/keypair-vault.ts
+++ b/packages/sdk/src/credentials/keypair-vault.ts
@@ -7,7 +7,12 @@ import type { ChecksummedAddress } from "../schemas/primitives";
 import { nowSeconds } from "./utils";
 
 interface KeypairVaultConfig {
-  generator: () => Promise<Keypair>;
+  /**
+   * Produce a fresh keypair. The optional `chainId` lets the vault route
+   * generation to a specific chain's relayer when warmup happens for a wallet
+   * connected to a non-active chain — without mutating dispatcher state.
+   */
+  generator: (chainId?: number) => Promise<Keypair>;
   storage: GenericStorage;
   /** Keypair lifetime in seconds. Pre-validated by the caller. */
   ttl: number;
@@ -20,7 +25,7 @@ interface KeypairVaultConfig {
  * permit revocations. Storage entries are keyed only by the signer address.
  */
 export class KeypairVault {
-  readonly #generator: () => Promise<Keypair>;
+  readonly #generator: (chainId?: number) => Promise<Keypair>;
   readonly #storage: GenericStorage;
   readonly #ttl: number;
   readonly #pending = new Map<ChecksummedAddress, Promise<StoredKeypair>>();
@@ -53,9 +58,14 @@ export class KeypairVault {
   /**
    * Return the cached keypair, generating and persisting a fresh one if absent or expired.
    *
-   * @remarks Deduplicates concurrent calls — simultaneous requests share one generation promise.
+   * @remarks Deduplicates concurrent calls — simultaneous requests share one
+   * generation promise. The dedup key is the signer address only: if two
+   * warmups race for the same signer with different `chainId`s, the second
+   * reuses the first. That is correct because the keypair is signer-scoped
+   * and chain-independent — the chain only picks which relayer runs the
+   * generation.
    */
-  async getOrCreate(signerAddress: ChecksummedAddress): Promise<StoredKeypair> {
+  async getOrCreate(signerAddress: ChecksummedAddress, chainId?: number): Promise<StoredKeypair> {
     const existing = this.#pending.get(signerAddress);
     if (existing) {
       return existing;
@@ -66,7 +76,7 @@ export class KeypairVault {
       if (cached !== null) {
         return cached;
       }
-      const fresh = await this.#generator();
+      const fresh = await this.#generator(chainId);
       const createdAt = nowSeconds();
       const stored: StoredKeypair = {
         publicKey: fresh.publicKey,

--- a/packages/sdk/src/errors/base.ts
+++ b/packages/sdk/src/errors/base.ts
@@ -34,6 +34,8 @@ export const ZamaErrorCode = {
   RelayerRequestFailed: "RELAYER_REQUEST_FAILED",
   /** SDK configuration is invalid (e.g. forbidden chain ID, unsupported type). */
   Configuration: "CONFIGURATION",
+  /** Web Worker runtime is not available (e.g. server-side rendering). */
+  WorkerUnavailable: "WORKER_UNAVAILABLE",
   /** Delegation cannot target self (delegate === msg.sender). */
   DelegationSelfNotAllowed: "DELEGATION_SELF_NOT_ALLOWED",
   /** Only one delegate/revoke per (delegator, delegate, contract) per block. */

--- a/packages/sdk/src/errors/index.ts
+++ b/packages/sdk/src/errors/index.ts
@@ -3,7 +3,7 @@ export { SigningRejectedError, SigningFailedError } from "./signing";
 export { EncryptionFailedError, DecryptionFailedError } from "./encryption";
 export { TransactionRevertedError } from "./transaction";
 export { KeypairExpiredError, InvalidKeypairError, NoCiphertextError } from "./credential";
-export { RelayerRequestFailedError, ConfigurationError } from "./relayer";
+export { RelayerRequestFailedError, ConfigurationError, WorkerUnavailableError } from "./relayer";
 export { ChainMismatchError } from "./chain";
 export {
   SignerRequiredError,

--- a/packages/sdk/src/errors/relayer.ts
+++ b/packages/sdk/src/errors/relayer.ts
@@ -19,3 +19,18 @@ export class ConfigurationError extends ZamaError {
     this.name = "ConfigurationError";
   }
 }
+
+/**
+ * Web Worker runtime is not available in this environment.
+ *
+ * Thrown when the `web()` relayer is used outside a browser (e.g. during
+ * Next.js server-side rendering). Callers that perform eager warmup should
+ * treat this as expected: warmup is irrelevant in non-browser environments
+ * since the SDK will be reconstructed once the app hydrates client-side.
+ */
+export class WorkerUnavailableError extends ZamaError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(ZamaErrorCode.WorkerUnavailable, message, options);
+    this.name = "WorkerUnavailableError";
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -160,6 +160,7 @@ export {
   NoCiphertextError,
   RelayerRequestFailedError,
   ConfigurationError,
+  WorkerUnavailableError,
   ChainMismatchError,
   SignerRequiredError,
   SignerNotConfiguredError,

--- a/packages/sdk/src/relayer/__tests__/relayer-dispatcher.test.ts
+++ b/packages/sdk/src/relayer/__tests__/relayer-dispatcher.test.ts
@@ -130,6 +130,58 @@ describe("RelayerDispatcher", () => {
     });
   });
 
+  describe("generateKeypair chain routing", () => {
+    test("without options, routes to the active relayer", async ({
+      createMockChain,
+      createMockRelayer,
+    }) => {
+      const chainA = createMockChain({ id: 1 });
+      const chainB = createMockChain({ id: 2 });
+      const relayerA = createMockRelayer();
+      const relayerB = createMockRelayer();
+      const dispatcher = new RelayerDispatcher([chainA, chainB], {
+        [1]: { type: "web", createRelayer: () => relayerA },
+        [2]: { type: "web", createRelayer: () => relayerB },
+      });
+
+      await dispatcher.generateKeypair();
+      expect(relayerA.generateKeypair).toHaveBeenCalledTimes(1);
+      expect(relayerB.generateKeypair).not.toHaveBeenCalled();
+    });
+
+    test("with explicit chainId, routes to that relayer without mutating active chain", async ({
+      createMockChain,
+      createMockRelayer,
+    }) => {
+      const chainA = createMockChain({ id: 1 });
+      const chainB = createMockChain({ id: 2 });
+      const relayerA = createMockRelayer();
+      const relayerB = createMockRelayer();
+      const dispatcher = new RelayerDispatcher([chainA, chainB], {
+        [1]: { type: "web", createRelayer: () => relayerA },
+        [2]: { type: "web", createRelayer: () => relayerB },
+      });
+
+      await dispatcher.generateKeypair({ chainId: 2 });
+      expect(relayerB.generateKeypair).toHaveBeenCalledTimes(1);
+      expect(relayerA.generateKeypair).not.toHaveBeenCalled();
+      // Active chain unchanged — explicit chainId is a peek, not a switch.
+      expect(dispatcher.chain).toEqual(chainA);
+    });
+
+    test("throws ConfigurationError on unknown chainId", ({
+      createMockChain,
+      createMockRelayer,
+    }) => {
+      const chainA = createMockChain({ id: 1 });
+      const dispatcher = new RelayerDispatcher(
+        [chainA],
+        relayerConfigs([chainA], createMockRelayer),
+      );
+      expect(() => dispatcher.generateKeypair({ chainId: 999 })).toThrow(ConfigurationError);
+    });
+  });
+
   describe("dispatches all RelayerSDK methods", () => {
     test.for([
       ["generateKeypair", []],

--- a/packages/sdk/src/relayer/relayer-dispatcher.ts
+++ b/packages/sdk/src/relayer/relayer-dispatcher.ts
@@ -125,8 +125,27 @@ export class RelayerDispatcher implements RelayerSDK, Disposable {
     return relayer;
   }
 
-  generateKeypair(): Promise<KeypairType<Hex>> {
-    return this.#active.generateKeypair();
+  /**
+   * Generate a fresh ML-KEM keypair via the relayer for the requested chain.
+   *
+   * Without `options.chainId`, routes to the active chain — preserving the
+   * `RelayerSDK` interface contract. With `options.chainId`, peeks at a
+   * specific chain's relayer without mutating active chain state, so callers
+   * like credential warmup can target the connected wallet's chain
+   * independently of dispatcher state.
+   */
+  generateKeypair(options?: { chainId?: number }): Promise<KeypairType<Hex>> {
+    if (options?.chainId === undefined) {
+      return this.#active.generateKeypair();
+    }
+    if (!this.#chains.has(options.chainId)) {
+      throw new ConfigurationError(
+        `No relayer configured for chain ${options.chainId}. Add it to the chains array.`,
+      );
+    }
+    const relayer = this.#relayers.get(options.chainId);
+    assertNonNullable(relayer, "RelayerDispatcher: relayer");
+    return relayer.generateKeypair();
   }
 
   createEIP712(

--- a/packages/sdk/src/services/__tests__/lifecycle-service.test.ts
+++ b/packages/sdk/src/services/__tests__/lifecycle-service.test.ts
@@ -59,11 +59,15 @@ describe("LifecycleService", () => {
   });
 
   describe("change dispatch", () => {
-    test("runs credential cleanup, cache clear, and relayer switch before listeners", async ({
+    test("switches the relayer chain first, then runs credential cleanup, then cache clear, then listeners", async ({
       createLifecycleService,
       createMockSigner,
       createMockRelayer,
     }) => {
+      // Ordering matters: switchChain must complete before credentialService
+      // and listeners run, so anything downstream observes the dispatcher in
+      // the right chain. (Was a `void swallow(...)` previously — the relayer
+      // switch could race with the warmup and listeners.)
       const calls: string[] = [];
       const handleWalletAccountChange = vi.fn(async () => {
         await Promise.resolve();
@@ -112,11 +116,61 @@ describe("LifecycleService", () => {
       dispatch!({ previous: prev, next });
 
       await vi.waitFor(() => {
-        expect(calls).toEqual(["credential", "cache", "relayer", "listener"]);
+        expect(calls).toEqual(["relayer", "credential", "cache", "listener"]);
       });
       expect(handleWalletAccountChange).toHaveBeenCalledWith(prev, next);
       expect(clearForRequester).toHaveBeenCalledWith(prev.address);
       expect(switchChain).toHaveBeenCalledWith(1);
+    });
+
+    test("awaits switchChain before invoking credential handler (no fire-and-forget)", async ({
+      createLifecycleService,
+      createMockSigner,
+      createMockRelayer,
+    }) => {
+      // Regression: a previous version used `void swallow("switch relayer chain", ...)`,
+      // so the credential handler could run while the switch was still pending.
+      let resolveSwitch: () => void = () => {};
+      const switchChain = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSwitch = resolve;
+          }),
+      );
+      const handleWalletAccountChange = vi.fn();
+      const credentialService = {
+        handleWalletAccountChange,
+      } as unknown as CredentialService;
+      const relayer = createMockRelayer({
+        switchChain: switchChain as unknown as () => void,
+      });
+      let dispatch: ((change: WalletAccountChange) => void) | undefined;
+      const signer = createMockSigner(undefined, {
+        walletAccount: {
+          getSnapshot: vi.fn(),
+          subscribe: vi.fn((listener: (change: WalletAccountChange) => void) => {
+            dispatch = listener;
+            return () => {};
+          }),
+          isReady: vi.fn().mockReturnValue(true),
+        },
+      });
+      createLifecycleService({ signer, relayer, credentialService });
+
+      dispatch!({
+        previous: undefined,
+        next: { address: "0x1111111111111111111111111111111111111111", chainId: 1 },
+      });
+
+      // Allow the microtask queue to drain — if switchChain were not awaited,
+      // handleWalletAccountChange would already have been called.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(switchChain).toHaveBeenCalledOnce();
+      expect(handleWalletAccountChange).not.toHaveBeenCalled();
+
+      resolveSwitch();
+      await vi.waitFor(() => expect(handleWalletAccountChange).toHaveBeenCalledOnce());
     });
 
     test("skips cache clear when previous account is undefined", async ({

--- a/packages/sdk/src/services/__tests__/lifecycle-service.test.ts
+++ b/packages/sdk/src/services/__tests__/lifecycle-service.test.ts
@@ -64,10 +64,9 @@ describe("LifecycleService", () => {
       createMockSigner,
       createMockRelayer,
     }) => {
-      // Ordering matters: switchChain must complete before credentialService
-      // and listeners run, so anything downstream observes the dispatcher in
-      // the right chain. (Was a `void swallow(...)` previously — the relayer
-      // switch could race with the warmup and listeners.)
+      // Invariant: switchChain must complete before the credential handler
+      // and downstream listeners run, so each step observes the dispatcher
+      // in a consistent chain state.
       const calls: string[] = [];
       const handleWalletAccountChange = vi.fn(async () => {
         await Promise.resolve();
@@ -128,8 +127,8 @@ describe("LifecycleService", () => {
       createMockSigner,
       createMockRelayer,
     }) => {
-      // Regression: a previous version used `void swallow("switch relayer chain", ...)`,
-      // so the credential handler could run while the switch was still pending.
+      // Invariant: if switchChain is async, the credential handler must not
+      // start until switchChain has resolved.
       let resolveSwitch: () => void = () => {};
       const switchChain = vi.fn(
         () =>
@@ -162,8 +161,9 @@ describe("LifecycleService", () => {
         next: { address: "0x1111111111111111111111111111111111111111", chainId: 1 },
       });
 
-      // Allow the microtask queue to drain — if switchChain were not awaited,
-      // handleWalletAccountChange would already have been called.
+      // Drain the microtask queue: when switchChain is awaited, the credential
+      // handler stays pending until resolveSwitch() runs. When it is not awaited,
+      // the handler runs immediately after the dispatch.
       await Promise.resolve();
       await Promise.resolve();
       expect(switchChain).toHaveBeenCalledOnce();

--- a/packages/sdk/src/services/lifecycle-service.ts
+++ b/packages/sdk/src/services/lifecycle-service.ts
@@ -58,6 +58,15 @@ export class LifecycleService {
   async #handleWalletAccountChange(change: WalletAccountChange): Promise<void> {
     const prev = change.previous;
     const next = change.next;
+
+    // Switch the dispatcher's active chain first so any code reached via the
+    // credential handler or downstream listeners sees a consistent state.
+    // Awaited (was `void`) so listeners cannot run with a stale active chain.
+    const nextChainId = next?.chainId;
+    if (nextChainId !== undefined) {
+      await swallow("switch relayer chain", () => this.#relayer.switchChain(nextChainId));
+    }
+
     const credentialService = this.#credentialService;
     if (credentialService) {
       await swallow("credential wallet account change", () =>
@@ -68,10 +77,6 @@ export class LifecycleService {
       await swallow("clear decrypt cache", () =>
         this.#cachingService.clearForRequester(prev.address),
       );
-    }
-    const nextChainId = next?.chainId;
-    if (nextChainId !== undefined) {
-      void swallow("switch relayer chain", () => this.#relayer.switchChain(nextChainId));
     }
     await Promise.all(
       Array.from(this.#walletAccountListeners, (listener) =>

--- a/packages/sdk/src/worker/__tests__/worker.client.test.ts
+++ b/packages/sdk/src/worker/__tests__/worker.client.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, type Mock } from "../../test-fixtures";
+import { WorkerUnavailableError } from "../../errors";
 import type { WorkerRequest, WorkerResponse } from "../worker.types";
 import { vi } from "vitest";
 // ---------------------------------------------------------------------------
@@ -220,6 +221,19 @@ describe("RelayerWorkerClient", () => {
     expect(lastMockWorker).not.toBeNull();
 
     client.terminate();
+  });
+
+  test("initWorker() throws WorkerUnavailableError when the Worker global is undefined (SSR)", async () => {
+    // Reproduce the Next.js SSR scenario: the `web()` relayer reaches creation
+    // in an environment without `Worker`. The SDK must surface a typed error
+    // so the credential warmup can silence it without spamming the console.
+    vi.stubGlobal("Worker", undefined);
+    try {
+      const client = new RelayerWorkerClient(defaultWebConfig());
+      await expect(client.initWorker()).rejects.toBeInstanceOf(WorkerUnavailableError);
+    } finally {
+      vi.stubGlobal("Worker", MockWorkerClass);
+    }
   });
 
   test("createWorker() revokes the blob URL after constructing the Worker", async () => {

--- a/packages/sdk/src/worker/__tests__/worker.client.test.ts
+++ b/packages/sdk/src/worker/__tests__/worker.client.test.ts
@@ -224,9 +224,9 @@ describe("RelayerWorkerClient", () => {
   });
 
   test("initWorker() throws WorkerUnavailableError when the Worker global is undefined (SSR)", async () => {
-    // Reproduce the Next.js SSR scenario: the `web()` relayer reaches creation
-    // in an environment without `Worker`. The SDK must surface a typed error
-    // so the credential warmup can silence it without spamming the console.
+    // Invariant: in an environment without the `Worker` global (e.g. SSR),
+    // createWorker() surfaces a typed error rather than letting the
+    // ReferenceError propagate, so callers can classify and silence it.
     vi.stubGlobal("Worker", undefined);
     try {
       const client = new RelayerWorkerClient(defaultWebConfig());

--- a/packages/sdk/src/worker/worker.client.ts
+++ b/packages/sdk/src/worker/worker.client.ts
@@ -1,4 +1,5 @@
 import type { FheChain } from "../chains/types";
+import { WorkerUnavailableError } from "../errors";
 import type {
   GenericLogger,
   UpdateCsrfResponseData,
@@ -36,6 +37,13 @@ export class RelayerWorkerClient extends BaseWorkerClient<Worker, WorkerClientCo
   }
 
   protected createWorker(): Worker {
+    if (typeof Worker === "undefined") {
+      throw new WorkerUnavailableError(
+        "Web Worker is not available in this environment. " +
+          "The web() relayer requires a browser runtime. " +
+          "For server-side or Node.js, use node() or cleartext().",
+      );
+    }
     const runtime = getBrowserExtensionRuntime();
     if (runtime) {
       return new Worker(runtime.getURL(workerFilename));


### PR DESCRIPTION
## Summary

Fixes two regressions in the credential warmup that fires when a wallet connects:

1. **Wrong chain.** `CredentialService` warmed the keypair via `RelayerDispatcher.generateKeypair()`, which routes to the dispatcher's *active* chain. The dispatcher initialises its active chain to `chains[0]`, so a wallet connected to (say) Anvil while `chains[0]` is mainnet would warm against the mainnet relayer — surfacing as a 403 in environments where mainnet credentials aren't configured. The lifecycle ordering made this worse: `switchChain` was a fire-and-forget `void swallow(...)` *after* the credential handler, so it couldn't even correct the active chain before warmup.

2. **SSR noise.** During Next.js SSR (which constructs `ZamaSDK` server-side because `"use client"` doesn't prevent SSR), the lazy Web Worker creation surfaced as a noisy `"Worker is not defined"` warning. The warmup should silently no-op in non-browser environments.

Linear: [SDK-189](https://linear.app/zama/issue/SDK-189/bug-warm-keypair-regression-investigation)

## What changed

| Concern | Change |
|---|---|
| Chain-explicit warmup | `RelayerDispatcher.generateKeypair({ chainId? })` peeks at a specific chain's relayer without mutating active state. `RelayerSDK` interface unchanged. |
| Vault threading | `KeypairVault` generator now accepts `chainId?`; `getOrCreate(addr, chainId?)` forwards it. Dedup key stays signer-address only (keypair is signer-scoped, chain-independent). |
| Credential service | `handleWalletAccountChange(prev?, next?)` takes full `WalletAccount` and forwards `next.chainId` to the vault. `WorkerUnavailableError` from warmup is treated as expected and silenced; other errors still warn. |
| Lifecycle ordering | `switchChain` is now `await`ed **first**, before the credential handler. Downstream listeners observe a consistent dispatcher state. |
| SSR-safe Worker | New `WorkerUnavailableError` (public export) thrown by `RelayerWorkerClient.createWorker()` when `typeof Worker === "undefined"`. |

Public API impact: `WorkerUnavailableError` and `ZamaErrorCode.WorkerUnavailable` are new public exports. `RelayerDispatcher.generateKeypair` accepts an optional `{ chainId? }` argument (interface-compatible widening, non-breaking). `etc/sdk.api.md` regenerated.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm lint` (oxlint + ast-grep) — 0 warnings, 0 errors
- [x] `pnpm format:check` — clean
- [x] `pnpm test:run` — 1489 passed, 5 skipped, 0 failures
- [x] `pnpm api-report:check:sdk` — green
- [x] Lock-in tests reproduce both regressions:
  - `relayer-dispatcher.test.ts` — explicit `chainId` routes correctly without mutating active chain
  - `credential-service.test.ts` — warmup forwards `next.chainId` instead of dispatcher's active chain; `WorkerUnavailableError` silenced while other errors still warn
  - `lifecycle-service.test.ts` — `switchChain` awaited before credential handler
  - `worker.client.test.ts` — `createWorker()` throws `WorkerUnavailableError` when `Worker` is undefined

## Out-of-scope (intentionally)

- `ZamaProvider`'s `useMemo(() => new ZamaSDK(...))` reconstruction on every `config` reference change — separate concern.
- Hoisting `walletAccount.subscribe` out of the `ZamaSDK` ctor into a `start()` lifecycle method — architectural cleanup beyond this fix.
- User-initiated calls (e.g. `grantPermit`) during SSR — the ticket scope is the eager warmup, not blanket SSR support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)