### PR TITLE
chore(sdk): drop stale jest/* lint disables

### DIFF
--- a/packages/sdk/src/relayer/__tests__/fhe-artifact-cache.integration.test.ts
+++ b/packages/sdk/src/relayer/__tests__/fhe-artifact-cache.integration.test.ts
@@ -1,6 +1,4 @@
 // oxlint-disable no-empty-pattern
-// oxlint-disable jest/expect-expect
-// oxlint-disable jest/no-disabled-tests
 import { randomBytes } from "node:crypto";
 import http from "node:http";
 import { test as base, describe, expect } from "vitest";

--- a/packages/sdk/src/test-fixtures/index.ts
+++ b/packages/sdk/src/test-fixtures/index.ts
@@ -1,5 +1,3 @@
-// oxlint-disable jest/expect-expect
-// oxlint-disable jest/no-disabled-tests
 import { test as base } from "vitest";
 import { addressFixtures, type AddressFixtures } from "./addresses";
 import { chainFixtures, type ChainFixtures } from "./chain";

--- a/packages/sdk/src/worker/__tests__/cjs.bundler.test.ts
+++ b/packages/sdk/src/worker/__tests__/cjs.bundler.test.ts
@@ -54,7 +54,6 @@ describe("CJS build smoke tests", () => {
 describe("package.json export conditions", () => {
   test("every export has a default condition", () => {
     for (const [subpath, conditions] of Object.entries(exports)) {
-      // oxlint-disable-next-line jest/valid-expect
       expect(conditions, `${subpath} missing "default"`).toHaveProperty("default");
     }
   });


### PR DESCRIPTION
## Summary

Three test/fixture files carried `// oxlint-disable jest/*` comments referencing rules from a plugin that isn't configured. `.oxlintrc.json` loads `vitest`, not `jest` — so `jest/expect-expect`, `jest/no-disabled-tests`, and `jest/valid-expect` are unknown rules and the disables do nothing.

Files touched:
- `packages/sdk/src/test-fixtures/index.ts`
- `packages/sdk/src/relayer/__tests__/fhe-artifact-cache.integration.test.ts`
- `packages/sdk/src/worker/__tests__/cjs.bundler.test.ts`

## Test plan

- [x] `pnpm exec oxlint <files>` — still passes with zero output after removal (confirms the disables were dead)
- [x] `pnpm typecheck` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)