### PR TITLE
refactor(examples): upgrade example-hoodi to @zama-fhe/sdk 3.1.0-alpha.10

### DIFF
--- a/examples/example-hoodi/package-lock.json
+++ b/examples/example-hoodi/package-lock.json
@@ -7,8 +7,8 @@
       "name": "hoodi-example",
       "dependencies": {
         "@tanstack/react-query": "^5.90.0",
-        "@zama-fhe/react-sdk": "2.2.0-alpha.4",
-        "@zama-fhe/sdk": "2.2.0-alpha.4",
+        "@zama-fhe/react-sdk": "3.1.0-alpha.10",
+        "@zama-fhe/sdk": "3.1.0-alpha.10",
         "ethers": "^6.13.0",
         "next": "^16.2.6",
         "react": "^19.2.0",
@@ -679,7 +679,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -795,7 +794,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
       "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -827,18 +825,18 @@
       }
     },
     "node_modules/@zama-fhe/react-sdk": {
-      "version": "2.2.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-2.2.0-alpha.4.tgz",
-      "integrity": "sha512-b6v8Yl4K4w5croL8WCjsFPdTRfdaXWtYis+lzIHkmXtaXdAjlN4GvUNywYeZHly2MYZ271x7xGRXU8FGYwSYUA==",
+      "version": "3.1.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.1.0-alpha.10.tgz",
+      "integrity": "sha512-wZTdi5uw/qn5HCPYlvcUlWop3cZFI2TRt8PbKW9IV6gwqwbmvAxPf9ioxKvSEAxOa3DCcVQAjxMPjeVTNs7Wsg==",
       "license": "BSD-3-Clause-Clear",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5",
-        "@zama-fhe/sdk": "^2.2.0-alpha.4",
+        "@zama-fhe/sdk": "^3.1.0-alpha.10",
         "react": ">=18",
-        "viem": "^2.47.0",
+        "viem": ">=2",
         "wagmi": ">=2"
       },
       "peerDependenciesMeta": {
@@ -848,9 +846,9 @@
       }
     },
     "node_modules/@zama-fhe/relayer-sdk": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.4.2.tgz",
-      "integrity": "sha512-3Q0tINKxz6YseaDxOrNP/648j5Wr2C4Utnjx5npZESjLAc20tWgWFE7BOfx0Kjhs8cx/ykU+tMZBq40+DsiUvA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.4.3.tgz",
+      "integrity": "sha512-/Lz+yBda4vppMx3FiCnqjRmBWxxEzGrcyOLeFQg1fqadnCWPU5GCmx7pSBQXesJHQz7MJ5hD07ERv2gdNjxv3w==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^14.0.0",
@@ -871,14 +869,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "2.2.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-2.2.0-alpha.4.tgz",
-      "integrity": "sha512-rczGMP1jkay7PpFNXl1hb6ttoqLZjnGrwMFHK4iBuBA7lqBtPu2xzkfAOec1JMaafTTF/dZHWGGdvc4mb6+8/Q==",
+      "version": "3.1.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0-alpha.10.tgz",
+      "integrity": "sha512-8Zj4hbVodYh9laCNk9mB0xw/V4glnW5mkSenrc3DTo9TwIsiUTEG4R3itoqSOod22SMnBoe7PyfBW+zb2tv7mA==",
       "license": "BSD-3-Clause-Clear",
