### PR TITLE
refactor(examples): upgrade example-ingen to @zama-fhe/sdk 3.1.0-alpha.10

### DIFF
--- a/examples/example-ingen/package-lock.json
+++ b/examples/example-ingen/package-lock.json
@@ -7,8 +7,8 @@
       "name": "example-ingen",
       "dependencies": {
         "@tanstack/react-query": "^5.90.0",
-        "@zama-fhe/react-sdk": "3.0.0-alpha.34",
-        "@zama-fhe/sdk": "3.0.0-alpha.34",
+        "@zama-fhe/react-sdk": "3.1.0-alpha.10",
+        "@zama-fhe/sdk": "3.1.0-alpha.10",
         "ethers": "^6.13.0",
         "next": "^16.2.5",
         "react": "^19.2.0",
@@ -867,18 +867,18 @@
       }
     },
     "node_modules/@zama-fhe/react-sdk": {
-      "version": "3.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.0.0-alpha.34.tgz",
-      "integrity": "sha512-htEbAF7tdBxwGFrEPSigr6OfyL8JTHzlgyE+FoJLu5lfLQIIgYwunM6kNcZ+X8tzYMYpqljxCQ2mrW3/AzPKSQ==",
+      "version": "3.1.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.1.0-alpha.10.tgz",
+      "integrity": "sha512-wZTdi5uw/qn5HCPYlvcUlWop3cZFI2TRt8PbKW9IV6gwqwbmvAxPf9ioxKvSEAxOa3DCcVQAjxMPjeVTNs7Wsg==",
       "license": "BSD-3-Clause-Clear",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5",
-        "@zama-fhe/sdk": "^3.0.0-alpha.34",
+        "@zama-fhe/sdk": "^3.1.0-alpha.10",
         "react": ">=18",
-        "viem": "^2.47.0",
+        "viem": ">=2",
         "wagmi": ">=2"
       },
       "peerDependenciesMeta": {
@@ -911,12 +911,12 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.0.0-alpha.34.tgz",
-      "integrity": "sha512-AHOaSC60sUUc9XltfdLvuf1aBswrGCCUPHsy2lfqJKDezTbV0WidTDFtyQeJTNOWa8AqHn6dvCua/ylCfb33sA==",
+      "version": "3.1.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0-alpha.10.tgz",
+      "integrity": "sha512-8Zj4hbVodYh9laCNk9mB0xw/V4glnW5mkSenrc3DTo9TwIsiUTEG4R3itoqSOod22SMnBoe7PyfBW+zb2tv7mA==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
-        "@zama-fhe/relayer-sdk": "~0.4.2",
+        "@zama-fhe/relayer-sdk": "~0.4.3",
         "viem": ">=2",
         "zod": ">=4"
       },
