### PR TITLE
refactor(examples): upgrade react-wagmi to @zama-fhe/sdk 3.1.0-alpha.10

### DIFF
--- a/examples/react-wagmi/package-lock.json
+++ b/examples/react-wagmi/package-lock.json
@@ -7,8 +7,8 @@
       "name": "react-wagmi-example",
       "dependencies": {
         "@tanstack/react-query": "^5.90.0",
-        "@zama-fhe/react-sdk": "3.0.0-alpha.30",
-        "@zama-fhe/sdk": "3.0.0-alpha.30",
+        "@zama-fhe/react-sdk": "3.1.0-alpha.10",
+        "@zama-fhe/sdk": "3.1.0-alpha.10",
         "next": "^16.2.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -682,7 +682,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -743,7 +742,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
       "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -754,7 +752,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
       "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -781,7 +778,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -838,7 +834,6 @@
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-3.4.1.tgz",
       "integrity": "sha512-sEiwTERUmmxYwcvTEmKfN8ERDftt7JwutSAwa8RRAjmtJblUNBJp5VcPEzgQ+NPfnSO9Kq05OBSKSiocLNhhOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -866,18 +861,18 @@
       }
     },
     "node_modules/@zama-fhe/react-sdk": {
-      "version": "3.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.0.0-alpha.30.tgz",
-      "integrity": "sha512-Zt8nsuFkErkY81MypC27zcm20lat2rRbSoPeMEFQx2B9faQ1s8zCYHx2sfJPXtFdX9rWwBVQLw9pqdvy1rKbNg==",
+      "version": "3.1.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.1.0-alpha.10.tgz",
+      "integrity": "sha512-wZTdi5uw/qn5HCPYlvcUlWop3cZFI2TRt8PbKW9IV6gwqwbmvAxPf9ioxKvSEAxOa3DCcVQAjxMPjeVTNs7Wsg==",
       "license": "BSD-3-Clause-Clear",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5",
-        "@zama-fhe/sdk": "^3.0.0-alpha.30",
+        "@zama-fhe/sdk": "^3.1.0-alpha.10",
         "react": ">=18",
-        "viem": "^2.47.0",
+        "viem": ">=2",
         "wagmi": ">=2"
       },
       "peerDependenciesMeta": {
@@ -887,9 +882,9 @@
       }
     },
     "node_modules/@zama-fhe/relayer-sdk": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.4.2.tgz",
-      "integrity": "sha512-3Q0tINKxz6YseaDxOrNP/648j5Wr2C4Utnjx5npZESjLAc20tWgWFE7BOfx0Kjhs8cx/ykU+tMZBq40+DsiUvA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.4.3.tgz",
+      "integrity": "sha512-/Lz+yBda4vppMx3FiCnqjRmBWxxEzGrcyOLeFQg1fqadnCWPU5GCmx7pSBQXesJHQz7MJ5hD07ERv2gdNjxv3w==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^14.0.0",
@@ -910,14 +905,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.0.0-alpha.30.tgz",
-      "integrity": "sha512-sW4EgJCRCBFFbgxKZhDYtc2BBC4F0QrlChtEibLPGOGXTc3Gtxh6/ft/dvHYUKc5GkkFFOabcZlufQVsXYwWoA==",
+      "version": "3.1.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0-alpha.10.tgz",
+      "integrity": "sha512-8Zj4hbVodYh9laCNk9mB0xw/V4glnW5mkSenrc3DTo9TwIsiUTEG4R3itoqSOod22SMnBoe7PyfBW+zb2tv7mA==",
       "license": "BSD-3-Clause-Clear",
