### PR TITLE
fix(react-sdk): accept enabled option and empty contract list in useHasPermit

### DIFF
--- a/docs/gitbook/src/reference/react/useHasPermit.md
+++ b/docs/gitbook/src/reference/react/useHasPermit.md
@@ -85,6 +85,26 @@ const { data: hasPermit } = useHasPermit({
 });
 ```
 
+An empty list is a no-op: the query is disabled and `data` stays `undefined`. This lets you call the hook unconditionally (as the Rules of Hooks require) even when there is nothing to check yet — no dummy probe address needed.
+
+```tsx
+// Safe to call with a list that may be empty.
+const { data: hasPermit } = useHasPermit({ contractAddresses });
+```
+
+## options
+
+`Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">` — **optional**
+
+Standard React Query options, forwarded to the underlying query. Pass `{ enabled: false }` to mount the hook in an idle state — it performs no work and triggers no signature while disabled.
+
+```tsx
+const { data: hasPermit } = useHasPermit(
+  { contractAddresses: ["0xContractA"] },
+  { enabled: isReady }, // hold the check until the app is ready
+);
+```
+
 {% hint style="warning" %}
 **You must gate decrypt queries yourself.** `useUserDecrypt` does not automatically wait for permits — if you call it before `useGrantPermit`, the user sees an unexpected wallet popup. Use `useHasPermit` to conditionally enable the decrypt query via `{ enabled: !!hasPermit }` as the second argument, or conditionally render the decrypt component only when `hasPermit` is `true`.
 {% endhint %}

--- a/docs/gitbook/src/reference/react/useHasPermit.md
+++ b/docs/gitbook/src/reference/react/useHasPermit.md
@@ -85,25 +85,13 @@ const { data: hasPermit } = useHasPermit({
 });
 ```
 
-An empty list is a no-op: the query is disabled and `data` stays `undefined`. This lets you call the hook unconditionally (as the Rules of Hooks require) even when there is nothing to check yet — no dummy probe address needed.
-
-```tsx
-// Safe to call with a list that may be empty.
-const { data: hasPermit } = useHasPermit({ contractAddresses });
-```
+An empty list is a no-op: the query is disabled and `data` stays `undefined`, so you can call the hook unconditionally even when there is nothing to check yet.
 
 ## options
 
 `Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">` — **optional**
 
-Standard React Query options, forwarded to the underlying query. Pass `{ enabled: false }` to mount the hook in an idle state — it performs no work and triggers no signature while disabled.
-
-```tsx
-const { data: hasPermit } = useHasPermit(
-  { contractAddresses: ["0xContractA"] },
-  { enabled: isReady }, // hold the check until the app is ready
-);
-```
+Standard React Query options forwarded to the underlying query. Pass `{ enabled: false }` to mount the hook in an idle state (no work, no signature while disabled).
 
 {% hint style="warning" %}
 **You must gate decrypt queries yourself.** `useUserDecrypt` does not automatically wait for permits — if you call it before `useGrantPermit`, the user sees an unexpected wallet popup. Use `useHasPermit` to conditionally enable the decrypt query via `{ enabled: !!hasPermit }` as the second argument, or conditionally render the decrypt component only when `hasPermit` is `true`.

