### PR TITLE
ci: harden e2e anvil deploy against flaky out-of-gas reverts

### DIFF
--- a/test/playwright/start-anvil.sh
+++ b/test/playwright/start-anvil.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
-# Start an anvil instance, deploy contracts, then keep anvil in the foreground.
+# Start anvil, deploy contracts, then keep anvil in the foreground.
 # Usage: ./start-anvil.sh <port>
 #
-# Multiple instances may run in parallel (Playwright starts all webServer
-# entries at once). The forge script step is serialized via a lockdir to avoid
-# broadcast-cache conflicts (both anvils share chain-id 31337).
-#
-# The contract deploy is the Playwright webServer boot, which Playwright does
-# NOT retry (its `retries` setting only re-runs tests). A transient deploy
-# revert would therefore kill the whole job, so the start+deploy is wrapped in
-# a retry loop that restarts anvil from a clean state on each attempt. Override
-# the attempt count with ANVIL_DEPLOY_ATTEMPTS (default 3).
+# Instances may run in parallel (Playwright boots all webServers at once), so
+# the forge step is lock-serialized to avoid broadcast-cache conflicts (shared
+# chain-id 31337). Playwright does not retry webServer boot, so start+deploy is
+# wrapped in a retry loop (ANVIL_DEPLOY_ATTEMPTS, default 3).
 set -euo pipefail
 
 PORT="${1:?Usage: start-anvil.sh <port>}"
