### PR TITLE
build(api-report): keep committed API reports semantic-only

### DIFF
--- a/api-extractor.base.json
+++ b/api-extractor.base.json
@@ -33,7 +33,7 @@
     },
     "extractorMessageReporting": {
       "default": { "logLevel": "warning" },
-      "ae-forgotten-export": { "logLevel": "warning", "addToApiReportFile": true },
+      "ae-forgotten-export": { "logLevel": "none", "addToApiReportFile": false },
       "ae-missing-release-tag": { "logLevel": "none" },
       "ae-unresolved-link": { "logLevel": "none" }
     },

--- a/packages/sdk/etc/sdk-ethers.api.md
+++ b/packages/sdk/etc/sdk-ethers.api.md
@@ -30,9 +30,6 @@ import * as SDK from '@zama-fhe/relayer-sdk/bundle';
 import { Signer } from 'ethers';
 import { ZKProofLike } from '@zama-fhe/relayer-sdk/bundle';
 
-// Warning: (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "ZamaConfig" needs to be exported by the entry point index.d.ts
-//
 // @public
 export function createConfig<const TChains extends readonly [FheChain, ...FheChain[]]>(params: ZamaConfigEthers<TChains>): ZamaConfig;
 
@@ -45,8 +42,6 @@ export { EIP1193Provider }
 // @public
 export type EncryptedValue = Bytes32Hex;
 