--- a/examples/react-viem/WALKTHROUGH.md
+++ b/examples/react-viem/WALKTHROUGH.md
@@ -337,8 +337,8 @@ function handleDecrypt() {
 `BalancesCard`.
 
 Token-dependent balance and authorization hooks are inside `SelectedTokenPanel`, so
-`useHasPermit` always receives a non-empty contract tuple and `useConfidentialBalance`
-always receives a real token address plus an explicit owner account.
+`useHasPermit` always receives the selected token's address (never an empty list) and
+`useConfidentialBalance` always receives a real token address plus an explicit owner account.
 
 ### Mint
 

--- a/examples/react-viem/WALKTHROUGH.md
+++ b/examples/react-viem/WALKTHROUGH.md
@@ -337,7 +337,6 @@ function handleDecrypt() {
 `BalancesCard`.
 
 Token-dependent balance and authorization hooks are inside `SelectedTokenPanel`, so
-`useHasPermit` always receives the selected token's address (never an empty list) and
 `useConfidentialBalance` always receives a real token address plus an explicit owner account.
 
 ### Mint

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10793,6 +10793,26 @@ const { data: hasPermit } = useHasPermit({
 });
 ```
 
+An empty list is a no-op: the query is disabled and `data` stays `undefined`. This lets you call the hook unconditionally (as the Rules of Hooks require) even when there is nothing to check yet — no dummy probe address needed.
+
+```tsx
+// Safe to call with a list that may be empty.
+const { data: hasPermit } = useHasPermit({ contractAddresses });
+```
+
+## options
+
+`Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">` — **optional**
+
+Standard React Query options, forwarded to the underlying query. Pass `{ enabled: false }` to mount the hook in an idle state — it performs no work and triggers no signature while disabled.
+
+```tsx
+const { data: hasPermit } = useHasPermit(
+  { contractAddresses: ["0xContractA"] },
+  { enabled: isReady }, // hold the check until the app is ready
+);
+```
+
 
 > [!WARNING]
 > **You must gate decrypt queries yourself.** `useUserDecrypt` does not automatically wait for permits — if you call it before `useGrantPermit`, the user sees an unexpected wallet popup. Use `useHasPermit` to conditionally enable the decrypt query via `{ enabled: !!hasPermit }` as the second argument, or conditionally render the decrypt component only when `hasPermit` is `true`.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17475,8 +17475,8 @@ function handleDecrypt() {
 `BalancesCard`.
 
 Token-dependent balance and authorization hooks are inside `SelectedTokenPanel`, so
-`useHasPermit` always receives a non-empty contract tuple and `useConfidentialBalance`
-always receives a real token address plus an explicit owner account.
+`useHasPermit` always receives the selected token's address (never an empty list) and
+`useConfidentialBalance` always receives a real token address plus an explicit owner account.
 
 ### Mint
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10793,25 +10793,13 @@ const { data: hasPermit } = useHasPermit({
 });
 ```
 
-An empty list is a no-op: the query is disabled and `data` stays `undefined`. This lets you call the hook unconditionally (as the Rules of Hooks require) even when there is nothing to check yet — no dummy probe address needed.
-
-```tsx
-// Safe to call with a list that may be empty.
-const { data: hasPermit } = useHasPermit({ contractAddresses });
-```
+An empty list is a no-op: the query is disabled and `data` stays `undefined`, so you can call the hook unconditionally even when there is nothing to check yet.
 
 ## options
 
 `Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">` — **optional**
 
-Standard React Query options, forwarded to the underlying query. Pass `{ enabled: false }` to mount the hook in an idle state — it performs no work and triggers no signature while disabled.
-
-```tsx
-const { data: hasPermit } = useHasPermit(
-  { contractAddresses: ["0xContractA"] },
-  { enabled: isReady }, // hold the check until the app is ready
-);
-```
+Standard React Query options forwarded to the underlying query. Pass `{ enabled: false }` to mount the hook in an idle state (no work, no signature while disabled).
 
 
 > [!WARNING]
@@ -17475,7 +17463,6 @@ function handleDecrypt() {
 `BalancesCard`.
 
 Token-dependent balance and authorization hooks are inside `SelectedTokenPanel`, so
-`useHasPermit` always receives the selected token's address (never an empty list) and
 `useConfidentialBalance` always receives a real token address plus an explicit owner account.
 
 ### Mint

--- a/packages/react-sdk/etc/react-sdk.api.md
+++ b/packages/react-sdk/etc/react-sdk.api.md
@@ -154,11 +154,11 @@ export function useFinalizeUnwrap(address: Address, options?: UseMutationOptions
 export function useGrantPermit(options?: UseMutationOptions<void, Error, Address[]>): UseMutationResult<void, Error, `0x${string}`[], unknown>;
 
 // @public
-export function useHasPermit(config: UseHasPermitConfig): UseQueryResult<boolean, Error>;
+export function useHasPermit(config: UseHasPermitConfig, options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">): UseQueryResult<boolean, Error>;
 
 // @public
 export interface UseHasPermitConfig {
-    contractAddresses: [Address, ...Address[]];
+    contractAddresses: Address[];
 }
 
 // @public

--- a/packages/react-sdk/src/permits/__tests__/use-has-permit.test.tsx
+++ b/packages/react-sdk/src/permits/__tests__/use-has-permit.test.tsx
@@ -72,4 +72,40 @@ describe("useHasPermit", () => {
       );
     });
   });
+
+  test("is disabled when options.enabled is false, even with a signer", async ({
+    renderWithProviders,
+  }) => {
+    vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+    const signer = makeSigner();
+
+    renderWithProviders(
+      () => useHasPermit({ contractAddresses: [CONTRACT_A] }, { enabled: false }),
+      { signer },
+    );
+
+    await waitFor(() => {
+      expect(vi.mocked(useQuery)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: zamaQueryKeys.hasPermit.scope([CONTRACT_A], signer.walletAccount.getSnapshot()),
+          enabled: false,
+        }),
+      );
+    });
+  });
+
+  test("is disabled when the contract list is empty", async ({ renderWithProviders }) => {
+    vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+    const signer = makeSigner();
+
+    renderWithProviders(() => useHasPermit({ contractAddresses: [] }), { signer });
+
+    await waitFor(() => {
+      expect(vi.mocked(useQuery)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: false,
+        }),
+      );
+    });
+  });
 });

