### PR TITLE
refactor(examples): upgrade node-ethers to @zama-fhe/sdk 3.1.0-alpha.10

### DIFF
--- a/examples/node-ethers/package-lock.json
+++ b/examples/node-ethers/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "node-ethers-example",
       "dependencies": {
-        "@zama-fhe/sdk": "3.0.0-alpha.34",
+        "@zama-fhe/sdk": "3.1.0-alpha.10",
         "ethers": "^6.13.0"
       },
       "devDependencies": {
@@ -583,9 +583,9 @@
       }
     },
     "node_modules/@zama-fhe/relayer-sdk": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.4.2.tgz",
-      "integrity": "sha512-3Q0tINKxz6YseaDxOrNP/648j5Wr2C4Utnjx5npZESjLAc20tWgWFE7BOfx0Kjhs8cx/ykU+tMZBq40+DsiUvA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.4.3.tgz",
+      "integrity": "sha512-/Lz+yBda4vppMx3FiCnqjRmBWxxEzGrcyOLeFQg1fqadnCWPU5GCmx7pSBQXesJHQz7MJ5hD07ERv2gdNjxv3w==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^14.0.0",
@@ -606,12 +606,12 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.0.0-alpha.34.tgz",
-      "integrity": "sha512-AHOaSC60sUUc9XltfdLvuf1aBswrGCCUPHsy2lfqJKDezTbV0WidTDFtyQeJTNOWa8AqHn6dvCua/ylCfb33sA==",
+      "version": "3.1.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0-alpha.10.tgz",
+      "integrity": "sha512-8Zj4hbVodYh9laCNk9mB0xw/V4glnW5mkSenrc3DTo9TwIsiUTEG4R3itoqSOod22SMnBoe7PyfBW+zb2tv7mA==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
-        "@zama-fhe/relayer-sdk": "~0.4.2",
+        "@zama-fhe/relayer-sdk": "~0.4.3",
         "viem": ">=2",
         "zod": ">=4"
       },

--- a/examples/node-ethers/package.json
+++ b/examples/node-ethers/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@zama-fhe/sdk": "3.0.0-alpha.34",
+    "@zama-fhe/sdk": "3.1.0-alpha.10",
     "ethers": "^6.13.0"
   },
   "devDependencies": {

--- a/examples/node-ethers/src/index.ts
+++ b/examples/node-ethers/src/index.ts
@@ -99,9 +99,10 @@ async function main() {
   console.log("ERC-20 token:        ", TOKEN_ADDRESS);
   console.log("Confidential wrapper:", confidentialTokenAddress);
 
-  // createToken() takes the confidential token address. The SDK resolves the
-  // underlying ERC-20 automatically via underlyingContract(this.wrapper).
-  const tokenA = sdkA.createToken(confidentialTokenAddress);
+  // createWrappedToken() takes the confidential token address. The SDK resolves the
+  // underlying ERC-20 automatically via underlyingContract(this.wrapper). Account A
+  // shields/unshields, so it needs a WrappedToken; Account B only reads balances.
+  const tokenA = sdkA.createWrappedToken(confidentialTokenAddress);
   const tokenB = sdkB.createToken(confidentialTokenAddress);
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -191,9 +192,13 @@ async function main() {
 
   // 4a. Grant: A delegates decrypt rights to B
   console.log("── 4a. Grant delegation: A → B ──");
-  await tokenA.delegateDecryption({ delegateAddress: walletB.address as Address });
+  await sdkA.delegations.delegateDecryption({
+    contractAddress: confidentialTokenAddress,
+    delegateAddress: walletB.address as Address,
+  });
 
-  const isDelegated = await tokenA.isDelegated({
+  const isDelegated = await sdkA.delegations.isActive({
+    contractAddress: confidentialTokenAddress,
     delegatorAddress: walletA.address as Address,
     delegateAddress: walletB.address as Address,
   });
@@ -234,9 +239,13 @@ async function main() {
 
   // 4c. Revoke: A removes B's decrypt rights
   console.log("\n── 4c. Revoke delegation ──");
-  await tokenA.revokeDelegation({ delegateAddress: walletB.address as Address });
+  await sdkA.delegations.revokeDelegation({
+    contractAddress: confidentialTokenAddress,
+    delegateAddress: walletB.address as Address,
+  });
 
-  const isDelegatedAfter = await tokenA.isDelegated({
+  const isDelegatedAfter = await sdkA.delegations.isActive({
+    contractAddress: confidentialTokenAddress,
     delegatorAddress: walletA.address as Address,
     delegateAddress: walletB.address as Address,
   });


### PR DESCRIPTION
Upgrades the **node-ethers** example from `3.0.0-alpha.34` to the `3.1.0-alpha.10` SDK line.

## What changed
- Bumps `@zama-fhe/sdk` to `3.1.0-alpha.10`.
- `shield`/`unshield` moved to `WrappedToken`: the shielding account's token is now created with `sdk.createWrappedToken` instead of `sdk.createToken`.
- Delegation moved off `Token` to the `sdk.delegations` API (each now takes an explicit `contractAddress`):
  - `Token.delegateDecryption` → `sdk.delegations.delegateDecryption`
  - `Token.revokeDelegation` → `sdk.delegations.revokeDelegation`
  - `Token.isDelegated` → `sdk.delegations.isActive`

## Verification
- `npm run typecheck` → exit 0 against the published `3.1.0-alpha.10` packages.

Part of the SDK-208 example-app upgrade rollout (one PR per app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)