### PR TITLE
docs(gitbook): convert host-absolute internal links to relative (prerelease) [SDK-228]

### DIFF
--- a/docs/gitbook/src/concepts/permit-model.md
+++ b/docs/gitbook/src/concepts/permit-model.md
@@ -5,7 +5,7 @@ description: How EIP-712 signed permits authorize FHE decryption for specific co
 
 # Permit model
 
-Decrypting an on-chain FHE ciphertext requires two things: an FHE keypair (generated once, stored persistently — see [Security Model](/concepts/security-model#credential-storage)) and a **signed permit** that authorizes decryption for specific contract addresses. This page explains how permits work.
+Decrypting an on-chain FHE ciphertext requires two things: an FHE keypair (generated once, stored persistently — see [Security Model](./security-model.md#credential-storage)) and a **signed permit** that authorizes decryption for specific contract addresses. This page explains how permits work.
 
 ## What is a permit
 
@@ -86,7 +86,7 @@ Permits can be removed in two ways:
 - **Selective** — `sdk.permits.revokePermits(["0xTokenA"])` removes permits touching those contracts on the current chain. Other permits are untouched.
 - **Full wipe** — `sdk.permits.revokePermits()` removes all permits for the current signer across all chains and delegators. The FHE keypair is not affected.
 
-For a complete "log out" that also removes the FHE keypair, use `sdk.permits.clear()`. See the [ZamaSDK reference](/reference/sdk/ZamaSDK#permits-revokepermits) for the full API.
+For a complete "log out" that also removes the FHE keypair, use `sdk.permits.clear()`. See the [ZamaSDK reference](../reference/sdk/ZamaSDK.md#permits-revokepermits) for the full API.
 
 ## Wallet account changes
 
@@ -98,10 +98,10 @@ The SDK automatically manages permits when the wallet state changes:
 | **Account switch**    | Previous account's permits cleared; new account starts fresh                      |
 | **Chain switch**      | Permits are chain-scoped, so existing permits on the previous chain remain intact |
 
-See [ZamaSDK.onWalletAccountChange](/reference/sdk/ZamaSDK#onwalletaccountchange) for programmatic access to these transitions.
+See [ZamaSDK.onWalletAccountChange](../reference/sdk/ZamaSDK.md#onwalletaccountchange) for programmatic access to these transitions.
 
 ## Related
 
-- [Security Model](/concepts/security-model) — keypair storage, threat model, and trust assumptions
-- [Configuration](/guides/configuration#5-optional-configure-ttls-and-event-listener) — `keypairTTL` and `permitTTL` settings
-- [ZamaSDK](/reference/sdk/ZamaSDK) — `permits.grantPermit()`, `permits.revokePermits()`, `permits.clear()` API
+- [Security Model](./security-model.md) — keypair storage, threat model, and trust assumptions
+- [Configuration](../guides/configuration.md#5-optional-configure-ttls-and-event-listener) — `keypairTTL` and `permitTTL` settings
+- [ZamaSDK](../reference/sdk/ZamaSDK.md) — `permits.grantPermit()`, `permits.revokePermits()`, `permits.clear()` API

--- a/docs/gitbook/src/concepts/security-model.md
+++ b/docs/gitbook/src/concepts/security-model.md
@@ -64,7 +64,7 @@ The FHE private key is stored in plaintext in the configured storage backend (ty
 | Key format | Plaintext ML-KEM keypair                                         |
 | Scope      | One keypair per signer address (chain-independent)               |
 
-The security model relies on same-origin isolation: only JavaScript running on the same origin can read IndexedDB. See [Permit Model](/concepts/permit-model) for the full lifecycle.
+The security model relies on same-origin isolation: only JavaScript running on the same origin can read IndexedDB. See [Permit Model](./permit-model.md) for the full lifecycle.
 
 ### Limitations
 

--- a/docs/gitbook/src/guides/authentication.md
+++ b/docs/gitbook/src/guides/authentication.md
@@ -134,7 +134,7 @@ const mySepolia = {
 } as const satisfies FheChain;
 ```
 
-Then pass `mySepolia` to `createConfig` — the `auth` field is picked up automatically by the relayer. See the [Node.js backend guide](/guides/node-js-backend) for a complete example.
+Then pass `mySepolia` to `createConfig` — the `auth` field is picked up automatically by the relayer. See the [Node.js backend guide](./node-js-backend.md) for a complete example.
 
 The `auth` field supports multiple methods depending on how your relayer is configured.
 
@@ -159,11 +159,11 @@ auth: { __type: "ApiKeyCookie", value: "your-api-key" }
 auth: { __type: "BearerToken", value: "your-jwt-token" }
 ```
 
-When using `RelayerWeb` with a proxy, you can also add CSRF protection via the `security.getCsrfToken` callback. See the [RelayerWeb reference](/reference/sdk/RelayerWeb) for details.
+When using `RelayerWeb` with a proxy, you can also add CSRF protection via the `security.getCsrfToken` callback. See the [RelayerWeb reference](../reference/sdk/RelayerWeb.md) for details.
 
 ## Next steps
 
-- [Configuration](/guides/configuration) — full relayer, signer, and storage setup
-- [Shield Tokens](/guides/shield-tokens) — start converting public tokens to confidential form
-- [RelayerWeb reference](/reference/sdk/RelayerWeb) — security options and multi-threading
-- [RelayerNode reference](/reference/sdk/RelayerNode) — `node()` transport factory
+- [Configuration](./configuration.md) — full relayer, signer, and storage setup
+- [Shield Tokens](./shield-tokens.md) — start converting public tokens to confidential form
+- [RelayerWeb reference](../reference/sdk/RelayerWeb.md) — security options and multi-threading
+- [RelayerNode reference](../reference/sdk/RelayerNode.md) — `node()` transport factory

--- a/docs/gitbook/src/guides/check-balances.md
+++ b/docs/gitbook/src/guides/check-balances.md
@@ -176,7 +176,7 @@ const { data: meta } = useMetadata("0xToken");
 // meta.name, meta.symbol, meta.decimals
 ```
 
-See [useMetadata reference](/reference/react/useMetadata) for full options.
+See [useMetadata reference](../reference/react/useMetadata.md) for full options.
 
 ### 8. Use the balance hooks in React
 
@@ -254,6 +254,6 @@ queryClient.invalidateQueries({
 ## Next steps
 
 - See [Avoid blind-sign wallet popups](encrypt-decrypt.md#gating-useconfidentialbalance) to gate balance queries behind explicit user action.
-- See [Token Operations](/reference/sdk/Token) for the full `Token` API.
-- See [Hooks](/reference/react/query-keys) for `useConfidentialBalance`, `useConfidentialBalances`, and query key details.
+- See [Token Operations](../reference/sdk/Token.md) for the full `Token` API.
+- See [Hooks](../reference/react/query-keys.md) for `useConfidentialBalance`, `useConfidentialBalances`, and query key details.
 - To handle `NoCiphertextError` and other failures, see [Handle Errors](handle-errors.md).

--- a/docs/gitbook/src/guides/configuration.md
+++ b/docs/gitbook/src/guides/configuration.md
@@ -107,7 +107,7 @@ const walletClient = createWalletClient({
 {% endtab %}
 {% endtabs %}
 
-For full type information, see the [ViemProvider](/reference/sdk/ViemProvider) / [ViemSigner](/reference/sdk/ViemSigner) and [EthersProvider](/reference/sdk/EthersProvider) / [EthersSigner](/reference/sdk/EthersSigner) reference pages. You can also implement [GenericProvider](/reference/sdk/GenericProvider) and [GenericSigner](/reference/sdk/GenericSigner) for a custom integration.
+For full type information, see the [ViemProvider](../reference/sdk/ViemProvider.md) / [ViemSigner](../reference/sdk/ViemSigner.md) and [EthersProvider](../reference/sdk/EthersProvider.md) / [EthersSigner](../reference/sdk/EthersSigner.md) reference pages. You can also implement [GenericProvider](../reference/sdk/GenericProvider.md) and [GenericSigner](../reference/sdk/GenericSigner.md) for a custom integration.
 
 ### 4. Create the config
 
@@ -252,7 +252,7 @@ const config = createConfig({
 const sdk = new ZamaSDK(config);
 ```
 
-See [GenericSigner](/reference/sdk/GenericSigner) and [GenericProvider](/reference/sdk/GenericProvider) for the interfaces your adapter must implement.
+See [GenericSigner](../reference/sdk/GenericSigner.md) and [GenericProvider](../reference/sdk/GenericProvider.md) for the interfaces your adapter must implement.
 
 {% endtab %}
 {% tab title="Web Extensions" %}
@@ -284,12 +284,12 @@ const config = createConfig({
 const sdk = new ZamaSDK(config);
 ```
 
-Your `manifest.json` must include the `"storage"` permission. See the [Web Extensions guide](/guides/web-extensions) for manifest configuration, multi-context sharing, and browser close behavior.
+Your `manifest.json` must include the `"storage"` permission. See the [Web Extensions guide](./web-extensions.md) for manifest configuration, multi-context sharing, and browser close behavior.
 
 {% endtab %}
 {% endtabs %}
 
-Browser apps should proxy relayer requests through a backend to keep the API key secret. See the [Authentication guide](/guides/authentication) for the full setup.
+Browser apps should proxy relayer requests through a backend to keep the API key secret. See the [Authentication guide](./authentication.md) for the full setup.
 
 ### 5. (Optional) Configure TTLs and event listener
 
@@ -326,7 +326,7 @@ import { indexedDBStorage, memoryStorage } from "@zama-fhe/sdk";
 // import { asyncLocalStorage } from "@zama-fhe/sdk/node";
 ```
 
-For full storage options see the [GenericStorage](/reference/sdk/GenericStorage) reference.
+For full storage options see the [GenericStorage](../reference/sdk/GenericStorage.md) reference.
 
 ## Shared relayer options
 
@@ -355,7 +355,7 @@ Chains that pass the _same_ `options` object (by reference) share a single relay
 
 ## Next steps
 
-- [Authentication](/guides/authentication) — set up a backend proxy or use a direct API key
-- [Shield Tokens](/guides/shield-tokens) — convert public ERC-20 tokens into confidential form
-- [Chain Objects](/reference/sdk/network-presets) — pre-configured chain definitions for Sepolia, Mainnet, and more
-- [GenericStorage reference](/reference/sdk/GenericStorage) — custom storage implementations
+- [Authentication](./authentication.md) — set up a backend proxy or use a direct API key
+- [Shield Tokens](./shield-tokens.md) — convert public ERC-20 tokens into confidential form
+- [Chain Objects](../reference/sdk/network-presets.md) — pre-configured chain definitions for Sepolia, Mainnet, and more
+- [GenericStorage reference](../reference/sdk/GenericStorage.md) — custom storage implementations

--- a/docs/gitbook/src/guides/delegated-decryption.md
+++ b/docs/gitbook/src/guides/delegated-decryption.md
@@ -12,7 +12,7 @@ Common use cases:
 - **Portfolio dashboards** — a read-only service decrypts balances across wallets without holding keys.
 - **Auditors** — a third party verifies holdings without the token owner being online.
 
-This guide uses `sdk.delegations` and `token.decryptBalanceAs`. Before starting, make sure your project is set up following the [Configuration](/guides/configuration) guide.
+This guide uses `sdk.delegations` and `token.decryptBalanceAs`. Before starting, make sure your project is set up following the [Configuration](./configuration.md) guide.
 
 ## Example
 
@@ -207,11 +207,11 @@ try {
 {% endtab %}
 {% endtabs %}
 
-See [Handle errors](/guides/handle-errors) for full error-handling patterns and [Error types](/reference/sdk/errors) for the complete list.
+See [Handle errors](./handle-errors.md) for full error-handling patterns and [Error types](../reference/sdk/errors.md) for the complete list.
 
 ## Next steps
 
-- [Delegations reference](/reference/sdk/delegation) — full `Delegations` namespace API
-- [useDelegateDecryption](/reference/react/useDelegateDecryption) — React hook to grant delegation
-- [useDecryptBalanceAs](/reference/react/useDecryptBalanceAs) — React hook to decrypt as a delegate
-- [useDelegationStatus](/reference/react/useDelegationStatus) — React hook to query delegation status
+- [Delegations reference](../reference/sdk/delegation.md) — full `Delegations` namespace API
+- [useDelegateDecryption](../reference/react/useDelegateDecryption.md) — React hook to grant delegation
+- [useDecryptBalanceAs](../reference/react/useDecryptBalanceAs.md) — React hook to decrypt as a delegate
+- [useDelegationStatus](../reference/react/useDelegationStatus.md) — React hook to query delegation status

--- a/docs/gitbook/src/guides/encrypt-decrypt.md
+++ b/docs/gitbook/src/guides/encrypt-decrypt.md
@@ -7,7 +7,7 @@ description: How to encrypt values and decrypt FHE encrypted values for custom c
 
 The high-level token hooks (`useShield`, `useConfidentialTransfer`, `useConfidentialBalance`) handle encryption and decryption automatically for wrapped confidential ERC-20 tokens. This guide is for a different scenario: **your smart contract uses FHE types directly** (e.g. a confidential voting contract, a sealed-bid auction, or any non-token contract that stores `euint` values). In that case, you need `useEncrypt` and `useDecryptValues` to interact with your contract's encrypted parameters and return values.
 
-Before starting, make sure your project is set up following the [Configuration](/guides/configuration) guide.
+Before starting, make sure your project is set up following the [Configuration](./configuration.md) guide.
 
 ## Example
 
@@ -123,7 +123,7 @@ export default defineConfig({
 {% endtab %}
 {% endtabs %}
 
-See [Configuration](/guides/configuration) for full setup instructions.
+See [Configuration](./configuration.md) for full setup instructions.
 {% endhint %}
 
 {% hint style="warning" %}

--- a/docs/gitbook/src/guides/handle-errors.md
+++ b/docs/gitbook/src/guides/handle-errors.md
@@ -188,6 +188,6 @@ When `matchZamaError` returns `undefined` (because the error is not a `ZamaError
 
 ## Next steps
 
-- See [Error types reference](/reference/sdk/errors) for the full error type reference.
-- See [Hooks](/reference/react/query-keys) for error handling patterns with React Query.
+- See [Error types reference](../reference/sdk/errors.md) for the full error type reference.
+- See [Hooks](../reference/react/query-keys.md) for error handling patterns with React Query.
 - For interrupted unshields specifically, see [Unshield Tokens](unshield-tokens.md).

--- a/docs/gitbook/src/guides/local-development.md
+++ b/docs/gitbook/src/guides/local-development.md
@@ -111,6 +111,6 @@ Usually, you want to use the same `gatewayChainId` and verifying contract addres
 
 ## Next steps
 
-- [RelayerCleartext reference](/reference/sdk/RelayerCleartext) — full constructor options and `CleartextConfig` type
-- [Configuration](/guides/configuration) — production setup with `web()` or `node()` relayer factories
-- [Chain Objects](/reference/sdk/network-presets) — pre-configured chain definitions for Mainnet, Sepolia, and more
+- [RelayerCleartext reference](../reference/sdk/RelayerCleartext.md) — full constructor options and `CleartextConfig` type
+- [Configuration](./configuration.md) — production setup with `web()` or `node()` relayer factories
+- [Chain Objects](../reference/sdk/network-presets.md) — pre-configured chain definitions for Mainnet, Sepolia, and more

--- a/docs/gitbook/src/guides/nextjs-ssr.md
+++ b/docs/gitbook/src/guides/nextjs-ssr.md
@@ -171,6 +171,6 @@ The server renders the page shell, and the `TokenBalance` client component hydra
 
 ## Next steps
 
-- [ZamaProvider](/reference/react/ZamaProvider) -- all provider props and configuration
-- [useConfidentialBalance](/reference/react/useConfidentialBalance) -- balance hook API reference
-- [Provider Setup](/guides/configuration) -- full examples for wagmi, viem, and ethers setups
+- [ZamaProvider](../reference/react/ZamaProvider.md) -- all provider props and configuration
+- [useConfidentialBalance](../reference/react/useConfidentialBalance.md) -- balance hook API reference
+- [Provider Setup](./configuration.md) -- full examples for wagmi, viem, and ethers setups

--- a/docs/gitbook/src/guides/node-js-backend.md
+++ b/docs/gitbook/src/guides/node-js-backend.md
@@ -109,7 +109,7 @@ await wrappedToken.confidentialTransfer("0xRecipient", 500n);
 const balance = await wrappedToken.balanceOf(account.address);
 ```
 
-See the [Token Operations](/reference/sdk/Token) reference for the full API.
+See the [Token Operations](../reference/sdk/Token.md) reference for the full API.
 
 ### 6. Use direct API key auth
 
@@ -145,7 +145,7 @@ process.on("SIGTERM", () => {
 
 ### 8. (Optional) Use a custom signer
 
-If you are using a transaction relayer (e.g. OpenZeppelin Defender) instead of a local wallet, implement the [GenericSigner](/reference/sdk/GenericSigner) and [GenericProvider](/reference/sdk/GenericProvider) interfaces and use the generic `createConfig` from `@zama-fhe/sdk`:
+If you are using a transaction relayer (e.g. OpenZeppelin Defender) instead of a local wallet, implement the [GenericSigner](../reference/sdk/GenericSigner.md) and [GenericProvider](../reference/sdk/GenericProvider.md) interfaces and use the generic `createConfig` from `@zama-fhe/sdk`:
 
 ```ts
 import { createConfig, ZamaSDK, memoryStorage } from "@zama-fhe/sdk";
@@ -171,11 +171,11 @@ const config = createConfig({
 const sdk = new ZamaSDK(config);
 ```
 
-The signer handles `signTypedData` and `writeContract`; the provider handles `readContract`, `waitForTransactionReceipt`, `getChainId`, and `getBlockTimestamp`. See [GenericSigner](/reference/sdk/GenericSigner) for the full interface.
+The signer handles `signTypedData` and `writeContract`; the provider handles `readContract`, `waitForTransactionReceipt`, `getChainId`, and `getBlockTimestamp`. See [GenericSigner](../reference/sdk/GenericSigner.md) for the full interface.
 
 ## Next steps
 
-- [RelayerNode](/reference/sdk/RelayerNode) -- `node()` transport factory options
-- [asyncLocalStorage](/reference/sdk/GenericStorage) -- the `GenericStorage` interface it implements
-- [Configuration](/guides/configuration) -- chains, relayers, authentication, and permit management
-- [GenericSigner](/reference/sdk/GenericSigner) -- custom signer interface for non-standard wallet integrations
+- [RelayerNode](../reference/sdk/RelayerNode.md) -- `node()` transport factory options
+- [asyncLocalStorage](../reference/sdk/GenericStorage.md) -- the `GenericStorage` interface it implements
+- [Configuration](./configuration.md) -- chains, relayers, authentication, and permit management
+- [GenericSigner](../reference/sdk/GenericSigner.md) -- custom signer interface for non-standard wallet integrations

--- a/docs/gitbook/src/guides/operator-approvals.md
+++ b/docs/gitbook/src/guides/operator-approvals.md
@@ -108,7 +108,7 @@ This is a distinct concern from transfer approval: approving an operator for tra
 
 ## Next steps
 
-- [Token.setOperator](/reference/sdk/Token) -- full method signature and options
-- [useConfidentialSetOperator](/reference/react/useConfidentialSetOperator) -- React hook reference
-- [useConfidentialIsOperator](/reference/react/useConfidentialIsOperator) -- query hook reference
-- [useConfidentialTransferFrom](/reference/react/useConfidentialTransferFrom) -- operator transfer hook reference
+- [Token.setOperator](../reference/sdk/Token.md) -- full method signature and options
+- [useConfidentialSetOperator](../reference/react/useConfidentialSetOperator.md) -- React hook reference
+- [useConfidentialIsOperator](../reference/react/useConfidentialIsOperator.md) -- query hook reference
+- [useConfidentialTransferFrom](../reference/react/useConfidentialTransferFrom.md) -- operator transfer hook reference

--- a/docs/gitbook/src/guides/shield-tokens.md
+++ b/docs/gitbook/src/guides/shield-tokens.md
@@ -31,13 +31,13 @@ Among the wrapped tokens registered on Ethereum mainnet today, the routing is:
 | cWETH                | WETH       | `approve` + `wrap` (two txs)  |
 | cBRON                | BRON       | `approve` + `wrap` (two txs)  |
 
-ERC-1363 is a conditional optimisation, not a recommended new default — only a small subset of tokens implement it today. Tokens that don't (USDC, USDT, DAI, and most existing ERC-20s) continue to use `approve` + `wrap`. Any newly deployed wrapper picks up the `transferAndCall` path automatically if its underlying ERC-20 implements ERC-1363 — no opt-in is required from your code. See the [`WrappersRegistry` reference](/reference/sdk/WrappersRegistry) for how to look up the wrapper for a given ERC-20.
+ERC-1363 is a conditional optimisation, not a recommended new default — only a small subset of tokens implement it today. Tokens that don't (USDC, USDT, DAI, and most existing ERC-20s) continue to use `approve` + `wrap`. Any newly deployed wrapper picks up the `transferAndCall` path automatically if its underlying ERC-20 implements ERC-1363 — no opt-in is required from your code. See the [`WrappersRegistry` reference](../reference/sdk/WrappersRegistry.md) for how to look up the wrapper for a given ERC-20.
 
 ## Steps
 
 ### 1. Create a wrapped-token instance
 
-Start from a configured SDK instance (see [Configuration](/guides/configuration)) and create a `WrappedToken` pointing at your confidential wrapper contract. The wrapper _is_ the confidential token: `createWrappedToken(addr)` takes a single address — the wrapper's own address.
+Start from a configured SDK instance (see [Configuration](./configuration.md)) and create a `WrappedToken` pointing at your confidential wrapper contract. The wrapper _is_ the confidential token: `createWrappedToken(addr)` takes a single address — the wrapper's own address.
 
 If you only have the underlying ERC-20 address, the built-in registry resolves the matching wrapper.
 
@@ -192,6 +192,6 @@ In React, balance caches are automatically invalidated after a successful shield
 
 ## Next steps
 
-- [Transfer Privately](/guides/transfer-privately) — send confidential tokens to another address
-- [WrappedToken.shield reference](/reference/sdk/WrappedToken#shield) — full API signature and options
-- [useShield reference](/reference/react/useShield) — React hook details
+- [Transfer Privately](./transfer-privately.md) — send confidential tokens to another address
+- [WrappedToken.shield reference](../reference/sdk/WrappedToken.md#shield) — full API signature and options
+- [useShield reference](../reference/react/useShield.md) — React hook details

--- a/docs/gitbook/src/guides/transfer-privately.md
+++ b/docs/gitbook/src/guides/transfer-privately.md
@@ -11,7 +11,7 @@ Confidential transfers encrypt the amount before it reaches the chain -- no one 
 
 ### 1. Create a token instance
 
-Start from a configured SDK instance (see [Configuration](/guides/configuration)) and create a token pointing at your encrypted ERC-20 contract:
+Start from a configured SDK instance (see [Configuration](./configuration.md)) and create a token pointing at your encrypted ERC-20 contract:
 
 {% tabs %}
 {% tab title="Core SDK" %}
@@ -190,11 +190,11 @@ function TransferForm() {
 }
 ```
 
-The `matchZamaError` helper maps SDK error codes to user-friendly messages. See the [Error Handling guide](/guides/handle-errors) for the full list of error types.
+The `matchZamaError` helper maps SDK error codes to user-friendly messages. See the [Error Handling guide](./handle-errors.md) for the full list of error types.
 
 ## Next steps
 
-- [Shield Tokens](/guides/shield-tokens) — convert public ERC-20 tokens into confidential form
-- [Token.confidentialTransfer reference](/reference/sdk/Token#confidentialtransfer) — full API signature
-- [useConfidentialTransfer reference](/reference/react/useConfidentialTransfer) — React hook details
-- [useConfidentialTransferFrom reference](/reference/react/useConfidentialTransferFrom) — operator transfer hook
+- [Shield Tokens](./shield-tokens.md) — convert public ERC-20 tokens into confidential form
+- [Token.confidentialTransfer reference](../reference/sdk/Token.md#confidentialtransfer) — full API signature
+- [useConfidentialTransfer reference](../reference/react/useConfidentialTransfer.md) — React hook details
+- [useConfidentialTransferFrom reference](../reference/react/useConfidentialTransferFrom.md) — operator transfer hook

--- a/docs/gitbook/src/guides/unshield-tokens.md
+++ b/docs/gitbook/src/guides/unshield-tokens.md
@@ -175,6 +175,6 @@ All mutation hooks automatically invalidate balance queries on success, so your 
 
 ## Next steps
 
-- See [WrappedToken](/reference/sdk/WrappedToken) for the full `WrappedToken.unshield` and `WrappedToken.unshieldAll` API.
-- See [Hooks](/reference/react/query-keys) for `useUnshield`, `useUnshieldAll`, and `useResumeUnshield` details.
+- See [WrappedToken](../reference/sdk/WrappedToken.md) for the full `WrappedToken.unshield` and `WrappedToken.unshieldAll` API.
+- See [Hooks](../reference/react/query-keys.md) for `useUnshield`, `useUnshieldAll`, and `useResumeUnshield` details.
 - If your unshield fails, see [Handle Errors](handle-errors.md) for troubleshooting `TransactionRevertedError` and related issues.

--- a/docs/gitbook/src/guides/web-extensions.md
+++ b/docs/gitbook/src/guides/web-extensions.md
@@ -88,5 +88,5 @@ This mirrors the default browser SDK behavior (in-memory permits lost on tab clo
 
 ## Next steps
 
-- [GenericStorage](/reference/sdk/GenericStorage) -- implement a custom storage adapter for other extension APIs
-- [Permit Model](/concepts/permit-model) -- how the keypair vault, signed permits, and storage interact
+- [GenericStorage](../reference/sdk/GenericStorage.md) -- implement a custom storage adapter for other extension APIs
+- [Permit Model](../concepts/permit-model.md) -- how the keypair vault, signed permits, and storage interact

--- a/docs/gitbook/src/overview.md
+++ b/docs/gitbook/src/overview.md
@@ -45,10 +45,10 @@ TanStack Query-based hooks with cached decryption, automatic cache invalidation,
 
 ## Two packages, one import
 
-| Package                                                | Use when...                                                                   |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| [`@zama-fhe/sdk`](/reference/sdk/ZamaSDK)              | You are building with vanilla TypeScript, Node.js, or any non-React framework |
-| [`@zama-fhe/react-sdk`](/reference/react/ZamaProvider) | You are building a React app (hooks and React-specific providers)             |
+| Package                                                    | Use when...                                                                   |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [`@zama-fhe/sdk`](./reference/sdk/ZamaSDK.md)              | You are building with vanilla TypeScript, Node.js, or any non-React framework |
+| [`@zama-fhe/react-sdk`](./reference/react/ZamaProvider.md) | You are building a React app (hooks and React-specific providers)             |
 
 If you are using React, install both packages: `@zama-fhe/react-sdk` provides the hooks and `ZamaProvider`, while `@zama-fhe/sdk` is a peer dependency that provides core utilities, relayer factories, chain presets, and error helpers. For wagmi apps, build the config with `createConfig` from `@zama-fhe/react-sdk/wagmi` and pass it to `<ZamaProvider config={zamaConfig}>`. For non-React apps, use `createConfig` from `@zama-fhe/sdk/viem` or `@zama-fhe/sdk/ethers`.
 
@@ -125,7 +125,7 @@ await wrappedToken.confidentialTransfer("0xRecipient", 500n); // private send
 await wrappedToken.unshield(500n); // withdraw back to public
 ```
 
-Ready to build? Jump to the [Quick start](/tutorials/quick-start) for a full working example with your stack.
+Ready to build? Jump to the [Quick start](./tutorials/quick-start.md) for a full working example with your stack.
 
 ## Help center
 

--- a/docs/gitbook/src/reference/react/ZamaProvider.md
+++ b/docs/gitbook/src/reference/react/ZamaProvider.md
@@ -151,9 +151,9 @@ import { type ZamaProviderProps } from "@zama-fhe/react-sdk";
 
 `ZamaConfig`
 
-Configuration object created by [`createConfig`](/guides/configuration). Wires together chains, relayers, signer, and storage for the SDK.
+Configuration object created by [`createConfig`](../../guides/configuration.md). Wires together chains, relayers, signer, and storage for the SDK.
 
 ## Related
 
-- [Configuration guide](/guides/configuration)
-- [Permit Model](/concepts/permit-model)
+- [Configuration guide](../../guides/configuration.md)
+- [Permit Model](../../concepts/permit-model.md)

--- a/docs/gitbook/src/reference/react/query-keys.md
+++ b/docs/gitbook/src/reference/react/query-keys.md
@@ -95,7 +95,7 @@ On-chain wrappers registry queries.
 
 ### `zamaQueryKeys.decryption`
 
-Cached decrypted values. Populated by [`useDecryptValues`](/reference/react/useDecryptValues).
+Cached decrypted values. Populated by [`useDecryptValues`](./useDecryptValues.md).
 
 ```ts
 import { zamaQueryKeys } from "@zama-fhe/sdk/query";
@@ -134,5 +134,5 @@ queryClient.removeQueries({ queryKey: zamaQueryKeys.confidentialBalance.all });
 
 ## Related
 
-- [ZamaProvider](/reference/react/ZamaProvider) — provider setup and hook overview
-- [`useConfidentialBalance`](/reference/react/useConfidentialBalance) — the hook whose cache these keys control
+- [ZamaProvider](./ZamaProvider.md) — provider setup and hook overview
+- [`useConfidentialBalance`](./useConfidentialBalance.md) — the hook whose cache these keys control

--- a/docs/gitbook/src/reference/react/useBatchDecryptBalancesAs.md
+++ b/docs/gitbook/src/reference/react/useBatchDecryptBalancesAs.md
@@ -138,6 +138,6 @@ await batchDecryptAs({
 
 ## Related
 
-- [`useDecryptBalanceAs`](/reference/react/useDecryptBalanceAs) -- single-token variant
-- [`useDelegationStatus`](/reference/react/useDelegationStatus) -- check delegation status before decrypting
-- [Delegated Decryption](/reference/sdk/delegation) -- SDK reference
+- [`useDecryptBalanceAs`](./useDecryptBalanceAs.md) -- single-token variant
+- [`useDelegationStatus`](./useDelegationStatus.md) -- check delegation status before decrypting
+- [Delegated Decryption](../sdk/delegation.md) -- SDK reference

--- a/docs/gitbook/src/reference/react/useClearCredentials.md
+++ b/docs/gitbook/src/reference/react/useClearCredentials.md
@@ -57,7 +57,7 @@ clearCredentials();
 
 - Wipes the FHE keypair for the connected wallet.
 - Cascade-deletes every permit across all chains and delegators.
-- Auto-invalidates all [`useHasPermit`](/reference/react/useHasPermit) queries on success.
+- Auto-invalidates all [`useHasPermit`](./useHasPermit.md) queries on success.
 - After clearing, any decrypt operation will generate a fresh keypair and prompt for new permits.
 
 {% hint style="info" %}
@@ -66,6 +66,6 @@ The SDK auto-clears credentials on wallet disconnect or account change when the 
 
 ## Related
 
-- [`useRevokePermits`](/reference/react/useRevokePermits) — remove permits without touching the keypair
-- [`useGrantPermit`](/reference/react/useGrantPermit) — sign permits for contracts
-- [`useHasPermit`](/reference/react/useHasPermit) — check whether stored permits cover contracts
+- [`useRevokePermits`](./useRevokePermits.md) — remove permits without touching the keypair
+- [`useGrantPermit`](./useGrantPermit.md) — sign permits for contracts
+- [`useHasPermit`](./useHasPermit.md) — check whether stored permits cover contracts

--- a/docs/gitbook/src/reference/react/useConfidentialBalance.md
+++ b/docs/gitbook/src/reference/react/useConfidentialBalance.md
@@ -134,6 +134,6 @@ The `data` property is `bigint | undefined` -- the decrypted token balance.
 
 ## Related
 
-- [useConfidentialBalances](/reference/react/useConfidentialBalances) -- batch variant for multiple tokens
-- [Check Balances guide](/guides/check-balances)
-- [Query Keys](/reference/react/query-keys) -- `zamaQueryKeys.confidentialBalance`
+- [useConfidentialBalances](./useConfidentialBalances.md) -- batch variant for multiple tokens
+- [Check Balances guide](../../guides/check-balances.md)
+- [Query Keys](./query-keys.md) -- `zamaQueryKeys.confidentialBalance`

--- a/docs/gitbook/src/reference/react/useConfidentialBalances.md
+++ b/docs/gitbook/src/reference/react/useConfidentialBalances.md
@@ -5,7 +5,7 @@ description: Decrypt and poll multiple tokens' confidential balances in a single
 
 # useConfidentialBalances
 
-Decrypt and poll multiple tokens' confidential balances in a single query. Returns a `BatchBalancesResult` with results and errors maps. Each token uses the same cached decryption strategy as [`useConfidentialBalance`](/reference/react/useConfidentialBalance).
+Decrypt and poll multiple tokens' confidential balances in a single query. Returns a `BatchBalancesResult` with results and errors maps. Each token uses the same cached decryption strategy as [`useConfidentialBalance`](./useConfidentialBalance.md).
 
 ## Import
 
@@ -124,6 +124,6 @@ The `data` property is `BatchBalancesResult | undefined` -- an object with `resu
 
 ## Related
 
-- [useConfidentialBalance](/reference/react/useConfidentialBalance) -- single-token variant
-- [Check Balances guide](/guides/check-balances)
-- [Query Keys](/reference/react/query-keys) -- `zamaQueryKeys.confidentialBalances`
+- [useConfidentialBalance](./useConfidentialBalance.md) -- single-token variant
+- [Check Balances guide](../../guides/check-balances.md)
+- [Query Keys](./query-keys.md) -- `zamaQueryKeys.confidentialBalances`

--- a/docs/gitbook/src/reference/react/useConfidentialIsOperator.md
+++ b/docs/gitbook/src/reference/react/useConfidentialIsOperator.md
@@ -116,5 +116,5 @@ function App() {
 
 ## Related
 
-- [`useConfidentialSetOperator`](/reference/react/useConfidentialSetOperator) — approve an operator
-- [`Token.isOperator()`](/reference/sdk/Token#isoperator) — imperative equivalent on the SDK class
+- [`useConfidentialSetOperator`](./useConfidentialSetOperator.md) — approve an operator
+- [`Token.isOperator()`](../sdk/Token.md#isoperator) — imperative equivalent on the SDK class

--- a/docs/gitbook/src/reference/react/useConfidentialSetOperator.md
+++ b/docs/gitbook/src/reference/react/useConfidentialSetOperator.md
@@ -91,6 +91,6 @@ await setOperator({
 
 ## Related
 
-- [`useConfidentialIsOperator`](/reference/react/useConfidentialIsOperator) — check if a spender is currently an operator
-- [`useConfidentialTransferFrom`](/reference/react/useConfidentialTransferFrom) — operator transfer using an existing approval
-- [`Token.setOperator()`](/reference/sdk/Token#setoperator) — imperative equivalent on the SDK class
+- [`useConfidentialIsOperator`](./useConfidentialIsOperator.md) — check if a spender is currently an operator
+- [`useConfidentialTransferFrom`](./useConfidentialTransferFrom.md) — operator transfer using an existing approval
+- [`Token.setOperator()`](../sdk/Token.md#setoperator) — imperative equivalent on the SDK class

--- a/docs/gitbook/src/reference/react/useConfidentialTokenAddress.md
+++ b/docs/gitbook/src/reference/react/useConfidentialTokenAddress.md
@@ -65,7 +65,7 @@ The `data` field resolves to `readonly [boolean, Address]`:
 
 ## Related
 
-- [useTokenAddress](/reference/react/useTokenAddress) -- reverse lookup (confidential &rarr; plain)
-- [useIsConfidentialTokenValid](/reference/react/useIsConfidentialTokenValid) -- check if a confidential token is valid
-- [useWrapperDiscovery](/reference/react/useWrapperDiscovery) -- alternative lookup via the deployment coordinator
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getConfidentialTokenAddress()` method
+- [useTokenAddress](./useTokenAddress.md) -- reverse lookup (confidential &rarr; plain)
+- [useIsConfidentialTokenValid](./useIsConfidentialTokenValid.md) -- check if a confidential token is valid
+- [useWrapperDiscovery](./useWrapperDiscovery.md) -- alternative lookup via the deployment coordinator
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getConfidentialTokenAddress()` method

--- a/docs/gitbook/src/reference/react/useConfidentialTransfer.md
+++ b/docs/gitbook/src/reference/react/useConfidentialTransfer.md
@@ -5,7 +5,7 @@ description: Send confidential ERC-20 tokens privately.
 
 # useConfidentialTransfer
 
-Send confidential ERC-20 tokens privately. The amount is encrypted client-side before the transaction is submitted on-chain. Automatically invalidates the [`useConfidentialBalance`](/reference/react/useConfidentialBalance) cache on success.
+Send confidential ERC-20 tokens privately. The amount is encrypted client-side before the transaction is submitted on-chain. Automatically invalidates the [`useConfidentialBalance`](./useConfidentialBalance.md) cache on success.
 
 ## Import
 
@@ -173,6 +173,6 @@ The `data` property (after a successful mutation) is `{ txHash: Hex, receipt: Tr
 
 ## Related
 
-- [useConfidentialTransferFrom](/reference/react/useConfidentialTransferFrom) -- operator transfer variant
-- [Transfer Privately guide](/guides/transfer-privately)
-- [useConfidentialBalance](/reference/react/useConfidentialBalance) -- auto-invalidated on success
+- [useConfidentialTransferFrom](./useConfidentialTransferFrom.md) -- operator transfer variant
+- [Transfer Privately guide](../../guides/transfer-privately.md)
+- [useConfidentialBalance](./useConfidentialBalance.md) -- auto-invalidated on success

--- a/docs/gitbook/src/reference/react/useConfidentialTransferFrom.md
+++ b/docs/gitbook/src/reference/react/useConfidentialTransferFrom.md
@@ -5,7 +5,7 @@ description: Transfer confidential tokens on behalf of an owner who approved you
 
 # useConfidentialTransferFrom
 
-Transfer confidential tokens on behalf of an owner who approved you as an operator. The sender must have been granted approval via [`useConfidentialSetOperator`](/reference/react/useConfidentialSetOperator) before calling this hook. Automatically invalidates the [`useConfidentialBalance`](/reference/react/useConfidentialBalance) cache on success.
+Transfer confidential tokens on behalf of an owner who approved you as an operator. The sender must have been granted approval via [`useConfidentialSetOperator`](./useConfidentialSetOperator.md) before calling this hook. Automatically invalidates the [`useConfidentialBalance`](./useConfidentialBalance.md) cache on success.
 
 ## Import
 
@@ -141,7 +141,7 @@ The `data` property (after a successful mutation) is `{ txHash: Hex, receipt: Tr
 
 ## Related
 
-- [useConfidentialTransfer](/reference/react/useConfidentialTransfer) -- direct transfer (no operator)
-- [useConfidentialSetOperator](/reference/react/useConfidentialSetOperator) -- grant operator approval
-- [Operator Approvals guide](/guides/operator-approvals)
-- [useConfidentialBalance](/reference/react/useConfidentialBalance) -- auto-invalidated on success
+- [useConfidentialTransfer](./useConfidentialTransfer.md) -- direct transfer (no operator)
+- [useConfidentialSetOperator](./useConfidentialSetOperator.md) -- grant operator approval
+- [Operator Approvals guide](../../guides/operator-approvals.md)
+- [useConfidentialBalance](./useConfidentialBalance.md) -- auto-invalidated on success

--- a/docs/gitbook/src/reference/react/useDecryptBalanceAs.md
+++ b/docs/gitbook/src/reference/react/useDecryptBalanceAs.md
@@ -99,7 +99,7 @@ await decryptAs({
 
 ## Related
 
-- [`useBatchDecryptBalancesAs`](/reference/react/useBatchDecryptBalancesAs) -- batch variant for multiple tokens
-- [`useDelegationStatus`](/reference/react/useDelegationStatus) -- check delegation status before decrypting
-- [`useConfidentialBalance`](/reference/react/useConfidentialBalance) -- decrypt your own balance (non-delegated)
-- [Delegated Decryption](/reference/sdk/delegation) -- SDK reference
+- [`useBatchDecryptBalancesAs`](./useBatchDecryptBalancesAs.md) -- batch variant for multiple tokens
+- [`useDelegationStatus`](./useDelegationStatus.md) -- check delegation status before decrypting
+- [`useConfidentialBalance`](./useConfidentialBalance.md) -- decrypt your own balance (non-delegated)
+- [Delegated Decryption](../sdk/delegation.md) -- SDK reference

--- a/docs/gitbook/src/reference/react/useDecryptValues.md
+++ b/docs/gitbook/src/reference/react/useDecryptValues.md
@@ -5,14 +5,14 @@ description: Query hook that automatically decrypts FHE encrypted values once cr
 
 # useDecryptValues
 
-Query hook for user decryption. Automatically fires when credentials are available (acquired via [`useGrantPermit`](/reference/react/useGrantPermit)) and inputs are provided. Checks the persistent decrypt cache first and only hits the relayer for uncached entries.
+Query hook for user decryption. Automatically fires when credentials are available (acquired via [`useGrantPermit`](./useGrantPermit.md)) and inputs are provided. Checks the persistent decrypt cache first and only hits the relayer for uncached entries.
 
 {% hint style="info" %}
 Renamed from `useUserDecrypt` to align with the Zama glossary (prerelease rename). If you were on the old name, update imports to `useDecryptValues`.
 {% endhint %}
 
 {% hint style="info" %}
-**This is the recommended way to decrypt.** For token balances, prefer [`useConfidentialBalance`](/reference/react/useConfidentialBalance) which handles decryption and caching automatically. Use `useDecryptValues` when your smart contract uses FHE types directly (e.g. a confidential voting contract, a sealed-bid auction, or any non-token contract).
+**This is the recommended way to decrypt.** For token balances, prefer [`useConfidentialBalance`](./useConfidentialBalance.md) which handles decryption and caching automatically. Use `useDecryptValues` when your smart contract uses FHE types directly (e.g. a confidential voting contract, a sealed-bid auction, or any non-token contract).
 {% endhint %}
 
 ## Import
@@ -110,7 +110,7 @@ When all requested inputs are already cached, `data` contains the cached values 
 2. **Decrypt** — calls `sdk.decryption.decryptValues(inputs)` which checks the persistent cache, then hits the relayer for any uncached entries.
 
 {% hint style="warning" %}
-**`useDecryptValues` does not automatically gate on permits.** If permits are not cached when the query fires, the SDK will prompt the user's wallet for a signature. To avoid unexpected popups, gate the query yourself using [`useHasPermit`](/reference/react/useHasPermit):
+**`useDecryptValues` does not automatically gate on permits.** If permits are not cached when the query fires, the SDK will prompt the user's wallet for a signature. To avoid unexpected popups, gate the query yourself using [`useHasPermit`](./useHasPermit.md):
 
 ```tsx
 const { data: hasPermit } = useHasPermit({ contractAddresses: ["0xContract"] });
@@ -124,7 +124,7 @@ This ensures the decrypt query only fires after `useGrantPermit` has been called
 
 ## Permit caching
 
-`useDecryptValues` relies on permits acquired via [`useGrantPermit`](/reference/react/useGrantPermit):
+`useDecryptValues` relies on permits acquired via [`useGrantPermit`](./useGrantPermit.md):
 
 - **First `grantPermit()` call** — generates a new FHE keypair, creates EIP-712 typed data, and requests a wallet signature. The permits are then cached.
 - **Subsequent queries** — reuse the cached permits if they are still valid (not expired).
@@ -134,8 +134,8 @@ This means users only see a wallet signature prompt once per TTL window, even if
 
 ## Related
 
-- [`useGrantPermit`](/reference/react/useGrantPermit) — pre-authorize contracts with one wallet signature (required before `useDecryptValues` fires)
-- [`useHasPermit`](/reference/react/useHasPermit) — check whether permits are cached and cover specific contracts
-- [`useConfidentialBalance`](/reference/react/useConfidentialBalance) — high-level hook that decrypts token balances with automatic caching
-- [`useEncrypt`](/reference/react/useEncrypt) — reverse operation, encrypt a plaintext value for on-chain submission
-- [Encrypt & Decrypt guide](/guides/encrypt-decrypt) — full walkthrough with end-to-end examples
+- [`useGrantPermit`](./useGrantPermit.md) — pre-authorize contracts with one wallet signature (required before `useDecryptValues` fires)
+- [`useHasPermit`](./useHasPermit.md) — check whether permits are cached and cover specific contracts
+- [`useConfidentialBalance`](./useConfidentialBalance.md) — high-level hook that decrypts token balances with automatic caching
+- [`useEncrypt`](./useEncrypt.md) — reverse operation, encrypt a plaintext value for on-chain submission
+- [Encrypt & Decrypt guide](../../guides/encrypt-decrypt.md) — full walkthrough with end-to-end examples

--- a/docs/gitbook/src/reference/react/useDelegateDecryption.md
+++ b/docs/gitbook/src/reference/react/useDelegateDecryption.md
@@ -5,7 +5,7 @@ description: Mutation hook that grants FHE decryption rights for a token to anot
 
 # useDelegateDecryption
 
-Mutation hook that grants FHE decryption rights for a token to another address via the on-chain ACL. Automatically invalidates [`useDelegationStatus`](/reference/react/useDelegationStatus) queries on success.
+Mutation hook that grants FHE decryption rights for a token to another address via the on-chain ACL. Automatically invalidates [`useDelegationStatus`](./useDelegationStatus.md) queries on success.
 
 ## Import
 
@@ -94,7 +94,7 @@ await delegate({
 
 ## Related
 
-- [`useRevokeDelegation`](/reference/react/useRevokeDelegation) -- revoke a previously granted delegation
-- [`useDelegationStatus`](/reference/react/useDelegationStatus) -- check whether a delegation is active
-- [`useDecryptBalanceAs`](/reference/react/useDecryptBalanceAs) -- decrypt a balance as the delegate
-- [Delegated Decryption](/reference/sdk/delegation) -- SDK reference
+- [`useRevokeDelegation`](./useRevokeDelegation.md) -- revoke a previously granted delegation
+- [`useDelegationStatus`](./useDelegationStatus.md) -- check whether a delegation is active
+- [`useDecryptBalanceAs`](./useDecryptBalanceAs.md) -- decrypt a balance as the delegate
+- [Delegated Decryption](../sdk/delegation.md) -- SDK reference

--- a/docs/gitbook/src/reference/react/useDelegationStatus.md
+++ b/docs/gitbook/src/reference/react/useDelegationStatus.md
@@ -103,6 +103,6 @@ import { type DelegationStatusData } from "@zama-fhe/sdk/query";
 
 ## Related
 
-- [`useDelegateDecryption`](/reference/react/useDelegateDecryption) -- grant delegation
-- [`useRevokeDelegation`](/reference/react/useRevokeDelegation) -- revoke delegation
-- [Delegated Decryption](/reference/sdk/delegation) -- SDK reference
+- [`useDelegateDecryption`](./useDelegateDecryption.md) -- grant delegation
+- [`useRevokeDelegation`](./useRevokeDelegation.md) -- revoke delegation
+- [Delegated Decryption](../sdk/delegation.md) -- SDK reference

--- a/docs/gitbook/src/reference/react/useEncrypt.md
+++ b/docs/gitbook/src/reference/react/useEncrypt.md
@@ -8,7 +8,7 @@ description: Low-level mutation hook that encrypts a plaintext value using the r
 Low-level mutation hook that encrypts plaintext values using the relayer's FHE engine. Returns encrypted values and an input proof for on-chain submission.
 
 {% hint style="warning" %}
-For **confidential ERC-20 tokens**, use [`useShield`](/reference/react/useShield) or [`useConfidentialTransfer`](/reference/react/useConfidentialTransfer) — they handle encryption automatically.
+For **confidential ERC-20 tokens**, use [`useShield`](./useShield.md) or [`useConfidentialTransfer`](./useConfidentialTransfer.md) — they handle encryption automatically.
 
 Use `useEncrypt` when your smart contract uses FHE types directly (e.g. a confidential voting contract, a sealed-bid auction, or any non-token contract that accepts encrypted parameters).
 {% endhint %}
@@ -108,7 +108,7 @@ import { type EncryptResult } from "@zama-fhe/sdk";
 
 ## Related
 
-- [`useShield`](/reference/react/useShield) — high-level hook that encrypts and shields in one step
-- [`useConfidentialTransfer`](/reference/react/useConfidentialTransfer) — high-level hook that encrypts and transfers
-- [`useDecryptValues`](/reference/react/useDecryptValues) — reverse operation, decrypt encrypted values back to plaintext
-- [Encrypt & Decrypt guide](/guides/encrypt-decrypt) — full walkthrough with examples
+- [`useShield`](./useShield.md) — high-level hook that encrypts and shields in one step
+- [`useConfidentialTransfer`](./useConfidentialTransfer.md) — high-level hook that encrypts and transfers
+- [`useDecryptValues`](./useDecryptValues.md) — reverse operation, decrypt encrypted values back to plaintext
+- [Encrypt & Decrypt guide](../../guides/encrypt-decrypt.md) — full walkthrough with examples

--- a/docs/gitbook/src/reference/react/useFinalizeUnwrap.md
+++ b/docs/gitbook/src/reference/react/useFinalizeUnwrap.md
@@ -5,10 +5,10 @@ description: Low-level mutation hook that finalizes an unwrap with the decryptio
 
 # useFinalizeUnwrap
 
-Low-level mutation hook that finalizes an unwrap with the decryption proof. Call this after [`useUnwrap`](/reference/react/useUnwrap) or [`useUnwrapAll`](/reference/react/useUnwrapAll) has submitted the initial unwrap transaction.
+Low-level mutation hook that finalizes an unwrap with the decryption proof. Call this after [`useUnwrap`](./useUnwrap.md) or [`useUnwrapAll`](./useUnwrapAll.md) has submitted the initial unwrap transaction.
 
 {% hint style="info" %}
-Most apps should use [`useUnshield`](/reference/react/useUnshield) instead, which orchestrates both steps (unwrap + finalize) in a single call. Use this hook for custom multi-step flows where you need control over each phase.
+Most apps should use [`useUnshield`](./useUnshield.md) instead, which orchestrates both steps (unwrap + finalize) in a single call. Use this hook for custom multi-step flows where you need control over each phase.
 {% endhint %}
 
 ## Import
@@ -93,7 +93,7 @@ await finalize({ burnAmount: encryptedAmount });
 
 ## Related
 
-- [`useUnwrap`](/reference/react/useUnwrap) -- request unwrap for a specific amount
-- [`useUnwrapAll`](/reference/react/useUnwrapAll) -- request unwrap for the full balance
-- [`useResumeUnshield`](/reference/react/useResumeUnshield) -- resume an interrupted unshield
-- [`useUnshield`](/reference/react/useUnshield) -- high-level hook that handles both steps
+- [`useUnwrap`](./useUnwrap.md) -- request unwrap for a specific amount
+- [`useUnwrapAll`](./useUnwrapAll.md) -- request unwrap for the full balance
+- [`useResumeUnshield`](./useResumeUnshield.md) -- resume an interrupted unshield
+- [`useUnshield`](./useUnshield.md) -- high-level hook that handles both steps

--- a/docs/gitbook/src/reference/react/useGrantPermit.md
+++ b/docs/gitbook/src/reference/react/useGrantPermit.md
@@ -7,7 +7,7 @@ description: Mutation hook that signs an EIP-712 message authorizing decryption 
 
 Mutation hook that signs an EIP-712 message authorizing decryption of confidential encrypted values for a list of contract addresses. This is **not token-specific** — any contract that uses FHE-encrypted values (confidential tokens, DeFi vaults, games, etc.) can be authorized in a single wallet signature.
 
-Call this early (e.g. after wallet connect) so that [`useDecryptValues`](/reference/react/useDecryptValues) queries fire automatically without wallet popups. Automatically invalidates [`useHasPermit`](/reference/react/useHasPermit) queries on success.
+Call this early (e.g. after wallet connect) so that [`useDecryptValues`](./useDecryptValues.md) queries fire automatically without wallet popups. Automatically invalidates [`useHasPermit`](./useHasPermit.md) queries on success.
 
 {% hint style="warning" %}
 **Include all contracts you plan to decrypt.** `useDecryptValues` checks that stored permits cover every contract address in its `inputs` before firing the query. If any contract is missing, the query stays disabled.
@@ -90,7 +90,7 @@ Returns a standard TanStack Query `UseMutationResult<void, Error, Address[]>`.
 
 ## Related
 
-- [`useHasPermit`](/reference/react/useHasPermit) -- check whether stored permits cover contracts
-- [`useRevokePermits`](/reference/react/useRevokePermits) -- revoke permits for specific contracts
-- [`useClearCredentials`](/reference/react/useClearCredentials) -- wipe the keypair and all permits
-- [Permit Model](/concepts/permit-model) -- permit lifecycle and TTL configuration
+- [`useHasPermit`](./useHasPermit.md) -- check whether stored permits cover contracts
+- [`useRevokePermits`](./useRevokePermits.md) -- revoke permits for specific contracts
+- [`useClearCredentials`](./useClearCredentials.md) -- wipe the keypair and all permits
+- [Permit Model](../../concepts/permit-model.md) -- permit lifecycle and TTL configuration

--- a/docs/gitbook/src/reference/react/useHasPermit.md
+++ b/docs/gitbook/src/reference/react/useHasPermit.md
@@ -106,13 +106,13 @@ Standard React Query options forwarded to the underlying query. Pass `{ enabled:
 `data` is a `boolean`:
 
 - `true` -- stored permits cover all specified addresses; decrypts will not prompt the wallet.
-- `false` -- no stored permits, or the `permitTTL` has expired. Call [`useGrantPermit`](/reference/react/useGrantPermit) to authorize.
+- `false` -- no stored permits, or the `permitTTL` has expired. Call [`useGrantPermit`](./useGrantPermit.md) to authorize.
 
 {% include ".gitbook/includes/query-result.md" %}
 
 ## Related
 
-- [Avoid blind-sign wallet popups](/guides/encrypt-decrypt#3-avoid-blind-sign-wallet-popups) -- gating balance queries to avoid blind-sign popups
-- [`useGrantPermit`](/reference/react/useGrantPermit) -- pre-authorize contracts with one wallet signature
-- [`useRevokePermits`](/reference/react/useRevokePermits) -- revoke permits
-- [Permit Model](/concepts/permit-model) -- permit lifecycle and TTL configuration
+- [Avoid blind-sign wallet popups](../../guides/encrypt-decrypt.md#3-avoid-blind-sign-wallet-popups) -- gating balance queries to avoid blind-sign popups
+- [`useGrantPermit`](./useGrantPermit.md) -- pre-authorize contracts with one wallet signature
+- [`useRevokePermits`](./useRevokePermits.md) -- revoke permits
+- [Permit Model](../../concepts/permit-model.md) -- permit lifecycle and TTL configuration

--- a/docs/gitbook/src/reference/react/useHasPermit.md
+++ b/docs/gitbook/src/reference/react/useHasPermit.md
@@ -112,7 +112,7 @@ Standard React Query options forwarded to the underlying query. Pass `{ enabled:
 
 ## Related
 
-- [Avoid blind-sign wallet popups](../../guides/encrypt-decrypt.md#3-avoid-blind-sign-wallet-popups) -- gating balance queries to avoid blind-sign popups
+- [Avoid blind-sign wallet popups](../../guides/encrypt-decrypt.md#gating-useconfidentialbalance) -- gating balance queries to avoid blind-sign popups
 - [`useGrantPermit`](./useGrantPermit.md) -- pre-authorize contracts with one wallet signature
 - [`useRevokePermits`](./useRevokePermits.md) -- revoke permits
 - [Permit Model](../../concepts/permit-model.md) -- permit lifecycle and TTL configuration

--- a/docs/gitbook/src/reference/react/useIsConfidentialTokenValid.md
+++ b/docs/gitbook/src/reference/react/useIsConfidentialTokenValid.md
@@ -67,6 +67,6 @@ The `data` field resolves to `boolean`:
 
 ## Related
 
-- [useConfidentialTokenAddress](/reference/react/useConfidentialTokenAddress) -- look up the wrapper for an ERC-20
-- [useTokenAddress](/reference/react/useTokenAddress) -- reverse lookup (confidential &rarr; plain)
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `isConfidentialTokenValid()` method
+- [useConfidentialTokenAddress](./useConfidentialTokenAddress.md) -- look up the wrapper for an ERC-20
+- [useTokenAddress](./useTokenAddress.md) -- reverse lookup (confidential &rarr; plain)
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `isConfidentialTokenValid()` method

--- a/docs/gitbook/src/reference/react/useListPairs.md
+++ b/docs/gitbook/src/reference/react/useListPairs.md
@@ -137,7 +137,7 @@ Results are cached with a TTL matching the SDK's `registryTTL` (default: 24 hour
 
 ## Related
 
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level registry class with `listPairs()` method
-- [useTokenPairsRegistry](/reference/react/useTokenPairsRegistry) -- fetch all pairs at once (no pagination)
-- [useConfidentialTokenAddress](/reference/react/useConfidentialTokenAddress) -- look up a single token's wrapper
-- [Query Keys](/reference/react/query-keys) -- manual cache control via `zamaQueryKeys.wrappersRegistry`
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level registry class with `listPairs()` method
+- [useTokenPairsRegistry](./useTokenPairsRegistry.md) -- fetch all pairs at once (no pagination)
+- [useConfidentialTokenAddress](./useConfidentialTokenAddress.md) -- look up a single token's wrapper
+- [Query Keys](./query-keys.md) -- manual cache control via `zamaQueryKeys.wrappersRegistry`

--- a/docs/gitbook/src/reference/react/useMetadata.md
+++ b/docs/gitbook/src/reference/react/useMetadata.md
@@ -87,6 +87,6 @@ function TokenHeader({ tokenAddress }: { tokenAddress: `0x${string}` }) {
 
 ## Related
 
-- [useWrapperDiscovery](/reference/react/useWrapperDiscovery) -- find the wrapper address for a token
-- [useConfidentialBalance](/reference/react/useConfidentialBalance) -- read the decrypted confidential balance
-- [Hooks overview](/reference/react/query-keys) -- all available hooks
+- [useWrapperDiscovery](./useWrapperDiscovery.md) -- find the wrapper address for a token
+- [useConfidentialBalance](./useConfidentialBalance.md) -- read the decrypted confidential balance
+- [Hooks overview](./query-keys.md) -- all available hooks

--- a/docs/gitbook/src/reference/react/useResumeUnshield.md
+++ b/docs/gitbook/src/reference/react/useResumeUnshield.md
@@ -126,6 +126,6 @@ Auto-invalidates the `confidentialBalance` cache on success.
 
 ## Related
 
-- [useUnshield](/reference/react/useUnshield) — standard unshield (handles both steps automatically)
-- [useUnshieldAll](/reference/react/useUnshieldAll) — unshield the entire balance
-- [WrappedToken.resumeUnshield](/reference/sdk/WrappedToken#resumeunshield) — imperative equivalent on the `WrappedToken` class
+- [useUnshield](./useUnshield.md) — standard unshield (handles both steps automatically)
+- [useUnshieldAll](./useUnshieldAll.md) — unshield the entire balance
+- [WrappedToken.resumeUnshield](../sdk/WrappedToken.md#resumeunshield) — imperative equivalent on the `WrappedToken` class

--- a/docs/gitbook/src/reference/react/useRevokeDelegation.md
+++ b/docs/gitbook/src/reference/react/useRevokeDelegation.md
@@ -5,7 +5,7 @@ description: Mutation hook that revokes FHE decryption delegation for a token.
 
 # useRevokeDelegation
 
-Mutation hook that revokes a previously granted FHE decryption delegation for a token. Automatically invalidates [`useDelegationStatus`](/reference/react/useDelegationStatus) queries on success.
+Mutation hook that revokes a previously granted FHE decryption delegation for a token. Automatically invalidates [`useDelegationStatus`](./useDelegationStatus.md) queries on success.
 
 ## Import
 
@@ -82,6 +82,6 @@ await revoke({ delegateAddress: "0xDelegate" });
 
 ## Related
 
-- [`useDelegateDecryption`](/reference/react/useDelegateDecryption) -- grant delegation
-- [`useDelegationStatus`](/reference/react/useDelegationStatus) -- check whether a delegation is active
-- [Delegated Decryption](/reference/sdk/delegation) -- SDK reference
+- [`useDelegateDecryption`](./useDelegateDecryption.md) -- grant delegation
+- [`useDelegationStatus`](./useDelegationStatus.md) -- check whether a delegation is active
+- [Delegated Decryption](../sdk/delegation.md) -- SDK reference

--- a/docs/gitbook/src/reference/react/useRevokePermits.md
+++ b/docs/gitbook/src/reference/react/useRevokePermits.md
@@ -5,7 +5,7 @@ description: Revoke FHE permits for specific contract addresses, or all permits 
 
 # useRevokePermits
 
-Revoke FHE permits for the current signer. With a contract list, removes direct-decrypt permits on the current chain. Without arguments, removes every permit across all chains and delegators. The keypair survives — use [`useClearCredentials`](/reference/react/useClearCredentials) to also wipe the keypair.
+Revoke FHE permits for the current signer. With a contract list, removes direct-decrypt permits on the current chain. Without arguments, removes every permit across all chains and delegators. The keypair survives — use [`useClearCredentials`](./useClearCredentials.md) to also wipe the keypair.
 
 ## Import
 
@@ -78,11 +78,11 @@ revokePermits(); // all permits, all chains
 ## Behavior
 
 - Removes signed permits from the permission store.
-- Auto-invalidates all [`useHasPermit`](/reference/react/useHasPermit) queries on success.
+- Auto-invalidates all [`useHasPermit`](./useHasPermit.md) queries on success.
 - The FHE keypair is not affected — only permits are removed.
 
 ## Related
 
-- [`useClearCredentials`](/reference/react/useClearCredentials) — wipe the keypair and all permits
-- [`useGrantPermit`](/reference/react/useGrantPermit) — sign permits for contracts
-- [`useHasPermit`](/reference/react/useHasPermit) — check whether stored permits cover contracts
+- [`useClearCredentials`](./useClearCredentials.md) — wipe the keypair and all permits
+- [`useGrantPermit`](./useGrantPermit.md) — sign permits for contracts
+- [`useHasPermit`](./useHasPermit.md) — check whether stored permits cover contracts

--- a/docs/gitbook/src/reference/react/useShield.md
+++ b/docs/gitbook/src/reference/react/useShield.md
@@ -173,5 +173,5 @@ Auto-invalidates the `confidentialBalance` cache on success.
 
 ## Related
 
-- [useUnshield](/reference/react/useUnshield) — reverse operation, unshield back to public ERC-20
-- [WrappedToken.shield](/reference/sdk/WrappedToken#shield) — imperative equivalent on the `WrappedToken` class
+- [useUnshield](./useUnshield.md) — reverse operation, unshield back to public ERC-20
+- [WrappedToken.shield](../sdk/WrappedToken.md#shield) — imperative equivalent on the `WrappedToken` class

--- a/docs/gitbook/src/reference/react/useTokenAddress.md
+++ b/docs/gitbook/src/reference/react/useTokenAddress.md
@@ -65,6 +65,6 @@ The `data` field resolves to `readonly [boolean, Address]`:
 
 ## Related
 
-- [useConfidentialTokenAddress](/reference/react/useConfidentialTokenAddress) -- forward lookup (plain &rarr; confidential)
-- [useIsConfidentialTokenValid](/reference/react/useIsConfidentialTokenValid) -- check if a confidential token is valid
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getTokenAddress()` method
+- [useConfidentialTokenAddress](./useConfidentialTokenAddress.md) -- forward lookup (plain &rarr; confidential)
+- [useIsConfidentialTokenValid](./useIsConfidentialTokenValid.md) -- check if a confidential token is valid
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getTokenAddress()` method

--- a/docs/gitbook/src/reference/react/useTokenPair.md
+++ b/docs/gitbook/src/reference/react/useTokenPair.md
@@ -69,6 +69,6 @@ interface TokenWrapperPair {
 
 ## Related
 
-- [useTokenPairsLength](/reference/react/useTokenPairsLength) -- get total count to know valid indices
-- [useTokenPairsSlice](/reference/react/useTokenPairsSlice) -- fetch a range of pairs
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getTokenPair()` method
+- [useTokenPairsLength](./useTokenPairsLength.md) -- get total count to know valid indices
+- [useTokenPairsSlice](./useTokenPairsSlice.md) -- fetch a range of pairs
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getTokenPair()` method

--- a/docs/gitbook/src/reference/react/useTokenPairsLength.md
+++ b/docs/gitbook/src/reference/react/useTokenPairsLength.md
@@ -47,6 +47,6 @@ The `data` field resolves to `bigint` -- the total number of registered pairs.
 
 ## Related
 
-- [useListPairs](/reference/react/useListPairs) -- paginated pair listing
-- [useTokenPairsSlice](/reference/react/useTokenPairsSlice) -- fetch a range of pairs by index
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getTokenPairsLength()` method
+- [useListPairs](./useListPairs.md) -- paginated pair listing
+- [useTokenPairsSlice](./useTokenPairsSlice.md) -- fetch a range of pairs by index
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getTokenPairsLength()` method

--- a/docs/gitbook/src/reference/react/useTokenPairsRegistry.md
+++ b/docs/gitbook/src/reference/react/useTokenPairsRegistry.md
@@ -7,7 +7,7 @@ description: Fetch all token wrapper pairs from the on-chain registry.
 
 Fetches all token wrapper pairs from the `ConfidentialTokenWrappersRegistry` contract on the current chain in a single call.
 
-For large registries, prefer [`useListPairs`](/reference/react/useListPairs) with pagination.
+For large registries, prefer [`useListPairs`](./useListPairs.md) with pagination.
 
 ## Import
 
@@ -65,6 +65,6 @@ interface TokenWrapperPair {
 
 ## Related
 
-- [useListPairs](/reference/react/useListPairs) -- paginated listing with optional metadata
-- [useTokenPairsLength](/reference/react/useTokenPairsLength) -- get total count without fetching pairs
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getTokenPairs()` method
+- [useListPairs](./useListPairs.md) -- paginated listing with optional metadata
+- [useTokenPairsLength](./useTokenPairsLength.md) -- get total count without fetching pairs
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getTokenPairs()` method

--- a/docs/gitbook/src/reference/react/useTokenPairsSlice.md
+++ b/docs/gitbook/src/reference/react/useTokenPairsSlice.md
@@ -5,7 +5,7 @@ description: Fetch a range of token wrapper pairs from the registry by index.
 
 # useTokenPairsSlice
 
-Fetches a range of token wrapper pairs from the registry using start and end indices. This is the low-level pagination primitive — for page-based pagination, use [`useListPairs`](/reference/react/useListPairs) instead.
+Fetches a range of token wrapper pairs from the registry using start and end indices. This is the low-level pagination primitive — for page-based pagination, use [`useListPairs`](./useListPairs.md) instead.
 
 ## Import
 
@@ -87,7 +87,7 @@ interface TokenWrapperPair {
 
 ## Related
 
-- [useListPairs](/reference/react/useListPairs) -- page-based pagination with metadata support
-- [useTokenPairsLength](/reference/react/useTokenPairsLength) -- get total count for pagination bounds
-- [useTokenPair](/reference/react/useTokenPair) -- fetch a single pair by index
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getTokenPairsSlice()` method
+- [useListPairs](./useListPairs.md) -- page-based pagination with metadata support
+- [useTokenPairsLength](./useTokenPairsLength.md) -- get total count for pagination bounds
+- [useTokenPair](./useTokenPair.md) -- fetch a single pair by index
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getTokenPairsSlice()` method

--- a/docs/gitbook/src/reference/react/useUnderlyingAllowance.md
+++ b/docs/gitbook/src/reference/react/useUnderlyingAllowance.md
@@ -112,5 +112,5 @@ function App() {
 
 ## Related
 
-- [`useShield`](/reference/react/useShield) — shield tokens (handles approval automatically)
-- [`zamaQueryKeys.underlyingAllowance`](/reference/react/query-keys) — cache keys for manual invalidation
+- [`useShield`](./useShield.md) — shield tokens (handles approval automatically)
+- [`zamaQueryKeys.underlyingAllowance`](./query-keys.md) — cache keys for manual invalidation

--- a/docs/gitbook/src/reference/react/useUnshield.md
+++ b/docs/gitbook/src/reference/react/useUnshield.md
@@ -158,7 +158,7 @@ Auto-invalidates the `confidentialBalance` cache on success.
 
 ## Related
 
-- [useUnshieldAll](/reference/react/useUnshieldAll) — unshield the entire confidential balance
-- [useResumeUnshield](/reference/react/useResumeUnshield) — resume an interrupted unshield
-- [useShield](/reference/react/useShield) — reverse operation, shield public tokens
-- [WrappedToken.unshield](/reference/sdk/WrappedToken#unshield) — imperative equivalent on the `WrappedToken` class
+- [useUnshieldAll](./useUnshieldAll.md) — unshield the entire confidential balance
+- [useResumeUnshield](./useResumeUnshield.md) — resume an interrupted unshield
+- [useShield](./useShield.md) — reverse operation, shield public tokens
+- [WrappedToken.unshield](../sdk/WrappedToken.md#unshield) — imperative equivalent on the `WrappedToken` class

--- a/docs/gitbook/src/reference/react/useUnshieldAll.md
+++ b/docs/gitbook/src/reference/react/useUnshieldAll.md
@@ -131,7 +131,7 @@ Auto-invalidates the `confidentialBalance` cache on success.
 
 ## Related
 
-- [useUnshield](/reference/react/useUnshield) — unshield a specific amount
-- [useResumeUnshield](/reference/react/useResumeUnshield) — resume an interrupted unshield
-- [useShield](/reference/react/useShield) — reverse operation, shield public tokens
-- [WrappedToken.unshieldAll](/reference/sdk/WrappedToken#unshieldall) — imperative equivalent on the `WrappedToken` class
+- [useUnshield](./useUnshield.md) — unshield a specific amount
+- [useResumeUnshield](./useResumeUnshield.md) — resume an interrupted unshield
+- [useShield](./useShield.md) — reverse operation, shield public tokens
+- [WrappedToken.unshieldAll](../sdk/WrappedToken.md#unshieldall) — imperative equivalent on the `WrappedToken` class

--- a/docs/gitbook/src/reference/react/useUnwrap.md
+++ b/docs/gitbook/src/reference/react/useUnwrap.md
@@ -5,10 +5,10 @@ description: Low-level mutation hook that requests an unwrap for a specific amou
 
 # useUnwrap
 
-Low-level mutation hook that requests an unwrap for a specific amount. You must finalize manually with [`useFinalizeUnwrap`](/reference/react/useFinalizeUnwrap).
+Low-level mutation hook that requests an unwrap for a specific amount. You must finalize manually with [`useFinalizeUnwrap`](./useFinalizeUnwrap.md).
 
 {% hint style="info" %}
-Most apps should use [`useUnshield`](/reference/react/useUnshield) instead, which orchestrates both steps (unwrap + finalize) in a single call.
+Most apps should use [`useUnshield`](./useUnshield.md) instead, which orchestrates both steps (unwrap + finalize) in a single call.
 {% endhint %}
 
 ## Import
@@ -78,6 +78,6 @@ The mutation resolves with `{ txHash: Hex, receipt: TransactionReceipt }`.
 
 ## Related
 
-- [`useFinalizeUnwrap`](/reference/react/useFinalizeUnwrap) -- finalize the unwrap with a decryption proof
-- [`useUnwrapAll`](/reference/react/useUnwrapAll) -- unwrap the full balance
-- [`useUnshield`](/reference/react/useUnshield) -- high-level hook that handles both steps
+- [`useFinalizeUnwrap`](./useFinalizeUnwrap.md) -- finalize the unwrap with a decryption proof
+- [`useUnwrapAll`](./useUnwrapAll.md) -- unwrap the full balance
+- [`useUnshield`](./useUnshield.md) -- high-level hook that handles both steps

--- a/docs/gitbook/src/reference/react/useUnwrapAll.md
+++ b/docs/gitbook/src/reference/react/useUnwrapAll.md
@@ -5,10 +5,10 @@ description: Low-level mutation hook that requests an unwrap for the full confid
 
 # useUnwrapAll
 
-Low-level mutation hook that requests an unwrap for the full confidential balance. You must finalize manually with [`useFinalizeUnwrap`](/reference/react/useFinalizeUnwrap).
+Low-level mutation hook that requests an unwrap for the full confidential balance. You must finalize manually with [`useFinalizeUnwrap`](./useFinalizeUnwrap.md).
 
 {% hint style="info" %}
-Most apps should use [`useUnshieldAll`](/reference/react/useUnshieldAll) instead, which orchestrates both steps in a single call.
+Most apps should use [`useUnshieldAll`](./useUnshieldAll.md) instead, which orchestrates both steps in a single call.
 {% endhint %}
 
 ## Import
@@ -66,6 +66,6 @@ The mutation resolves with `{ txHash: Hex, receipt: TransactionReceipt }`.
 
 ## Related
 
-- [`useFinalizeUnwrap`](/reference/react/useFinalizeUnwrap) -- finalize the unwrap with a decryption proof
-- [`useUnwrap`](/reference/react/useUnwrap) -- unwrap a specific amount
-- [`useUnshieldAll`](/reference/react/useUnshieldAll) -- high-level hook that handles both steps
+- [`useFinalizeUnwrap`](./useFinalizeUnwrap.md) -- finalize the unwrap with a decryption proof
+- [`useUnwrap`](./useUnwrap.md) -- unwrap a specific amount
+- [`useUnshieldAll`](./useUnshieldAll.md) -- high-level hook that handles both steps

--- a/docs/gitbook/src/reference/react/useWrapperDiscovery.md
+++ b/docs/gitbook/src/reference/react/useWrapperDiscovery.md
@@ -91,5 +91,5 @@ function WrapperInfo({ tokenAddress }: { tokenAddress: `0x${string}` }) {
 
 ## Related
 
-- [useMetadata](/reference/react/useMetadata) -- read token name, symbol, and decimals
-- [Hooks overview](/reference/react/query-keys) -- all available hooks
+- [useMetadata](./useMetadata.md) -- read token name, symbol, and decimals
+- [Hooks overview](./query-keys.md) -- all available hooks

--- a/docs/gitbook/src/reference/react/useWrappersRegistryAddress.md
+++ b/docs/gitbook/src/reference/react/useWrappersRegistryAddress.md
@@ -51,6 +51,6 @@ The underlying chain ID query uses `staleTime: 30000` (30 seconds). Chain switch
 
 ## Related
 
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level registry class
-- [Network Presets](/reference/sdk/network-presets) -- built-in chain configurations and `DefaultRegistryAddresses`
-- [useListPairs](/reference/react/useListPairs) -- paginated pair listing (depends on this hook internally)
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level registry class
+- [Network Presets](../sdk/network-presets.md) -- built-in chain configurations and `DefaultRegistryAddresses`
+- [useListPairs](./useListPairs.md) -- paginated pair listing (depends on this hook internally)

--- a/docs/gitbook/src/reference/react/useZamaSDK.md
+++ b/docs/gitbook/src/reference/react/useZamaSDK.md
@@ -77,6 +77,6 @@ The configured SDK instance. Throws if called outside a `ZamaProvider`.
 
 ## Related
 
-- [useToken](/reference/react/useToken) — memoised `Token` instance for a given address
-- [useWrappedToken](/reference/react/useWrappedToken) — memoised `WrappedToken` for ERC-7984 wrapper operations
-- [ZamaSDK](/reference/sdk/ZamaSDK) — full API reference for the SDK class
+- [useToken](./useToken.md) — memoised `Token` instance for a given address
+- [useWrappedToken](./useWrappedToken.md) — memoised `WrappedToken` for ERC-7984 wrapper operations
+- [ZamaSDK](../sdk/ZamaSDK.md) — full API reference for the SDK class

--- a/docs/gitbook/src/reference/sdk/EthersProvider.md
+++ b/docs/gitbook/src/reference/sdk/EthersProvider.md
@@ -5,7 +5,7 @@ description: Provider adapter that wraps an ethers Provider or EIP-1193 source f
 
 # EthersProvider
 
-Provider adapter that wraps an ethers `Provider` or EIP-1193 source for read-only chain access. Implements [GenericProvider](/reference/sdk/GenericProvider).
+Provider adapter that wraps an ethers `Provider` or EIP-1193 source for read-only chain access. Implements [GenericProvider](./GenericProvider.md).
 
 ## Import
 
@@ -74,11 +74,11 @@ const provider = new EthersProvider({
 
 ## Methods
 
-All methods are inherited from [GenericProvider](/reference/sdk/GenericProvider).
+All methods are inherited from [GenericProvider](./GenericProvider.md).
 
 ## Related
 
-- [GenericProvider](/reference/sdk/GenericProvider) -- interface this class implements
-- [EthersSigner](/reference/sdk/EthersSigner) -- companion signer adapter
-- [ViemProvider](/reference/sdk/ViemProvider) -- viem alternative
-- [Configuration guide](/guides/configuration) -- full setup walkthrough
+- [GenericProvider](./GenericProvider.md) -- interface this class implements
+- [EthersSigner](./EthersSigner.md) -- companion signer adapter
+- [ViemProvider](./ViemProvider.md) -- viem alternative
+- [Configuration guide](../../guides/configuration.md) -- full setup walkthrough

--- a/docs/gitbook/src/reference/sdk/EthersSigner.md
+++ b/docs/gitbook/src/reference/sdk/EthersSigner.md
@@ -5,7 +5,7 @@ description: Signer adapter that wraps an ethers Signer or EIP-1193 source for w
 
 # EthersSigner
 
-Signer adapter that wraps an ethers `Signer` or EIP-1193 source for wallet operations. Implements [GenericSigner](/reference/sdk/GenericSigner).
+Signer adapter that wraps an ethers `Signer` or EIP-1193 source for wallet operations. Implements [GenericSigner](./GenericSigner.md).
 
 ## Import
 
@@ -79,7 +79,7 @@ const signer = new EthersSigner({
 
 ## Methods
 
-All methods are inherited from [GenericSigner](/reference/sdk/GenericSigner).
+All methods are inherited from [GenericSigner](./GenericSigner.md).
 
 | Method                   | Browser | Node.js |
 | ------------------------ | ------- | ------- |
@@ -94,7 +94,7 @@ Only the browser mode (passing `ethereum`) emits wallet account transitions. In 
 
 ## Related
 
-- [GenericSigner](/reference/sdk/GenericSigner) -- interface this class implements
-- [EthersProvider](/reference/sdk/EthersProvider) -- companion provider adapter
-- [ViemSigner](/reference/sdk/ViemSigner) -- viem alternative
-- [Configuration guide](/guides/configuration) -- full setup walkthrough
+- [GenericSigner](./GenericSigner.md) -- interface this class implements
+- [EthersProvider](./EthersProvider.md) -- companion provider adapter
+- [ViemSigner](./ViemSigner.md) -- viem alternative
+- [Configuration guide](../../guides/configuration.md) -- full setup walkthrough

--- a/docs/gitbook/src/reference/sdk/FheArtifactCache.md
+++ b/docs/gitbook/src/reference/sdk/FheArtifactCache.md
@@ -235,7 +235,7 @@ Cache entries are scoped by chain ID:
 
 ## Related
 
-- [RelayerWeb](/reference/sdk/RelayerWeb) — browser relayer that creates an `FheArtifactCache` internally
-- [RelayerNode](/reference/sdk/RelayerNode) — Node.js relayer variant
-- [GenericStorage](/reference/sdk/GenericStorage) — storage interface used by the cache
-- [Configuration guide](/guides/configuration) — network presets and relayer setup
+- [RelayerWeb](./RelayerWeb.md) — browser relayer that creates an `FheArtifactCache` internally
+- [RelayerNode](./RelayerNode.md) — Node.js relayer variant
+- [GenericStorage](./GenericStorage.md) — storage interface used by the cache
+- [Configuration guide](../../guides/configuration.md) — network presets and relayer setup

--- a/docs/gitbook/src/reference/sdk/GenericProvider.md
+++ b/docs/gitbook/src/reference/sdk/GenericProvider.md
@@ -5,7 +5,7 @@ description: Interface that all provider adapters must implement for read-only c
 
 # GenericProvider
 
-Interface that all provider adapters must implement for read-only chain access. You only need this if you are building a custom provider -- otherwise use [ViemProvider](/reference/sdk/ViemProvider), [EthersProvider](/reference/sdk/EthersProvider), or the wagmi `createConfig` which builds one internally.
+Interface that all provider adapters must implement for read-only chain access. You only need this if you are building a custom provider -- otherwise use [ViemProvider](./ViemProvider.md), [EthersProvider](./EthersProvider.md), or the wagmi `createConfig` which builds one internally.
 
 ## Import
 
@@ -99,7 +99,7 @@ Return the timestamp of the latest block.
 
 ## Related
 
-- [ViemProvider](/reference/sdk/ViemProvider) -- viem implementation
-- [EthersProvider](/reference/sdk/EthersProvider) -- ethers implementation
-- [GenericSigner](/reference/sdk/GenericSigner) -- wallet authority interface
-- [Configuration guide](/guides/configuration) -- full setup walkthrough
+- [ViemProvider](./ViemProvider.md) -- viem implementation
+- [EthersProvider](./EthersProvider.md) -- ethers implementation
+- [GenericSigner](./GenericSigner.md) -- wallet authority interface
+- [Configuration guide](../../guides/configuration.md) -- full setup walkthrough

--- a/docs/gitbook/src/reference/sdk/GenericSigner.md
+++ b/docs/gitbook/src/reference/sdk/GenericSigner.md
@@ -5,7 +5,7 @@ description: Interface that all signer adapters must implement for the SDK to in
 
 # GenericSigner
 
-Interface that all signer adapters must implement for the SDK to interact with wallets. You only need this if you are building a custom signer -- otherwise use [ViemSigner](/reference/sdk/ViemSigner) or [EthersSigner](/reference/sdk/EthersSigner).
+Interface that all signer adapters must implement for the SDK to interact with wallets. You only need this if you are building a custom signer -- otherwise use [ViemSigner](./ViemSigner.md) or [EthersSigner](./EthersSigner.md).
 
 ## Import
 
@@ -32,7 +32,7 @@ interface WalletAccountStore {
 ```
 
 {% hint style="info" %}
-For read operations (`readContract`, `waitForTransactionReceipt`), see [GenericProvider](/reference/sdk/GenericProvider).
+For read operations (`readContract`, `waitForTransactionReceipt`), see [GenericProvider](./GenericProvider.md).
 {% endhint %}
 
 ## Usage with `createConfig`
@@ -160,7 +160,7 @@ When `previous` is present, the SDK clears that previous account's keypair, perm
 
 ## Related
 
-- [GenericProvider](/reference/sdk/GenericProvider) -- read-only chain access interface
-- [ViemSigner](/reference/sdk/ViemSigner) -- viem implementation
-- [EthersSigner](/reference/sdk/EthersSigner) -- ethers implementation
-- [Configuration guide](/guides/configuration) -- full setup walkthrough
+- [GenericProvider](./GenericProvider.md) -- read-only chain access interface
+- [ViemSigner](./ViemSigner.md) -- viem implementation
+- [EthersSigner](./EthersSigner.md) -- ethers implementation
+- [Configuration guide](../../guides/configuration.md) -- full setup walkthrough

--- a/docs/gitbook/src/reference/sdk/GenericStorage.md
+++ b/docs/gitbook/src/reference/sdk/GenericStorage.md
@@ -152,5 +152,5 @@ const sdk = new ZamaSDK(config);
 
 ## Related
 
-- [ZamaSDK](/reference/sdk/ZamaSDK) -- accepts `storage` and `permitStorage` parameters
-- [Configuration guide](/guides/configuration) -- storage selection guidance
+- [ZamaSDK](./ZamaSDK.md) -- accepts `storage` and `permitStorage` parameters
+- [Configuration guide](../../guides/configuration.md) -- storage selection guidance

--- a/docs/gitbook/src/reference/sdk/RelayerCleartext.md
+++ b/docs/gitbook/src/reference/sdk/RelayerCleartext.md
@@ -14,7 +14,7 @@ import { RelayerCleartext } from "@zama-fhe/sdk/cleartext";
 ```
 
 {% hint style="info" %}
-For most applications, prefer the `cleartext()` transport factory with `createConfig` instead of constructing `RelayerCleartext` directly. See [Network Presets](/reference/sdk/network-presets) for examples.
+For most applications, prefer the `cleartext()` transport factory with `createConfig` instead of constructing `RelayerCleartext` directly. See [Network Presets](./network-presets.md) for examples.
 {% endhint %}
 
 ## Usage
@@ -105,7 +105,7 @@ The cleartext relayer implements the full `RelayerSDK` interface:
 
 ## Related
 
-- [Local Development guide](/guides/local-development) — when and how to use cleartext mode
-- [RelayerWeb](/reference/sdk/RelayerWeb) — browser relayer with real FHE
-- [RelayerNode](/reference/sdk/RelayerNode) — Node.js relayer with real FHE
-- [Network Presets](/reference/sdk/network-presets) — production network configs
+- [Local Development guide](../../guides/local-development.md) — when and how to use cleartext mode
+- [RelayerWeb](./RelayerWeb.md) — browser relayer with real FHE
+- [RelayerNode](./RelayerNode.md) — Node.js relayer with real FHE
+- [Network Presets](./network-presets.md) — production network configs

--- a/docs/gitbook/src/reference/sdk/RelayerNode.md
+++ b/docs/gitbook/src/reference/sdk/RelayerNode.md
@@ -59,6 +59,6 @@ How long cached FHE artifacts remain valid, in seconds. Must be a non-negative i
 
 ## Related
 
-- [ZamaSDK](/reference/sdk/ZamaSDK) — pass the config to the SDK constructor
-- [RelayerWeb](/reference/sdk/RelayerWeb) — browser variant using Web Workers and WASM
-- [Configuration guide](/guides/configuration) — authentication and network presets
+- [ZamaSDK](./ZamaSDK.md) — pass the config to the SDK constructor
+- [RelayerWeb](./RelayerWeb.md) — browser variant using Web Workers and WASM
+- [Configuration guide](../../guides/configuration.md) — authentication and network presets

--- a/docs/gitbook/src/reference/sdk/RelayerWeb.md
+++ b/docs/gitbook/src/reference/sdk/RelayerWeb.md
@@ -14,7 +14,7 @@ import { RelayerWeb } from "@zama-fhe/sdk/web";
 ```
 
 {% hint style="info" %}
-For most applications, prefer the `web()` transport factory with `createConfig` instead of constructing `RelayerWeb` directly. See [Network Presets](/reference/sdk/network-presets) for examples.
+For most applications, prefer the `web()` transport factory with `createConfig` instead of constructing `RelayerWeb` directly. See [Network Presets](./network-presets.md) for examples.
 {% endhint %}
 
 ## Usage
@@ -115,6 +115,6 @@ How long cached FHE artifacts remain valid, in seconds.
 
 ## Related
 
-- [ZamaSDK](/reference/sdk/ZamaSDK) — pass the relayer to the SDK constructor
-- [RelayerNode](/reference/sdk/RelayerNode) — Node.js variant using worker threads
-- [Configuration guide](/guides/configuration) — authentication and network presets
+- [ZamaSDK](./ZamaSDK.md) — pass the relayer to the SDK constructor
+- [RelayerNode](./RelayerNode.md) — Node.js variant using worker threads
+- [Configuration guide](../../guides/configuration.md) — authentication and network presets

--- a/docs/gitbook/src/reference/sdk/Token.md
+++ b/docs/gitbook/src/reference/sdk/Token.md
@@ -150,5 +150,5 @@ Batch delegated decryption.
 
 ## Related
 
-- [ZamaSDK](/reference/sdk/ZamaSDK) — creates `Token` via `createToken()`
-- [WrappedToken](/reference/sdk/WrappedToken) — extends `Token` with shield / unshield / allowance / wrapper operations
+- [ZamaSDK](./ZamaSDK.md) — creates `Token` via `createToken()`
+- [WrappedToken](./WrappedToken.md) — extends `Token` with shield / unshield / allowance / wrapper operations

--- a/docs/gitbook/src/reference/sdk/ViemProvider.md
+++ b/docs/gitbook/src/reference/sdk/ViemProvider.md
@@ -5,7 +5,7 @@ description: Provider adapter that wraps a viem PublicClient for read-only chain
 
 # ViemProvider
 
-Provider adapter that wraps a viem `PublicClient` for read-only chain access. Implements [GenericProvider](/reference/sdk/GenericProvider).
+Provider adapter that wraps a viem `PublicClient` for read-only chain access. Implements [GenericProvider](./GenericProvider.md).
 
 ## Import
 
@@ -48,11 +48,11 @@ const provider = new ViemProvider({
 
 ## Methods
 
-All methods are inherited from [GenericProvider](/reference/sdk/GenericProvider).
+All methods are inherited from [GenericProvider](./GenericProvider.md).
 
 ## Related
 
-- [GenericProvider](/reference/sdk/GenericProvider) -- interface this class implements
-- [ViemSigner](/reference/sdk/ViemSigner) -- companion signer adapter
-- [EthersProvider](/reference/sdk/EthersProvider) -- ethers alternative
-- [Configuration guide](/guides/configuration) -- full setup walkthrough
+- [GenericProvider](./GenericProvider.md) -- interface this class implements
+- [ViemSigner](./ViemSigner.md) -- companion signer adapter
+- [EthersProvider](./EthersProvider.md) -- ethers alternative
+- [Configuration guide](../../guides/configuration.md) -- full setup walkthrough

--- a/docs/gitbook/src/reference/sdk/ViemSigner.md
+++ b/docs/gitbook/src/reference/sdk/ViemSigner.md
@@ -5,7 +5,7 @@ description: Signer adapter that wraps a viem WalletClient for wallet operations
 
 # ViemSigner
 
-Signer adapter that wraps a viem `WalletClient` for wallet operations. Implements [GenericSigner](/reference/sdk/GenericSigner).
+Signer adapter that wraps a viem `WalletClient` for wallet operations. Implements [GenericSigner](./GenericSigner.md).
 
 ## Import
 
@@ -63,7 +63,7 @@ const signer = new ViemSigner({
 
 ## Methods
 
-All methods are inherited from [GenericSigner](/reference/sdk/GenericSigner).
+All methods are inherited from [GenericSigner](./GenericSigner.md).
 
 | Method                   | Behavior              |
 | ------------------------ | --------------------- |
@@ -78,7 +78,7 @@ Wallet account transitions are only emitted when you pass the `ethereum` option.
 
 ## Related
 
-- [GenericSigner](/reference/sdk/GenericSigner) -- interface this class implements
-- [ViemProvider](/reference/sdk/ViemProvider) -- companion provider adapter
-- [EthersSigner](/reference/sdk/EthersSigner) -- ethers alternative
-- [Configuration guide](/guides/configuration) -- full setup walkthrough
+- [GenericSigner](./GenericSigner.md) -- interface this class implements
+- [ViemProvider](./ViemProvider.md) -- companion provider adapter
+- [EthersSigner](./EthersSigner.md) -- ethers alternative
+- [Configuration guide](../../guides/configuration.md) -- full setup walkthrough

--- a/docs/gitbook/src/reference/sdk/WrappedToken.md
+++ b/docs/gitbook/src/reference/sdk/WrappedToken.md
@@ -210,6 +210,6 @@ await wrappedToken.finalizeUnwrap(event.unwrapRequestId);
 
 - [Token](Token.md) — base ERC-7984 confidential-token API
 - [ZamaSDK](ZamaSDK.md) — creates `WrappedToken` via `createWrappedToken()`
-- [Shield tokens](/guides/shield-tokens) — full shield flow
-- [Unshield tokens](/guides/unshield-tokens) — full unshield flow
-- [useWrappedToken](/reference/react/useWrappedToken) — React hook returning a `WrappedToken`
+- [Shield tokens](../../guides/shield-tokens.md) — full shield flow
+- [Unshield tokens](../../guides/unshield-tokens.md) — full unshield flow
+- [useWrappedToken](../react/useWrappedToken.md) — React hook returning a `WrappedToken`

--- a/docs/gitbook/src/reference/sdk/WrappersRegistry.md
+++ b/docs/gitbook/src/reference/sdk/WrappersRegistry.md
@@ -260,10 +260,10 @@ console.log(DefaultRegistryAddresses[1]); // "0xeb5015fF021DB115aCe010f23F55C259
 
 ## Related
 
-- [ZamaSDK](/reference/sdk/ZamaSDK) — `sdk.registry` shared instance and `createWrappersRegistry()` factory
-- [useListPairs](/reference/react/useListPairs) — React hook for paginated pair listing
-- [useConfidentialTokenAddress](/reference/react/useConfidentialTokenAddress) — React hook for forward lookup
-- [useTokenAddress](/reference/react/useTokenAddress) — React hook for reverse lookup
-- [useIsConfidentialTokenValid](/reference/react/useIsConfidentialTokenValid) — React hook for validity check
-- [Contract Builders](/reference/sdk/contract-builders) — low-level registry builders
-- [Network Presets](/reference/sdk/network-presets) — built-in chain configurations
+- [ZamaSDK](./ZamaSDK.md) — `sdk.registry` shared instance and `createWrappersRegistry()` factory
+- [useListPairs](../react/useListPairs.md) — React hook for paginated pair listing
+- [useConfidentialTokenAddress](../react/useConfidentialTokenAddress.md) — React hook for forward lookup
+- [useTokenAddress](../react/useTokenAddress.md) — React hook for reverse lookup
+- [useIsConfidentialTokenValid](../react/useIsConfidentialTokenValid.md) — React hook for validity check
+- [Contract Builders](./contract-builders.md) — low-level registry builders
+- [Network Presets](./network-presets.md) — built-in chain configurations

--- a/docs/gitbook/src/reference/sdk/ZamaSDK.md
+++ b/docs/gitbook/src/reference/sdk/ZamaSDK.md
@@ -362,7 +362,7 @@ emitter.on(
 {% endtabs %}
 
 {% hint style="info" %}
-This is the SDK-level entry point for user decryption — a single method that takes a list of value/contract **pairs** and decrypts them with the connected wallet's credentials (the Zama glossary splits this into `decryptValue`/`decryptValues`/`decryptValuesFromPairs`; the SDK intentionally exposes just one). It is distinct from `decryptPublicValues` (gateway-level decryption that happens on-chain without user authentication). In React, use [`useDecryptValues`](/reference/react/useDecryptValues) which wraps `sdk.decryption.decryptValues` with TanStack Query semantics.
+This is the SDK-level entry point for user decryption — a single method that takes a list of value/contract **pairs** and decrypts them with the connected wallet's credentials (the Zama glossary splits this into `decryptValue`/`decryptValues`/`decryptValuesFromPairs`; the SDK intentionally exposes just one). It is distinct from `decryptPublicValues` (gateway-level decryption that happens on-chain without user authentication). In React, use [`useDecryptValues`](../react/useDecryptValues.md) which wraps `sdk.decryption.decryptValues` with TanStack Query semantics.
 {% endhint %}
 
 ### onWalletAccountChange
@@ -408,7 +408,7 @@ await sdk.permits.clear();
 - `isActive({ contractAddress, delegatorAddress, delegateAddress })`
 - `getExpiry({ contractAddress, delegatorAddress, delegateAddress })`
 
-See the [Delegations reference](/reference/sdk/delegation) for the full API and propagation notes.
+See the [Delegations reference](./delegation.md) for the full API and propagation notes.
 
 ### dispose
 
@@ -432,7 +432,7 @@ sdk.terminate();
 
 ## Related
 
-- [Token](/reference/sdk/Token) — read/write token operations
-- [WrappedToken](/reference/sdk/WrappedToken) — ERC-7984 ERC-20 wrapper operations (shield, unshield, allowance)
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) — on-chain token wrappers registry
-- [Configuration guide](/guides/configuration) — relayer, signer, and storage setup
+- [Token](./Token.md) — read/write token operations
+- [WrappedToken](./WrappedToken.md) — ERC-7984 ERC-20 wrapper operations (shield, unshield, allowance)
+- [WrappersRegistry](./WrappersRegistry.md) — on-chain token wrappers registry
+- [Configuration guide](../../guides/configuration.md) — relayer, signer, and storage setup

--- a/docs/gitbook/src/reference/sdk/contract-builders.md
+++ b/docs/gitbook/src/reference/sdk/contract-builders.md
@@ -22,7 +22,7 @@ type WriteContractConfig = ReadContractConfig & {
 ```
 
 {% hint style="warning" %}
-The [Token API](/reference/sdk/Token) (`shield`, `unshield`, `confidentialTransfer`, etc.) handles contract calls, encryption, and multi-step flows for you. Use builders only when you need raw contract-level control — custom transaction pipelines, batching, or integrating with systems that expect ABI-encoded call data.
+The [Token API](./Token.md) (`shield`, `unshield`, `confidentialTransfer`, etc.) handles contract calls, encryption, and multi-step flows for you. Use builders only when you need raw contract-level control — custom transaction pipelines, batching, or integrating with systems that expect ABI-encoded call data.
 {% endhint %}
 
 ## Import
@@ -123,7 +123,7 @@ Use `totalSupplyQueryOptions` / React `useTotalSupply` for cached reads — they
 | `isConfidentialTokenValidContract(registry, confidentialToken)` | Check if a confidential token is valid in the registry |
 
 {% hint style="info" %}
-The [WrappersRegistry class](/reference/sdk/WrappersRegistry) wraps these builders with automatic address resolution. Use builders only when you need raw contract-level control.
+The [WrappersRegistry class](./WrappersRegistry.md) wraps these builders with automatic address resolution. Use builders only when you need raw contract-level control.
 {% endhint %}
 
 ## Delegation
@@ -187,5 +187,5 @@ All builders validate addresses at call time. A malformed address throws immedia
 
 ## Related
 
-- [Token](/reference/sdk/Token) — high-level API that wraps these builders
-- [Event Decoders](/reference/sdk/event-decoders) — decode on-chain logs into typed events
+- [Token](./Token.md) — high-level API that wraps these builders
+- [Event Decoders](./event-decoders.md) — decode on-chain logs into typed events

--- a/docs/gitbook/src/reference/sdk/delegation.md
+++ b/docs/gitbook/src/reference/sdk/delegation.md
@@ -226,7 +226,7 @@ See [Event Decoders](./event-decoders.md#acl-delegation-events) for the full lis
 
 - [Delegated decryption guide](../../guides/delegated-decryption.md) — step-by-step walkthrough
 - [Token.decryptBalanceAs](./Token.md#decryptbalanceas) — decrypt a delegator's balance
-- [Token.batchDecryptBalancesAs](./Token.md#batchdecryptbalancesas-static) — batch delegated decryption
+- [Token.batchDecryptBalancesAs](./Token.md#token-batchdecryptbalancesas-static) — batch delegated decryption
 - [Contract builders](./contract-builders.md#delegation) — low-level ACL delegation builders
 - [useDelegateDecryption](../react/useDelegateDecryption.md) — React hook to grant delegation
 - [useRevokeDelegation](../react/useRevokeDelegation.md) — React hook to revoke delegation

--- a/docs/gitbook/src/reference/sdk/delegation.md
+++ b/docs/gitbook/src/reference/sdk/delegation.md
@@ -7,7 +7,7 @@ description: On-chain delegation management — grant, revoke, and query decrypt
 
 `sdk.delegations` manages on-chain decryption delegation through the ACL contract. The delegate never receives the delegator's private keys — they sign with their own wallet, and the relayer verifies the on-chain delegation.
 
-For a step-by-step walkthrough, see the [Delegated decryption](/guides/delegated-decryption) guide.
+For a step-by-step walkthrough, see the [Delegated decryption](../../guides/delegated-decryption.md) guide.
 
 ## Import
 
@@ -171,7 +171,7 @@ A delegation between `(delegator, delegate, contract)` can be in one of four sta
 | **Expired**   | Past non-zero timestamp  | `isActive()` returns `false`, `getExpiry()` returns a non-zero past value                                               |
 | **Revoked**   | `0n` (reset by contract) | Indistinguishable from **never set** via state reads — use `RevokedDelegationForUserDecryption` events to differentiate |
 
-The ACL contract resets the expiry to `0n` on revocation, so `DelegationNotFoundError` covers both the never-set and revoked cases. To distinguish them, query `RevokedDelegationForUserDecryption` events using the [ACL event decoders](/reference/sdk/event-decoders#acl-delegation-events).
+The ACL contract resets the expiry to `0n` on revocation, so `DelegationNotFoundError` covers both the never-set and revoked cases. To distinguish them, query `RevokedDelegationForUserDecryption` events using the [ACL event decoders](./event-decoders.md#acl-delegation-events).
 
 ## Low-level contract builders
 
@@ -185,7 +185,7 @@ const isDelegated = await publicClient.readContract(
 );
 ```
 
-See [Contract Builders](/reference/sdk/contract-builders#delegation) for the full list.
+See [Contract Builders](./contract-builders.md#delegation) for the full list.
 
 ## On-chain delegation events
 
@@ -220,16 +220,16 @@ if (delegated) {
 }
 ```
 
-See [Event Decoders](/reference/sdk/event-decoders#acl-delegation-events) for the full list of ACL event decoders.
+See [Event Decoders](./event-decoders.md#acl-delegation-events) for the full list of ACL event decoders.
 
 ## Related
 
-- [Delegated decryption guide](/guides/delegated-decryption) — step-by-step walkthrough
-- [Token.decryptBalanceAs](/reference/sdk/Token#decryptbalanceas) — decrypt a delegator's balance
-- [Token.batchDecryptBalancesAs](/reference/sdk/Token#batchdecryptbalancesas-static) — batch delegated decryption
-- [Contract builders](/reference/sdk/contract-builders#delegation) — low-level ACL delegation builders
-- [useDelegateDecryption](/reference/react/useDelegateDecryption) — React hook to grant delegation
-- [useRevokeDelegation](/reference/react/useRevokeDelegation) — React hook to revoke delegation
-- [useDelegationStatus](/reference/react/useDelegationStatus) — React hook to query delegation status
-- [useDecryptBalanceAs](/reference/react/useDecryptBalanceAs) — React hook to decrypt as a delegate
-- [useBatchDecryptBalancesAs](/reference/react/useBatchDecryptBalancesAs) — React hook for batch delegation decryption
+- [Delegated decryption guide](../../guides/delegated-decryption.md) — step-by-step walkthrough
+- [Token.decryptBalanceAs](./Token.md#decryptbalanceas) — decrypt a delegator's balance
+- [Token.batchDecryptBalancesAs](./Token.md#batchdecryptbalancesas-static) — batch delegated decryption
+- [Contract builders](./contract-builders.md#delegation) — low-level ACL delegation builders
+- [useDelegateDecryption](../react/useDelegateDecryption.md) — React hook to grant delegation
+- [useRevokeDelegation](../react/useRevokeDelegation.md) — React hook to revoke delegation
+- [useDelegationStatus](../react/useDelegationStatus.md) — React hook to query delegation status
+- [useDecryptBalanceAs](../react/useDecryptBalanceAs.md) — React hook to decrypt as a delegate
+- [useBatchDecryptBalancesAs](../react/useBatchDecryptBalancesAs.md) — React hook for batch delegation decryption

--- a/docs/gitbook/src/reference/sdk/errors.md
+++ b/docs/gitbook/src/reference/sdk/errors.md
@@ -526,7 +526,7 @@ matchZamaError(error, {
 **How to handle:** Wait for the ACL contract to be unpaused. This is an operator-level action — contact the protocol team if this persists.
 
 {% hint style="info" %}
-The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses on `delegateDecryption` and `revokeDelegation`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation error reference](./delegation.md#on-chain-revert-errors) for the full mapping.
+The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses on `delegateDecryption` and `revokeDelegation`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation method reference](./delegation.md#methods) for the full mapping.
 {% endhint %}
 
 ## Common problems

--- a/docs/gitbook/src/reference/sdk/errors.md
+++ b/docs/gitbook/src/reference/sdk/errors.md
@@ -526,7 +526,7 @@ matchZamaError(error, {
 **How to handle:** Wait for the ACL contract to be unpaused. This is an operator-level action — contact the protocol team if this persists.
 
 {% hint style="info" %}
-The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses on `delegateDecryption` and `revokeDelegation`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation error reference](/reference/sdk/delegation#on-chain-revert-errors) for the full mapping.
+The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses on `delegateDecryption` and `revokeDelegation`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation error reference](./delegation.md#on-chain-revert-errors) for the full mapping.
 {% endhint %}
 
 ## Common problems
@@ -547,5 +547,5 @@ The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError
 
 ## Related
 
-- [Error handling guide](/guides/handle-errors) — practical patterns for catching and displaying errors
-- [ZamaSDK](/reference/sdk/ZamaSDK) — SDK constructor and permit management
+- [Error handling guide](../../guides/handle-errors.md) — practical patterns for catching and displaying errors
+- [ZamaSDK](./ZamaSDK.md) — SDK constructor and permit management

--- a/docs/gitbook/src/reference/sdk/event-decoders.md
+++ b/docs/gitbook/src/reference/sdk/event-decoders.md
@@ -226,5 +226,5 @@ ACL delegation events are **not** included in `TOKEN_TOPICS` or `decodeOnChainEv
 
 ## Related
 
-- [Delegated Decryption](/reference/sdk/delegation) — delegation API with on-chain event examples
-- [Token](/reference/sdk/Token) — high-level API for token operations
+- [Delegated Decryption](./delegation.md) — delegation API with on-chain event examples
+- [Token](./Token.md) — high-level API for token operations

--- a/docs/gitbook/src/reference/sdk/network-presets.md
+++ b/docs/gitbook/src/reference/sdk/network-presets.md
@@ -148,7 +148,7 @@ import { sepolia, mainnet } from "@zama-fhe/sdk/chains";
 
 ## DefaultRegistryAddresses
 
-A convenience export of built-in registry addresses for known chains (Mainnet, Sepolia, Hoodi) as a `Record<number, Address>` map. Used internally by the [WrappersRegistry](/reference/sdk/WrappersRegistry) class.
+A convenience export of built-in registry addresses for known chains (Mainnet, Sepolia, Hoodi) as a `Record<number, Address>` map. Used internally by the [WrappersRegistry](./WrappersRegistry.md) class.
 
 ```ts
 import { DefaultRegistryAddresses } from "@zama-fhe/sdk";
@@ -158,11 +158,11 @@ console.log(DefaultRegistryAddresses);
 ```
 
 {% hint style="info" %}
-`hardhat` has no registry address by default. Pass one via `registryAddresses` when creating a [WrappersRegistry](/reference/sdk/WrappersRegistry), or set `registryAddress` on the chain definition.
+`hardhat` has no registry address by default. Pass one via `registryAddresses` when creating a [WrappersRegistry](./WrappersRegistry.md), or set `registryAddress` on the chain definition.
 {% endhint %}
 
 ## Related
 
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) — high-level registry query API
-- [Configuration guide](/guides/configuration) — full chains, relayers, signer, and storage setup
-- [ZamaSDK](/reference/sdk/ZamaSDK) — SDK constructor reference
+- [WrappersRegistry](./WrappersRegistry.md) — high-level registry query API
+- [Configuration guide](../../guides/configuration.md) — full chains, relayers, signer, and storage setup
+- [ZamaSDK](./ZamaSDK.md) — SDK constructor reference

--- a/docs/gitbook/src/tutorials/first-confidential-dapp.md
+++ b/docs/gitbook/src/tutorials/first-confidential-dapp.md
@@ -80,7 +80,7 @@ export const WRAPPER_ADDRESS = "0xYourWrapperAddress" as const;
 {% endtab %}
 {% endtabs %}
 
-Replace `YOUR_KEY` with your Infura (or Alchemy) project ID, and update the relayer URL to point at your backend proxy. See the [Authentication guide](/guides/authentication) for proxy setup details.
+Replace `YOUR_KEY` with your Infura (or Alchemy) project ID, and update the relayer URL to point at your backend proxy. See the [Authentication guide](../guides/authentication.md) for proxy setup details.
 
 ## 4. Create the App layout with providers
 
@@ -295,11 +295,11 @@ export function UnshieldForm() {
 {% endtab %}
 {% endtabs %}
 
-See [Hooks > useUnshield](/reference/react/useUnshield) for the full callback reference.
+See [Hooks > useUnshield](../reference/react/useUnshield.md) for the full callback reference.
 
 ## 9. Add error handling
 
-Create `src/ErrorMessage.tsx`. The `matchZamaError` utility maps SDK error codes to user-friendly messages without long `instanceof` chains. See [Error Handling](/guides/handle-errors) for the full list of error codes.
+Create `src/ErrorMessage.tsx`. The `matchZamaError` utility maps SDK error codes to user-friendly messages without long `instanceof` chains. See [Error Handling](../guides/handle-errors.md) for the full list of error codes.
 
 {% tabs %}
 {% tab title="src/ErrorMessage.tsx" %}
@@ -375,7 +375,7 @@ Open the app in your browser, connect your wallet, and try the full flow: shield
 
 ## Next steps
 
-- [Configuration](/guides/configuration) -- customize authentication, storage backends, and network presets
-- [Error Handling](/guides/handle-errors) -- handle every SDK error type
-- [React Hooks](/reference/react/query-keys) -- explore all available hooks
-- [Core SDK](/reference/sdk/ZamaSDK) -- use the imperative API for non-React apps
+- [Configuration](../guides/configuration.md) -- customize authentication, storage backends, and network presets
+- [Error Handling](../guides/handle-errors.md) -- handle every SDK error type
+- [React Hooks](../reference/react/query-keys.md) -- explore all available hooks
+- [Core SDK](../reference/sdk/ZamaSDK.md) -- use the imperative API for non-React apps

--- a/docs/gitbook/src/tutorials/quick-start.md
+++ b/docs/gitbook/src/tutorials/quick-start.md
@@ -31,7 +31,7 @@ const mySepolia = {
 } as const satisfies FheChain;
 ```
 
-See [Authentication](/guides/authentication) for a backend proxy example.
+See [Authentication](../guides/authentication.md) for a backend proxy example.
 
 ## Install
 
@@ -253,7 +253,7 @@ const sdk = new ZamaSDK(config);
 {% endtabs %}
 
 {% hint style="info" %}
-**FHE artifact caching** — Both `web()` and `node()` relayers automatically cache the multi-MB FHE public key and parameters so they are not re-downloaded on every startup. Browser uses IndexedDB (persists across reloads), Node.js uses in-memory storage (lost on restart). The cache revalidates against the CDN every 24 hours. Configure via the relayer options in the second argument. See [FheArtifactCache](/reference/sdk/FheArtifactCache) for details.
+**FHE artifact caching** — Both `web()` and `node()` relayers automatically cache the multi-MB FHE public key and parameters so they are not re-downloaded on every startup. Browser uses IndexedDB (persists across reloads), Node.js uses in-memory storage (lost on restart). The cache revalidates against the CDN every 24 hours. Configure via the relayer options in the second argument. See [FheArtifactCache](../reference/sdk/FheArtifactCache.md) for details.
 {% endhint %}
 
 ## Your first confidential transfer
@@ -440,8 +440,8 @@ The hooks and SDK methods handle FHE encryption, wallet signing, ERC-20 approval
 
 ## Next steps
 
-- [Configuration](/guides/configuration) -- chains, relayers, provider, signer, storage, and authentication setup
-- [Shield Tokens](/guides/shield-tokens) -- move tokens into confidential form
-- [Chain Objects](/reference/sdk/network-presets) -- pre-configured chain definitions for Sepolia, Mainnet, and more
-- [React Hooks](/reference/react/ZamaProvider) -- provider setup and all available hooks
-- [Security Model](/concepts/security-model) -- understand the cryptography and trust assumptions
+- [Configuration](../guides/configuration.md) -- chains, relayers, provider, signer, storage, and authentication setup
+- [Shield Tokens](../guides/shield-tokens.md) -- move tokens into confidential form
+- [Chain Objects](../reference/sdk/network-presets.md) -- pre-configured chain definitions for Sepolia, Mainnet, and more
+- [React Hooks](../reference/react/ZamaProvider.md) -- provider setup and all available hooks
+- [Security Model](../concepts/security-model.md) -- understand the cryptography and trust assumptions

--- a/docs/gitbook/src/tutorials/wallet-exchange-integration.md
+++ b/docs/gitbook/src/tutorials/wallet-exchange-integration.md
@@ -17,7 +17,7 @@ By the end of this guide, you will be able to:
 
 ## Core concepts
 
-While building support for [ERC-7984 confidential tokens](https://eips.ethereum.org/EIPS/eip-7984) you will encounter the following terminology. For a deeper architectural overview, see [Architecture](/concepts/architecture).
+While building support for [ERC-7984 confidential tokens](https://eips.ethereum.org/EIPS/eip-7984) you will encounter the following terminology. For a deeper architectural overview, see [Architecture](../concepts/architecture.md).
 
 - **FHEVM** — Zama's library for computations on encrypted values. Each **encrypted value** is represented on-chain as a `bytes32` reference (also called a "handle" in Solidity / FHE.sol).
 - **Host chain** — the EVM network your users connect to (e.g. Ethereum mainnet, Sepolia).
@@ -32,15 +32,15 @@ While building support for [ERC-7984 confidential tokens](https://eips.ethereum.
 
 You do **not** need to run FHE infrastructure to integrate. Wallets and exchanges interact with the protocol entirely through the Zama SDK:
 
-1. Install and configure `@zama-fhe/sdk` (or `@zama-fhe/react-sdk` for React apps). See [Quick start](/tutorials/quick-start) for stack-by-stack setup.
-2. Initialize a `ZamaSDK` instance with a relayer, signer, and storage. See the [`ZamaSDK` reference](/reference/sdk/ZamaSDK).
+1. Install and configure `@zama-fhe/sdk` (or `@zama-fhe/react-sdk` for React apps). See [Quick start](./quick-start.md) for stack-by-stack setup.
+2. Initialize a `ZamaSDK` instance with a relayer, signer, and storage. See the [`ZamaSDK` reference](../reference/sdk/ZamaSDK.md).
 3. For each confidential token contract, build a `Token` handle via `sdk.createToken(address)`.
 4. Read encrypted balances, build transfers, and manage operators using the `Token` API or React hooks.
 
 ## What wallets and exchanges should support
 
-- **Transfers**: Support the ERC-7984 transfer variants documented by OpenZeppelin, including forms that use an input proof and optional receiver callbacks. The SDK's [`Token.confidentialTransfer`](/reference/sdk/Token) and [`useConfidentialTransfer`](/reference/react/useConfidentialTransfer) handle the encrypted input pipeline for you. See [Transfer privately](/guides/transfer-privately).
-- **Operators**: Operators can move any amount during an active window. UX must capture an expiry, show risk clearly, and make revoke easy. See [Operator approvals](/guides/operator-approvals).
+- **Transfers**: Support the ERC-7984 transfer variants documented by OpenZeppelin, including forms that use an input proof and optional receiver callbacks. The SDK's [`Token.confidentialTransfer`](../reference/sdk/Token.md) and [`useConfidentialTransfer`](../reference/react/useConfidentialTransfer.md) handle the encrypted input pipeline for you. See [Transfer privately](../guides/transfer-privately.md).
+- **Operators**: Operators can move any amount during an active window. UX must capture an expiry, show risk clearly, and make revoke easy. See [Operator approvals](../guides/operator-approvals.md).
 - **Events and metadata**: Names and symbols behave like conventional ERC-20s, but on-chain amounts remain encrypted. Render user-specific amounts only after user-decrypting them.
 
 ## Display confidential balances
@@ -102,7 +102,7 @@ function Balance() {
 {% endtab %}
 {% endtabs %}
 
-A common pattern is to call `useGrantPermit` once when the user first connects (covering every confidential contract you'll touch), then read balances anywhere in the app without further prompts. Credentials persist in IndexedDB and survive page reloads. See [Encrypt & decrypt](/guides/encrypt-decrypt) for the full pre-authorization pattern, and [Check balances](/guides/check-balances) for batch decryption across multiple tokens.
+A common pattern is to call `useGrantPermit` once when the user first connects (covering every confidential contract you'll touch), then read balances anywhere in the app without further prompts. Credentials persist in IndexedDB and survive page reloads. See [Encrypt & decrypt](../guides/encrypt-decrypt.md) for the full pre-authorization pattern, and [Check balances](../guides/check-balances.md) for batch decryption across multiple tokens.
 
 ## Send a confidential transfer
 
@@ -128,7 +128,7 @@ mutate({ to: "0xRecipient", amount: 500n });
 {% endtab %}
 {% endtabs %}
 
-For operator transfers (`transferFrom`-style with delegated authority), see [`useConfidentialTransferFrom`](/reference/react/useConfidentialTransferFrom) and [Operator approvals](/guides/operator-approvals).
+For operator transfers (`transferFrom`-style with delegated authority), see [`useConfidentialTransferFrom`](../reference/react/useConfidentialTransferFrom.md) and [Operator approvals](../guides/operator-approvals.md).
 
 ## Wrapping and unwrapping
 
@@ -149,7 +149,7 @@ In all cases, the user sees a single unified balance for the underlying asset.
 
 ### Shield (wrap)
 
-`WrappedToken.shield` wraps a standard ERC-20 into its ERC-7984 form. The SDK handles the wrapping flow internally — using `transferAndCall` for ERC-1363 underlyings (one transaction) or `approve` + `wrap` for everything else (two transactions) — plus decimal conversion. The encrypted balance lands in the recipient's address (defaulting to the connected wallet). See [Shielding paths](/guides/shield-tokens#shielding-paths) for which currently-wrapped tokens use which path.
+`WrappedToken.shield` wraps a standard ERC-20 into its ERC-7984 form. The SDK handles the wrapping flow internally — using `transferAndCall` for ERC-1363 underlyings (one transaction) or `approve` + `wrap` for everything else (two transactions) — plus decimal conversion. The encrypted balance lands in the recipient's address (defaulting to the connected wallet). See [Shielding paths](../guides/shield-tokens.md#shielding-paths) for which currently-wrapped tokens use which path.
 
 {% tabs %}
 {% tab title="SDK" %}
@@ -180,7 +180,7 @@ mutate({ amount: 1000n });
 {% endtab %}
 {% endtabs %}
 
-See [Shield tokens](/guides/shield-tokens) for the full options surface, including custom approval strategies and progress callbacks.
+See [Shield tokens](../guides/shield-tokens.md) for the full options surface, including custom approval strategies and progress callbacks.
 
 ### Unshield (unwrap)
 
@@ -218,7 +218,7 @@ mutate({ amount: 500n });
 {% endtab %}
 {% endtabs %}
 
-If the user closes the page between unwrap and finalize, resume with `WrappedToken.resumeUnshield` / [`useResumeUnshield`](/reference/react/useResumeUnshield). See [Unshield tokens](/guides/unshield-tokens) for the full flow.
+If the user closes the page between unwrap and finalize, resume with `WrappedToken.resumeUnshield` / [`useResumeUnshield`](../reference/react/useResumeUnshield.md). See [Unshield tokens](../guides/unshield-tokens.md) for the full flow.
 
 ### Decimal conversion in your UI
 
@@ -236,7 +236,7 @@ Display balances in the underlying asset's decimals when possible — your users
 
 The Confidential Token Wrappers Registry is an on-chain contract that maps ERC-20s to their ERC-7984 wrappers. It's the canonical directory for wallets and exchanges to discover which underlying tokens have official confidential wrappers.
 
-The SDK exposes it via `sdk.registry`. See the [`WrappersRegistry` reference](/reference/sdk/WrappersRegistry) for the full surface.
+The SDK exposes it via `sdk.registry`. See the [`WrappersRegistry` reference](../reference/sdk/WrappersRegistry.md) for the full surface.
 
 {% hint style="warning" %}
 **Always check validity.** A non-zero wrapper address may have been revoked. Treat `isValid: false` as no wrapper for that token.
@@ -333,26 +333,26 @@ Look up the underlying ERC-20 for each via `sdk.registry.getUnderlyingToken(addr
 
 ## End-to-end example
 
-For a runnable React dApp using these APIs end-to-end, follow [Build your first confidential dApp](/tutorials/first-confidential-dapp).
+For a runnable React dApp using these APIs end-to-end, follow [Build your first confidential dApp](./first-confidential-dapp.md).
 
 ## UI and UX recommendations
 
 - **Caching**: Decrypted values are cached client-side for the session lifetime. Offer a refresh action that repeats the decrypt flow.
-- **Permissions**: Treat user decryption as a permission grant with scope and duration. Show which contracts are included and when access expires. The SDK's session model is described in [Session model](/concepts/session-model).
+- **Permissions**: Treat user decryption as a permission grant with scope and duration. Show which contracts are included and when access expires. The SDK's permit model is described in [Permit model](../concepts/permit-model.md).
 - **Indicators**: Use distinct icons or badges for encrypted amounts. Avoid showing zero when a value is simply undisclosed.
-- **Operator visibility**: Always show current operator approvals with expiry and a one-tap revoke. See [`useConfidentialIsApproved`](/reference/react/useConfidentialIsApproved) and [`useRevoke`](/reference/react/useRevoke).
+- **Operator visibility**: Always show current operator approvals with expiry and a one-tap revoke. See [`useConfidentialIsOperator`](../reference/react/useConfidentialIsOperator.md) and [`useRevokePermits`](../reference/react/useRevokePermits.md).
 - **Wrapping/unwrapping**: Clearly indicate which token a user is converting between. Show the underlying ERC-20's name and symbol alongside the confidential token.
-- **Failure modes**: Differentiate between decryption denied, missing ACL grant, and expired session. Offer guided recovery actions. See [Handle errors](/guides/handle-errors).
+- **Failure modes**: Differentiate between decryption denied, missing ACL grant, and expired session. Offer guided recovery actions. See [Handle errors](../guides/handle-errors.md).
 
 ## Testing and environments
 
-- For local development against a Hardhat chain with no relayer, use [`RelayerCleartext`](/reference/sdk/RelayerCleartext). See [Local development](/guides/local-development).
-- For testnet, use the SDK's built-in Sepolia config or any other supported network — see [Network presets](/reference/sdk/network-presets).
+- For local development against a Hardhat chain with no relayer, use [`RelayerCleartext`](../reference/sdk/RelayerCleartext.md). See [Local development](../guides/local-development.md).
+- For testnet, use the SDK's built-in Sepolia config or any other supported network — see [Network presets](../reference/sdk/network-presets.md).
 - Keep chain selection in a single source of truth in your app.
 
 ## Further reading
 
 - [OpenZeppelin Confidential Contracts documentation](https://docs.openzeppelin.com/confidential-contracts) — ERC-7984 transfer variants, receiver callbacks, and operator semantics.
-- [`Token` reference](/reference/sdk/Token) — full method surface for shield, unshield, transfer, approve, and balance operations.
-- [`WrappersRegistry` reference](/reference/sdk/WrappersRegistry) — registry construction, caching, and pagination.
-- [Architecture](/concepts/architecture) — how the SDK, relayer, and gateway fit together.
+- [`Token` reference](../reference/sdk/Token.md) — full method surface for shield, unshield, transfer, approve, and balance operations.
+- [`WrappersRegistry` reference](../reference/sdk/WrappersRegistry.md) — registry construction, caching, and pagination.
+- [Architecture](../concepts/architecture.md) — how the SDK, relayer, and gateway fit together.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7093,7 +7093,7 @@ matchZamaError(error, {
 
 
 > [!INFO]
-> The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses on `delegateDecryption` and `revokeDelegation`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation error reference](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/sdk/delegation.md#on-chain-revert-errors) for the full mapping.
+> The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses on `delegateDecryption` and `revokeDelegation`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation method reference](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/sdk/delegation.md#methods) for the full mapping.
 
 
 ## Common problems
@@ -8020,7 +8020,7 @@ See [Event Decoders](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/git
 
 - [Delegated decryption guide](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/guides/delegated-decryption.md) — step-by-step walkthrough
 - [Token.decryptBalanceAs](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/sdk/Token.md#decryptbalanceas) — decrypt a delegator's balance
-- [Token.batchDecryptBalancesAs](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/sdk/Token.md#batchdecryptbalancesas-static) — batch delegated decryption
+- [Token.batchDecryptBalancesAs](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/sdk/Token.md#token-batchdecryptbalancesas-static) — batch delegated decryption
 - [Contract builders](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/sdk/contract-builders.md#delegation) — low-level ACL delegation builders
 - [useDelegateDecryption](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/react/useDelegateDecryption.md) — React hook to grant delegation
 - [useRevokeDelegation](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/react/useRevokeDelegation.md) — React hook to revoke delegation
@@ -10877,7 +10877,7 @@ The current status of the query. Prefer the boolean flags above for conditional 
 
 ## Related
 
-- [Avoid blind-sign wallet popups](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/guides/encrypt-decrypt.md#3-avoid-blind-sign-wallet-popups) -- gating balance queries to avoid blind-sign popups
+- [Avoid blind-sign wallet popups](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/guides/encrypt-decrypt.md#gating-useconfidentialbalance) -- gating balance queries to avoid blind-sign popups
 - [`useGrantPermit`](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/react/useGrantPermit.md) -- pre-authorize contracts with one wallet signature
 - [`useRevokePermits`](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/react/useRevokePermits.md) -- revoke permits
 - [Permit Model](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/concepts/permit-model.md) -- permit lifecycle and TTL configuration

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -68,8 +68,8 @@ TanStack Query-based hooks with cached decryption, automatic cache invalidation,
 
 ## Two packages, one import
 
-| Package                                                | Use when...                                                                   |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| Package                                                    | Use when...                                                                   |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | [`@zama-fhe/sdk`](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/sdk/ZamaSDK.md)              | You are building with vanilla TypeScript, Node.js, or any non-React framework |
 | [`@zama-fhe/react-sdk`](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/react/ZamaProvider.md) | You are building a React app (hooks and React-specific providers)             |
 
@@ -1278,9 +1278,9 @@ For a runnable React dApp using these APIs end-to-end, follow [Build your first 
 ## UI and UX recommendations
 
 - **Caching**: Decrypted values are cached client-side for the session lifetime. Offer a refresh action that repeats the decrypt flow.
-- **Permissions**: Treat user decryption as a permission grant with scope and duration. Show which contracts are included and when access expires. The SDK's session model is described in [Session model](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/concepts/session-model.md).
+- **Permissions**: Treat user decryption as a permission grant with scope and duration. Show which contracts are included and when access expires. The SDK's permit model is described in [Permit model](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/concepts/permit-model.md).
 - **Indicators**: Use distinct icons or badges for encrypted amounts. Avoid showing zero when a value is simply undisclosed.
-- **Operator visibility**: Always show current operator approvals with expiry and a one-tap revoke. See [`useConfidentialIsApproved`](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/react/useConfidentialIsApproved.md) and [`useRevoke`](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/react/useRevoke.md).
+- **Operator visibility**: Always show current operator approvals with expiry and a one-tap revoke. See [`useConfidentialIsOperator`](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/react/useConfidentialIsOperator.md) and [`useRevokePermits`](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/reference/react/useRevokePermits.md).
 - **Wrapping/unwrapping**: Clearly indicate which token a user is converting between. Show the underlying ERC-20's name and symbol alongside the confidential token.
 - **Failure modes**: Differentiate between decryption denied, missing ACL grant, and expired session. Offer guided recovery actions. See [Handle errors](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/guides/handle-errors.md).
 


### PR DESCRIPTION
Closes SDK-228. Sub-task of SDK-224. **Content-only link fixes for the prerelease GitBook space** — the link-checking tooling and mdbook removal are now separate stacked PRs.

## Problem

GitBook serves each space under a sub-path (`docs.zama.org/protocol/sdk/...`), so host-absolute internal links like `[RelayerWeb reference](/reference/sdk/RelayerWeb)` resolve against the site root, miss the space, and render as broken external GitHub URLs → page-not-found.

## Fix

- Converted **352 host-absolute internal links across 79 pages** to relative `.md` paths.
- 3 stale page retargets (`session-model`→`permit-model`, `useConfidentialIsApproved`→`useConfidentialIsOperator`, `useRevoke`→`useRevokePermits`).
- 3 stale heading-anchor fixes.
- Regenerated `llms-full.txt`.

## Stack (SDK-224)

1. **this PR — fix links (prerelease)**
2. [SDK-227] link-checking tooling (`docs:check-links` + lychee) — stacked on this
3. [SDK-225] remove mdbook (#439) — stacked on the tooling PR

The `main` equivalent is SDK-226 (separate PR off `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)