@@ -61,9 +56,8 @@ start_anvil() {
   anvil --port "$PORT" --chain-id 31337 --silent &
   ANVIL_PID=$!
 
-  # Poll a real RPC call rather than a bare TCP accept: anvil can have the
-  # port open before it is ready to serve, and deploying against a not-yet-
-  # ready node is exactly the race the retry loop would otherwise paper over.
+  # Poll a real RPC call, not a bare TCP accept: the port can open before anvil
+  # is ready to serve, and deploying against it then is a needless race.
   local n=0
   while [ $n -lt 150 ]; do
     cast chain-id --rpc-url "http://127.0.0.1:$PORT" >/dev/null 2>&1 && return 0
@@ -75,9 +69,8 @@ start_anvil() {
   return 1
 }
 
-# Acquire an exclusive lock for the forge script only.
-# mkdir is atomic on all POSIX systems. Timeout after 120s.
-# If the lock exists but the holder is dead (e.g. Playwright was killed), clean it up.
+# Exclusive lock for the forge step (mkdir is atomic). Times out after 120s, and
+# reclaims the lock if its holder died (e.g. Playwright was killed).
 acquire_lock() {
   local lock_wait=0
   while ! mkdir "$LOCK_DIR" 2>/dev/null; do
@@ -104,15 +97,13 @@ acquire_lock() {
   LOCK_ACQUIRED=true
 }
 
-# Deploy the fhevm host stack and the project contracts onto the running anvil.
-# Returns non-zero (without exiting the script) on any failure so the caller can
-# restart anvil and retry.
+# Deploy the fhevm host stack + project contracts. Returns non-zero (without
+# exiting) on failure so the caller can restart anvil and retry.
 deploy_contracts() {
   local attempt_num="$1"
 
-  # Deploy fhevm host stack — independent per port, no lock needed.
-  # In CI, artifacts are pre-built and cached; skip the internal forge build
-  # to avoid failures when soldeer dependencies are absent (cache-hit path).
+  # fhevm host stack — independent per port, no lock needed. Skip the internal
+  # forge build in CI, where artifacts are prebuilt and soldeer deps may be absent.
   local deploy_args=(--anvil-port "$PORT")
   [ -n "${CI:-}" ] && deploy_args+=(--skip-build)
   if ! "$FORGE_FHEVM_DIR/deploy-local.sh" "${deploy_args[@]}"; then
@@ -126,19 +117,14 @@ deploy_contracts() {
   # would see stale artifacts from the first and fail with "nonce too low".
   rm -rf "$CONTRACTS_DIR/broadcast"
 
-  # Deploy project contracts.
-  # --slow sends one tx at a time, waiting for each receipt. Besides avoiding a
-  #   self-race across anvil's auto-mined blocks, it makes each tx's gas usage
-  #   deterministic (fixed order → stable EIP-2929 cold/warm access costs), which
-  #   was the actual cause of the intermittent out-of-gas reverts under batch
-  #   broadcast. We deliberately do NOT pass --gas-estimate-multiplier: forge's
-  #   default estimation is left intact so a genuine gas regression surfaces
-  #   rather than being masked by an inflated limit. If a deploy ever does fail,
-  #   the final attempt below runs verbosely with the full forge trace.
-  local forge_args=(--broadcast --slow)
+  # Deploy project contracts. forge's batched simulation estimates gas with warm
+  # storage (EIP-2929), but each broadcast tx runs cold, so the FHE-heavy wrap()
+  # txs exceed the default 1.3x headroom and revert out-of-gas. --skip-simulation
+  # sizes each tx from a live (cold) eth_estimateGas and --slow lets it see the
+  # prior tx — accurate gas, without padding the limit via --gas-estimate-multiplier.
+  local forge_args=(--broadcast --slow --skip-simulation)
   if [ "$attempt_num" -ge "$MAX_ATTEMPTS" ]; then
-    # Last attempt: drop --silent so a persistent (non-transient) failure shows
-    # the forge revert reason / trace instead of failing blind after N retries.
+    # Last attempt: drop --silent so a persistent failure shows the forge trace.
     echo "Final deploy attempt — running forge verbosely to surface the failure" >&2
   else
     forge_args+=(--silent)
@@ -161,8 +147,7 @@ while :; do
     break
   fi
 
-  # deploy_contracts always releases the lock before returning; the EXIT trap
-  # is the remaining safety net. Just tear anvil down before the next attempt.
+  # deploy_contracts already released the lock; just tear anvil down to retry.
   stop_anvil
 
   if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then

--- a/test/playwright/start-anvil.sh
+++ b/test/playwright/start-anvil.sh
@@ -52,19 +52,21 @@ stop_anvil() {
     wait "$ANVIL_PID" 2>/dev/null || true
     ANVIL_PID=
   fi
-  free_port
 }
 
-# Start anvil in the background and wait until it accepts connections.
+# Start anvil in the background and wait until it is serving RPC requests.
 start_anvil() {
   free_port
 
   anvil --port "$PORT" --chain-id 31337 --silent &
   ANVIL_PID=$!
 
+  # Poll a real RPC call rather than a bare TCP accept: anvil can have the
+  # port open before it is ready to serve, and deploying against a not-yet-
+  # ready node is exactly the race the retry loop would otherwise paper over.
   local n=0
   while [ $n -lt 150 ]; do
-    nc -z 127.0.0.1 "$PORT" 2>/dev/null && return 0
+    cast chain-id --rpc-url "http://127.0.0.1:$PORT" >/dev/null 2>&1 && return 0
     sleep 0.2
     n=$((n + 1))
   done
@@ -145,7 +147,8 @@ while :; do
     break
   fi
 
-  release_lock
+  # deploy_contracts always releases the lock before returning; the EXIT trap
+  # is the remaining safety net. Just tear anvil down before the next attempt.
   stop_anvil
 
   if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then

--- a/test/playwright/start-anvil.sh
+++ b/test/playwright/start-anvil.sh
@@ -5,6 +5,12 @@
 # Multiple instances may run in parallel (Playwright starts all webServer
 # entries at once). The forge script step is serialized via a lockdir to avoid
 # broadcast-cache conflicts (both anvils share chain-id 31337).
+#
+# The contract deploy is the Playwright webServer boot, which Playwright does
+# NOT retry (its `retries` setting only re-runs tests). A transient deploy
+# revert would therefore kill the whole job, so the start+deploy is wrapped in
+# a retry loop that restarts anvil from a clean state on each attempt. Override
+# the attempt count with ANVIL_DEPLOY_ATTEMPTS (default 3).
 set -euo pipefail
 
 PORT="${1:?Usage: start-anvil.sh <port>}"
@@ -17,84 +23,139 @@ DEPLOYER_PK="${DEPLOYER_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478c
 DEPLOYER_ADDR="$(cast wallet address --private-key "$DEPLOYER_PK")"
 
 LOCK_DIR="$CONTRACTS_DIR/.forge-deploy-lock"
+MAX_ATTEMPTS="${ANVIL_DEPLOY_ATTEMPTS:-3}"
 ANVIL_PID=
 LOCK_ACQUIRED=false
 
 cleanup() {
-  [ "$LOCK_ACQUIRED" = true ] && rm -rf "$LOCK_DIR" 2>/dev/null || true
-  [ -n "$ANVIL_PID" ] && kill "$ANVIL_PID" 2>/dev/null || true
+  release_lock
+  stop_anvil
 }
 trap cleanup EXIT
 
-# Kill any stale process on the port from a previous run
-if lsof -ti :"$PORT" >/dev/null 2>&1; then
-  lsof -ti :"$PORT" | xargs kill -9 2>/dev/null || true
-  sleep 1
-fi
+release_lock() {
+  [ "$LOCK_ACQUIRED" = true ] && rm -rf "$LOCK_DIR" 2>/dev/null || true
+  LOCK_ACQUIRED=false
+}
 
-# Start anvil in the background
-anvil --port "$PORT" --chain-id 31337 --silent &
-ANVIL_PID=$!
+# Free the port, killing any stale process (a previous run or a half-dead anvil).
+free_port() {
+  if lsof -ti :"$PORT" >/dev/null 2>&1; then
+    lsof -ti :"$PORT" | xargs kill -9 2>/dev/null || true
+    sleep 1
+  fi
+}
 
-# Wait for anvil to accept connections
-n=0
-while [ $n -lt 150 ]; do
-  nc -z 127.0.0.1 "$PORT" 2>/dev/null && break
-  sleep 0.2
-  n=$((n + 1))
-done
+stop_anvil() {
+  if [ -n "$ANVIL_PID" ]; then
+    kill "$ANVIL_PID" 2>/dev/null || true
+    wait "$ANVIL_PID" 2>/dev/null || true
+    ANVIL_PID=
+  fi
+  free_port
+}
 
-if ! nc -z 127.0.0.1 "$PORT" 2>/dev/null; then
+# Start anvil in the background and wait until it accepts connections.
+start_anvil() {
+  free_port
+
+  anvil --port "$PORT" --chain-id 31337 --silent &
+  ANVIL_PID=$!
+
+  local n=0
+  while [ $n -lt 150 ]; do
+    nc -z 127.0.0.1 "$PORT" 2>/dev/null && return 0
+    sleep 0.2
+    n=$((n + 1))
+  done
+
   echo "Anvil on port $PORT failed to start" >&2
-  exit 1
-fi
+  return 1
+}
 
-# Deploy fhevm host stack — independent per port, no lock needed.
-# In CI, artifacts are pre-built and cached; skip the internal forge build
-# to avoid failures when soldeer dependencies are absent (cache-hit path).
-DEPLOY_ARGS=(--anvil-port "$PORT")
-[ -n "${CI:-}" ] && DEPLOY_ARGS+=(--skip-build)
-"$FORGE_FHEVM_DIR/deploy-local.sh" "${DEPLOY_ARGS[@]}"
-
-# Acquire an exclusive lock for forge script only.
+# Acquire an exclusive lock for the forge script only.
 # mkdir is atomic on all POSIX systems. Timeout after 120s.
 # If the lock exists but the holder is dead (e.g. Playwright was killed), clean it up.
-lock_wait=0
-while ! mkdir "$LOCK_DIR" 2>/dev/null; do
-  if [ -f "$LOCK_DIR/pid" ]; then
-    holder=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
-    if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+acquire_lock() {
+  local lock_wait=0
+  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    if [ -f "$LOCK_DIR/pid" ]; then
+      local holder
+      holder=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+      if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+        rm -rf "$LOCK_DIR" 2>/dev/null || true
+        continue
+      fi
+    else
+      # Lock dir exists but no pid file — stale from a hard kill. Clean up.
       rm -rf "$LOCK_DIR" 2>/dev/null || true
       continue
     fi
-  else
-    # Lock dir exists but no pid file — stale from a hard kill. Clean up.
-    rm -rf "$LOCK_DIR" 2>/dev/null || true
-    continue
+    sleep 0.5
+    lock_wait=$((lock_wait + 1))
+    if [ $lock_wait -ge 240 ]; then
+      echo "Timed out waiting for forge deploy lock after 120s" >&2
+      return 1
+    fi
+  done
+  echo $$ > "$LOCK_DIR/pid"
+  LOCK_ACQUIRED=true
+}
+
+# Deploy the fhevm host stack and the project contracts onto the running anvil.
+# Returns non-zero (without exiting the script) on any failure so the caller can
+# restart anvil and retry.
+deploy_contracts() {
+  # Deploy fhevm host stack — independent per port, no lock needed.
+  # In CI, artifacts are pre-built and cached; skip the internal forge build
+  # to avoid failures when soldeer dependencies are absent (cache-hit path).
+  local deploy_args=(--anvil-port "$PORT")
+  [ -n "${CI:-}" ] && deploy_args+=(--skip-build)
+  if ! "$FORGE_FHEVM_DIR/deploy-local.sh" "${deploy_args[@]}"; then
+    echo "fhevm host stack deploy failed on port $PORT" >&2
+    return 1
   fi
-  sleep 0.5
-  lock_wait=$((lock_wait + 1))
-  if [ $lock_wait -ge 240 ]; then
-    echo "Timed out waiting for forge deploy lock after 120s" >&2
+
+  acquire_lock || return 1
+
+  # Clear broadcast cache — both anvils share chain-id 31337, so the second run
+  # would see stale artifacts from the first and fail with "nonce too low".
+  rm -rf "$CONTRACTS_DIR/broadcast"
+
+  # Deploy project contracts.
+  # --slow sends one tx at a time, waiting for each receipt, so the broadcast
+  #   never races itself across anvil's auto-mined blocks.
+  # --gas-estimate-multiplier 200 doubles forge's simulated gas limit, absorbing
+  #   the simulation-vs-live gas delta on the FHE-heavy wrap() txs (which touch
+  #   the cheat-materialized host contracts) that otherwise reverts out-of-gas.
+  local rc=0
+  (cd "$CONTRACTS_DIR" && forge script script/Deploy.s.sol \
+    --rpc-url "http://127.0.0.1:$PORT" \
+    --broadcast --slow --gas-estimate-multiplier 200 --silent \
+    --sender "$DEPLOYER_ADDR" \
+    --private-key "$DEPLOYER_PK") || rc=$?
+
+  release_lock
+  return "$rc"
+}
+
+attempt=1
+while :; do
+  if start_anvil && deploy_contracts; then
+    break
+  fi
+
+  release_lock
+  stop_anvil
+
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "Contract deploy failed after $MAX_ATTEMPTS attempt(s) on port $PORT" >&2
     exit 1
   fi
+  echo "Deploy attempt $attempt/$MAX_ATTEMPTS failed on port $PORT — restarting anvil and retrying" >&2
+  attempt=$((attempt + 1))
+  sleep 1
 done
-echo $$ > "$LOCK_DIR/pid"
-LOCK_ACQUIRED=true
-
-# Clear broadcast cache — both anvils share chain-id 31337, so the second run
-# would see stale artifacts from the first and fail with "nonce too low".
-rm -rf "$CONTRACTS_DIR/broadcast"
-
-# Deploy project contracts
-(cd "$CONTRACTS_DIR" && forge script script/Deploy.s.sol \
-  --rpc-url "http://127.0.0.1:$PORT" \
-  --broadcast --silent \
-  --sender "$DEPLOYER_ADDR" \
-  --private-key "$DEPLOYER_PK")
-
-rm -rf "$LOCK_DIR" 2>/dev/null || true
-LOCK_ACQUIRED=false
 
 echo "Anvil ready on port $PORT"
 

--- a/test/playwright/start-anvil.sh
+++ b/test/playwright/start-anvil.sh
@@ -108,6 +108,8 @@ acquire_lock() {
 # Returns non-zero (without exiting the script) on any failure so the caller can
 # restart anvil and retry.
 deploy_contracts() {
+  local attempt_num="$1"
+
   # Deploy fhevm host stack — independent per port, no lock needed.
   # In CI, artifacts are pre-built and cached; skip the internal forge build
   # to avoid failures when soldeer dependencies are absent (cache-hit path).
@@ -130,10 +132,19 @@ deploy_contracts() {
   # --gas-estimate-multiplier 200 doubles forge's simulated gas limit, absorbing
   #   the simulation-vs-live gas delta on the FHE-heavy wrap() txs (which touch
   #   the cheat-materialized host contracts) that otherwise reverts out-of-gas.
+  local forge_args=(--broadcast --slow --gas-estimate-multiplier 200)
+  if [ "$attempt_num" -ge "$MAX_ATTEMPTS" ]; then
+    # Last attempt: drop --silent so a persistent (non-transient) failure shows
+    # the forge revert reason / trace instead of failing blind after N retries.
+    echo "Final deploy attempt — running forge verbosely to surface the failure" >&2
+  else
+    forge_args+=(--silent)
+  fi
+
   local rc=0
   (cd "$CONTRACTS_DIR" && forge script script/Deploy.s.sol \
     --rpc-url "http://127.0.0.1:$PORT" \
-    --broadcast --slow --gas-estimate-multiplier 200 --silent \
+    "${forge_args[@]}" \
     --sender "$DEPLOYER_ADDR" \
     --private-key "$DEPLOYER_PK") || rc=$?
 
@@ -143,7 +154,7 @@ deploy_contracts() {
 
 attempt=1
 while :; do
-  if start_anvil && deploy_contracts; then
+  if start_anvil && deploy_contracts "$attempt"; then
     break
   fi
 

--- a/test/playwright/start-anvil.sh
+++ b/test/playwright/start-anvil.sh
@@ -127,12 +127,15 @@ deploy_contracts() {
   rm -rf "$CONTRACTS_DIR/broadcast"
 
   # Deploy project contracts.
-  # --slow sends one tx at a time, waiting for each receipt, so the broadcast
-  #   never races itself across anvil's auto-mined blocks.
-  # --gas-estimate-multiplier 200 doubles forge's simulated gas limit, absorbing
-  #   the simulation-vs-live gas delta on the FHE-heavy wrap() txs (which touch
-  #   the cheat-materialized host contracts) that otherwise reverts out-of-gas.
-  local forge_args=(--broadcast --slow --gas-estimate-multiplier 200)
+  # --slow sends one tx at a time, waiting for each receipt. Besides avoiding a
+  #   self-race across anvil's auto-mined blocks, it makes each tx's gas usage
+  #   deterministic (fixed order → stable EIP-2929 cold/warm access costs), which
+  #   was the actual cause of the intermittent out-of-gas reverts under batch
+  #   broadcast. We deliberately do NOT pass --gas-estimate-multiplier: forge's
+  #   default estimation is left intact so a genuine gas regression surfaces
+  #   rather than being masked by an inflated limit. If a deploy ever does fail,
+  #   the final attempt below runs verbosely with the full forge trace.
+  local forge_args=(--broadcast --slow)
   if [ "$attempt_num" -ge "$MAX_ATTEMPTS" ]; then
     # Last attempt: drop --silent so a persistent (non-transient) failure shows
     # the forge revert reason / trace instead of failing blind after N retries.


### PR DESCRIPTION
# Summary

Hardens the e2e Playwright anvil deploy (`test/playwright/start-anvil.sh`) against intermittent failures at `webServer` boot:

```
[anvil-*] Error: Transaction Failure: 0x...
Error: Process from config.webServer was not able to start. Exit code: 1
```

**Root cause (reproduced and traced locally):** the script deploys project contracts via `forge script Deploy.s.sol --broadcast`. forge estimates each tx's gas from a single batched simulation where storage is already **warm** (EIP-2929), but each broadcast tx runs **cold** in its own block — so the FHE-heavy `wrap()` txs cost more than forge's default 1.3× headroom and revert **out-of-gas** (`cast run` on the failing tx shows `[OutOfGas] EvmError: OutOfGas`). Playwright does not retry `webServer` startup (only tests), so one revert fails the whole job.

**Fix:**
1. `--skip-simulation` — forge sizes each tx from a live `eth_estimateGas` against real (cold) state instead of the warm batch simulation, so the gas limit is **accurate**. Chosen over `--gas-estimate-multiplier` so we don't pad the limit with a magic number that could mask a genuine future gas regression.
2. `--slow` — broadcast one tx at a time, waiting for each receipt, so each cold estimate sees the committed prior tx (and the broadcast doesn't self-race across auto-mined blocks).
3. Retry loop (`ANVIL_DEPLOY_ATTEMPTS`, default 3) restarting anvil from a clean state — a safety net for genuine infra transients, not a substitute for the fix above.
4. Wait on a real RPC call (`cast chain-id`) rather than a bare TCP accept, so deploy never starts before anvil is serving (drops the `nc` dependency).
5. Keep `--silent` on retry attempts but drop it on the **final** attempt, so a persistent failure surfaces forge's trace instead of failing blind.

Start/deploy steps were refactored into functions; lock, broadcast-cache clear, and fixed deployer behavior are preserved.

## Scope

- [ ] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-components`
- [ ] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [ ] Examples (`examples/`)
- [x] CI/workflows
- [ ] Docs

## Validation

- `bash -n` and `shellcheck`: clean.
- **Local reproduction** (anvil + fhevm host stack + project deploy):
  - default gas (no multiplier) → reverts **deterministically** out-of-gas on the `wrap()` tx (same tx hash every run).
  - `--skip-simulation --slow` → **succeeds repeatedly (3/3)** with no multiplier.
  - `--gas-estimate-multiplier 200` → succeeds (confirms the failure is purely gas-limit-bound, i.e. OOG, not a logic revert).
- Stubbed control-flow runs verifying retry-then-succeed and give-up-after-N (final attempt runs forge verbosely).
- Re-validating end-to-end on this PR's own `test-vite` / `test-nextjs` / `test-node` jobs.

## Related

Surfaced while triaging recurring e2e flakes on dependabot PRs (#350, #379). No tracking issue.

## Demo (if possible)

N/A — CI reliability change, no user-facing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)