### PR TITLE
refactor(sdk): sync Wrap event ABI with protocol-apps (Tier 1) [SDK-216]

### DIFF
--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -1171,10 +1171,15 @@ export function confidentialBalanceOfContract(tokenAddress: Address, userAddress
         }, {
             readonly indexed: false;
             readonly internalType: "uint256";
-            readonly name: "amountIn";
+            readonly name: "roundedAmount";
             readonly type: "uint256";
+        }, {
+            readonly indexed: false;
+            readonly internalType: "euint64";
+            readonly name: "encryptedWrappedAmount";
+            readonly type: "bytes32";
         }];
-        readonly name: "Wrapped";
+        readonly name: "Wrap";
         readonly type: "event";
     }, {
         readonly inputs: readonly [];
@@ -2492,10 +2497,15 @@ export function confidentialTotalSupplyContract(tokenAddress: Address): {
         }, {
             readonly indexed: false;
             readonly internalType: "uint256";
-            readonly name: "amountIn";
+            readonly name: "roundedAmount";
             readonly type: "uint256";
+        }, {
+            readonly indexed: false;
+            readonly internalType: "euint64";
+            readonly name: "encryptedWrappedAmount";
+            readonly type: "bytes32";
         }];
-        readonly name: "Wrapped";
+        readonly name: "Wrap";
         readonly type: "event";
     }, {
         readonly inputs: readonly [];
@@ -3813,10 +3823,15 @@ export function confidentialTransferContract(encryptedErc20: Address, to: Addres
         }, {
             readonly indexed: false;
             readonly internalType: "uint256";
-            readonly name: "amountIn";
+            readonly name: "roundedAmount";
             readonly type: "uint256";
+        }, {
+            readonly indexed: false;
+            readonly internalType: "euint64";
+            readonly name: "encryptedWrappedAmount";
+            readonly type: "bytes32";
         }];
-        readonly name: "Wrapped";
+        readonly name: "Wrap";
         readonly type: "event";
     }, {
         readonly inputs: readonly [];
@@ -5143,10 +5158,15 @@ export function confidentialTransferFromContract(encryptedErc20: Address, from: 
         }, {
             readonly indexed: false;
             readonly internalType: "uint256";
-            readonly name: "amountIn";
+            readonly name: "roundedAmount";
             readonly type: "uint256";
+        }, {
+            readonly indexed: false;
+            readonly internalType: "euint64";
+            readonly name: "encryptedWrappedAmount";
+            readonly type: "bytes32";
         }];