--- a/packages/react-sdk/src/permits/use-has-permit.ts
+++ b/packages/react-sdk/src/permits/use-has-permit.ts
@@ -9,29 +9,18 @@ import { useWalletAccount } from "../utils/wallet-account";
 
 /** Configuration for {@link useHasPermit}. */
 export interface UseHasPermitConfig {
-  /**
-   * Contract addresses to check credentials against. An empty list disables the
-   * query (it is a no-op rather than a type or runtime error).
-   */
+  /** Contract addresses to check credentials against. */
   contractAddresses: Address[];
 }
 
 /**
  * Check whether stored permits cover the given contract addresses for the
- * connected signer. Returns `true` if decrypt operations can proceed without
- * a wallet prompt.
+ * connected signer.
  *
- * @param config - Contract addresses to check credentials against.
- * @param options - React Query options (forwarded to `useQuery`). Pass
- *   `{ enabled: false }` to mount the hook in an idle state — it performs no
- *   work and triggers no signature while disabled.
- * @returns Query result with `data: boolean` — `true` if a stored permit covers
- *   every entry in `contractAddresses`. The query auto-disables when no signer is
- *   configured, when `contractAddresses` is empty, or when `options.enabled` is
- *   `false` (`data` stays `undefined`, `status` stays `"pending"`).
- * @remarks The internal signer/empty-list guard is combined with `options.enabled`
- *   via `&&`, so it always wins: passing `enabled: true` cannot re-enable the query
- *   while no signer is configured or `contractAddresses` is empty.
+ * @param config - Contract addresses to check credentials against. The query is
+ *   disabled while the list is empty or no signer is configured.
+ * @param options - React Query options (forwarded to `useQuery`).
+ * @returns Query result with `data: boolean`.
  *
  * @example
  * ```tsx

--- a/packages/react-sdk/src/permits/use-has-permit.ts
+++ b/packages/react-sdk/src/permits/use-has-permit.ts
@@ -29,8 +29,9 @@ export interface UseHasPermitConfig {
  *   every entry in `contractAddresses`. The query auto-disables when no signer is
  *   configured, when `contractAddresses` is empty, or when `options.enabled` is
  *   `false` (`data` stays `undefined`, `status` stays `"pending"`).
- * @throws if the query runs without a signer configured (the `enabled` guard normally
- *   prevents this; only reachable if the caller forces `enabled: true`). {@link SignerNotConfiguredError}
+ * @remarks The internal signer/empty-list guard is combined with `options.enabled`
+ *   via `&&`, so it always wins: passing `enabled: true` cannot re-enable the query
+ *   while no signer is configured or `contractAddresses` is empty.
  *
  * @example
  * ```tsx

--- a/packages/react-sdk/src/permits/use-has-permit.ts
+++ b/packages/react-sdk/src/permits/use-has-permit.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "../utils/query";
+import type { UseQueryOptions } from "@tanstack/react-query";
 import type { Address } from "@zama-fhe/sdk";
 import { hasPermitQueryOptions } from "@zama-fhe/sdk/query";
 import { useZamaSDK } from "../provider";
@@ -8,8 +9,11 @@ import { useWalletAccount } from "../utils/wallet-account";
 
 /** Configuration for {@link useHasPermit}. */
 export interface UseHasPermitConfig {
-  /** Contract addresses to check credentials against (at least one required). */
-  contractAddresses: [Address, ...Address[]];
+  /**
+   * Contract addresses to check credentials against. An empty list disables the
+   * query (it is a no-op rather than a type or runtime error).
+   */
+  contractAddresses: Address[];
 }
 
 /**
@@ -17,19 +21,33 @@ export interface UseHasPermitConfig {
  * connected signer. Returns `true` if decrypt operations can proceed without
  * a wallet prompt.
  *
+ * @param config - Contract addresses to check credentials against.
+ * @param options - React Query options (forwarded to `useQuery`). Pass
+ *   `{ enabled: false }` to mount the hook in an idle state — it performs no
+ *   work and triggers no signature while disabled.
  * @returns Query result with `data: boolean` — `true` if a stored permit covers
- *   every entry in `contractAddresses`. The query auto-disables when no signer is configured
- *   (`data` stays `undefined`, `status` stays `"pending"`).
+ *   every entry in `contractAddresses`. The query auto-disables when no signer is
+ *   configured, when `contractAddresses` is empty, or when `options.enabled` is
+ *   `false` (`data` stays `undefined`, `status` stays `"pending"`).
  * @throws if the query runs without a signer configured (the `enabled` guard normally
- *   prevents this; only reachable if the caller forces `query: { enabled: true }`). {@link SignerNotConfiguredError}
+ *   prevents this; only reachable if the caller forces `enabled: true`). {@link SignerNotConfiguredError}
  *
  * @example
  * ```tsx
  * const { data: hasPermit } = useHasPermit({ contractAddresses: ["0xToken"] });
  * ```
  */
