### PR TITLE
refactor(sdk): rename remaining public *Handle fields to glossary terms [SDK-203]

### DIFF
--- a/docs/gitbook/src/reference/react/useFinalizeUnwrap.md
+++ b/docs/gitbook/src/reference/react/useFinalizeUnwrap.md
@@ -77,14 +77,14 @@ The unwrap request ID emitted in the `UnwrapRequested` event. This is the prefer
 await finalize({ unwrapRequestId: requestId });
 ```
 
-### burnAmountHandle
+### burnAmount
 
 `EncryptedValue`
 
 Alternative input accepted when no `unwrapRequestId` is available (e.g. when resuming an unshield persisted by an older SDK version).
 
 ```tsx
-await finalize({ burnAmountHandle: encryptedAmount });
+await finalize({ burnAmount: encryptedAmount });
 ```
 
 ## Return Type

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10498,14 +10498,14 @@ The unwrap request ID emitted in the `UnwrapRequested` event. This is the prefer
 await finalize({ unwrapRequestId: requestId });
 ```
 
-### burnAmountHandle
+### burnAmount
 
 `EncryptedValue`
 
 Alternative input accepted when no `unwrapRequestId` is available (e.g. when resuming an unshield persisted by an older SDK version).
 
 ```tsx
-await finalize({ burnAmountHandle: encryptedAmount });
+await finalize({ burnAmount: encryptedAmount });
 ```
 
 ## Return Type

--- a/packages/react-sdk/src/test-fixtures/mutations.ts
+++ b/packages/react-sdk/src/test-fixtures/mutations.ts
@@ -9,7 +9,7 @@ import type { FixturesOf } from "./types";
 const tokenAddress = "0x1a1A1A1A1a1A1A1a1A1a1a1a1a1a1a1A1A1a1a1a" as Address;
 const userAddress = "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B" as Address;
 
-const burnAmountHandle = `0x${"22".repeat(32)}` as const;
+const burnAmount = `0x${"22".repeat(32)}` as const;
 const unwrapRequestedTopic =
   "0x4b1bfb262557cf08a74ddeefb8aef086b81deb08484bdc1820b9f420cdd1aa0e" as const;
 