-// Warning: (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts
-//
 // @public
 export class EthersProvider implements GenericProvider {
     constructor(config: EthersProviderConfig);
@@ -54,12 +49,8 @@ export class EthersProvider implements GenericProvider {
     getBlockTimestamp(): Promise<bigint>;
     // (undocumented)
     getChainId(): Promise<number>;
-    // Warning: (ae-forgotten-export) The symbol "ReadContractConfig" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readContract<const TAbi extends Abi | readonly unknown[], TFunctionName extends ContractFunctionName<TAbi, "pure" | "view">, const TArgs extends ContractFunctionArgs<TAbi, "pure" | "view", TFunctionName>>(config: ReadContractConfig<TAbi, TFunctionName, TArgs>): Promise<ContractFunctionReturnType<TAbi, "pure" | "view", TFunctionName, TArgs>>;
-    // Warning: (ae-forgotten-export) The symbol "TransactionReceipt" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt>;
 }
@@ -71,8 +62,6 @@ export type EthersProviderConfig = {
     provider: ethers.Provider;
 };
 
-// Warning: (ae-forgotten-export) The symbol "BaseSigner" needs to be exported by the entry point index.d.ts
-//
 // @public
 export class EthersSigner extends BaseSigner {
     constructor(config: EthersSignerConfig);
@@ -80,16 +69,10 @@ export class EthersSigner extends BaseSigner {
     protected onDispose(): void;
     // (undocumented)
     refreshWalletAccount(): Promise<WalletAccount | undefined>;
-    // Warning: (ae-forgotten-export) The symbol "WalletAccount" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     requireWalletAccount(operation: string): WalletAccount;
-    // Warning: (ae-forgotten-export) The symbol "EIP712TypedData" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     signTypedData(typedData: EIP712TypedData): Promise<Hex>;
-    // Warning: (ae-forgotten-export) The symbol "WriteContractConfig" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     writeContract<const TAbi extends Abi | readonly unknown[], TFunctionName extends ContractFunctionName<TAbi, "nonpayable" | "payable">, const TArgs extends ContractFunctionArgs<TAbi, "nonpayable" | "payable", TFunctionName>>(config: WriteContractConfig<TAbi, TFunctionName, TArgs>): Promise<Hex>;
 }
@@ -109,8 +92,6 @@ export { ProviderMessage }
 
 export { ProviderRpcError }
 
-// Warning: (ae-forgotten-export) The symbol "EthersCallProvider" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export function readConfidentialBalanceOfContract(provider: EthersCallProvider, tokenAddress: Address, userAddress: Address): Promise<unknown>;
 
@@ -141,8 +122,6 @@ export function readTokenPairsSliceContract(provider: EthersCallProvider, regist
 // @public (undocumented)
 export function readUnderlyingTokenContract(provider: EthersCallProvider, wrapperAddress: Address): Promise<unknown>;
 
-// Warning: (ae-forgotten-export) The symbol "EthersTransactionSigner" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export function writeConfidentialTransferContract(signer: EthersTransactionSigner, tokenAddress: Address, to: Address, encryptedAmount: EncryptedValue, inputProof: Hex): Promise<`0x${string}`>;
 
@@ -161,9 +140,6 @@ export function writeUnwrapFromBalanceContract(signer: EthersTransactionSigner, 
 // @public (undocumented)
 export function writeWrapContract(signer: EthersTransactionSigner, wrapperAddress: Address, to: Address, amount: bigint): Promise<`0x${string}`>;
 
-// Warning: (ae-forgotten-export) The symbol "AtLeastOneChain" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "ZamaConfigBase" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type ZamaConfigEthers<TChains extends AtLeastOneChain = AtLeastOneChain> = ZamaConfigBase<TChains> & ({
     ethereum: EIP1193Provider;

--- a/packages/sdk/etc/sdk-node.api.md
+++ b/packages/sdk/etc/sdk-node.api.md
@@ -38,8 +38,6 @@ export const anvil: {
     readonly executorAddress: "0xe3a9105a3a932253A70F126eb1E3b589C643dD24";
 };
 
-// Warning: (ae-forgotten-export) The symbol "GenericStorage" needs to be exported by the entry point index.d.ts
-//
 // @public
 export class AsyncLocalMapStorage implements GenericStorage {
     // (undocumented)
@@ -100,8 +98,6 @@ export abstract class BaseWorkerClient<TWorker, TConfig> {
     protected readonly logger: GenericLogger | undefined;
     protected onWorkerReady?(_worker: TWorker): void;
     protected abstract postMessage(worker: TWorker, request: WorkerRequest): void;
-    // Warning: (ae-forgotten-export) The symbol "PublicDecryptPayload" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     publicDecrypt(params: PublicDecryptPayload): Promise<PublicDecryptResponseData>;
     // (undocumented)
@@ -118,13 +114,9 @@ export abstract class BaseWorkerClient<TWorker, TConfig> {
     protected abstract wireEvents(worker: TWorker): void;
 }
 
-// Warning: (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
-//
 // @public
 export const chains: Record<number, FheChain>;
 
-// Warning: (ae-forgotten-export) The symbol "CleartextRelayerConfig" needs to be exported by the entry point index.d.ts
-//
 // @public
 export function cleartext(): CleartextRelayerConfig;
 
@@ -182,8 +174,6 @@ export interface DelegatedUserDecryptParams {
     delegatorAddress: Address;
     // (undocumented)
     durationDays: number;
-    // Warning: (ae-forgotten-export) The symbol "EncryptedValue" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     encryptedValues: EncryptedValue[];
     // (undocumented)
@@ -236,7 +226,6 @@ export interface EncryptParams {
     contractAddress: Address;
     // (undocumented)
     userAddress: Address;
-    // Warning: (ae-forgotten-export) The symbol "EncryptInput" needs to be exported by the entry point index.d.ts
     values: EncryptInput[];
 }
 
@@ -265,8 +254,6 @@ export type EncryptResult = {
     inputProof: Hex;
 };
 
-// Warning: (ae-forgotten-export) The symbol "BaseResponse" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export interface ErrorResponse extends BaseResponse {
     // (undocumented)
@@ -375,9 +362,6 @@ export const hoodi: {
     readonly executorAddress: "0xC316692627de536368d82e9121F1D44a550894E6";
 };
 
-// Warning: (ae-forgotten-export) The symbol "InitWebPayload" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "InitNodePayload" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export type InitPayload = InitWebPayload | InitNodePayload;
 
@@ -420,12 +404,8 @@ export interface NodePoolOptions {
 
 // @public
 export interface NodeRelayerConfig extends RelayerConfig {
-    // Warning: (ae-forgotten-export) The symbol "RelayerNode" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly createRelayer: (chain: FheChain, worker: NodeWorkerPool) => RelayerNode;
-    // Warning: (ae-forgotten-export) The symbol "NodeWorkerPool" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly createWorker: (chains: FheChain[]) => NodeWorkerPool;
     // (undocumented)
@@ -486,8 +466,6 @@ export interface RelayerNodeConfig {
     pool: NodeWorkerPool;
 }
 
-// Warning: (ae-forgotten-export) The symbol "FheOperations" needs to be exported by the entry point index.d.ts
-//
 // @public
 export interface RelayerSDK extends FheOperations {
     getAclAddress(): Promise<Address>;

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -362,33 +362,6 @@ export interface EncryptStartEvent extends BaseEvent {
 }
 
 // @public
-export interface FheChain<TId extends number = number> {
-    // (undocumented)
-    readonly aclContractAddress: Address;
-    readonly auth?: Auth;
-    readonly executorAddress?: Address | undefined;
-    // (undocumented)
-    readonly gatewayChainId: number;
-    // (undocumented)
-    readonly id: TId;
-    readonly inputSignerPrivateKey?: Hex;
-    // (undocumented)
-    readonly inputVerifierContractAddress: Address;
-    // (undocumented)
-    readonly kmsContractAddress: Address;
-    readonly kmsSignerPrivateKey?: Hex;
-    // (undocumented)
-    readonly network: EIP1193Provider | string;
-    readonly registryAddress: Address | undefined;
-    // (undocumented)
-    readonly relayerUrl: string;
-    // (undocumented)
-    readonly verifyingContractAddressDecryption: Address;
-    // (undocumented)
-    readonly verifyingContractAddressInputVerification: Address;
-}
-
-// @public
 export function filterQueryOptions<TOptions extends Record<string, unknown>>(options: TOptions): Omit<TOptions, StrippedQueryOptionKeys>;
 
 // @public (undocumented)
@@ -417,14 +390,6 @@ export interface FinalizeUnwrapSubmittedEvent extends BaseEvent {
     txHash: Hex;
     // (undocumented)
     type: typeof ZamaSDKEvents.FinalizeUnwrapSubmitted;
-}
-
-// @public
-export interface GenericProvider {
-    getBlockTimestamp(): Promise<bigint>;
-    getChainId(): Promise<number>;
-    readContract<const TAbi extends ContractAbi, TFunctionName extends ReadFunctionName<TAbi>, const TArgs extends ReadContractArgs<TAbi, TFunctionName>>(config: ReadContractConfig<TAbi, TFunctionName, TArgs>): Promise<ReadContractReturnType<TAbi, TFunctionName, TArgs>>;
-    waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt>;
 }
 
 // @public
@@ -581,43 +546,6 @@ export interface QueryLike {
 export interface RawLog {
     readonly data: Hex;
     readonly topics: readonly Hex[];
-}
-
-// @public
-export class RelayerDispatcher implements RelayerSDK, Disposable {
-    // (undocumented)
-    [Symbol.dispose](): void;
-    constructor(chains: readonly [FheChain, ...FheChain[]], configs: Readonly<Record<number, RelayerConfig>>);
-    // (undocumented)
-    get chain(): FheChain;
-    // (undocumented)
-    get chains(): readonly FheChain[];
-    // (undocumented)
-    createDelegatedUserDecryptEIP712(publicKey: Hex, contractAddresses: Address[], delegatorAddress: Address, startTimestamp: number, durationDays?: number): Promise<KmsDelegatedUserDecryptEIP712Type>;
-    // (undocumented)
-    createEIP712(publicKey: Hex, contractAddresses: Address[], startTimestamp: number, durationDays?: number): Promise<EIP712TypedData>;
-    // (undocumented)
-    delegatedUserDecrypt(params: DelegatedUserDecryptParams): Promise<Readonly<Record<EncryptedValue, ClearValue>>>;
-    // (undocumented)
-    encrypt(params: EncryptParams): Promise<EncryptResult>;
-    // (undocumented)
-    generateKeypair(): Promise<KeypairType<Hex>>;
-    // (undocumented)
-    getAclAddress(): Promise<Address>;
-    // (undocumented)
-    getPublicKey(): Promise<PublicKeyData | null>;
-    // (undocumented)
-    getPublicParams(bits: number): Promise<PublicParamsData | null>;
-    // (undocumented)
-    publicDecrypt(encryptedValues: EncryptedValue[]): Promise<PublicDecryptResult>;
-    // (undocumented)
-    requestZKProofVerification(zkProof: ZKProofLike): Promise<InputProofBytesType>;
-    // (undocumented)
-    switchChain(chainId: number): void;
-    // (undocumented)
-    terminate(): void;
-    // (undocumented)
-    userDecrypt(params: UserDecryptParams): Promise<Readonly<Record<EncryptedValue, ClearValue>>>;
 }
 
 // @public

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -60,7 +60,6 @@ export interface BaseEvent {
 
 // @public
 export interface BatchBalancesResult {
-    // Warning: (ae-forgotten-export) The symbol "ZamaError" needs to be exported by the entry point index.d.ts
     errors: Map<Address, ZamaError>;
     results: Map<Address, bigint>;
 }
@@ -96,8 +95,6 @@ export interface ConfidentialBalanceQueryConfig {
     tokenAddress: Address;
 }
 
-// Warning: (ae-forgotten-export) The symbol "SignerQueryContext" needs to be exported by the entry point index.d.ts
-//
 // @public
 export function confidentialBalanceQueryOptions(token: Token, config: ConfidentialBalanceQueryConfig, signerContext?: SignerQueryContext): QueryFactoryOptions<bigint, Error, bigint, ReturnType<typeof zamaQueryKeys.confidentialBalance.owner>>;
 
@@ -365,6 +362,33 @@ export interface EncryptStartEvent extends BaseEvent {
 }
 
 // @public
+export interface FheChain<TId extends number = number> {
+    // (undocumented)
+    readonly aclContractAddress: Address;
+    readonly auth?: Auth;
+    readonly executorAddress?: Address | undefined;
+    // (undocumented)
+    readonly gatewayChainId: number;
+    // (undocumented)
+    readonly id: TId;
+    readonly inputSignerPrivateKey?: Hex;
+    // (undocumented)
+    readonly inputVerifierContractAddress: Address;
+    // (undocumented)
+    readonly kmsContractAddress: Address;
+    readonly kmsSignerPrivateKey?: Hex;
+    // (undocumented)
+    readonly network: EIP1193Provider | string;
+    readonly registryAddress: Address | undefined;
+    // (undocumented)
+    readonly relayerUrl: string;
+    // (undocumented)
+    readonly verifyingContractAddressDecryption: Address;
+    // (undocumented)
+    readonly verifyingContractAddressInputVerification: Address;
+}
+
+// @public
 export function filterQueryOptions<TOptions extends Record<string, unknown>>(options: TOptions): Omit<TOptions, StrippedQueryOptionKeys>;
 
 // @public (undocumented)
@@ -396,17 +420,20 @@ export interface FinalizeUnwrapSubmittedEvent extends BaseEvent {
 }
 
 // @public
+export interface GenericProvider {
+    getBlockTimestamp(): Promise<bigint>;
+    getChainId(): Promise<number>;
+    readContract<const TAbi extends ContractAbi, TFunctionName extends ReadFunctionName<TAbi>, const TArgs extends ReadContractArgs<TAbi, TFunctionName>>(config: ReadContractConfig<TAbi, TFunctionName, TArgs>): Promise<ReadContractReturnType<TAbi, TFunctionName, TArgs>>;
+    waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt>;
+}
+
+// @public
 export interface GenericSigner {
     dispose?(): void;
     refreshWalletAccount?(): Promise<WalletAccount | undefined>;
     requireWalletAccount(operation: string): WalletAccount;
     signTypedData(typedData: EIP712TypedData): Promise<Hex>;
-    // Warning: (ae-forgotten-export) The symbol "WalletAccountStore" needs to be exported by the entry point index.d.ts
     readonly walletAccount: WalletAccountStore;
-    // Warning: (ae-forgotten-export) The symbol "ContractAbi" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "WriteFunctionName" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "WriteContractArgs" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "WriteContractConfig" needs to be exported by the entry point index.d.ts
     writeContract<const TAbi extends ContractAbi, TFunctionName extends WriteFunctionName<TAbi>, const TArgs extends WriteContractArgs<TAbi, TFunctionName>>(config: WriteContractConfig<TAbi, TFunctionName, TArgs>): Promise<Hex>;
 }
 
@@ -501,11 +528,6 @@ export interface ListPairsQueryConfig {
     registryAddress: Address | undefined;
 }
 
-// Warning: (ae-forgotten-export) The symbol "WrappersRegistry" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "PaginatedResult" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "TokenWrapperPair" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "TokenWrapperPairWithMetadata" needs to be exported by the entry point index.d.ts
-//
 // @public
 export function listPairsQueryOptions(registry: WrappersRegistry, config: ListPairsQueryConfig): QueryFactoryOptions<PaginatedResult<TokenWrapperPair | TokenWrapperPairWithMetadata>, Error, PaginatedResult<TokenWrapperPair | TokenWrapperPairWithMetadata>, ReturnType<typeof zamaQueryKeys.wrappersRegistry.listPairs>>;
 
@@ -536,8 +558,6 @@ export interface QueryClientLike {
     removeQueries(filters: QueryFilterLike): void;
 }
 
-// Warning: (ae-forgotten-export) The symbol "RequiredBy" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export type QueryFactoryOptions<TQueryFnData = unknown, TError = Error, TData = TQueryFnData, TQueryKey extends QueryKey = QueryKey> = Omit<RequiredBy<QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>, "queryKey">, "queryFn" | "queryHash" | "queryKeyHashFn" | "throwOnError"> & {
     queryFn: Exclude<QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>["queryFn"], typeof skipToken | undefined>;
@@ -563,8 +583,43 @@ export interface RawLog {
     readonly topics: readonly Hex[];
 }
 
-// Warning: (ae-forgotten-export) The symbol "FheOperations" needs to be exported by the entry point index.d.ts
-//
+// @public
+export class RelayerDispatcher implements RelayerSDK, Disposable {
+    // (undocumented)
+    [Symbol.dispose](): void;
+    constructor(chains: readonly [FheChain, ...FheChain[]], configs: Readonly<Record<number, RelayerConfig>>);
+    // (undocumented)
+    get chain(): FheChain;
+    // (undocumented)
+    get chains(): readonly FheChain[];
+    // (undocumented)
+    createDelegatedUserDecryptEIP712(publicKey: Hex, contractAddresses: Address[], delegatorAddress: Address, startTimestamp: number, durationDays?: number): Promise<KmsDelegatedUserDecryptEIP712Type>;
+    // (undocumented)
+    createEIP712(publicKey: Hex, contractAddresses: Address[], startTimestamp: number, durationDays?: number): Promise<EIP712TypedData>;
+    // (undocumented)
+    delegatedUserDecrypt(params: DelegatedUserDecryptParams): Promise<Readonly<Record<EncryptedValue, ClearValue>>>;
+    // (undocumented)
+    encrypt(params: EncryptParams): Promise<EncryptResult>;
+    // (undocumented)
+    generateKeypair(): Promise<KeypairType<Hex>>;
+    // (undocumented)
+    getAclAddress(): Promise<Address>;
+    // (undocumented)
+    getPublicKey(): Promise<PublicKeyData | null>;
+    // (undocumented)
+    getPublicParams(bits: number): Promise<PublicParamsData | null>;
+    // (undocumented)
+    publicDecrypt(encryptedValues: EncryptedValue[]): Promise<PublicDecryptResult>;
+    // (undocumented)
+    requestZKProofVerification(zkProof: ZKProofLike): Promise<InputProofBytesType>;
+    // (undocumented)
+    switchChain(chainId: number): void;
+    // (undocumented)
+    terminate(): void;
+    // (undocumented)
+    userDecrypt(params: UserDecryptParams): Promise<Readonly<Record<EncryptedValue, ClearValue>>>;
+}
+
 // @public
 export interface RelayerSDK extends FheOperations {
     getAclAddress(): Promise<Address>;
@@ -753,8 +808,6 @@ export interface TransactionErrorEvent extends BaseEvent {
     type: typeof ZamaSDKEvents.TransactionError;
 }
 
-// Warning: (ae-forgotten-export) The symbol "transactionOperationMetadata" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type TransactionOperation = keyof typeof transactionOperationMetadata;
 
@@ -1205,9 +1258,7 @@ export class ZamaSDK {
     createToken(address: Address): Token;
     createWrappedToken(address: Address): WrappedToken;
     createWrappersRegistry(registryAddresses?: Record<number, Address>): WrappersRegistry;
-    // Warning: (ae-forgotten-export) The symbol "Decryption" needs to be exported by the entry point index.d.ts
     readonly decryption: Decryption;
-    // Warning: (ae-forgotten-export) The symbol "Delegations" needs to be exported by the entry point index.d.ts
     readonly delegations: Delegations;
     dispose(): void;
     // @internal
@@ -1215,7 +1266,6 @@ export class ZamaSDK {
     encrypt(params: EncryptParams): Promise<EncryptResult>;
     // @internal
     onWalletAccountChange(listener: WalletAccountListener): () => void;
-    // Warning: (ae-forgotten-export) The symbol "Permits" needs to be exported by the entry point index.d.ts
     readonly permits: Permits;
     // (undocumented)
     readonly provider: GenericProvider;
@@ -1260,12 +1310,6 @@ export const ZamaSDKEvents: {
     readonly UnshieldPhase2Started: "unshield:phase2_started";
     readonly UnshieldPhase2Submitted: "unshield:phase2_submitted";
 };
-
-// Warnings were encountered during analysis:
-//
-// dist/esm/types-Cqh3uOZC.d.ts:637:3 - (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
-// dist/esm/types-Cqh3uOZC.d.ts:638:3 - (ae-forgotten-export) The symbol "RelayerDispatcher" needs to be exported by the entry point index.d.ts
-// dist/esm/types-Cqh3uOZC.d.ts:639:3 - (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/etc/sdk-viem.api.md
+++ b/packages/sdk/etc/sdk-viem.api.md
@@ -24,9 +24,6 @@ import * as SDK from '@zama-fhe/relayer-sdk/bundle';
 import { WalletClient } from 'viem';
 import { ZKProofLike } from '@zama-fhe/relayer-sdk/bundle';
 
-// Warning: (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "ZamaConfig" needs to be exported by the entry point index.d.ts
-//
 // @public
 export function createConfig<const TChains extends readonly [FheChain, ...FheChain[]]>(params: ZamaConfigViem<TChains>): ZamaConfig;
 
@@ -77,8 +74,6 @@ export function readTokenPairsSliceContract(client: PublicClient, registry: Addr
 // @public (undocumented)
 export function readUnderlyingTokenContract(client: PublicClient, wrapperAddress: Address): Promise<`0x${string}`>;
 
-// Warning: (ae-forgotten-export) The symbol "GenericProvider" needs to be exported by the entry point index.d.ts
-//
 // @public
 export class ViemProvider implements GenericProvider {
     constructor(config: ViemProviderConfig);
@@ -86,12 +81,8 @@ export class ViemProvider implements GenericProvider {
     getBlockTimestamp(): Promise<bigint>;
     // (undocumented)
     getChainId(): Promise<number>;
-    // Warning: (ae-forgotten-export) The symbol "ReadContractConfig" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readContract<const TAbi extends Abi | readonly unknown[], TFunctionName extends ContractFunctionName<TAbi, "pure" | "view">, const TArgs extends ContractFunctionArgs<TAbi, "pure" | "view", TFunctionName>>(config: ReadContractConfig<TAbi, TFunctionName, TArgs>): Promise<ContractFunctionReturnType<TAbi, "pure" | "view", TFunctionName, TArgs>>;
-    // Warning: (ae-forgotten-export) The symbol "TransactionReceipt" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt>;
 }
@@ -101,19 +92,13 @@ export interface ViemProviderConfig {
     publicClient: PublicClient;
 }
 
-// Warning: (ae-forgotten-export) The symbol "BaseSigner" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export class ViemSigner extends BaseSigner {
     constructor(config: ViemSignerConfig);
     // (undocumented)
     protected onDispose(): void;
-    // Warning: (ae-forgotten-export) The symbol "EIP712TypedData" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     signTypedData(typedData: EIP712TypedData): Promise<Hex>;
-    // Warning: (ae-forgotten-export) The symbol "WriteContractConfig" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     writeContract<const TAbi extends Abi | readonly unknown[], TFunctionName extends ContractFunctionName<TAbi, "nonpayable" | "payable">, const TArgs extends ContractFunctionArgs<TAbi, "nonpayable" | "payable", TFunctionName>>(config: WriteContractConfig<TAbi, TFunctionName, TArgs>): Promise<Hex>;
 }
@@ -143,9 +128,6 @@ export function writeUnwrapFromBalanceContract(client: WalletClient, encryptedEr
 // @public (undocumented)
 export function writeWrapContract(client: WalletClient, wrapperAddress: Address, to: Address, amount: bigint): Promise<`0x${string}`>;
 
-// Warning: (ae-forgotten-export) The symbol "AtLeastOneChain" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "ZamaConfigBase" needs to be exported by the entry point index.d.ts
-//
 // @public
 export interface ZamaConfigViem<TChains extends AtLeastOneChain = AtLeastOneChain> extends ZamaConfigBase<TChains> {
     // (undocumented)

--- a/packages/sdk/etc/sdk-web.api.md
+++ b/packages/sdk/etc/sdk-web.api.md
@@ -18,39 +18,24 @@ import { PublicDecryptResults } from '@zama-fhe/relayer-sdk/bundle';
 import * as SDK from '@zama-fhe/relayer-sdk/bundle';
 import { ZKProofLike } from '@zama-fhe/relayer-sdk/bundle';
 
-// Warning: (ae-forgotten-export) The symbol "BaseRelayer" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "RelayerSDK" needs to be exported by the entry point index.d.ts
-//
 // @public
 export class RelayerWeb extends BaseRelayer implements RelayerSDK, Disposable {
     [Symbol.dispose](): void;
     constructor(config: RelayerWebConfig);
-    // Warning: (ae-forgotten-export) The symbol "FheChain" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     protected get chain(): FheChain;
     createDelegatedUserDecryptEIP712(publicKey: Hex, contractAddresses: Address[], delegatorAddress: Address, startTimestamp: number, durationDays?: number): Promise<KmsDelegatedUserDecryptEIP712Type>;
-    // Warning: (ae-forgotten-export) The symbol "EIP712TypedData" needs to be exported by the entry point index.d.ts
     createEIP712(publicKey: Hex, contractAddresses: Address[], startTimestamp: number, durationDays?: number): Promise<EIP712TypedData>;
-    // Warning: (ae-forgotten-export) The symbol "DelegatedUserDecryptParams" needs to be exported by the entry point index.d.ts
     delegatedUserDecrypt(params: DelegatedUserDecryptParams): Promise<Readonly<Record<EncryptedValue, ClearValue>>>;
-    // Warning: (ae-forgotten-export) The symbol "EncryptParams" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "EncryptResult" needs to be exported by the entry point index.d.ts
     encrypt(params: EncryptParams): Promise<EncryptResult>;
     generateKeypair(): Promise<KeypairType<Hex>>;
-    // Warning: (ae-forgotten-export) The symbol "PublicKeyData" needs to be exported by the entry point index.d.ts
     getPublicKey(): Promise<PublicKeyData | null>;
-    // Warning: (ae-forgotten-export) The symbol "PublicParamsData" needs to be exported by the entry point index.d.ts
     getPublicParams(bits: number): Promise<PublicParamsData | null>;
     // (undocumented)
     protected init(): Promise<void>;
-    // Warning: (ae-forgotten-export) The symbol "PublicDecryptResult" needs to be exported by the entry point index.d.ts
     publicDecrypt(encryptedValues: EncryptedValue[]): Promise<PublicDecryptResult>;
     requestZKProofVerification(zkProof: ZKProofLike): Promise<InputProofBytesType>;
     terminate(): void;
-    // Warning: (ae-forgotten-export) The symbol "UserDecryptParams" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "EncryptedValue" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "ClearValue" needs to be exported by the entry point index.d.ts
     userDecrypt(params: UserDecryptParams): Promise<Readonly<Record<EncryptedValue, ClearValue>>>;
 }
 
@@ -58,13 +43,10 @@ export class RelayerWeb extends BaseRelayer implements RelayerSDK, Disposable {
 export interface RelayerWebConfig {
     chain: FheChain;
     fheArtifactCacheTTL?: number;
-    // Warning: (ae-forgotten-export) The symbol "GenericStorage" needs to be exported by the entry point index.d.ts
     fheArtifactStorage?: GenericStorage;
-    // Warning: (ae-forgotten-export) The symbol "GenericLogger" needs to be exported by the entry point index.d.ts
     logger?: GenericLogger;
     security?: RelayerWebSecurityConfig;
     threads?: number;
-    // Warning: (ae-forgotten-export) The symbol "RelayerWorkerClient" needs to be exported by the entry point index.d.ts
     worker: RelayerWorkerClient;
 }
 
@@ -77,8 +59,6 @@ export interface RelayerWebSecurityConfig {
 // @public
 export function web(options?: WebRelayerOptions): WebRelayerConfig;
 
-// Warning: (ae-forgotten-export) The symbol "RelayerConfig" needs to be exported by the entry point index.d.ts
-//
 // @public
 export interface WebRelayerConfig extends RelayerConfig {
     // (undocumented)

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -621,8 +621,6 @@ export function cleartext(): CleartextRelayerConfig;
 
 // @public
 export interface CleartextRelayerConfig extends RelayerConfig {
-    // Warning: (ae-forgotten-export) The symbol "RelayerCleartext" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly createRelayer: (chain: FheChain, worker: unknown) => RelayerCleartext;
     // (undocumented)
@@ -11681,8 +11679,6 @@ export interface PendingUnshieldRequest {
     readonly unwrapTxHash: Hex;
 }
 
-// Warning: (ae-forgotten-export) The symbol "PermissionSchema" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type Permission = z.infer<typeof PermissionSchema>;
 
@@ -13113,8 +13109,6 @@ export class RelayerRequestFailedError extends ZamaError {
     readonly statusCode: number | undefined;
 }
 
-// Warning: (ae-forgotten-export) The symbol "FheOperations" needs to be exported by the entry point index.d.ts
-//
 // @public
 export interface RelayerSDK extends FheOperations {
     getAclAddress(): Promise<Address>;
@@ -14640,8 +14634,6 @@ export class SigningRejectedError extends ZamaError {
     constructor(message: string, options?: ErrorOptions);
 }
 
-// Warning: (ae-forgotten-export) The symbol "StoredKeypairSchema" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type StoredKeypair = z.infer<typeof StoredKeypairSchema>;
 
@@ -14894,8 +14886,6 @@ export interface TransactionErrorEvent extends BaseEvent {
     type: typeof ZamaSDKEvents.TransactionError;
 }
 
-// Warning: (ae-forgotten-export) The symbol "transactionOperationMetadata" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type TransactionOperation = keyof typeof transactionOperationMetadata;
 
@@ -19977,13 +19967,6 @@ export type ZamaSDKEventType = (typeof ZamaSDKEvents)[keyof typeof ZamaSDKEvents
 export const ZERO_HANDLE: "0x0000000000000000000000000000000000000000000000000000000000000000";
 
 export { ZKProofLike }
-
-// Warnings were encountered during analysis:
-//
-// dist/esm/index-Cq1_BuG_.d.ts:19573:5 - (ae-forgotten-export) The symbol "DecryptionService" needs to be exported by the entry point index.d.ts
-// dist/esm/index-Cq1_BuG_.d.ts:19702:5 - (ae-forgotten-export) The symbol "DelegationService" needs to be exported by the entry point index.d.ts
-// dist/esm/index-Cq1_BuG_.d.ts:19804:5 - (ae-forgotten-export) The symbol "CachingService" needs to be exported by the entry point index.d.ts
-// dist/esm/index-Cq1_BuG_.d.ts:19805:5 - (ae-forgotten-export) The symbol "CredentialService" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/src/query/index.ts
+++ b/packages/sdk/src/query/index.ts
@@ -3,13 +3,6 @@ export type { StrippedQueryOptionKeys } from "./utils";
 export type { QueryFactoryOptions, MutationFactoryOptions } from "./factory-types";
 export { zamaQueryKeys } from "./query-keys";
 
-// Re-export public types referenced by this entry point's query/mutation option
-// signatures so they resolve from `@zama-fhe/sdk/query` directly (already public
-// via the root entry; this avoids api-extractor ae-forgotten-export warnings).
-export type { FheChain } from "../chains/types";
-export type { GenericProvider } from "../types";
-export type { RelayerDispatcher } from "../relayer/relayer-dispatcher";
-
 export {
   invalidateAfterApproveUnderlying,
   invalidateAfterSetOperator,

--- a/packages/sdk/src/query/index.ts
+++ b/packages/sdk/src/query/index.ts
@@ -3,6 +3,13 @@ export type { StrippedQueryOptionKeys } from "./utils";
 export type { QueryFactoryOptions, MutationFactoryOptions } from "./factory-types";
 export { zamaQueryKeys } from "./query-keys";
 
+// Re-export public types referenced by this entry point's query/mutation option
+// signatures so they resolve from `@zama-fhe/sdk/query` directly (already public
+// via the root entry; this avoids api-extractor ae-forgotten-export warnings).
+export type { FheChain } from "../chains/types";
+export type { GenericProvider } from "../types";
+export type { RelayerDispatcher } from "../relayer/relayer-dispatcher";
+
 export {
   invalidateAfterApproveUnderlying,
   invalidateAfterSetOperator,


### PR DESCRIPTION
## Summary

Removes the volatile, non-semantic content from the committed API reports — the source of the api-report churn surfaced by the rolldown 1.0.0 → 1.1.0 bump (#401).

### Problem

api-extractor routes `ae-forgotten-export` warnings into the committed `.api.md` files (`addToApiReportFile: true`). Some of those warnings embed **rolldown chunk content-hashes and line numbers**:

```
// dist/esm/index-Cq1_BuG_.d.ts:19573:5 - (ae-forgotten-export) The symbol "DecryptionService" needs to be exported ...
```

Any build-tool bump (new chunk hash) or unrelated source shift (new line numbers) then churns the reports with diffs that look like API changes but aren't.

These warnings are also a false positive for this repo: api-extractor analyses each entry point as if it were a standalone package, but the sub-path entries (`@zama-fhe/sdk/query`, `/viem`, `/ethers`, `/node`, `/web`) are not — they cannot be used without the root `@zama-fhe/sdk`, so the "needs to be exported" symbols are already reachable from the root entry.

### Change

**`api-extractor.base.json`** — `ae-forgotten-export: { logLevel: none, addToApiReportFile: false }`.

The committed reports are now a pure snapshot of the public API surface, with **no public-surface changes** in this PR — every report diff is warning-line removal only; `react-sdk.api.md` is untouched.

api-extractor has no "warn but pass" mode for this rule in check mode (verified on-branch): in-file routing (status quo) carries the volatile coordinates; console-at-`warning` fails `api-report:check` outright. So the rule is silenced (`logLevel: none`) and the leak inventory + the per-symbol export-or-hide audit is tracked in **SDK-209**, whose done-state re-enables it as `logLevel: error`.

### Why not resolve the leaks instead? (evaluated, deferred to SDK-209)

Driving `ae-forgotten-export` to zero via `stripInternal` was attempted and **breaks the build**: 7 cross-module `@internal` cascades, including genuinely public-facing surface (`NodeWorkerPool` referenced by the public `RelayerNodeConfig.pool`, the alignment helpers used by every write path, `buildZamaConfig` used by the viem/ethers config factories). Resolving those is a deliberate API-design audit, not a churn fix.

### Validation

- Zero `ae-forgotten-export` / warning footers across all committed reports
- Report diffs are warning-removal only — **no added/changed public declarations** in any of the 6 reports; `react-sdk.api.md` untouched
- `pnpm api-report:check` exit 0 (direct exit-code capture; all 8 extractor runs clean)
- `pnpm typecheck` across all workspaces
- `test-nextjs` + `test-vite` production builds
- `npm pack` + scratch-consumer typecheck (`--strict --skipLibCheck false`): published types self-contained

### Sequencing

Independent of #402. Whichever lands second needs a `pnpm api-report` regen-sync (the footers stop existing once this merges, so the rolldown hash churn from #401 won't recur).