-export function useHasPermit(config: UseHasPermitConfig) {
+export function useHasPermit(
+  config: UseHasPermitConfig,
+  options?: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn">,
+) {
   const sdk = useZamaSDK();
   const walletAccount = useWalletAccount(sdk);
-  return useQuery<boolean>(hasPermitQueryOptions(sdk, config, { walletAccount }));
+  const baseOpts = hasPermitQueryOptions(sdk, config, { walletAccount });
+
+  return useQuery<boolean>({
+    ...baseOpts,
+    ...options,
+    enabled: (baseOpts.enabled ?? true) && (options?.enabled ?? true),
+  });
 }

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -422,7 +422,7 @@ export function hashFn(queryKey: readonly unknown[]): string;
 
 // @public (undocumented)
 export interface HasPermitQueryConfig {
-    contractAddresses: [Address, ...Address[]];
+    contractAddresses: Address[];
     query?: Record<string, unknown>;
 }
 

--- a/packages/sdk/src/query/__tests__/grant-permit-revoke.test.ts
+++ b/packages/sdk/src/query/__tests__/grant-permit-revoke.test.ts
@@ -94,6 +94,14 @@ describe("hasPermitQueryOptions", () => {
     expect(options.enabled).toBe(false);
   });
 
+  test("is disabled when the contract list is empty", ({ sdk }) => {
+    const options = hasPermitQueryOptions(sdk, {
+      contractAddresses: [],
+    });
+
+    expect(options.enabled).toBe(false);
+  });
+
   test("is disabled when signer is absent", ({ createSDK }) => {
     const sdk = createSDK({ signer: undefined });
     const options = hasPermitQueryOptions(sdk, {

--- a/packages/sdk/src/query/has-permit.ts
+++ b/packages/sdk/src/query/has-permit.ts
@@ -6,8 +6,11 @@ import type { SignerQueryContext } from "./signer-query-context";
 import { filterQueryOptions } from "./utils";
 
 export interface HasPermitQueryConfig {
-  /** Contract addresses to check credentials against. */
-  contractAddresses: [Address, ...Address[]];
+  /**
+   * Contract addresses to check credentials against. An empty list disables the
+   * query (it is a no-op rather than a type or runtime error).
+   */
+  contractAddresses: Address[];
   /**
    * Standard TanStack query options. `hasPermit` intentionally overrides cache
    * timing because permit state is wallet-local, not server state: every fetch

--- a/packages/sdk/src/query/has-permit.ts
+++ b/packages/sdk/src/query/has-permit.ts
@@ -6,10 +6,7 @@ import type { SignerQueryContext } from "./signer-query-context";
 import { filterQueryOptions } from "./utils";
 
 export interface HasPermitQueryConfig {
-  /**
-   * Contract addresses to check credentials against. An empty list disables the
-   * query (it is a no-op rather than a type or runtime error).
-   */
+  /** Contract addresses to check credentials against. */
   contractAddresses: Address[];
   /**
    * Standard TanStack query options. `hasPermit` intentionally overrides cache


### PR DESCRIPTION
## What

`useHasPermit` (`@zama-fhe/react-sdk`) now:

- accepts a second `options` argument (TanStack query options), so callers can pass `{ enabled: false }` to mount the hook in an idle state — no work, no signature while disabled;
- tolerates an **empty** `contractAddresses` list as a no-op (query disabled, `data` stays `undefined`) instead of a type/runtime error.

This follows the package convention already used by `useConfidentialIsOperator`, `useConfidentialBalance`, etc. (2nd-arg `options`, `enabled` combined). The SDK-level factory (`hasPermitQueryOptions`) already respected `query.enabled` and disabled on empty lists at runtime — the gap was purely the React hook's API surface and the non-empty tuple type.

## Why

Closes [SDK-190](https://linear.app/zama/issue/SDK-190). Rules of Hooks force `useHasPermit` to be called unconditionally even when there's nothing to check yet (e.g. a chain with no confidential tokens). Consumers had to pass a dummy `[zeroAddress]` probe and discard the result. They can now call the hook with a possibly-empty list directly.

## Design note

Empty list → **disabled / `data: undefined`** (no-op), not "enabled returning `true`". This keeps the hook aligned with the rest of the package (missing input → disabled query) and removes the ugly probe; the residual `length === 0 ? true` decision stays with the consumer where it belongs.

## Changes

- `packages/sdk/src/query/has-permit.ts` — `contractAddresses` type `[Address, ...Address[]]` → `Address[]` (+ JSDoc)
- `packages/react-sdk/src/permits/use-has-permit.ts` — loosen type, add `options?` arg, combine `enabled`, JSDoc
- tests: +1 SDK factory (empty list disabled), +2 React (`enabled: false` with signer; empty list disabled)
- `docs/gitbook/src/reference/react/useHasPermit.md` — document `options`/`enabled` + empty-list no-op
- `llms-full.txt` — regenerated by pre-commit hook from the docs corpus

No changeset file: repo uses semantic-release / conventional commits.

## Verification

- ✅ typecheck (`@zama-fhe/sdk`, `@zama-fhe/react-sdk`)
- ✅ tests: 10 SDK factory, 4 React `useHasPermit`
- ✅ oxlint + oxfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)