@@ -160,14 +160,14 @@ async function mutateAndExpectOnSuccess(
 }
 
 export interface MutationFixtures {
-  burnAmountHandle: typeof burnAmountHandle;
+  burnAmount: typeof burnAmount;
   wagmiBalanceKey: typeof wagmiBalanceKey;
   createUnwrapRequestedLog: typeof createUnwrapRequestedLog;
   mutateAndExpectOnSuccess: typeof mutateAndExpectOnSuccess;
 }
 
 export const mutationFixtures: FixturesOf<MutationFixtures> = {
-  burnAmountHandle,
+  burnAmount,
   wagmiBalanceKey,
   createUnwrapRequestedLog: async ({}, use) => {
     await use(createUnwrapRequestedLog);

--- a/packages/react-sdk/src/unshield/__tests__/use-resume-unshield.test.tsx
+++ b/packages/react-sdk/src/unshield/__tests__/use-resume-unshield.test.tsx
@@ -15,7 +15,7 @@ describe("useResumeUnshield", () => {
   test("cache: invalidates balance, allowance, and wagmi after resume unshield", async ({
     renderWithProviders,
     provider,
-    burnAmountHandle,
+    burnAmount,
     otherTokenAddress,
     tokenAddress,
     userAddress,
@@ -23,7 +23,7 @@ describe("useResumeUnshield", () => {
     createUnwrapRequestedLog,
   }) => {
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
-      logs: [createUnwrapRequestedLog(burnAmountHandle)],
+      logs: [createUnwrapRequestedLog(burnAmount)],
     });
 
     const { result, queryClient } = renderWithProviders(() => useResumeUnshield(tokenAddress));
@@ -50,7 +50,7 @@ describe("useResumeUnshield", () => {
   test("behavior: forwards onSuccess callback", async ({
     renderWithProviders,
     provider,
-    burnAmountHandle,
+    burnAmount,
     tokenAddress,
     userAddress,
     wagmiBalanceKey,
@@ -58,7 +58,7 @@ describe("useResumeUnshield", () => {
     mutateAndExpectOnSuccess,
   }) => {
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
-      logs: [createUnwrapRequestedLog(burnAmountHandle)],
+      logs: [createUnwrapRequestedLog(burnAmount)],
     });
 
     const balanceKey = zamaQueryKeys.confidentialBalance.owner(tokenAddress, userAddress);

--- a/packages/react-sdk/src/unshield/__tests__/use-unshield-all.test.tsx
+++ b/packages/react-sdk/src/unshield/__tests__/use-unshield-all.test.tsx
@@ -15,7 +15,7 @@ describe("useUnshieldAll", () => {
   test("cache: invalidates balance, allowance, and wagmi after unshield all", async ({
     renderWithProviders,
     provider,
-    burnAmountHandle,
+    burnAmount,
     handle,
     otherTokenAddress,
     tokenAddress,
@@ -25,7 +25,7 @@ describe("useUnshieldAll", () => {
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
-      logs: [createUnwrapRequestedLog(burnAmountHandle)],
+      logs: [createUnwrapRequestedLog(burnAmount)],
     });
 
     const { result, queryClient } = renderWithProviders(() => useUnshieldAll(tokenAddress));
@@ -52,7 +52,7 @@ describe("useUnshieldAll", () => {
   test("behavior: forwards onSuccess callback", async ({
     renderWithProviders,
     provider,
-    burnAmountHandle,
+    burnAmount,
     handle,
     tokenAddress,
     userAddress,
@@ -62,7 +62,7 @@ describe("useUnshieldAll", () => {
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
-      logs: [createUnwrapRequestedLog(burnAmountHandle)],
+      logs: [createUnwrapRequestedLog(burnAmount)],
     });
 
     const balanceKey = zamaQueryKeys.confidentialBalance.owner(tokenAddress, userAddress);

--- a/packages/react-sdk/src/unshield/__tests__/use-unshield.test.tsx
+++ b/packages/react-sdk/src/unshield/__tests__/use-unshield.test.tsx
@@ -15,7 +15,7 @@ describe("useUnshield", () => {
   test("cache: invalidates balance, allowance, and wagmi after unshield", async ({
     renderWithProviders,
     provider,
-    burnAmountHandle,
+    burnAmount,
     otherTokenAddress,
     tokenAddress,
     userAddress,
@@ -23,7 +23,7 @@ describe("useUnshield", () => {
     createUnwrapRequestedLog,
   }) => {
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
-      logs: [createUnwrapRequestedLog(burnAmountHandle)],
+      logs: [createUnwrapRequestedLog(burnAmount)],
     });
 
     const { result, queryClient } = renderWithProviders(() => useUnshield(tokenAddress));
@@ -50,7 +50,7 @@ describe("useUnshield", () => {
   test("behavior: forwards onSuccess callback", async ({
     renderWithProviders,
     provider,
-    burnAmountHandle,
+    burnAmount,
     tokenAddress,
     userAddress,
     wagmiBalanceKey,
@@ -58,7 +58,7 @@ describe("useUnshield", () => {
     mutateAndExpectOnSuccess,
   }) => {
     vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
-      logs: [createUnwrapRequestedLog(burnAmountHandle)],
+      logs: [createUnwrapRequestedLog(burnAmount)],
     });
 
     const balanceKey = zamaQueryKeys.confidentialBalance.owner(tokenAddress, userAddress);

--- a/packages/react-sdk/src/unwrap/__tests__/use-finalize-unwrap.test.tsx
+++ b/packages/react-sdk/src/unwrap/__tests__/use-finalize-unwrap.test.tsx
@@ -15,7 +15,7 @@ describe("useFinalizeUnwrap", () => {
 
   test("cache: invalidates balance, allowance, and wagmi after finalize", async ({
     renderWithProviders,
-    burnAmountHandle,
+    burnAmount,
     otherTokenAddress,
     tokenAddress,
     userAddress,
@@ -34,7 +34,7 @@ describe("useFinalizeUnwrap", () => {
     queryClient.setQueryData(otherBalanceKey, 777n);
     queryClient.setQueryData(otherAllowanceKey, 333n);
 
-    await act(() => result.current.mutateAsync({ unwrapRequestId: burnAmountHandle }));
+    await act(() => result.current.mutateAsync({ unwrapRequestId: burnAmount }));
 
     expect(queryClient).toHaveInvalidatedQueries([balanceKey, allowanceKey]);
     expect(queryClient).toHaveCacheInvalidated(wagmiBalanceKey);
@@ -44,7 +44,7 @@ describe("useFinalizeUnwrap", () => {
 
   test("behavior: forwards onSuccess callback", async ({
     renderWithProviders,
-    burnAmountHandle,
+    burnAmount,
     tokenAddress,
     userAddress,
     wagmiBalanceKey,
@@ -63,7 +63,7 @@ describe("useFinalizeUnwrap", () => {
     queryClient.setQueryData(wagmiBalanceKey, 2000n);
 
     await mutateAndExpectOnSuccess(
-      () => result.current.mutateAsync({ unwrapRequestId: burnAmountHandle }),
+      () => result.current.mutateAsync({ unwrapRequestId: burnAmount }),
       onSuccess,
       (client: QueryClient) => {
         expect(client).toHaveInvalidatedQueries([balanceKey, allowanceKey]);

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -144,7 +144,7 @@ export function confidentialTokenAddressQueryOptions(sdk: ZamaSDK, config: Confi
 
 // @public
 export interface ConfidentialTransferEvent {
-    readonly encryptedAmountHandle: EncryptedValue;
+    readonly encryptedAmount: EncryptedValue;
     // (undocumented)
     readonly eventName: "ConfidentialTransfer";
     readonly from: Address;
@@ -401,10 +401,10 @@ export function finalizeUnwrapMutationOptions(token: WrappedToken): MutationFact
 // @public
 export type FinalizeUnwrapParams = /** Identifier from an `UnwrapRequested` event. Preferred. */{
     unwrapRequestId: EncryptedValue;
-    burnAmountHandle?: never;
+    burnAmount?: never;
 }
 /**
-* Encrypted burn-amount handle. Direct-call escape hatch for resuming an
+* Encrypted burn amount. Direct-call escape hatch for resuming an
 * unshield persisted by an older SDK version that did not record
 * `unwrapRequestId`; the orchestrated `WrappedToken.resumeUnshield()` flow
 * always rediscovers `unwrapRequestId` from the receipt and never reaches
@@ -412,7 +412,7 @@ export type FinalizeUnwrapParams = /** Identifier from an `UnwrapRequested` even
 */
 | {
     unwrapRequestId?: never;
-    burnAmountHandle: EncryptedValue;
+    burnAmount: EncryptedValue;
 };
 
 // @public (undocumented)

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -4595,7 +4595,7 @@ export function confidentialTransferContract(encryptedErc20: Address, to: Addres
 
 // @public
 export interface ConfidentialTransferEvent {
-    readonly encryptedAmountHandle: EncryptedValue;
+    readonly encryptedAmount: EncryptedValue;
     // (undocumented)
     readonly eventName: "ConfidentialTransfer";
     readonly from: Address;

--- a/packages/sdk/src/__tests__/events.test.ts
+++ b/packages/sdk/src/__tests__/events.test.ts
@@ -49,10 +49,10 @@ describe("Topic constants match keccak256", () => {
 describe("decodeConfidentialTransfer", () => {
   const from = addr("aaa1");
   const to = addr("bbb2");
-  const handle = bytes32("cc".repeat(32));
+  const encryptedAmount = bytes32("cc".repeat(32));
 
   const log: RawLog = {
-    topics: [Topics.ConfidentialTransfer, topic("aaa1"), topic("bbb2"), handle],
+    topics: [Topics.ConfidentialTransfer, topic("aaa1"), topic("bbb2"), encryptedAmount],
     data: "0x",
   };
 
@@ -62,7 +62,7 @@ describe("decodeConfidentialTransfer", () => {
       eventName: "ConfidentialTransfer",
       from,
       to,
-      encryptedAmountHandle: handle,
+      encryptedAmount,
     });
   });
 

--- a/packages/sdk/src/events/__tests__/onchain-events.test.ts
+++ b/packages/sdk/src/events/__tests__/onchain-events.test.ts
@@ -65,7 +65,7 @@ describe("decodeConfidentialTransfer", () => {
     expect(event!.eventName).toBe("ConfidentialTransfer");
     expect(event!.from.toLowerCase()).toBe(ALICE.toLowerCase());
     expect(event!.to.toLowerCase()).toBe(BOB.toLowerCase());
-    expect(event!.encryptedAmountHandle).toBe(HANDLE);
+    expect(event!.encryptedAmount).toBe(HANDLE);
   });
 
   test("returns null for wrong topic0", () => {

--- a/packages/sdk/src/events/onchain-events.ts
+++ b/packages/sdk/src/events/onchain-events.ts
@@ -51,7 +51,7 @@ export interface ConfidentialTransferEvent {
   /** Receiver address. */
   readonly to: Address;
   /** FHE encrypted value for the transferred amount. */
-  readonly encryptedAmountHandle: EncryptedValue;
+  readonly encryptedAmount: EncryptedValue;
 }
 
 // NOTE: New wrapper contracts no longer emit this event — shields now emit
@@ -178,7 +178,7 @@ export function decodeConfidentialTransfer(log: RawLog): ConfidentialTransferEve
     eventName: "ConfidentialTransfer",
     from: topicToAddress(log.topics[1]!),
     to: topicToAddress(log.topics[2]!),
-    encryptedAmountHandle: topicToBytes32(log.topics[3]!),
+    encryptedAmount: topicToBytes32(log.topics[3]!),
   };
 }
 

--- a/packages/sdk/src/query/__tests__/finalize-unwrap.test.ts
+++ b/packages/sdk/src/query/__tests__/finalize-unwrap.test.ts
@@ -15,11 +15,11 @@ describe("finalizeUnwrapMutationOptions", () => {
     );
   });
 
-  test("accepts burnAmountHandle as alternative input", async ({ mockWrappedToken }) => {
+  test("accepts burnAmount as alternative input", async ({ mockWrappedToken }) => {
     const options = finalizeUnwrapMutationOptions(mockWrappedToken);
 
     await options.mutationFn({
-      burnAmountHandle: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbBbbbbbbbbbbbbbbbbbbbb",
+      burnAmount: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbBbbbbbbbbbbbbbbbbbbbb",
     });
 
     expect(mockWrappedToken.finalizeUnwrap).toHaveBeenCalledWith(
@@ -27,7 +27,9 @@ describe("finalizeUnwrapMutationOptions", () => {
     );
   });
 
-  test("throws ConfigurationError when no handle is provided", async ({ mockWrappedToken }) => {
+  test("throws ConfigurationError when no encrypted value is provided", async ({
+    mockWrappedToken,
+  }) => {
     const options = finalizeUnwrapMutationOptions(mockWrappedToken);
 
     await expect(options.mutationFn({} as never)).rejects.toThrow(ConfigurationError);

--- a/packages/sdk/src/query/finalize-unwrap.ts
+++ b/packages/sdk/src/query/finalize-unwrap.ts
@@ -7,15 +7,15 @@ import type { Address } from "viem";
 /** Variables for {@link finalizeUnwrapMutationOptions}. */
 export type FinalizeUnwrapParams =
   /** Identifier from an `UnwrapRequested` event. Preferred. */
-  | { unwrapRequestId: EncryptedValue; burnAmountHandle?: never }
+  | { unwrapRequestId: EncryptedValue; burnAmount?: never }
   /**
-   * Encrypted burn-amount handle. Direct-call escape hatch for resuming an
+   * Encrypted burn amount. Direct-call escape hatch for resuming an
    * unshield persisted by an older SDK version that did not record
    * `unwrapRequestId`; the orchestrated `WrappedToken.resumeUnshield()` flow
    * always rediscovers `unwrapRequestId` from the receipt and never reaches
    * this branch.
    */
-  | { unwrapRequestId?: never; burnAmountHandle: EncryptedValue };
+  | { unwrapRequestId?: never; burnAmount: EncryptedValue };
 
 export function finalizeUnwrapMutationOptions(
   token: WrappedToken,
@@ -27,11 +27,11 @@ export function finalizeUnwrapMutationOptions(
   return {
     mutationKey: ["zama.finalizeUnwrap", token.address] as const,
     mutationFn: async (params) => {
-      const handle = params.unwrapRequestId ?? params.burnAmountHandle;
-      if (!handle) {
-        throw new ConfigurationError("finalizeUnwrap requires unwrapRequestId or burnAmountHandle");
+      const encryptedValue = params.unwrapRequestId ?? params.burnAmount;
+      if (!encryptedValue) {
+        throw new ConfigurationError("finalizeUnwrap requires unwrapRequestId or burnAmount");
       }
-      return token.finalizeUnwrap(handle);
+      return token.finalizeUnwrap(encryptedValue);
     },
   };
 }

--- a/packages/sdk/src/token/wrapped-token.ts
+++ b/packages/sdk/src/token/wrapped-token.ts
@@ -415,7 +415,7 @@ export class WrappedToken extends Token {
    * Call this after an unshield request has been processed on-chain.
    *
    * @param unwrapRequestIdOrAmount - `unwrapRequestId` from the `UnwrapRequested` event.
-   *   The `burnAmountHandle` form is accepted only to resume unshields persisted by an
+   *   The `burnAmount` form is accepted only to resume unshields persisted by an
    *   older SDK version.
    * @returns The transaction hash and mined receipt.
    *

--- a/test/test-components/src/unwrap-manual-form.tsx
+++ b/test/test-components/src/unwrap-manual-form.tsx
@@ -12,7 +12,7 @@ import { useAccount } from "wagmi";
 
 type FinalizeUnwrapInput =
   | { label: "Unwrap request ID"; params: { unwrapRequestId: Hex } }
-  | { label: "Legacy burn handle"; params: { burnAmountHandle: Hex } };
+  | { label: "Legacy burn handle"; params: { burnAmount: Hex } };
 
 export function UnwrapManualForm({
   tokenAddress,
@@ -46,7 +46,7 @@ export function UnwrapManualForm({
                   }
                 : {
                     label: "Legacy burn handle",
-                    params: { burnAmountHandle: event.encryptedAmount },
+                    params: { burnAmount: event.encryptedAmount },
                   },
             );
           }
@@ -94,7 +94,7 @@ export function UnwrapManualForm({
             {finalizeInput.label}:{" "}
             {"unwrapRequestId" in finalizeInput.params
               ? finalizeInput.params.unwrapRequestId
-              : finalizeInput.params.burnAmountHandle}
+              : finalizeInput.params.burnAmount}
           </p>
         )}
 


### PR DESCRIPTION
## Summary

Closes [SDK-203](https://linear.app/zama/issue/SDK-203/handle-encryptedvalue-remaining-public-surface-renames). Part of [SDK-202](https://linear.app/zama/issue/SDK-202/align-sdk-public-surface-with-the-fhevm-glossary) — the public-surface alignment with the FHEVM glossary, following PR #386 (decrypt wording).

Drops the `*Handle` suffix from the only two public-facing fields that still carried it outside the decrypt surface:

- `ConfidentialTransferEvent.encryptedAmountHandle` → `encryptedAmount` — matches the sibling `UnwrapRequested` / `UnwrapFinalized` event fields that already use `encryptedAmount`.
- `FinalizeUnwrapParams.burnAmountHandle` → `burnAmount` — mirrors the on-chain `UnwrappedStarted.burnAmount` field per the per-method Solidity-mirror convention. (The ticket flagged `burnEncryptedHandle` as a possible target; the on-chain decoder shows the canonical name is `burnAmount`.)

Deliberate Solidity / on-chain mirrors are kept as-is (ABI fragments, `isHandleDelegatedForUserDecryption`, `handlesList`, etc.) per the SDK-202 rule.

The PR also updates the `WrappedToken.finalizeUnwrap` JSDoc, the gitbook reference for `useFinalizeUnwrap`, the affected error string, the call site in `test/test-components/src/unwrap-manual-form.tsx`, and regenerates the committed API reports and LLM artifacts.

## Test plan

- [x] `pnpm typecheck` (all 6 packages)
- [x] `pnpm lint` (oxlint + ast-grep)
- [x] `pnpm test run` — 1602 passed / 5 skipped, no type errors
- [x] `pnpm api-report:sdk` / `pnpm api-report:react-sdk` regenerated, committed
- [x] `pnpm llm:build` regenerated, committed (`llms.txt` re-staged automatically by the pre-commit hook)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)