### PR TITLE
chore(contracts): bump soldeer wrapper to ConfidentialWrapperV3 and deploy V3 in tests [SDK-220]

### DIFF
--- a/contracts/VERSIONS.md
+++ b/contracts/VERSIONS.md
@@ -2,28 +2,63 @@
 
 ## confidential-wrapper
 
-Source: `zama-ai/protocol-apps` @ `3bd308fb7cb1`, imported through
-the Soldeer dependency alias `protocol-apps-wrapper`.
+Source: `zama-ai/protocol-apps` @ `71611c624ddc` (no release tags exist —
+`main` is the deployment), imported through the Soldeer dependency alias
+`protocol-apps-wrapper`.
 
-This commit reflects the post-mainnet-upgrade state.
+This pin matches `ConfidentialWrapperV3`, which is the version live on both
+mainnet and Sepolia.
 
 Includes:
 
+- `contracts/confidential-wrapper/contracts/ConfidentialWrapper.sol` (V1 base)
+- `contracts/confidential-wrapper/contracts/upgrades/ConfidentialWrapperV2.sol`
+- `contracts/confidential-wrapper/contracts/upgrades/ConfidentialWrapperV3.sol`
 - `contracts/confidential-wrapper/contracts/extensions/ERC7984ERC20WrapperUpgradeable.sol`
 - `contracts/confidential-wrapper/contracts/interfaces/IERC7984ERC20Wrapper.sol`
 - `contracts/confidential-wrapper/contracts/token/ERC7984Upgradeable.sol`
 - `contracts/confidential-wrapper/contracts/fhevm/ZamaEthereumConfigUpgradeable.sol`
-- `contracts/confidential-wrapper/contracts/ConfidentialWrapper.sol`
 
-Key properties of this version:
+### V1 base / V2 properties (inherited by V3)
 
 - `finalizeUnwrap` first param: `bytes32 unwrapRequestId`
 - `unwrap()` returns `bytes32 unwrapRequestId`
 - Events `UnwrapRequested` and `UnwrapFinalized` include `bytes32 indexed unwrapRequestId`
 - Functions `unwrapAmount(bytes32)` and `unwrapRequester(bytes32)` available
-- `wrap()` and `onTransferReceived()` do not emit `Wrapped`
+- `wrap()` and `onTransferReceived()` emit `Wrap(address indexed to, uint256 roundedAmount, euint64 encryptedWrappedAmount)`
 - ERC-165 interfaceId: `0x1f1c62b2`
-- Plaintext supply accessor renamed to `inferredTotalSupply()`
+- Plaintext supply accessor named `inferredTotalSupply()`
+
+### V3 denylist surface (added in protocol-apps#175)
+
+Owner-controlled denylist preventing blocked addresses from participating in
+confidential transfers, wraps, and unwraps.
+
+Functions:
+
+- `reinitializeV3(address[] blockedUsers, bytes4 underlyingDenyListSelector, bool hasUnderlyingDenyListSelector_)` — seeds the denylist on upgrade from V2
+- `blockUser(address user)` — owner only
+- `unblockUser(address user)` — owner only
+- `isBlocked(address user) → bool`
+- `getUnderlyingDenyListSelector() → (bool isSet, bytes4 selector)`
+
+Events:
+
+- `UserBlocked(address indexed user)`
+- `UserUnblocked(address indexed user)`
+
+Errors:
+
+- `BlockedUser(address user)`
+- `UserAlreadyBlocked(address user)`
+- `UserAlreadyUnblocked(address user)`
+- `UnderlyingDenyListCallFailed()`
+- `InvalidUnderlyingDenyListResponse()`
+- `UnderlyingDenyListedAddress(address user)`
+
+The test harness (`script/Deploy.s.sol`) deploys `ConfidentialWrapperV3` as the
+implementation and calls `reinitializeV3([], bytes4(0), false)` on each proxy,
+so SDK tests touching the denylist surface have something to run against.
 
 ## confidential-token-wrappers-registry
 

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -13,5 +13,5 @@ fs_permissions = [{ access = "read-write", path = "./" }]
 line_length = 120
 
 [dependencies]
-"protocol-apps-wrapper" = { version = "3bd308fb7cb1", git = "https://github.com/zama-ai/protocol-apps", rev = "3bd308fb7cb1" }
+"protocol-apps-wrapper" = { version = "71611c624ddc", git = "https://github.com/zama-ai/protocol-apps", rev = "71611c624ddc" }
 "protocol-apps-registry" = { version = "0647c5fd9e41", git = "https://github.com/zama-ai/protocol-apps", rev = "0647c5fd9e41" }

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -6,4 +6,4 @@ encrypted-types/=lib/forge-fhevm/dependencies/@encrypted-types-0.0.4/
 forge-fhevm/=lib/forge-fhevm/src/
 forge-std/=lib/forge-fhevm/dependencies/forge-std-1.14.0/src/
 protocol-apps-registry/=dependencies/protocol-apps-registry-0647c5fd9e41/