@@ -1208,9 +1208,9 @@
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/ox": {
-      "version": "0.14.22",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.22.tgz",
-      "integrity": "sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==",
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
       "funding": [
         {
           "type": "github",
@@ -1509,9 +1509,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.50.4",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.50.4.tgz",
-      "integrity": "sha512-rf98F4s3Vlb+uJZEKfay3IbBw3CNCbVtx5Y3UIljlO2tSX420g/J0WQSYsjzBSasUFgxgsXabji14O9kGbiqgg==",
+      "version": "2.52.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.2.tgz",
+      "integrity": "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==",
       "funding": [
         {
           "type": "github",
@@ -1526,7 +1526,7 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.22",
+        "ox": "0.14.29",
         "ws": "8.20.1"
       },
       "peerDependencies": {

--- a/examples/example-ingen/package.json
+++ b/examples/example-ingen/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "3.0.0-alpha.34",
-    "@zama-fhe/sdk": "3.0.0-alpha.34",
+    "@zama-fhe/react-sdk": "3.1.0-alpha.10",
+    "@zama-fhe/sdk": "3.1.0-alpha.10",
     "ethers": "^6.13.0",
     "next": "^16.2.5",
     "react": "^19.2.0",

--- a/examples/example-ingen/src/app/page.tsx
+++ b/examples/example-ingen/src/app/page.tsx
@@ -5,8 +5,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatEther, formatUnits, parseUnits, JsonRpcProvider } from "ethers";
 import {
   useConfidentialBalance,
-  useIsAllowed,
-  useAllow,
+  useHasPermit,
+  useGrantPermit,
   useListPairs,
   useZamaSDK,
 } from "@zama-fhe/react-sdk";
@@ -99,7 +99,7 @@ function SelectedTokenPanel({
   const queryClient = useQueryClient();
   const sdk = useZamaSDK();
 
-  const { data: isAllowed } = useIsAllowed({
+  const { data: isAllowed } = useHasPermit({
     contractAddresses: [token.confidentialTokenAddress],
   });
 
@@ -108,7 +108,7 @@ function SelectedTokenPanel({
   const confidentialSymbol = token.confidential.symbol;
   const erc20Symbol = token.underlying.symbol;
 
-  const allowTokens = useAllow();
+  const allowTokens = useGrantPermit();
   function handleDecrypt() {
     if (validPairs.length === 0) return;
     allowTokens.mutate(validPairs.map((p) => p.confidentialTokenAddress));
@@ -135,13 +135,14 @@ function SelectedTokenPanel({
   };
 
   const balance = useConfidentialBalance(
-    { tokenAddress: token.confidentialTokenAddress, account: address },
+    { address: token.confidentialTokenAddress, account: address },
     { enabled: isIngen && !!isAllowed },
   );
 
   const mint = useMutation({
     mutationFn: async () => {
-      const signer = sdk.requireSigner("mint");
+      const signer = sdk.signer;
+      if (!signer) throw new Error("A wallet signer is required to mint");
       const txHash = await signer.writeContract({
         address: token.tokenAddress,
         abi: MINT_ABI,

--- a/examples/example-ingen/src/components/DecryptAsCard.tsx
+++ b/examples/example-ingen/src/components/DecryptAsCard.tsx
@@ -48,14 +48,11 @@ export function DecryptAsCard({
   // delegatorAddress = the owner who granted the delegation.
   // delegateAddress  = the connected wallet (us).
   const delegationStatus = useDelegationStatus({
-    tokenAddress,
+    contractAddress: tokenAddress,
     delegatorAddress: ownerIsValid ? (ownerAddress as Address) : undefined,
     delegateAddress: connectedAddress,
   });
 
-  // Note: useDecryptBalanceAs takes a positional tokenAddress argument, unlike
-  // useDelegateDecryption / useRevokeDelegation which use a config object { tokenAddress }.
-  // This asymmetry is a current SDK API design decision.
   const decryptAs = useDecryptBalanceAs(tokenAddress);
 
   function handleDecrypt() {
@@ -87,12 +84,12 @@ export function DecryptAsCard({
               Unable to check delegation status: {delegationStatus.error?.message}
             </span>
           )}
-          {delegationStatus.data?.isDelegated && (
+          {delegationStatus.data?.isActive && (
             <span className="delegation-status-active">
               ✓ Delegated · {formatExpiry(delegationStatus.data.expiryTimestamp)}
             </span>
           )}
-          {delegationStatus.data && !delegationStatus.data.isDelegated && (
+          {delegationStatus.data && !delegationStatus.data.isActive && (
             <span className="delegation-status-none">No active delegation for this token</span>
           )}
         </div>

--- a/examples/example-ingen/src/components/DelegateDecryptionCard.tsx
+++ b/examples/example-ingen/src/components/DelegateDecryptionCard.tsx
@@ -20,16 +20,13 @@ export function DelegateDecryptionCard({
   const [noExpiry, setNoExpiry] = useState(true);
   const [expirationInput, setExpirationInput] = useState("");
 
-  const delegate = useDelegateDecryption(
-    { tokenAddress },
-    {
-      onSuccess: () => {
-        setDelegateAddress("");
-        setNoExpiry(true);
-        setExpirationInput("");
-      },
+  const delegate = useDelegateDecryption(tokenAddress, {
+    onSuccess: () => {
+      setDelegateAddress("");
+      setNoExpiry(true);
+      setExpirationInput("");
     },
-  );
+  });
 
   // ACL contract enforces a minimum of 1 hour — reject anything shorter at the UI level.
   const isExpiryValid =

--- a/examples/example-ingen/src/components/PendingUnshieldCard.tsx
+++ b/examples/example-ingen/src/components/PendingUnshieldCard.tsx
@@ -26,19 +26,15 @@ export function PendingUnshieldCard({ tokenAddress, label, onSuccess }: PendingU
       });
   }, [storage, tokenAddress]);
 
-  const resume = useResumeUnshield(
-    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
-    { tokenAddress, wrapperAddress: tokenAddress },
-    {
-      onSuccess: () => {
-        clearPendingUnshield(storage, tokenAddress).catch((err) =>
-          console.error("[PendingUnshieldCard] Failed to clear pending unshield:", err),
-        );
-        setPendingTxHash(null);
-        onSuccess?.();
-      },
+  const resume = useResumeUnshield(tokenAddress, {
+    onSuccess: () => {
+      clearPendingUnshield(storage, tokenAddress).catch((err) =>
+        console.error("[PendingUnshieldCard] Failed to clear pending unshield:", err),
+      );
+      setPendingTxHash(null);
+      onSuccess?.();
     },
-  );
+  });
 
   if (loadError) {
     return (

--- a/examples/example-ingen/src/components/RevokeDelegationCard.tsx
+++ b/examples/example-ingen/src/components/RevokeDelegationCard.tsx
@@ -17,12 +17,9 @@ export function RevokeDelegationCard({
 }: RevokeDelegationCardProps) {
   const [delegateAddress, setDelegateAddress] = useState("");
 
-  const revoke = useRevokeDelegation(
-    { tokenAddress },
-    {
-      onSuccess: () => setDelegateAddress(""),
-    },
-  );
+  const revoke = useRevokeDelegation(tokenAddress, {
+    onSuccess: () => setDelegateAddress(""),
+  });
 
   function handleRevoke() {
     revoke.mutate({ delegateAddress: delegateAddress as Address });

--- a/examples/example-ingen/src/components/ShieldCard.tsx
+++ b/examples/example-ingen/src/components/ShieldCard.tsx
@@ -59,8 +59,9 @@ export function ShieldCard({
   // to the reset path when the user said no.
   const shield = useMutation({
     mutationFn: async (amount: bigint) => {
-      const signer = sdk.requireSigner("shield");
-      const token = sdk.createToken(tokenAddress);
+      const signer = sdk.signer;
+      if (!signer) throw new Error("A wallet signer is required to shield");
+      const token = sdk.createWrappedToken(tokenAddress);
       const userAddress = signer.requireWalletAccount("shield").address;
 
       // Read the current ERC-20 allowance granted to the wrapper.

--- a/examples/example-ingen/src/components/TransferCard.tsx
+++ b/examples/example-ingen/src/components/TransferCard.tsx
@@ -28,7 +28,7 @@ export function TransferCard({
   const [recipient, setRecipient] = useState("");
   const [step, setStep] = useState<1 | 2>(1);
 
-  const transfer = useConfidentialTransfer({ tokenAddress }, { onSuccess });
+  const transfer = useConfidentialTransfer({ address: tokenAddress }, { onSuccess });
 
   const parsedAmount = parseAmount(amount, decimals);
   const pendingLabel = step === 2 ? "Submitting…" : "Encrypting…";

--- a/examples/example-ingen/src/components/UnshieldCard.tsx
+++ b/examples/example-ingen/src/components/UnshieldCard.tsx
@@ -30,21 +30,17 @@ export function UnshieldCard({
 
   const { storage } = useZamaSDK();
 
-  const unshield = useUnshield(
-    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
-    { tokenAddress, wrapperAddress: tokenAddress },
-    {
-      onSuccess: () => {
-        clearPendingUnshield(storage, tokenAddress).catch((err) =>
-          console.error("[UnshieldCard] Failed to clear pending unshield:", err),
-        );
-        onSuccess?.();
-      },
-      // Clear the active token ref on failure so a stale address is never used by the
-      // onEvent handler in ZamaProvider if a subsequent UnshieldPhase1Submitted fires.
-      onError: () => setActiveUnshieldToken(null),
+  const unshield = useUnshield(tokenAddress, {
+    onSuccess: () => {
+      clearPendingUnshield(storage, tokenAddress).catch((err) =>
+        console.error("[UnshieldCard] Failed to clear pending unshield:", err),
+      );
+      onSuccess?.();
     },
-  );
+    // Clear the active token ref on failure so a stale address is never used by the
+    // onEvent handler in ZamaProvider if a subsequent UnshieldPhase1Submitted fires.
+    onError: () => setActiveUnshieldToken(null),
+  });
 
   const parsedAmount = parseAmount(amount, decimals);
   const pendingLabel = step === 2 ? "Unshielding… (2/2)" : "Unshielding… (1/2)";


### PR DESCRIPTION
Upgrades the **example-ingen** app from `3.0.0-alpha.34` to the `3.1.0-alpha.10` SDK line.

## What changed
- Bumps `@zama-fhe/sdk` and `@zama-fhe/react-sdk` to `3.1.0-alpha.10`.
- Permit hooks renamed: `useIsAllowed` → `useHasPermit`, `useAllow` → `useGrantPermit`.
- Token hooks take the address directly instead of `{ tokenAddress, wrapperAddress }`:
  - positional address: `useUnshield`, `useResumeUnshield`, `useDelegateDecryption`, `useRevokeDelegation`
  - `{ address }` object: `useConfidentialBalance`, `useConfidentialTransfer`
- `useDelegationStatus` config field `tokenAddress` → `contractAddress`; `DelegationStatusData.isDelegated` → `isActive`.
- `ZamaSDK.requireSigner` removed → use `sdk.signer` with an explicit null check.
- `shield()` lives on `WrappedToken` → `createToken` becomes `createWrappedToken` in the manual ShieldCard flow.

## Verification
- `npm run typecheck` → exit 0 against the published `3.1.0-alpha.10` packages.

Part of the SDK-208 example-app upgrade rollout (one PR per app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)