### PR TITLE
docs: point agents to CONTRIBUTING and fix dev-command refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Load these on demand during planning — they are not preloaded:
 - [`docs/agents/architecture.md`](docs/agents/architecture.md) — repo layout, how operations flow through the system (balance, transfer, shield, unshield, routing)
 - [`docs/agents/conventions.md`](docs/agents/conventions.md) — shared naming rules and design decisions (contracts-vs-tokens, Solidity-mirror params, pure contract call builders, stage-gate docs language, …)
 - [`docs/agents/gotchas.md`](docs/agents/gotchas.md) — shared footguns: address normalization in query keys, PR base branch, shared-branch safety
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — dev commands (build, test, E2E, typecheck, lint, format), LLM artifact generation (`pnpm llm:build` / `llm:check`), API reports (`pnpm api-report*`), and the PR/release workflow
 
 Some packages add their own AGENTS.md with package-specific rules — they merge with this root file when you're working in that subtree:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,14 +49,14 @@ Use descriptive branch names:
 
 ### Making Changes
 
-1. Create a feature branch from `main`
+1. Create a feature branch from `prerelease` (the default PR base; `main` is reserved for release/CI-infra PRs)
 2. Make your changes
 3. Ensure all checks pass:
 
 ```bash
 pnpm typecheck    # Type checking
-pnpm lint         # ESLint
-pnpm format:check # Prettier formatting
+pnpm lint         # oxlint + ast-grep rules
+pnpm format:check # oxfmt formatting
 pnpm test:run     # Unit tests
 pnpm build        # Build output
 ```
@@ -80,6 +80,16 @@ pnpm llm:check
 
 The pre-commit hook regenerates and stages the LLM artifacts automatically when relevant staged sources change. If a corpus source is partially staged, stage or discard the remaining changes before committing so the generated files match the committed source state.
 
+### API Reports
+
+Public API surface is tracked with [API Extractor](https://api-extractor.com/) reports committed to the repo. When you change a public export, regenerate the reports and commit the result:
+
+```bash
+pnpm api-report        # regenerate all reports locally (runs a build first)
+pnpm api-report:check  # CI gate — fails if committed reports are stale
+pnpm api-report:diff   # show what changed in the public surface
+```
+
 ### Running Tests
 
 ```bash
@@ -102,7 +112,7 @@ pnpm e2e:test
 ### Code Style
 
 - **ESM-only** — all packages use `"type": "module"`
-- **Prettier + ESLint** — enforced via pre-commit hooks (Husky + lint-staged)
+- **oxfmt + oxlint** — enforced via pre-commit hooks (Husky + lint-staged); ast-grep adds custom AST lint rules
 - **Unused variables** — prefix with `_` (e.g., `_unused`)
 - **Tests** — place in `__tests__/` directories adjacent to source files, use vitest with `vi.fn()` for mocks
 - **React SDK** — all source files use `"use client"` directive
@@ -112,7 +122,7 @@ pnpm e2e:test
 1. **Keep PRs focused** — one feature or fix per PR
 2. **Add tests** — new features and bug fixes should include tests
 3. **Update types** — if you change public APIs, update TypeScript types accordingly
-4. **Run all checks** — ensure `pnpm typecheck && pnpm lint && pnpm test:run && pnpm build` passes
+4. **Run all checks** — ensure `pnpm typecheck && pnpm lint && pnpm test:run && pnpm build` passes; if you changed public APIs or docs/corpus sources, also run `pnpm api-report:check` and `pnpm llm:check`
 5. **Use a Conventional Commit PR title** — examples: `fix: handle signer timeout`, `feat(react-sdk): add cached token balance hook`
 
 ### Release Automation


### PR DESCRIPTION
# Summary

Make the contributor command reference discoverable to coding agents and correct several stale references in `CONTRIBUTING.md`.

- **AGENTS.md** — add a load-on-demand pointer to `CONTRIBUTING.md` in *Further reading*, naming the dev / LLM-artifact / api-report command families it covers so agents don't rediscover them from `package.json`.
- **CONTRIBUTING.md** — fix lint/format tooling refs (`oxlint`/`oxfmt`, not ESLint/Prettier; note ast-grep), document the `api-report` commands, correct the feature-branch base (`prerelease`, not `main`), and extend the pre-PR check gate to mention `api-report:check` / `llm:check`.

## Scope

- [ ] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-components`
- [ ] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [ ] Examples (`examples/`)
- [ ] CI/workflows
- [x] Docs

## Validation

Docs-only change. Verified every referenced command exists in `package.json`, every referenced path resolves, and the corrected tooling (oxlint/oxfmt) matches the `lint`/`format` scripts.

## Related

<!-- Link issue(s) / related PR(s), if any. -->

## Demo (if possible)

N/A — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)