-      "peer": true,
       "dependencies": {
-        "@zama-fhe/relayer-sdk": "~0.4.2",
-        "viem": ">=2"
+        "@zama-fhe/relayer-sdk": "~0.4.3",
+        "viem": ">=2",
+        "zod": ">=4"
       },
       "engines": {
         "node": ">=22"
@@ -1131,7 +1126,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1399,7 +1393,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1409,7 +1402,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -1580,7 +1572,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1600,7 +1591,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -1622,7 +1612,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -1647,7 +1636,6 @@
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-3.6.0.tgz",
       "integrity": "sha512-PIpihH3N4tDbtiJNmH4uExPjE4nwL7zU+y+DlUBoSGPw92bXl11mU6NXlruSCx+JKG+/ThAYeJivh+ByTpPQrw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wagmi/connectors": "8.0.0",
         "@wagmi/core": "3.4.1",
@@ -1679,7 +1667,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1694,6 +1681,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/examples/react-wagmi/package.json
+++ b/examples/react-wagmi/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "3.0.0-alpha.30",
-    "@zama-fhe/sdk": "3.0.0-alpha.30",
+    "@zama-fhe/react-sdk": "3.1.0-alpha.10",
+    "@zama-fhe/sdk": "3.1.0-alpha.10",
     "next": "^16.2.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/examples/react-wagmi/src/app/page.tsx
+++ b/examples/react-wagmi/src/app/page.tsx
@@ -8,8 +8,8 @@ import { injected } from "wagmi/connectors";
 import { sepolia } from "wagmi/chains";
 import {
   useConfidentialBalance,
-  useIsAllowed,
-  useAllow,
+  useHasPermit,
+  useGrantPermit,
   useListPairs,
   useZamaSDK,
 } from "@zama-fhe/react-sdk";
@@ -265,7 +265,7 @@ function TokenWorkspace({ address, token, validPairs, refetchEth }: TokenWorkspa
 
   // Check whether cached credentials cover the selected confidential token.
   // This component only mounts once a token is selected, so no placeholder address is needed.
-  const { data: isAllowed } = useIsAllowed({
+  const { data: isAllowed } = useHasPermit({
     contractAddresses: [token.confidentialTokenAddress],
   });
 
@@ -279,7 +279,7 @@ function TokenWorkspace({ address, token, validPairs, refetchEth }: TokenWorkspa
   // Triggers the EIP-712 wallet signature to create FHE decrypt credentials.
   // All registry pairs are passed at once — a single signature covers all tokens,
   // so switching tokens does not require a second wallet prompt.
-  const allowTokens = useAllow();
+  const allowTokens = useGrantPermit();
   function handleDecrypt() {
     allowTokens.mutate(validPairs.map((p) => p.confidentialTokenAddress));
   }
@@ -301,7 +301,7 @@ function TokenWorkspace({ address, token, validPairs, refetchEth }: TokenWorkspa
   // Only run once the user has explicitly authorized decrypt for the selected token.
   // Prevents the hook from firing an EIP-712 prompt on mount (blind-signing anti-pattern).
   const balance = useConfidentialBalance(
-    { tokenAddress: token.confidentialTokenAddress, account: address },
+    { address: token.confidentialTokenAddress, account: address },
     { enabled: !!isAllowed },
   );
 

--- a/examples/react-wagmi/src/components/DelegateDecryptionCard.tsx
+++ b/examples/react-wagmi/src/components/DelegateDecryptionCard.tsx
@@ -20,16 +20,13 @@ export function DelegateDecryptionCard({
   const [noExpiry, setNoExpiry] = useState(true);
   const [expirationInput, setExpirationInput] = useState("");
 
-  const delegate = useDelegateDecryption(
-    { tokenAddress },
-    {
-      onSuccess: () => {
-        setDelegateAddress("");
-        setNoExpiry(true);
-        setExpirationInput("");
-      },
+  const delegate = useDelegateDecryption(tokenAddress, {
+    onSuccess: () => {
+      setDelegateAddress("");
+      setNoExpiry(true);
+      setExpirationInput("");
     },
-  );
+  });
 
   // ACL contract enforces a minimum of 1 hour — reject anything shorter at the UI level.
   const isExpiryValid =

--- a/examples/react-wagmi/src/components/PendingUnshieldCard.tsx
+++ b/examples/react-wagmi/src/components/PendingUnshieldCard.tsx
@@ -25,19 +25,15 @@ export function PendingUnshieldCard({ tokenAddress, label, onSuccess }: PendingU
       });
   }, [storage, tokenAddress]);
 
-  const resume = useResumeUnshield(
-    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
-    { tokenAddress, wrapperAddress: tokenAddress },
-    {
-      onSuccess: () => {
-        clearPendingUnshield(storage, tokenAddress).catch((err) =>
-          console.error("[PendingUnshieldCard] Failed to clear pending unshield:", err),
-        );
-        setPendingTxHash(null);
-        onSuccess?.();
-      },
+  const resume = useResumeUnshield(tokenAddress, {
+    onSuccess: () => {
+      clearPendingUnshield(storage, tokenAddress).catch((err) =>
+        console.error("[PendingUnshieldCard] Failed to clear pending unshield:", err),
+      );
+      setPendingTxHash(null);
+      onSuccess?.();
     },
-  );
+  });
 
   if (loadError) {
     return (

--- a/examples/react-wagmi/src/components/RevokeDelegationCard.tsx
+++ b/examples/react-wagmi/src/components/RevokeDelegationCard.tsx
@@ -17,12 +17,9 @@ export function RevokeDelegationCard({
 }: RevokeDelegationCardProps) {
   const [delegateAddress, setDelegateAddress] = useState("");
 
-  const revoke = useRevokeDelegation(
-    { tokenAddress },
-    {
-      onSuccess: () => setDelegateAddress(""),
-    },
-  );
+  const revoke = useRevokeDelegation(tokenAddress, {
+    onSuccess: () => setDelegateAddress(""),
+  });
 
   function handleRevoke() {
     revoke.mutate({ delegateAddress: delegateAddress as Address });

--- a/examples/react-wagmi/src/components/ShieldCard.tsx
+++ b/examples/react-wagmi/src/components/ShieldCard.tsx
@@ -24,11 +24,7 @@ export function ShieldCard({
   const [amount, setAmount] = useState("");
   const [phase, setPhase] = useState<"prepare" | "approve" | "wrap">("prepare");
 
-  const shield = useShield(
-    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
-    { tokenAddress, wrapperAddress: tokenAddress },
-    { onSuccess },
-  );
+  const shield = useShield({ address: tokenAddress }, { onSuccess });
 
   const parsedAmount = parseAmount(amount, decimals);
   const pendingLabel =

--- a/examples/react-wagmi/src/components/TransferCard.tsx
+++ b/examples/react-wagmi/src/components/TransferCard.tsx
@@ -28,7 +28,7 @@ export function TransferCard({
   const [recipient, setRecipient] = useState("");
   const [step, setStep] = useState<1 | 2>(1);
 
-  const transfer = useConfidentialTransfer({ tokenAddress }, { onSuccess });
+  const transfer = useConfidentialTransfer({ address: tokenAddress }, { onSuccess });
 
   const parsedAmount = parseAmount(amount, decimals);
   const pendingLabel = step === 2 ? "Submitting…" : "Encrypting…";

--- a/examples/react-wagmi/src/components/UnshieldCard.tsx
+++ b/examples/react-wagmi/src/components/UnshieldCard.tsx
@@ -29,21 +29,17 @@ export function UnshieldCard({
 
   const { storage } = useZamaSDK();
 
-  const unshield = useUnshield(
-    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
-    { tokenAddress, wrapperAddress: tokenAddress },
-    {
-      onSuccess: () => {
-        clearPendingUnshield(storage, tokenAddress).catch((err) =>
-          console.error("[UnshieldCard] Failed to clear pending unshield:", err),
-        );
-        onSuccess?.();
-      },
-      // Clear the active token ref on failure so a stale address is never used by the
-      // onEvent handler in ZamaProvider if a subsequent UnshieldPhase1Submitted fires.
-      onError: () => setActiveUnshieldToken(null),
+  const unshield = useUnshield(tokenAddress, {
+    onSuccess: () => {
+      clearPendingUnshield(storage, tokenAddress).catch((err) =>
+        console.error("[UnshieldCard] Failed to clear pending unshield:", err),
+      );
+      onSuccess?.();
     },
-  );
+    // Clear the active token ref on failure so a stale address is never used by the
+    // onEvent handler in ZamaProvider if a subsequent UnshieldPhase1Submitted fires.
+    onError: () => setActiveUnshieldToken(null),
+  });
 
   const parsedAmount = parseAmount(amount, decimals);
   const pendingLabel = step === 2 ? "Unshielding… (2/2)" : "Unshielding… (1/2)";

--- a/examples/react-wagmi/src/providers.tsx
+++ b/examples/react-wagmi/src/providers.tsx
@@ -22,7 +22,7 @@ import { getActiveUnshieldToken, setActiveUnshieldToken } from "@/lib/activeUnsh
 //     wagmiConfig,
 //     relayers: { [mySepolia.id]: web() },
 //     storage: indexedDBStorage,
-//     sessionStorage: indexedDBStorage,
+//     permitStorage: indexedDBStorage,
 //   });
 //   <ZamaProvider config={zamaConfig}>
 //
@@ -53,7 +53,7 @@ const zamaConfig = createZamaConfig({
   wagmiConfig,
   relayers: { [mySepolia.id]: web() },
   storage: indexedDBStorage,
-  sessionStorage: indexedDBStorage,
+  permitStorage: indexedDBStorage,
   onEvent: (event) => {
     // ZamaSDKEvents.UnshieldPhase1Submitted fires after Phase 1 is mined (the SDK
     // awaits the receipt before emitting). Saving here ensures the pending state


### PR DESCRIPTION
Upgrades the **react-wagmi** example from `3.0.0-alpha.30` to the `3.1.0-alpha.10` SDK line.

## What changed
- Bumps `@zama-fhe/sdk` and `@zama-fhe/react-sdk` to `3.1.0-alpha.10`.
- Permit hooks renamed: `useIsAllowed` → `useHasPermit`, `useAllow` → `useGrantPermit`.
- Token hooks now take the address directly instead of a `{ tokenAddress, wrapperAddress }` config object:
  - positional address: `useUnshield`, `useResumeUnshield`, `useDelegateDecryption`, `useRevokeDelegation`
  - `{ address }` object: `useShield`, `useConfidentialTransfer`, `useConfidentialBalance`
- `ZamaConfigWagmi`: `sessionStorage` renamed to `permitStorage`.

## Verification
- `npm run typecheck` → exit 0 against the published `3.1.0-alpha.10` packages.

Part of the SDK-208 example-app upgrade rollout (one PR per app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)