-      "peer": true,
       "dependencies": {
-        "@zama-fhe/relayer-sdk": "~0.4.2",
-        "viem": "^2.47.6"
+        "@zama-fhe/relayer-sdk": "~0.4.3",
+        "viem": ">=2",
+        "zod": ">=4"
       },
       "engines": {
         "node": ">=22"
@@ -1035,7 +1033,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1183,9 +1180,9 @@
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/ox": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.7.tgz",
-      "integrity": "sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==",
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
       "funding": [
         {
           "type": "github",
@@ -1316,7 +1313,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1326,7 +1322,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -1497,7 +1492,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1519,9 +1513,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.47.6",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.6.tgz",
-      "integrity": "sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==",
+      "version": "2.52.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.2.tgz",
+      "integrity": "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==",
       "funding": [
         {
           "type": "github",
@@ -1529,7 +1523,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -1537,8 +1530,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.7",
-        "ws": "8.18.3"
+        "ox": "0.14.29",
+        "ws": "8.20.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -1577,9 +1570,9 @@
       }
     },
     "node_modules/viem/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -1608,7 +1601,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1623,6 +1615,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/examples/example-hoodi/package.json
+++ b/examples/example-hoodi/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "2.2.0-alpha.4",
-    "@zama-fhe/sdk": "2.2.0-alpha.4",
+    "@zama-fhe/react-sdk": "3.1.0-alpha.10",
+    "@zama-fhe/sdk": "3.1.0-alpha.10",
     "ethers": "^6.13.0",
     "next": "^16.2.6",
     "react": "^19.2.0",

--- a/examples/example-hoodi/src/app/page.tsx
+++ b/examples/example-hoodi/src/app/page.tsx
@@ -5,15 +5,14 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatEther, formatUnits, parseUnits, JsonRpcProvider } from "ethers";
 import {
   useConfidentialBalance,
-  useIsAllowed,
-  useAllow,
+  useHasPermit,
+  useGrantPermit,
   useListPairs,
   useZamaSDK,
-  balanceOfContract,
 } from "@zama-fhe/react-sdk";
-import type { TokenWrapperPair, TokenWrapperPairWithMetadata } from "@zama-fhe/sdk";
+import { balanceOfContract } from "@zama-fhe/sdk";
+import type { TokenWrapperPair, TokenWrapperPairWithMetadata, Address } from "@zama-fhe/sdk";
 import { zamaQueryKeys } from "@zama-fhe/sdk/query"; // query key builders for SDK-managed caches — /query subpath export
-import type { Address } from "@zama-fhe/react-sdk";
 import { BalancesCard } from "@/components/BalancesCard";
 import { ShieldCard } from "@/components/ShieldCard";
 import { TransferCard } from "@/components/TransferCard";
@@ -149,10 +148,10 @@ export default function Home() {
   const token = validPairs.find((p) => p.confidentialTokenAddress === selectedTokenAddress);
 
   // Check whether cached credentials cover the currently selected confidential token.
-  const { data: isAllowed } = useIsAllowed({
-    contractAddresses: token ? [token.confidentialTokenAddress] : [],
-    query: { enabled: Boolean(token) },
-  });
+  const { data: isAllowed } = useHasPermit(
+    { contractAddresses: token ? [token.confidentialTokenAddress] : [] },
+    { enabled: Boolean(token) },
+  );
 
   // Metadata for the selected token pair — sourced directly from the registry response
   // (useListPairs with metadata: true). Defaults to safe zero values until the pair loads.
@@ -164,7 +163,7 @@ export default function Home() {
   // Triggers the EIP-712 wallet signature to create FHE decrypt credentials.
   // All registry pairs are passed at once — a single signature covers all tokens,
   // so switching tokens does not require a second wallet prompt.
-  const allowTokens = useAllow();
+  const allowTokens = useGrantPermit();
   function handleDecrypt() {
     if (validPairs.length === 0) return;
     allowTokens.mutate(validPairs.map((p) => p.confidentialTokenAddress));
@@ -282,7 +281,7 @@ export default function Home() {
   const { data: erc20Balance } = useQuery({
     queryKey: erc20BalanceKey,
     queryFn: async () =>
-      sdk.signer.readContract(
+      sdk.provider.readContract(
         balanceOfContract(token!.tokenAddress, address as Address),
       ) as Promise<bigint>,
     enabled: !!address && isHoodi && !!token,
@@ -295,7 +294,7 @@ export default function Home() {
     // any operation that changes the confidential balance (shield, unshield, transfer).
     if (token) {
       queryClient.invalidateQueries({
-        queryKey: zamaQueryKeys.confidentialHandle.token(token.confidentialTokenAddress),
+        queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
       });
     }
   };
@@ -305,20 +304,22 @@ export default function Home() {
   // ZERO_ADDRESS is used as a stable placeholder while no token pair is selected —
   // the query is disabled (enabled: false) so no actual RPC call is made.
   const balance = useConfidentialBalance(
-    { tokenAddress: token?.confidentialTokenAddress ?? ZERO_ADDRESS },
+    { address: token?.confidentialTokenAddress ?? ZERO_ADDRESS, account: address as Address },
     { enabled: !!address && isHoodi && !!isAllowed && !!token },
   );
 
   // Mint 10 whole tokens on the underlying ERC-20 contract.
   const mint = useMutation({
     mutationFn: async () => {
-      const txHash = await sdk.signer.writeContract({
+      const signer = sdk.signer;
+      if (!signer) throw new Error("A wallet signer is required to mint");
+      const txHash = await signer.writeContract({
         address: token!.tokenAddress,
         abi: MINT_ABI,
         functionName: "mint",
         args: [address as Address, parseUnits("10", erc20Decimals)],
       });
-      await sdk.signer.waitForTransactionReceipt(txHash);
+      await sdk.provider.waitForTransactionReceipt(txHash);
       return txHash;
     },
     onSuccess: refreshBalances,
@@ -452,9 +453,7 @@ export default function Home() {
       <BalancesCard
         formattedErc20={formattedErc20}
         formattedConfidential={formattedConfidential}
-        // handleQuery.isLoading: fetching the encrypted handle from chain (Phase 1).
-        // balance.isLoading: decrypting it via RelayerCleartext (Phase 2).
-        isLoadingConfidential={balance.handleQuery.isLoading || balance.isLoading}
+        isLoadingConfidential={balance.isLoading || balance.isFetching}
         erc20Symbol={erc20Symbol}
         onMint={() => mint.mutate()}
         isMinting={mint.isPending}

--- a/examples/example-hoodi/src/components/DecryptAsCard.tsx
+++ b/examples/example-hoodi/src/components/DecryptAsCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { isAddress, formatUnits } from "ethers";
 import { useDelegationStatus, useDecryptBalanceAs } from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { DelegationNotFoundError, DelegationExpiredError } from "@zama-fhe/sdk";
 
 // Matches the SDK's internal sentinel value for permanent (no-expiry) delegations.

--- a/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
+++ b/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { isAddress } from "ethers";
 import { useDelegateDecryption } from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 
 interface DelegateDecryptionCardProps {
@@ -17,16 +17,13 @@ export function DelegateDecryptionCard({ tokenAddress, disabled }: DelegateDecry
   const [noExpiry, setNoExpiry] = useState(true);
   const [expirationInput, setExpirationInput] = useState("");
 
-  const delegate = useDelegateDecryption(
-    { tokenAddress },
-    {
-      onSuccess: () => {
-        setDelegateAddress("");
-        setNoExpiry(true);
-        setExpirationInput("");
-      },
+  const delegate = useDelegateDecryption(tokenAddress, {
+    onSuccess: () => {
+      setDelegateAddress("");
+      setNoExpiry(true);
+      setExpirationInput("");
     },
-  );
+  });
 
   const isExpiryValid = noExpiry || (!!expirationInput && new Date(expirationInput) > new Date());
   const canSubmit = isAddress(delegateAddress) && isExpiryValid;

--- a/examples/example-hoodi/src/components/PendingUnshieldCard.tsx
+++ b/examples/example-hoodi/src/components/PendingUnshieldCard.tsx
@@ -1,13 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import {
-  useZamaSDK,
-  useResumeUnshield,
-  loadPendingUnshield,
-  clearPendingUnshield,
-} from "@zama-fhe/react-sdk";
-import type { Address, Hex } from "@zama-fhe/react-sdk";
+import { useZamaSDK, useResumeUnshield } from "@zama-fhe/react-sdk";
+import { loadPendingUnshield, clearPendingUnshield } from "@zama-fhe/sdk";
+import type { Address, Hex } from "@zama-fhe/sdk";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 
 interface PendingUnshieldCardProps {
@@ -26,19 +22,15 @@ export function PendingUnshieldCard({ tokenAddress, label, onSuccess }: PendingU
       .catch((err) => console.error("[PendingUnshieldCard] loadPendingUnshield failed:", err));
   }, [storage, tokenAddress]);
 
-  const resume = useResumeUnshield(
-    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
-    { tokenAddress, wrapperAddress: tokenAddress },
-    {
-      onSuccess: () => {
-        clearPendingUnshield(storage, tokenAddress).catch((err) =>
-          console.error("[PendingUnshieldCard] Failed to clear pending unshield:", err),
-        );
-        setPendingTxHash(null);
-        onSuccess?.();
-      },
+  const resume = useResumeUnshield(tokenAddress, {
+    onSuccess: () => {
+      clearPendingUnshield(storage, tokenAddress).catch((err) =>
+        console.error("[PendingUnshieldCard] Failed to clear pending unshield:", err),
+      );
+      setPendingTxHash(null);
+      onSuccess?.();
     },
-  );
+  });
 
   if (!pendingTxHash) return null;
 

--- a/examples/example-hoodi/src/components/RevokeDelegationCard.tsx
+++ b/examples/example-hoodi/src/components/RevokeDelegationCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { isAddress } from "ethers";
 import { useRevokeDelegation } from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 
 interface RevokeDelegationCardProps {
@@ -14,12 +14,9 @@ interface RevokeDelegationCardProps {
 export function RevokeDelegationCard({ tokenAddress, disabled }: RevokeDelegationCardProps) {
   const [delegateAddress, setDelegateAddress] = useState("");
 
-  const revoke = useRevokeDelegation(
-    { tokenAddress },
-    {
-      onSuccess: () => setDelegateAddress(""),
-    },
-  );
+  const revoke = useRevokeDelegation(tokenAddress, {
+    onSuccess: () => setDelegateAddress(""),
+  });
 
   function handleRevoke() {
     revoke.mutate({ delegateAddress: delegateAddress as Address });

--- a/examples/example-hoodi/src/components/ShieldCard.tsx
+++ b/examples/example-hoodi/src/components/ShieldCard.tsx
@@ -3,13 +3,9 @@
 import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { isError } from "ethers";
-import {
-  useZamaSDK,
-  allowanceContract,
-  approveContract,
-  balanceOfContract,
-} from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import { useZamaSDK } from "@zama-fhe/react-sdk";
+import { allowanceContract, approveContract, balanceOfContract } from "@zama-fhe/sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { parseAmount } from "@/lib/parseAmount";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 
@@ -61,17 +57,19 @@ export function ShieldCard({
   // to the reset path when the user said no.
   const shield = useMutation({
     mutationFn: async (amount: bigint) => {
-      const token = sdk.createToken(tokenAddress);
-      const userAddress = await sdk.signer.getAddress();
+      const signer = sdk.signer;
+      if (!signer) throw new Error("A wallet signer is required to shield");
+      const token = sdk.createWrappedToken(tokenAddress);
+      const userAddress = signer.requireWalletAccount("shield").address;
 
       // Read the current ERC-20 allowance granted to the wrapper.
-      const currentAllowance = (await sdk.signer.readContract(
+      const currentAllowance = (await sdk.provider.readContract(
         allowanceContract(underlyingAddress, userAddress, tokenAddress),
       )) as bigint;
 
       if (currentAllowance < amount) {
         // Fetch the user's full ERC-20 balance to use as the new spend cap.
-        const erc20Balance = (await sdk.signer.readContract(
+        const erc20Balance = (await sdk.provider.readContract(
           balanceOfContract(underlyingAddress, userAddress),
         )) as bigint;
 
@@ -83,31 +81,31 @@ export function ShieldCard({
           // - USDT-style: eth_estimateGas reverts → caught below → reset path (2 confirmations).
           let needsReset = false;
           try {
-            const approveTxHash = await sdk.signer.writeContract(
+            const approveTxHash = await signer.writeContract(
               approveContract(underlyingAddress, tokenAddress, erc20Balance),
             );
-            await sdk.signer.waitForTransactionReceipt(approveTxHash);
+            await sdk.provider.waitForTransactionReceipt(approveTxHash);
           } catch (err) {
             if (isError(err, "ACTION_REJECTED")) throw err; // user rejected — stop here
             needsReset = true; // eth_estimateGas reverted → USDT-style token
           }
 
           if (needsReset) {
-            const resetTxHash = await sdk.signer.writeContract(
+            const resetTxHash = await signer.writeContract(
               approveContract(underlyingAddress, tokenAddress, 0n),
             );
-            await sdk.signer.waitForTransactionReceipt(resetTxHash);
-            const approveTxHash = await sdk.signer.writeContract(
+            await sdk.provider.waitForTransactionReceipt(resetTxHash);
+            const approveTxHash = await signer.writeContract(
               approveContract(underlyingAddress, tokenAddress, erc20Balance),
             );
-            await sdk.signer.waitForTransactionReceipt(approveTxHash);
+            await sdk.provider.waitForTransactionReceipt(approveTxHash);
           }
         } else {
           // Zero allowance: simple approve — no reset needed for any token.
-          const approveTxHash = await sdk.signer.writeContract(
+          const approveTxHash = await signer.writeContract(
             approveContract(underlyingAddress, tokenAddress, erc20Balance),
           );
-          await sdk.signer.waitForTransactionReceipt(approveTxHash);
+          await sdk.provider.waitForTransactionReceipt(approveTxHash);
         }
 
         setPhase("wrap-after-approve");

--- a/examples/example-hoodi/src/components/TransferCard.tsx
+++ b/examples/example-hoodi/src/components/TransferCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { isAddress } from "ethers";
 import { useConfidentialTransfer } from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { parseAmount } from "@/lib/parseAmount";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 
@@ -28,7 +28,7 @@ export function TransferCard({
   const [recipient, setRecipient] = useState("");
   const [step, setStep] = useState<1 | 2>(1);
 
-  const transfer = useConfidentialTransfer({ tokenAddress }, { onSuccess });
+  const transfer = useConfidentialTransfer({ address: tokenAddress }, { onSuccess });
 
   const parsedAmount = parseAmount(amount, decimals);
   const pendingLabel = step === 2 ? "Submitting…" : "Encrypting…";
@@ -38,7 +38,7 @@ export function TransferCard({
     transfer.mutate({
       to: recipient as Address,
       amount: parsedAmount,
-      callbacks: { onEncryptComplete: () => setStep(2) },
+      onEncryptComplete: () => setStep(2),
     });
   }
 

--- a/examples/example-hoodi/src/components/UnshieldCard.tsx
+++ b/examples/example-hoodi/src/components/UnshieldCard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { useUnshield, useZamaSDK, clearPendingUnshield } from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import { useUnshield, useZamaSDK } from "@zama-fhe/react-sdk";
+import { clearPendingUnshield } from "@zama-fhe/sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { parseAmount } from "@/lib/parseAmount";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 import { setActiveUnshieldToken } from "@/lib/activeUnshield";
@@ -29,21 +30,17 @@ export function UnshieldCard({
 
   const { storage } = useZamaSDK();
 
-  const unshield = useUnshield(
-    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
-    { tokenAddress, wrapperAddress: tokenAddress },
-    {
-      onSuccess: () => {
-        clearPendingUnshield(storage, tokenAddress).catch((err) =>
-          console.error("[UnshieldCard] Failed to clear pending unshield:", err),
-        );
-        onSuccess?.();
-      },
-      // Clear the active token ref on failure so a stale address is never used by the
-      // onEvent handler in ZamaProvider if a subsequent UnshieldPhase1Submitted fires.
-      onError: () => setActiveUnshieldToken(null),
+  const unshield = useUnshield(tokenAddress, {
+    onSuccess: () => {
+      clearPendingUnshield(storage, tokenAddress).catch((err) =>
+        console.error("[UnshieldCard] Failed to clear pending unshield:", err),
+      );
+      onSuccess?.();
     },
-  );
+    // Clear the active token ref on failure so a stale address is never used by the
+    // onEvent handler in ZamaProvider if a subsequent UnshieldPhase1Submitted fires.
+    onError: () => setActiveUnshieldToken(null),
+  });
 
   const parsedAmount = parseAmount(amount, decimals);
   const pendingLabel = step === 2 ? "Unshielding… (2/2)" : "Unshielding… (1/2)";
@@ -57,10 +54,8 @@ export function UnshieldCard({
     setActiveUnshieldToken(tokenAddress);
     unshield.mutate({
       amount: parsedAmount,
-      callbacks: {
-        // onFinalizing fires between the two on-chain transactions, marking step 2.
-        onFinalizing: () => setStep(2),
-      },
+      // onFinalizing fires between the two on-chain transactions, marking step 2.
+      onFinalizing: () => setStep(2),
     });
   }
 

--- a/examples/example-hoodi/src/lib/activeUnshield.ts
+++ b/examples/example-hoodi/src/lib/activeUnshield.ts
@@ -1,4 +1,4 @@
-import type { Address } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 
 /**
  * Module-level bridge used to associate an in-flight unwrap transaction hash

--- a/examples/example-hoodi/src/providers.tsx
+++ b/examples/example-hoodi/src/providers.tsx
@@ -2,15 +2,16 @@
 
 import { useState, useEffect, useMemo, useRef, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ZamaProvider } from "@zama-fhe/react-sdk";
 import {
-  ZamaProvider,
   ZamaSDKEvents,
   IndexedDBStorage,
   indexedDBStorage,
   savePendingUnshield,
-} from "@zama-fhe/react-sdk";
-import { RelayerCleartext, hoodiCleartextConfig } from "@zama-fhe/sdk/cleartext";
-import { EthersSigner } from "@zama-fhe/sdk/ethers";
+  cleartext,
+} from "@zama-fhe/sdk";
+import { hoodi, type FheChain } from "@zama-fhe/sdk/chains";
+import { createConfig, type EIP1193Provider } from "@zama-fhe/sdk/ethers";
 import { JsonRpcProvider } from "ethers";
 import { HOODI_RPC_URL } from "@/lib/config";
 import { getActiveUnshieldToken, setActiveUnshieldToken } from "@/lib/activeUnshield";
@@ -226,28 +227,26 @@ export function Providers({ children }: { children: ReactNode }) {
     return () => ethereum.removeListener("accountsChanged", handleAccountsChanged);
   }, []);
 
-  // hoodiCleartextConfig and HOODI_RPC_URL are build-time constants — relayer never changes.
-  const relayer = useMemo(
-    () => new RelayerCleartext({ ...hoodiCleartextConfig, network: HOODI_RPC_URL }),
+  // The hoodi cleartext chain preset carries the executorAddress that cleartext() needs;
+  // the network override points SDK reads at HOODI_RPC_URL.
+  const hoodiChain = useMemo(
+    () => ({ ...hoodi, network: HOODI_RPC_URL }) as const satisfies FheChain,
     [],
   );
 
-  // Recreated on wallet switch so the new EthersSigner is bound to the new account address.
-  const signer = useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const hybridEthereum = createHybridEthereum(getEthereumProvider(), liveAccountsRef) as any;
-    return new EthersSigner({ ethereum: hybridEthereum });
-  }, [walletKey]);
-
-  return (
-    <QueryClientProvider client={queryClient}>
-      <ZamaProvider
-        key={walletKey}
-        relayer={relayer}
-        storage={indexedDBStorage}
-        sessionStorage={sessionDBStorage}
-        signer={signer}
-        onEvent={(event) => {
+  // Recreated on wallet switch so the ethers adapter is bound to the new account address.
+  const config = useMemo(
+    () =>
+      createConfig({
+        chains: [hoodiChain],
+        ethereum: createHybridEthereum(
+          getEthereumProvider(),
+          liveAccountsRef,
+        ) as unknown as EIP1193Provider,
+        relayers: { [hoodiChain.id]: cleartext() },
+        storage: indexedDBStorage,
+        permitStorage: sessionDBStorage,
+        onEvent: (event) => {
           // ZamaSDKEvents.UnshieldPhase1Submitted fires after Phase 1 is mined (the SDK
           // awaits the receipt before emitting). Saving here ensures the pending state
           // survives a tab close between Phase 1 and Phase 2.
@@ -261,8 +260,14 @@ export function Providers({ children }: { children: ReactNode }) {
               setActiveUnshieldToken(null);
             }
           }
-        }}
-      >
+        },
+      }),
+    [hoodiChain, walletKey],
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ZamaProvider key={walletKey} config={config}>
         {children}
       </ZamaProvider>
     </QueryClientProvider>


### PR DESCRIPTION
Upgrades the **example-hoodi** app **across the major** from `2.2.0-alpha.4` to the `3.1.0-alpha.10` SDK line. This is the cross-major migration of the rollout.

## What changed
**Package boundary** — `@zama-fhe/react-sdk` no longer re-exports SDK symbols. Now imported from `@zama-fhe/sdk`: `Address`/`Hex`, contract builders (`allowanceContract`/`approveContract`/`balanceOfContract`), storage (`IndexedDBStorage`/`indexedDBStorage`), `ZamaSDKEvents`, `savePendingUnshield`/`loadPendingUnshield`/`clearPendingUnshield`, and `cleartext()`.

**Provider model** — `ZamaProvider` now takes a single `{ config }` prop:
- build it with `createConfig({ chains, ethereum, relayers, storage, permitStorage, onEvent })`
- the cleartext relayer is the `cleartext()` `RelayerConfig` in the `relayers` map (was `new RelayerCleartext(...)`); the `hoodi` chain preset from `@zama-fhe/sdk/chains` carries the `executorAddress`
- `EthersSigner` is no longer constructed by hand — the ethers adapter derives it from the EIP-1193 provider
- `sessionStorage` → `permitStorage`

**Hooks & methods**
- permit hooks renamed: `useIsAllowed` → `useHasPermit`, `useAllow` → `useGrantPermit` (enabled moves to the 2nd options arg)
- token hooks take the address directly: positional for `useUnshield`/`useResumeUnshield`/`useDelegateDecryption`/`useRevokeDelegation`; `{ address }` (+ `account` for balance) for `useConfidentialBalance`/`useConfidentialTransfer`
- transfer/unshield callbacks passed flat in `mutate` (no `callbacks` wrapper)
- `useConfidentialBalance` returns a plain query result (`balance.handleQuery` removed)
- `shield()` lives on `WrappedToken` → `createWrappedToken`
- reads/receipts move from `sdk.signer` to `sdk.provider`; `sdk.signer` is nullable
- `zamaQueryKeys.confidentialHandle` → `zamaQueryKeys.confidentialBalance`

## Verification
- `npm run typecheck` → exit 0 against the published `3.1.0-alpha.10` packages (64 type errors → 0).

Part of the SDK-208 example-app upgrade rollout (one PR per app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)