-protocol-apps-wrapper/=dependencies/protocol-apps-wrapper-3bd308fb7cb1/
+protocol-apps-wrapper/=dependencies/protocol-apps-wrapper-71611c624ddc/

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -6,6 +6,8 @@ import {console} from "forge-std/console.sol";
 import {TestERC20} from "../src/mocks/Erc20Mintable.sol";
 import {TestERC1363} from "../src/mocks/Erc1363Mintable.sol";
 import {ConfidentialWrapper} from "protocol-apps-wrapper/contracts/confidential-wrapper/contracts/ConfidentialWrapper.sol";
+import {ConfidentialWrapperV3} from
+    "protocol-apps-wrapper/contracts/confidential-wrapper/contracts/upgrades/ConfidentialWrapperV3.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ConfidentialTokenWrappersRegistry} from "protocol-apps-registry/contracts/confidential-token-wrappers-registry/contracts/ConfidentialTokenWrappersRegistry.sol";
@@ -14,8 +16,10 @@ contract Deploy is Script {
     function run() external {
         vm.startBroadcast();
 
-        // 1. Deploy ConfidentialWrapper implementation (for UUPS proxies)
-        ConfidentialWrapper wrapperImpl = new ConfidentialWrapper();
+        // 1. Deploy ConfidentialWrapperV3 implementation (for UUPS proxies).
+        // V3 matches what's live on mainnet and sepolia (zama-ai/protocol-apps@main),
+        // and exposes the owner-controlled denylist surface (blockUser/unblockUser/isBlocked).
+        ConfidentialWrapperV3 wrapperImpl = new ConfidentialWrapperV3();
         console.log("WrapperImpl:", address(wrapperImpl));
 
         // 2. Deploy test ERC20 tokens
@@ -26,12 +30,12 @@ contract Deploy is Script {
         console.log("USDT:", address(usdt));
 
         // 3. Deploy wrapper proxies directly
-        ConfidentialWrapper cUSDC = _deployWrapper(
+        ConfidentialWrapperV3 cUSDC = _deployWrapper(
             address(wrapperImpl), "Confidential ERC20 Token", "cERC20", IERC20(address(usdc))
         );
         console.log("cUSDC:", address(cUSDC));
 
-        ConfidentialWrapper cUSDT = _deployWrapper(
+        ConfidentialWrapperV3 cUSDT = _deployWrapper(
             address(wrapperImpl), "Confidential Tether USD", "cUSDT", IERC20(address(usdt))
         );
         console.log("cUSDT:", address(cUSDT));
@@ -40,7 +44,7 @@ contract Deploy is Script {
         TestERC1363 erc1363Token = new TestERC1363("ERC1363 Token", "ERC1363", 6);
         console.log("ERC1363:", address(erc1363Token));
 
-        ConfidentialWrapper cERC1363 = _deployWrapper(
+        ConfidentialWrapperV3 cERC1363 = _deployWrapper(
             address(wrapperImpl), "Confidential ERC1363 Token", "cERC1363", IERC20(address(erc1363Token))
         );
         console.log("cERC1363:", address(cERC1363));
@@ -92,7 +96,7 @@ contract Deploy is Script {
         string memory name,
         string memory symbol,
         IERC20 underlying
-    ) internal returns (ConfidentialWrapper) {
+    ) internal returns (ConfidentialWrapperV3) {
         string memory contractURI = string.concat(
             "data:application/json;utf8,",
             '{"name":"', name, '","symbol":"', symbol, '"}'
@@ -101,6 +105,12 @@ contract Deploy is Script {
             ConfidentialWrapper.initialize,
             (name, symbol, contractURI, underlying, msg.sender)
         );
-        return ConfidentialWrapper(payable(address(new ERC1967Proxy(implementation, initData))));
+        ConfidentialWrapperV3 proxy =
+            ConfidentialWrapperV3(payable(address(new ERC1967Proxy(implementation, initData))));
+        // Bring the proxy storage to V3 so denylist admin (blockUser/unblockUser/isBlocked)
+        // and the V3 denylist enforcement on transfer/wrap/unwrap are active in tests.
+        // Empty initial denylist; no underlying denylist selector configured.
+        proxy.reinitializeV3(new address[](0), bytes4(0), false);
+        return proxy;
     }
 }

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -74,6 +74,17 @@ contract Deploy is Script {
         registry.registerConfidentialToken(address(erc1363Token), address(cERC1363));
         console.log("WrappersRegistry:", address(registry));
 
+        // 7. Bring each proxy to V3 storage so denylist admin (blockUser/unblockUser/isBlocked)
+        // and V3 denylist enforcement on transfer/wrap/unwrap are active in tests. Empty initial
+        // denylist; no underlying denylist selector configured.
+        // Deferred to the end of broadcast so that no transaction is inserted between contract
+        // creations — keeps every CREATE address identical to the pre-V3 deploy script, which
+        // matters because `contracts/deployments.json` is checked in and consumed at build time
+        // by test-nextjs/test-vite.
+        cUSDC.reinitializeV3(new address[](0), bytes4(0), false);
+        cUSDT.reinitializeV3(new address[](0), bytes4(0), false);
+        cERC1363.reinitializeV3(new address[](0), bytes4(0), false);
+
         vm.stopBroadcast();
 
         // 7. Write deployments.json
@@ -105,12 +116,6 @@ contract Deploy is Script {
             ConfidentialWrapper.initialize,
             (name, symbol, contractURI, underlying, msg.sender)
         );
-        ConfidentialWrapperV3 proxy =
-            ConfidentialWrapperV3(payable(address(new ERC1967Proxy(implementation, initData))));
-        // Bring the proxy storage to V3 so denylist admin (blockUser/unblockUser/isBlocked)
-        // and the V3 denylist enforcement on transfer/wrap/unwrap are active in tests.
-        // Empty initial denylist; no underlying denylist selector configured.
-        proxy.reinitializeV3(new address[](0), bytes4(0), false);
-        return proxy;
+        return ConfidentialWrapperV3(payable(address(new ERC1967Proxy(implementation, initData))));
     }
 }

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -87,7 +87,7 @@ contract Deploy is Script {
 
         vm.stopBroadcast();
 
-        // 7. Write deployments.json
+        // 8. Write deployments.json
         string memory json = "deployments";
         vm.serializeAddress(json, "erc20", address(usdc));
         vm.serializeAddress(json, "cToken", address(cUSDC));

--- a/contracts/soldeer.lock
+++ b/contracts/soldeer.lock
@@ -1,8 +1,8 @@
 [[dependencies]]
 name = "protocol-apps-wrapper"
-version = "3bd308fb7cb1"
+version = "71611c624ddc"
 git = "https://github.com/zama-ai/protocol-apps"
-rev = "3bd308fb7cb1"
+rev = "71611c624ddc"
 
 [[dependencies]]
 name = "protocol-apps-registry"

--- a/packages/sdk/src/contracts/__tests__/contracts.test.ts
+++ b/packages/sdk/src/contracts/__tests__/contracts.test.ts
@@ -213,11 +213,11 @@ describe("Wrapper contract builders", () => {
   });
 });
 
-// Regression: verify wrapperAbi matches protocol-apps@3bd308fb7cb1 (post-mainnet upgrade).
+// Regression: verify wrapperAbi matches protocol-apps@71611c624ddc (post-mainnet upgrade).
 // These assertions pin the wrapper interface shape: finalizeUnwrap takes a bytes32
 // unwrapRequestId, unwrapAmount / unwrapRequester are exposed, and both UnwrapRequested
 // and UnwrapFinalized events include the indexed unwrapRequestId topic.
-describe("wrapperAbi version smoke test (protocol-apps@3bd308fb7cb1)", () => {
+describe("wrapperAbi version smoke test (protocol-apps@71611c624ddc)", () => {
   type AbiFunction = {
     type: string;
     name: string;


### PR DESCRIPTION
## Summary

The wrapper deployed on mainnet and Sepolia is `ConfidentialWrapperV3` on `zama-ai/protocol-apps@main`, but the SDK's soldeer pin `protocol-apps-wrapper@3bd308fb7cb1` was V2-era and had no V3 / no denylist surface — so `contracts/script/Deploy.s.sol` couldn't exercise V3, and [SDK-215](https://linear.app/zama/issue/SDK-215) (#422) had to hand-mirror the denylist ABI.

- Bump `protocol-apps-wrapper` pin to `71611c624ddc` (latest on `protocol-apps@main`; no release tags exist, `main` is the deployment). Registry pin (`0647c5fd9e41`) untouched — no upstream change since April.
- `contracts/script/Deploy.s.sol`: deploy `ConfidentialWrapperV3` as the UUPS implementation and call `reinitializeV3([], bytes4(0), false)` on each proxy so denylist admin (`blockUser`/`unblockUser`/`isBlocked`) and V3 enforcement on transfer/wrap/unwrap are active in the test harness.
- Verified the compiled V3 ABI against the hand-mirrored entries added in [SDK-215](https://linear.app/zama/issue/SDK-215) (#422) — exact match on all 5 functions, 2 events, 6 errors. No reconciliation diff needed; #422 can land as-is.
- Refresh `contracts/VERSIONS.md`: new pin, V3 denylist section, corrected base properties (added missing `Wrap` event, fixed `inferredTotalSupply` accessor description).

Closes [SDK-220](https://linear.app/zama/issue/SDK-220).

## Test plan

- [x] `forge build` clean (V3 + V2 + base wrapper compile together)
- [x] `bash test/playwright/start-anvil.sh 8545` deploys cleanly end-to-end
- [x] On the live anvil proxy, V3 surface verified via `cast`:
  - `isBlocked(0x…01) → false` initially
  - `getUnderlyingDenyListSelector() → (false, 0x00000000)`
  - `blockUser(0x…99)` succeeds (owner = deployer)
  - `isBlocked(0x…99) → true` after blocking
- [x] `pnpm typecheck` clean
- [ ] CI green

## Follow-ups

- [SDK-216](https://linear.app/zama/issue/SDK-216): add the 3-field `Wrap` event to `wrapper.abi.ts` (now verifiable against the local compiled artifact).
- [SDK-223](https://linear.app/zama/issue/SDK-223) (blocked by this): generate ABIs from compiled artifacts instead of hand-maintaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)