-        readonly name: "Wrapped";
+        readonly name: "Wrap";
         readonly type: "event";
     }, {
         readonly inputs: readonly [];
@@ -7311,6 +7331,26 @@ export function finalizeUnwrapContract(wrapper: Address, unwrapRequestIdOrAmount
             readonly internalType: "bytes32";
         }, {
             readonly name: "amount";
+            readonly type: "bytes32";
+            readonly indexed: false;
+            readonly internalType: "euint64";
+        }];
+        readonly anonymous: false;
+    }, {
+        readonly type: "event";
+        readonly name: "Wrap";
+        readonly inputs: readonly [{
+            readonly name: "to";
+            readonly type: "address";
+            readonly indexed: true;
+            readonly internalType: "address";
+        }, {
+            readonly name: "roundedAmount";
+            readonly type: "uint256";
+            readonly indexed: false;
+            readonly internalType: "uint256";
+        }, {
+            readonly name: "encryptedWrappedAmount";
             readonly type: "bytes32";
             readonly indexed: false;
             readonly internalType: "euint64";
@@ -9601,6 +9641,26 @@ export function inferredTotalSupplyContract(wrapperAddress: Address): {
         readonly anonymous: false;
     }, {
         readonly type: "event";
+        readonly name: "Wrap";
+        readonly inputs: readonly [{
+            readonly name: "to";
+            readonly type: "address";
+            readonly indexed: true;
+            readonly internalType: "address";
+        }, {
+            readonly name: "roundedAmount";
+            readonly type: "uint256";
+            readonly indexed: false;
+            readonly internalType: "uint256";
+        }, {
+            readonly name: "encryptedWrappedAmount";
+            readonly type: "bytes32";
+            readonly indexed: false;
+            readonly internalType: "euint64";
+        }];
+        readonly anonymous: false;
+    }, {
+        readonly type: "event";
         readonly name: "Upgraded";
         readonly inputs: readonly [{
             readonly name: "implementation";
@@ -10680,10 +10740,15 @@ export function isOperatorContract(tokenAddress: Address, holder: Address, spend
         }, {
             readonly indexed: false;
             readonly internalType: "uint256";
-            readonly name: "amountIn";
+            readonly name: "roundedAmount";
             readonly type: "uint256";
+        }, {
+            readonly indexed: false;
+            readonly internalType: "euint64";
+            readonly name: "encryptedWrappedAmount";
+            readonly type: "bytes32";
         }];
-        readonly name: "Wrapped";
+        readonly name: "Wrap";
         readonly type: "event";
     }, {
         readonly inputs: readonly [];
@@ -12277,10 +12342,15 @@ export function rateContract(tokenAddress: Address): {
         }, {
             readonly indexed: false;
             readonly internalType: "uint256";
-            readonly name: "amountIn";
+            readonly name: "roundedAmount";
             readonly type: "uint256";
+        }, {
+            readonly indexed: false;
+            readonly internalType: "euint64";
+            readonly name: "encryptedWrappedAmount";
+            readonly type: "bytes32";
         }];
-        readonly name: "Wrapped";
+        readonly name: "Wrap";
         readonly type: "event";
     }, {
         readonly inputs: readonly [];
@@ -13822,10 +13892,15 @@ export function setOperatorContract(tokenAddress: Address, operator: Address, un
         }, {
             readonly indexed: false;
             readonly internalType: "uint256";
-            readonly name: "amountIn";
+            readonly name: "roundedAmount";
             readonly type: "uint256";
+        }, {
+            readonly indexed: false;
+            readonly internalType: "euint64";
+            readonly name: "encryptedWrappedAmount";
+            readonly type: "bytes32";
         }];
-        readonly name: "Wrapped";
+        readonly name: "Wrap";
         readonly type: "event";
     }, {
         readonly inputs: readonly [];
@@ -15775,6 +15850,26 @@ export function underlyingContract(wrapperAddress: Address): {
         readonly anonymous: false;
     }, {
         readonly type: "event";
+        readonly name: "Wrap";
+        readonly inputs: readonly [{
+            readonly name: "to";
+            readonly type: "address";
+            readonly indexed: true;
+            readonly internalType: "address";
+        }, {
+            readonly name: "roundedAmount";
+            readonly type: "uint256";
+            readonly indexed: false;
+            readonly internalType: "uint256";
+        }, {
+            readonly name: "encryptedWrappedAmount";
+            readonly type: "bytes32";
+            readonly indexed: false;
+            readonly internalType: "euint64";
+        }];
+        readonly anonymous: false;
+    }, {
+        readonly type: "event";
         readonly name: "Upgraded";
         readonly inputs: readonly [{
             readonly name: "implementation";
@@ -16547,10 +16642,15 @@ export function unwrapContract(encryptedErc20: Address, from: Address, to: Addre
         }, {
             readonly indexed: false;
             readonly internalType: "uint256";
-            readonly name: "amountIn";
+            readonly name: "roundedAmount";
             readonly type: "uint256";
+        }, {
+            readonly indexed: false;
+            readonly internalType: "euint64";
+            readonly name: "encryptedWrappedAmount";
+            readonly type: "bytes32";
         }];
-        readonly name: "Wrapped";
+        readonly name: "Wrap";
         readonly type: "event";
     }, {
         readonly inputs: readonly [];
@@ -17878,10 +17978,15 @@ export function unwrapFromBalanceContract(encryptedErc20: Address, from: Address
         }, {
             readonly indexed: false;
             readonly internalType: "uint256";
-            readonly name: "amountIn";
+            readonly name: "roundedAmount";
             readonly type: "uint256";
+        }, {
+            readonly indexed: false;
+            readonly internalType: "euint64";
+            readonly name: "encryptedWrappedAmount";
+            readonly type: "bytes32";
         }];
-        readonly name: "Wrapped";
+        readonly name: "Wrap";
         readonly type: "event";
     }, {
         readonly inputs: readonly [];
@@ -19518,6 +19623,26 @@ export function wrapContract(wrapperAddress: Address, to: Address, amount: bigin
             readonly internalType: "bytes32";
         }, {
             readonly name: "amount";
+            readonly type: "bytes32";
+            readonly indexed: false;
+            readonly internalType: "euint64";
+        }];
+        readonly anonymous: false;
+    }, {
+        readonly type: "event";
+        readonly name: "Wrap";
+        readonly inputs: readonly [{
+            readonly name: "to";
+            readonly type: "address";
+            readonly indexed: true;
+            readonly internalType: "address";
+        }, {
+            readonly name: "roundedAmount";
+            readonly type: "uint256";
+            readonly indexed: false;
+            readonly internalType: "uint256";
+        }, {
+            readonly name: "encryptedWrappedAmount";
             readonly type: "bytes32";
             readonly indexed: false;
             readonly internalType: "euint64";

--- a/packages/sdk/src/abi/encrypted.abi.ts
+++ b/packages/sdk/src/abi/encrypted.abi.ts
@@ -691,11 +691,17 @@ export const encryptedAbi = [
       {
         indexed: false,
         internalType: "uint256",
-        name: "amountIn",
+        name: "roundedAmount",
         type: "uint256",
       },
+      {
+        indexed: false,
+        internalType: "euint64",
+        name: "encryptedWrappedAmount",
+        type: "bytes32",
+      },
     ],
-    name: "Wrapped",
+    name: "Wrap",
     type: "event",
   },
   {

--- a/packages/sdk/src/abi/wrapper.abi.ts
+++ b/packages/sdk/src/abi/wrapper.abi.ts
@@ -1024,6 +1024,31 @@ export const wrapperAbi = [
   },
   {
     type: "event",
+    name: "Wrap",
+    inputs: [
+      {
+        name: "to",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "roundedAmount",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+      {
+        name: "encryptedWrappedAmount",
+        type: "bytes32",
+        indexed: false,
+        internalType: "euint64",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
     name: "Upgraded",
     inputs: [
       {


### PR DESCRIPTION
## Summary

- Verified against compiled artifact (`contracts/out/ERC7984ERC20WrapperUpgradeable.sol/ERC7984ERC20WrapperUpgradeable.json`): the deployed wrapper emits `Wrap(address indexed to, uint256 roundedAmount, euint64 encryptedWrappedAmount)`. The legacy `Wrapped(to, amountIn)` event does not exist in `protocol-apps/main` — no back-compat needed.
- `packages/sdk/src/abi/encrypted.abi.ts` — replace `Wrapped(to, amountIn)` with canonical `Wrap(to, roundedAmount, encryptedWrappedAmount)`.
- `packages/sdk/src/abi/wrapper.abi.ts` — add the missing `Wrap` event (the file had no wrap-side event at all), slotted between `UnwrapRequested` and `Upgraded` to match compiled-artifact order.

This is **Tier 1** scope from [SDK-216](https://linear.app/zama/issue/SDK-216) — ABI correctness fix only. Tier 2 (rename `decodeWrapped` / `findWrapped` / `Topics.Wrapped` → `decodeWrap` / `findWrap` / `Topics.Wrap`, expose the new fields) is a public-API change deferred to a follow-up PR.

## Why this hasn't caused user-visible bugs

The SDK does not actually use the ABI for wrap-event decoding — `decodeWrapped` in `events/onchain-events.ts` uses a hardcoded topic string (`Topics.Wrapped = eventTopic("Wrapped(address,uint256)")`), so it's decoupled from the ABI const. Today the decoder matches nothing on chain (deployed wrapper emits `Wrap`, decoder looks for `Wrapped`), and the public-side amount is the value the caller already passed. So the bug was invisible — but it was a bug.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test:run packages/sdk/src/{abi,__tests__,events,contracts}` — 205 tests pass
- [x] `forge build --force` compiles clean (68 files)
- [ ] CI green

## Follow-up

Tier 2 (decoder rename + new field exposure) tracked under [SDK-216](https://linear.app/zama/issue/SDK-216) — to be opened as a separate PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)