### PR TITLE
chore(sdk): drop stale biome-ignore comment in query/utils

### DIFF
--- a/packages/sdk/src/query/utils.ts
+++ b/packages/sdk/src/query/utils.ts
@@ -18,7 +18,6 @@ function isPlainObject(value: any): value is Object {
   }
 
   // If constructor does not have an Object-specific method
-  // biome-ignore lint/suspicious/noPrototypeBuiltins: using
   // eslint-disable-next-line no-prototype-builtins
   if (!prot.hasOwnProperty("isPrototypeOf")) {
     return false;


### PR DESCRIPTION
## Summary

`packages/sdk/src/query/utils.ts` had a `// biome-ignore` comment carried over when the helper was adapted from wagmi. This repo lints with oxlint; biome isn't configured. The line ignored nothing — the adjacent `// eslint-disable-next-line no-prototype-builtins` does the actual work (oxlint accepts ESLint disable comments).

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm exec lint-staged` — clean
- [x] `pnpm llm:check` — clean (no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)