### PR TITLE
docs(gitbook): convert host-absolute internal links to relative [SDK-226]

### DIFF
--- a/docs/gitbook/src/concepts/security-model.md
+++ b/docs/gitbook/src/concepts/security-model.md
@@ -70,7 +70,7 @@ The FHE private key is encrypted with AES-256-GCM before being written to storag
 | Cipher        | AES-256-GCM                    |
 | IV            | 12 random bytes per encryption |
 
-The signature itself is never persisted. It lives only in the in-memory session map, cleared on page reload or revocation. See [Session Model](/concepts/session-model) for the full lifecycle.
+The signature itself is never persisted. It lives only in the in-memory session map, cleared on page reload or revocation. See [Session Model](./session-model.md) for the full lifecycle.
 
 ### Storage key privacy
 

--- a/docs/gitbook/src/concepts/session-model.md
+++ b/docs/gitbook/src/concepts/session-model.md
@@ -179,7 +179,7 @@ To solve this, pass `chromeSessionStorage` as the `sessionStorage` option. This 
 - Is shared across popup, background, and content script contexts.
 - Is automatically cleared when the browser closes.
 
-See the [Web Extensions guide](/guides/web-extensions) for the full setup.
+See the [Web Extensions guide](../guides/web-extensions.md) for the full setup.
 
 ## Security properties
 
@@ -191,4 +191,4 @@ See the [Web Extensions guide](/guides/web-extensions) for the full setup.
 | Storage key privacy     | Wallet addresses are SHA-256 hashed before use as storage keys            |
 | Plaintext exposure      | FHE private key exists in plaintext only during active decrypt operations |
 
-For the full threat model and trust assumptions, see the [Security Model](/concepts/security-model).
+For the full threat model and trust assumptions, see the [Security Model](./security-model.md).

--- a/docs/gitbook/src/guides/activity-feeds.md
+++ b/docs/gitbook/src/guides/activity-feeds.md
@@ -195,6 +195,6 @@ queryClient.invalidateQueries({
 
 ## Next steps
 
-- See [Event Decoders](/reference/sdk/event-decoders) for the event decoder API (`decodeOnChainEvents`, `TOKEN_TOPICS`, individual decoders).
-- See [Hooks](/reference/react/query-keys) for `useActivityFeed` details and query key reference.
+- See [Event Decoders](../reference/sdk/event-decoders.md) for the event decoder API (`decodeOnChainEvents`, `TOKEN_TOPICS`, individual decoders).
+- See [Hooks](../reference/react/query-keys.md) for `useActivityFeed` details and query key reference.
 - To handle decryption errors during feed building, see [Handle Errors](handle-errors.md).

--- a/docs/gitbook/src/guides/authentication.md
+++ b/docs/gitbook/src/guides/authentication.md
@@ -151,11 +151,11 @@ auth: { __type: "ApiKeyCookie", value: "your-api-key" }
 auth: { __type: "BearerToken", token: "your-jwt-token" }
 ```
 
-When using `RelayerWeb` with a proxy, you can also add CSRF protection via the `security.getCsrfToken` callback. See the [RelayerWeb reference](/reference/sdk/RelayerWeb) for details.
+When using `RelayerWeb` with a proxy, you can also add CSRF protection via the `security.getCsrfToken` callback. See the [RelayerWeb reference](../reference/sdk/RelayerWeb.md) for details.
 
 ## Next steps
 
-- [Configuration](/guides/configuration) — full relayer, signer, and storage setup
-- [Shield Tokens](/guides/shield-tokens) — start converting public tokens to confidential form
-- [RelayerWeb reference](/reference/sdk/RelayerWeb) — security options and multi-threading
-- [RelayerNode reference](/reference/sdk/RelayerNode) — Node.js-specific configuration
+- [Configuration](./configuration.md) — full relayer, signer, and storage setup
+- [Shield Tokens](./shield-tokens.md) — start converting public tokens to confidential form
+- [RelayerWeb reference](../reference/sdk/RelayerWeb.md) — security options and multi-threading
+- [RelayerNode reference](../reference/sdk/RelayerNode.md) — Node.js-specific configuration

--- a/docs/gitbook/src/guides/check-balances.md
+++ b/docs/gitbook/src/guides/check-balances.md
@@ -158,7 +158,7 @@ const { data: meta } = useMetadata("0xToken");
 // meta.name, meta.symbol, meta.decimals
 ```
 
-See [useMetadata reference](/reference/react/useMetadata) for full options.
+See [useMetadata reference](../reference/react/useMetadata.md) for full options.
 
 ### 8. Use the balance hooks in React
 
@@ -229,6 +229,6 @@ queryClient.invalidateQueries({
 
 ## Next steps
 
-- See [Token Operations](/reference/sdk/Token) for the full `Token.balanceOf` and `ReadonlyToken` API.
-- See [Hooks](/reference/react/query-keys) for `useConfidentialBalance`, `useConfidentialBalances`, and query key details.
+- See [Token Operations](../reference/sdk/Token.md) for the full `Token.balanceOf` and `ReadonlyToken` API.
+- See [Hooks](../reference/react/query-keys.md) for `useConfidentialBalance`, `useConfidentialBalances`, and query key details.
 - To handle `NoCiphertextError` and other failures, see [Handle Errors](handle-errors.md).

--- a/docs/gitbook/src/guides/configuration.md
+++ b/docs/gitbook/src/guides/configuration.md
@@ -21,7 +21,7 @@ The SDK ships two relayer implementations. Pick the one that matches your runtim
 `RelayerWeb` runs FHE inside a Web Worker using WASM. `RelayerNode` uses native worker threads.
 
 {% hint style="info" %}
-For local Hardhat nodes or custom testnets deployed in cleartext mode, use [`createCleartextRelayer`](/guides/local-development) instead — no KMS, no gateway, no WASM needed.
+For local Hardhat nodes or custom testnets deployed in cleartext mode, use [`createCleartextRelayer`](./local-development.md) instead — no KMS, no gateway, no WASM needed.
 {% endhint %}
 
 ### 2. Set up a signer
@@ -74,11 +74,11 @@ const signer = new WagmiSigner({ config: wagmiConfig });
 {% endtab %}
 {% endtabs %}
 
-For full type information, see the [ViemSigner](/reference/sdk/ViemSigner), [EthersSigner](/reference/sdk/EthersSigner), and [WagmiSigner](/reference/sdk/WagmiSigner) reference pages. You can also implement the [GenericSigner](/reference/sdk/GenericSigner) interface for a custom wallet integration.
+For full type information, see the [ViemSigner](../reference/sdk/ViemSigner.md), [EthersSigner](../reference/sdk/EthersSigner.md), and [WagmiSigner](../reference/sdk/WagmiSigner.md) reference pages. You can also implement the [GenericSigner](../reference/sdk/GenericSigner.md) interface for a custom wallet integration.
 
 ### 3. Configure the relayer
 
-The relayer needs a `getChainId` callback and a transport map. Use the built-in [network presets](/reference/sdk/network-presets) (`SepoliaConfig`, `MainnetConfig`, `HardhatConfig`) so you don't have to specify contract addresses manually. Each preset provides `chainId`, `relayerUrl`, `gatewayAddress`, `aclAddress`, and `kmsVerifierAddress` for its network.
+The relayer needs a `getChainId` callback and a transport map. Use the built-in [network presets](../reference/sdk/network-presets.md) (`SepoliaConfig`, `MainnetConfig`, `HardhatConfig`) so you don't have to specify contract addresses manually. Each preset provides `chainId`, `relayerUrl`, `gatewayAddress`, `aclAddress`, and `kmsVerifierAddress` for its network.
 
 {% tabs %}
 {% tab title="Browser (RelayerWeb)" %}
@@ -126,9 +126,9 @@ const relayer = new RelayerNode({
 {% endtab %}
 {% endtabs %}
 
-Browser apps should proxy relayer requests through a backend to keep the API key secret. See the [Authentication guide](/guides/authentication) for the full setup.
+Browser apps should proxy relayer requests through a backend to keep the API key secret. See the [Authentication guide](./authentication.md) for the full setup.
 
-For details on multi-threaded FHE and security options, see the [RelayerWeb](/reference/sdk/RelayerWeb) and [RelayerNode](/reference/sdk/RelayerNode) reference pages.
+For details on multi-threaded FHE and security options, see the [RelayerWeb](../reference/sdk/RelayerWeb.md) and [RelayerNode](../reference/sdk/RelayerNode.md) reference pages.
 
 ### 4. Choose a storage backend
 
@@ -146,7 +146,7 @@ import { indexedDBStorage, memoryStorage } from "@zama-fhe/sdk";
 // import { asyncLocalStorage } from "@zama-fhe/sdk/node";
 ```
 
-For full storage options see the [GenericStorage](/reference/sdk/GenericStorage) reference.
+For full storage options see the [GenericStorage](../reference/sdk/GenericStorage.md) reference.
 
 ### 5. Create the SDK instance
 
@@ -242,7 +242,7 @@ const sdk = new ZamaSDK({
 });
 ```
 
-Your `manifest.json` must include the `"storage"` permission. See the [Web Extensions guide](/guides/web-extensions) for manifest configuration, multi-context sharing, and browser close behavior.
+Your `manifest.json` must include the `"storage"` permission. See the [Web Extensions guide](./web-extensions.md) for manifest configuration, multi-context sharing, and browser close behavior.
 
 {% endtab %}
 {% endtabs %}
@@ -268,7 +268,7 @@ Setting `sessionTTL: 0` disables session caching entirely — every operation tr
 
 ## Next steps
 
-- [Authentication](/guides/authentication) — set up a backend proxy or use a direct API key
-- [Shield Tokens](/guides/shield-tokens) — convert public ERC-20 tokens into confidential form
-- [RelayerWeb reference](/reference/sdk/RelayerWeb) — multi-threading, security options, CDN configuration
-- [GenericStorage reference](/reference/sdk/GenericStorage) — custom storage implementations
+- [Authentication](./authentication.md) — set up a backend proxy or use a direct API key
+- [Shield Tokens](./shield-tokens.md) — convert public ERC-20 tokens into confidential form
+- [RelayerWeb reference](../reference/sdk/RelayerWeb.md) — multi-threading, security options, CDN configuration
+- [GenericStorage reference](../reference/sdk/GenericStorage.md) — custom storage implementations

--- a/docs/gitbook/src/guides/encrypt-decrypt.md
+++ b/docs/gitbook/src/guides/encrypt-decrypt.md
@@ -7,7 +7,7 @@ description: How to encrypt values and decrypt FHE ciphertext handles for custom
 
 The high-level token hooks (`useShield`, `useConfidentialTransfer`, `useConfidentialBalance`) handle encryption and decryption automatically for wrapped confidential ERC-20 tokens. This guide is for a different scenario: **your smart contract uses FHE types directly** (e.g. a confidential voting contract, a sealed-bid auction, or any non-token contract that stores `euint` values). In that case, you need `useEncrypt` and `useUserDecrypt` to interact with your contract's encrypted parameters and return values.
 
-Before starting, make sure your project is set up following the [Configuration](/guides/configuration) guide.
+Before starting, make sure your project is set up following the [Configuration](./configuration.md) guide.
 
 ## Example
 
@@ -121,7 +121,7 @@ export default defineConfig({
 {% endtab %}
 {% endtabs %}
 
-See [Configuration](/guides/configuration) for full setup instructions.
+See [Configuration](./configuration.md) for full setup instructions.
 {% endhint %}
 
 {% hint style="warning" %}

--- a/docs/gitbook/src/guides/handle-errors.md
+++ b/docs/gitbook/src/guides/handle-errors.md
@@ -187,6 +187,6 @@ When `matchZamaError` returns `undefined` (because the error is not a `ZamaError
 
 ## Next steps
 
-- See [Error types reference](/reference/sdk/errors) for the full error type reference.
-- See [Hooks](/reference/react/query-keys) for error handling patterns with React Query.
+- See [Error types reference](../reference/sdk/errors.md) for the full error type reference.
+- See [Hooks](../reference/react/query-keys.md) for error handling patterns with React Query.
 - For interrupted unshields specifically, see [Unshield Tokens](unshield-tokens.md).

--- a/docs/gitbook/src/guides/local-development.md
+++ b/docs/gitbook/src/guides/local-development.md
@@ -104,6 +104,6 @@ Usually, you want to use the same `gatewayChainId` and verifying contract addres
 
 ## Next steps
 
-- [RelayerCleartext reference](/reference/sdk/RelayerCleartext) — full constructor options and `CleartextConfig` type
-- [Configuration](/guides/configuration) — production setup with `RelayerWeb` or `RelayerNode`
-- [Network Presets](/reference/sdk/network-presets) — preset configs for Mainnet, Sepolia, and Hardhat
+- [RelayerCleartext reference](../reference/sdk/RelayerCleartext.md) — full constructor options and `CleartextConfig` type
+- [Configuration](./configuration.md) — production setup with `RelayerWeb` or `RelayerNode`
+- [Network Presets](../reference/sdk/network-presets.md) — preset configs for Mainnet, Sepolia, and Hardhat

--- a/docs/gitbook/src/guides/nextjs-ssr.md
+++ b/docs/gitbook/src/guides/nextjs-ssr.md
@@ -163,6 +163,6 @@ The server renders the page shell, and the `TokenBalance` client component hydra
 
 ## Next steps
 
-- [ZamaProvider](/reference/react/ZamaProvider) -- all provider props and configuration
-- [useConfidentialBalance](/reference/react/useConfidentialBalance) -- balance hook API reference
-- [Provider Setup](/guides/configuration) -- full examples for wagmi, viem, and ethers setups
+- [ZamaProvider](../reference/react/ZamaProvider.md) -- all provider props and configuration
+- [useConfidentialBalance](../reference/react/useConfidentialBalance.md) -- balance hook API reference
+- [Provider Setup](./configuration.md) -- full examples for wagmi, viem, and ethers setups

--- a/docs/gitbook/src/guides/node-js-backend.md
+++ b/docs/gitbook/src/guides/node-js-backend.md
@@ -110,7 +110,7 @@ await token.confidentialTransfer("0xRecipient", 500n);
 const balance = await token.balanceOf();
 ```
 
-See the [Token Operations](/reference/sdk/Token) reference for the full API.
+See the [Token Operations](../reference/sdk/Token.md) reference for the full API.
 
 ### 7. Use direct API key auth
 
@@ -148,6 +148,6 @@ process.on("SIGTERM", () => {
 
 ## Next steps
 
-- [RelayerNode](/reference/sdk/RelayerNode) -- full constructor options and pool behavior
-- [asyncLocalStorage](/reference/sdk/GenericStorage) -- the `GenericStorage` interface it implements
-- [Configuration](/guides/configuration) -- authentication options, network presets, and session management
+- [RelayerNode](../reference/sdk/RelayerNode.md) -- full constructor options and pool behavior
+- [asyncLocalStorage](../reference/sdk/GenericStorage.md) -- the `GenericStorage` interface it implements
+- [Configuration](./configuration.md) -- authentication options, network presets, and session management

--- a/docs/gitbook/src/guides/operator-approvals.md
+++ b/docs/gitbook/src/guides/operator-approvals.md
@@ -107,7 +107,7 @@ This is a distinct concern from transfer approval: approving an operator for tra
 
 ## Next steps
 
-- [Token.approve](/reference/sdk/Token) -- full method signature and options
-- [useConfidentialApprove](/reference/react/useConfidentialApprove) -- React hook reference
-- [useConfidentialIsApproved](/reference/react/useConfidentialIsApproved) -- query hook reference
-- [useConfidentialTransferFrom](/reference/react/useConfidentialTransferFrom) -- operator transfer hook reference
+- [Token.approve](../reference/sdk/Token.md) -- full method signature and options
+- [useConfidentialApprove](../reference/react/useConfidentialApprove.md) -- React hook reference
+- [useConfidentialIsApproved](../reference/react/useConfidentialIsApproved.md) -- query hook reference
+- [useConfidentialTransferFrom](../reference/react/useConfidentialTransferFrom.md) -- operator transfer hook reference

--- a/docs/gitbook/src/guides/shield-tokens.md
+++ b/docs/gitbook/src/guides/shield-tokens.md
@@ -11,7 +11,7 @@ Shielding converts public ERC-20 tokens into confidential tokens. The SDK handle
 
 ### 1. Create a token instance
 
-Start from a configured SDK instance (see [Configuration](/guides/configuration)) and create a token pointing at your encrypted ERC-20 contract.
+Start from a configured SDK instance (see [Configuration](./configuration.md)) and create a token pointing at your encrypted ERC-20 contract.
 
 Some deployments use a **wrapper contract** that is separate from the token contract itself. If your setup has a separate wrapper address, pass it as the second argument to `createToken` or as `wrapperAddress` in hooks. If the token _is_ the wrapper (single-contract deployments), you can omit it.
 
@@ -181,6 +181,6 @@ In React, balance caches are automatically invalidated after a successful shield
 
 ## Next steps
 
-- [Transfer Privately](/guides/transfer-privately) — send confidential tokens to another address
-- [Token.shield reference](/reference/sdk/Token#shield) — full API signature and options
-- [useShield reference](/reference/react/useShield) — React hook details
+- [Transfer Privately](./transfer-privately.md) — send confidential tokens to another address
+- [Token.shield reference](../reference/sdk/Token.md#shield) — full API signature and options
+- [useShield reference](../reference/react/useShield.md) — React hook details

--- a/docs/gitbook/src/guides/transfer-privately.md
+++ b/docs/gitbook/src/guides/transfer-privately.md
@@ -11,7 +11,7 @@ Confidential transfers encrypt the amount before it reaches the chain -- no one 
 
 ### 1. Create a token instance
 
-Start from a configured SDK instance (see [Configuration](/guides/configuration)) and create a token pointing at your encrypted ERC-20 contract:
+Start from a configured SDK instance (see [Configuration](./configuration.md)) and create a token pointing at your encrypted ERC-20 contract:
 
 {% tabs %}
 {% tab title="Core SDK" %}
@@ -192,11 +192,11 @@ function TransferForm() {
 }
 ```
 
-The `matchZamaError` helper maps SDK error codes to user-friendly messages. See the [Error Handling guide](/guides/handle-errors) for the full list of error types.
+The `matchZamaError` helper maps SDK error codes to user-friendly messages. See the [Error Handling guide](./handle-errors.md) for the full list of error types.
 
 ## Next steps
 
-- [Shield Tokens](/guides/shield-tokens) — convert public ERC-20 tokens into confidential form
-- [Token.confidentialTransfer reference](/reference/sdk/Token#confidentialtransfer) — full API signature
-- [useConfidentialTransfer reference](/reference/react/useConfidentialTransfer) — React hook details
-- [useConfidentialTransferFrom reference](/reference/react/useConfidentialTransferFrom) — operator transfer hook
+- [Shield Tokens](./shield-tokens.md) — convert public ERC-20 tokens into confidential form
+- [Token.confidentialTransfer reference](../reference/sdk/Token.md#confidentialtransfer) — full API signature
+- [useConfidentialTransfer reference](../reference/react/useConfidentialTransfer.md) — React hook details
+- [useConfidentialTransferFrom reference](../reference/react/useConfidentialTransferFrom.md) — operator transfer hook

--- a/docs/gitbook/src/guides/unshield-tokens.md
+++ b/docs/gitbook/src/guides/unshield-tokens.md
@@ -173,6 +173,6 @@ All mutation hooks automatically invalidate balance queries on success, so your 
 
 ## Next steps
 
-- See [Token Operations](/reference/sdk/Token) for the full `Token.unshield` and `Token.unshieldAll` API.
-- See [Hooks](/reference/react/query-keys) for `useUnshield`, `useUnshieldAll`, and `useResumeUnshield` details.
+- See [Token Operations](../reference/sdk/Token.md) for the full `Token.unshield` and `Token.unshieldAll` API.
+- See [Hooks](../reference/react/query-keys.md) for `useUnshield`, `useUnshieldAll`, and `useResumeUnshield` details.
 - If your unshield fails, see [Handle Errors](handle-errors.md) for troubleshooting `TransactionRevertedError` and related issues.

--- a/docs/gitbook/src/guides/web-extensions.md
+++ b/docs/gitbook/src/guides/web-extensions.md
@@ -76,5 +76,5 @@ This mirrors the default browser SDK behavior (in-memory session lost on tab clo
 
 ## Next steps
 
-- [GenericStorage](/reference/sdk/GenericStorage) -- implement a custom storage adapter for other extension APIs
-- [Session Model](/concepts/session-model) -- how keypair encryption, session signatures, and storage interact
+- [GenericStorage](../reference/sdk/GenericStorage.md) -- implement a custom storage adapter for other extension APIs
+- [Session Model](../concepts/session-model.md) -- how keypair encryption, session signatures, and storage interact

--- a/docs/gitbook/src/overview.md
+++ b/docs/gitbook/src/overview.md
@@ -45,10 +45,10 @@ TanStack Query-based hooks with cached decryption, automatic cache invalidation,
 
 ## Two packages, one import
 
-| Package                                                | Use when...                                                                   |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| [`@zama-fhe/sdk`](/reference/sdk/ZamaSDK)              | You are building with vanilla TypeScript, Node.js, or any non-React framework |
-| [`@zama-fhe/react-sdk`](/reference/react/ZamaProvider) | You are building a React app (includes everything from the core SDK)          |
+| Package                                                    | Use when...                                                                   |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [`@zama-fhe/sdk`](./reference/sdk/ZamaSDK.md)              | You are building with vanilla TypeScript, Node.js, or any non-React framework |
+| [`@zama-fhe/react-sdk`](./reference/react/ZamaProvider.md) | You are building a React app (includes everything from the core SDK)          |
 
 If you are using React, `@zama-fhe/react-sdk` re-exports most of the core SDK (hooks, providers, `RelayerWeb`, storage singletons). You still import signer adapters from their sub-paths (e.g. `@zama-fhe/sdk/viem`, `@zama-fhe/sdk/ethers`).
 
@@ -122,7 +122,7 @@ await token.confidentialTransfer("0xRecipient", 500n); // private send
 await token.unshield(500n); // withdraw back to public
 ```
 
-Ready to build? Jump to the [Quick start](/tutorials/quick-start) for a full working example with your stack.
+Ready to build? Jump to the [Quick start](./tutorials/quick-start.md) for a full working example with your stack.
 
 ## Help center
 

--- a/docs/gitbook/src/reference/react/ZamaProvider.md
+++ b/docs/gitbook/src/reference/react/ZamaProvider.md
@@ -142,5 +142,5 @@ Callback fired for SDK lifecycle events (keypair generation, signing, encryption
 
 ## Related
 
-- [Configuration guide](/guides/configuration)
-- [Session Model](/concepts/session-model)
+- [Configuration guide](../../guides/configuration.md)
+- [Session Model](../../concepts/session-model.md)

--- a/docs/gitbook/src/reference/react/query-keys.md
+++ b/docs/gitbook/src/reference/react/query-keys.md
@@ -105,7 +105,7 @@ On-chain wrappers registry queries.
 
 ### `decryptionKeys`
 
-Cached decrypted values. Populated by [`useUserDecrypt`](/reference/react/useUserDecrypt).
+Cached decrypted values. Populated by [`useUserDecrypt`](./useUserDecrypt.md).
 
 ```ts
 import { decryptionKeys } from "@zama-fhe/react-sdk";
@@ -143,5 +143,5 @@ queryClient.removeQueries({ queryKey: zamaQueryKeys.confidentialBalance.all });
 
 ## Related
 
-- [ZamaProvider](/reference/react/ZamaProvider) — provider setup and hook overview
-- [`useConfidentialBalance`](/reference/react/useConfidentialBalance) — the hook whose cache these keys control
+- [ZamaProvider](./ZamaProvider.md) — provider setup and hook overview
+- [`useConfidentialBalance`](./useConfidentialBalance.md) — the hook whose cache these keys control

--- a/docs/gitbook/src/reference/react/useActivityFeed.md
+++ b/docs/gitbook/src/reference/react/useActivityFeed.md
@@ -151,6 +151,6 @@ Array<{
 
 ## Related
 
-- [useConfidentialBalance](/reference/react/useConfidentialBalance) -- read the decrypted balance
-- [useMetadata](/reference/react/useMetadata) -- token name, symbol, decimals
-- [Query keys](/reference/react/query-keys) -- `zamaQueryKeys.activityFeed` for cache control
+- [useConfidentialBalance](./useConfidentialBalance.md) -- read the decrypted balance
+- [useMetadata](./useMetadata.md) -- token name, symbol, decimals
+- [Query keys](./query-keys.md) -- `zamaQueryKeys.activityFeed` for cache control

--- a/docs/gitbook/src/reference/react/useAllow.md
+++ b/docs/gitbook/src/reference/react/useAllow.md
@@ -7,7 +7,7 @@ description: Mutation hook that signs an EIP-712 message authorizing decryption 
 
 Mutation hook that signs an EIP-712 message authorizing decryption of confidential handles for a list of contract addresses. This is **not token-specific** — any contract that uses FHE-encrypted values (confidential tokens, DeFi vaults, games, etc.) can be authorized in a single wallet signature.
 
-Call this early (e.g. after wallet connect) so that [`useUserDecrypt`](/reference/react/useUserDecrypt) queries fire automatically without wallet popups. Automatically invalidates [`useIsAllowed`](/reference/react/useIsAllowed) queries on success.
+Call this early (e.g. after wallet connect) so that [`useUserDecrypt`](./useUserDecrypt.md) queries fire automatically without wallet popups. Automatically invalidates [`useIsAllowed`](./useIsAllowed.md) queries on success.
 
 {% hint style="warning" %}
 **Include all contracts you plan to decrypt.** `useUserDecrypt` checks that cached credentials cover every contract address in its `handles` before firing the query. If any contract is missing, the query stays disabled.
@@ -90,7 +90,7 @@ Returns a standard TanStack Query `UseMutationResult<void, Error, Address[]>`.
 
 ## Related
 
-- [`useIsAllowed`](/reference/react/useIsAllowed) -- check whether a session signature is cached
-- [`useRevoke`](/reference/react/useRevoke) -- revoke decrypt authorization for specific contracts
-- [`useRevokeSession`](/reference/react/useRevokeSession) -- revoke the entire session
-- [Session Model](/concepts/session-model) -- security model and TTL configuration
+- [`useIsAllowed`](./useIsAllowed.md) -- check whether a session signature is cached
+- [`useRevoke`](./useRevoke.md) -- revoke decrypt authorization for specific contracts
+- [`useRevokeSession`](./useRevokeSession.md) -- revoke the entire session
+- [Session Model](../../concepts/session-model.md) -- security model and TTL configuration

--- a/docs/gitbook/src/reference/react/useBatchDecryptBalancesAs.md
+++ b/docs/gitbook/src/reference/react/useBatchDecryptBalancesAs.md
@@ -138,6 +138,6 @@ await batchDecryptAs({
 
 ## Related
 
-- [`useDecryptBalanceAs`](/reference/react/useDecryptBalanceAs) -- single-token variant
-- [`useDelegationStatus`](/reference/react/useDelegationStatus) -- check delegation status before decrypting
-- [Delegated Decryption](/reference/sdk/delegation) -- SDK reference
+- [`useDecryptBalanceAs`](./useDecryptBalanceAs.md) -- single-token variant
+- [`useDelegationStatus`](./useDelegationStatus.md) -- check delegation status before decrypting
+- [Delegated Decryption](../sdk/delegation.md) -- SDK reference

--- a/docs/gitbook/src/reference/react/useConfidentialApprove.md
+++ b/docs/gitbook/src/reference/react/useConfidentialApprove.md
@@ -93,6 +93,6 @@ The mutation resolves with a transaction hash (`Hex`).
 
 ## Related
 
-- [`useConfidentialIsApproved`](/reference/react/useConfidentialIsApproved) — check if a spender is currently approved
-- [`useConfidentialTransferFrom`](/reference/react/useConfidentialTransferFrom) — operator transfer using an existing approval
-- [`Token.approve()`](/reference/sdk/Token#approve) — imperative equivalent on the SDK class
+- [`useConfidentialIsApproved`](./useConfidentialIsApproved.md) — check if a spender is currently approved
+- [`useConfidentialTransferFrom`](./useConfidentialTransferFrom.md) — operator transfer using an existing approval
+- [`Token.approve()`](../sdk/Token.md#approve) — imperative equivalent on the SDK class

--- a/docs/gitbook/src/reference/react/useConfidentialBalance.md
+++ b/docs/gitbook/src/reference/react/useConfidentialBalance.md
@@ -126,6 +126,6 @@ The `data` property is `bigint | undefined` -- the decrypted token balance.
 
 ## Related
 
-- [useConfidentialBalances](/reference/react/useConfidentialBalances) -- batch variant for multiple tokens
-- [Check Balances guide](/guides/check-balances)
-- [Query Keys](/reference/react/query-keys) -- `zamaQueryKeys.confidentialBalance`
+- [useConfidentialBalances](./useConfidentialBalances.md) -- batch variant for multiple tokens
+- [Check Balances guide](../../guides/check-balances.md)
+- [Query Keys](./query-keys.md) -- `zamaQueryKeys.confidentialBalance`

--- a/docs/gitbook/src/reference/react/useConfidentialBalances.md
+++ b/docs/gitbook/src/reference/react/useConfidentialBalances.md
@@ -5,7 +5,7 @@ description: Decrypt and poll multiple tokens' confidential balances in a single
 
 # useConfidentialBalances
 
-Decrypt and poll multiple tokens' confidential balances in a single query. Returns a `BatchBalancesResult` with results and errors maps. Each token uses the same cached decryption strategy as [`useConfidentialBalance`](/reference/react/useConfidentialBalance).
+Decrypt and poll multiple tokens' confidential balances in a single query. Returns a `BatchBalancesResult` with results and errors maps. Each token uses the same cached decryption strategy as [`useConfidentialBalance`](./useConfidentialBalance.md).
 
 ## Import
 
@@ -130,6 +130,6 @@ The `data` property is `BatchBalancesResult | undefined` -- an object with `resu
 
 ## Related
 
-- [useConfidentialBalance](/reference/react/useConfidentialBalance) -- single-token variant
-- [Check Balances guide](/guides/check-balances)
-- [Query Keys](/reference/react/query-keys) -- `zamaQueryKeys.confidentialBalances`
+- [useConfidentialBalance](./useConfidentialBalance.md) -- single-token variant
+- [Check Balances guide](../../guides/check-balances.md)
+- [Query Keys](./query-keys.md) -- `zamaQueryKeys.confidentialBalances`

--- a/docs/gitbook/src/reference/react/useConfidentialIsApproved.md
+++ b/docs/gitbook/src/reference/react/useConfidentialIsApproved.md
@@ -110,5 +110,5 @@ function App() {
 
 ## Related
 
-- [`useConfidentialApprove`](/reference/react/useConfidentialApprove) — approve an operator
-- [`Token.isApproved()`](/reference/sdk/Token#isapproved) — imperative equivalent on the SDK class
+- [`useConfidentialApprove`](./useConfidentialApprove.md) — approve an operator
+- [`Token.isApproved()`](../sdk/Token.md#isapproved) — imperative equivalent on the SDK class

--- a/docs/gitbook/src/reference/react/useConfidentialTokenAddress.md
+++ b/docs/gitbook/src/reference/react/useConfidentialTokenAddress.md
@@ -64,7 +64,7 @@ The `data` field resolves to `readonly [boolean, Address]`:
 
 ## Related
 
-- [useTokenAddress](/reference/react/useTokenAddress) -- reverse lookup (confidential &rarr; plain)
-- [useIsConfidentialTokenValid](/reference/react/useIsConfidentialTokenValid) -- check if a confidential token is valid
-- [useWrapperDiscovery](/reference/react/useWrapperDiscovery) -- alternative lookup via the deployment coordinator
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getConfidentialTokenAddress()` method
+- [useTokenAddress](./useTokenAddress.md) -- reverse lookup (confidential &rarr; plain)
+- [useIsConfidentialTokenValid](./useIsConfidentialTokenValid.md) -- check if a confidential token is valid
+- [useWrapperDiscovery](./useWrapperDiscovery.md) -- alternative lookup via the deployment coordinator
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getConfidentialTokenAddress()` method

--- a/docs/gitbook/src/reference/react/useConfidentialTransfer.md
+++ b/docs/gitbook/src/reference/react/useConfidentialTransfer.md
@@ -5,7 +5,7 @@ description: Send confidential ERC-20 tokens privately.
 
 # useConfidentialTransfer
 
-Send confidential ERC-20 tokens privately. The amount is encrypted client-side before the transaction is submitted on-chain. Automatically invalidates the [`useConfidentialBalance`](/reference/react/useConfidentialBalance) cache on success.
+Send confidential ERC-20 tokens privately. The amount is encrypted client-side before the transaction is submitted on-chain. Automatically invalidates the [`useConfidentialBalance`](./useConfidentialBalance.md) cache on success.
 
 ## Import
 
@@ -164,6 +164,6 @@ The `data` property (after a successful mutation) is `{ txHash: Hex, receipt: Tr
 
 ## Related
 
-- [useConfidentialTransferFrom](/reference/react/useConfidentialTransferFrom) -- operator transfer variant
-- [Transfer Privately guide](/guides/transfer-privately)
-- [useConfidentialBalance](/reference/react/useConfidentialBalance) -- auto-invalidated on success
+- [useConfidentialTransferFrom](./useConfidentialTransferFrom.md) -- operator transfer variant
+- [Transfer Privately guide](../../guides/transfer-privately.md)
+- [useConfidentialBalance](./useConfidentialBalance.md) -- auto-invalidated on success

--- a/docs/gitbook/src/reference/react/useConfidentialTransferFrom.md
+++ b/docs/gitbook/src/reference/react/useConfidentialTransferFrom.md
@@ -5,7 +5,7 @@ description: Transfer confidential tokens on behalf of an owner who approved you
 
 # useConfidentialTransferFrom
 
-Transfer confidential tokens on behalf of an owner who approved you as an operator. The sender must have been granted approval via [`useConfidentialApprove`](/reference/react/useConfidentialApprove) before calling this hook. Automatically invalidates the [`useConfidentialBalance`](/reference/react/useConfidentialBalance) cache on success.
+Transfer confidential tokens on behalf of an owner who approved you as an operator. The sender must have been granted approval via [`useConfidentialApprove`](./useConfidentialApprove.md) before calling this hook. Automatically invalidates the [`useConfidentialBalance`](./useConfidentialBalance.md) cache on success.
 
 ## Import
 
@@ -153,7 +153,7 @@ The `data` property (after a successful mutation) is `{ txHash: Hex, receipt: Tr
 
 ## Related
 
-- [useConfidentialTransfer](/reference/react/useConfidentialTransfer) -- direct transfer (no operator)
-- [useConfidentialApprove](/reference/react/useConfidentialApprove) -- grant operator approval
-- [Operator Approvals guide](/guides/operator-approvals)
-- [useConfidentialBalance](/reference/react/useConfidentialBalance) -- auto-invalidated on success
+- [useConfidentialTransfer](./useConfidentialTransfer.md) -- direct transfer (no operator)
+- [useConfidentialApprove](./useConfidentialApprove.md) -- grant operator approval
+- [Operator Approvals guide](../../guides/operator-approvals.md)
+- [useConfidentialBalance](./useConfidentialBalance.md) -- auto-invalidated on success

--- a/docs/gitbook/src/reference/react/useDecryptBalanceAs.md
+++ b/docs/gitbook/src/reference/react/useDecryptBalanceAs.md
@@ -99,7 +99,7 @@ await decryptAs({
 
 ## Related
 
-- [`useBatchDecryptBalancesAs`](/reference/react/useBatchDecryptBalancesAs) -- batch variant for multiple tokens
-- [`useDelegationStatus`](/reference/react/useDelegationStatus) -- check delegation status before decrypting
-- [`useConfidentialBalance`](/reference/react/useConfidentialBalance) -- decrypt your own balance (non-delegated)
-- [Delegated Decryption](/reference/sdk/delegation) -- SDK reference
+- [`useBatchDecryptBalancesAs`](./useBatchDecryptBalancesAs.md) -- batch variant for multiple tokens
+- [`useDelegationStatus`](./useDelegationStatus.md) -- check delegation status before decrypting
+- [`useConfidentialBalance`](./useConfidentialBalance.md) -- decrypt your own balance (non-delegated)
+- [Delegated Decryption](../sdk/delegation.md) -- SDK reference

--- a/docs/gitbook/src/reference/react/useDelegateDecryption.md
+++ b/docs/gitbook/src/reference/react/useDelegateDecryption.md
@@ -5,7 +5,7 @@ description: Mutation hook that grants FHE decryption rights for a token to anot
 
 # useDelegateDecryption
 
-Mutation hook that grants FHE decryption rights for a token to another address via the on-chain ACL. Automatically invalidates [`useDelegationStatus`](/reference/react/useDelegationStatus) queries on success.
+Mutation hook that grants FHE decryption rights for a token to another address via the on-chain ACL. Automatically invalidates [`useDelegationStatus`](./useDelegationStatus.md) queries on success.
 
 ## Import
 
@@ -96,7 +96,7 @@ await delegate({
 
 ## Related
 
-- [`useRevokeDelegation`](/reference/react/useRevokeDelegation) -- revoke a previously granted delegation
-- [`useDelegationStatus`](/reference/react/useDelegationStatus) -- check whether a delegation is active
-- [`useDecryptBalanceAs`](/reference/react/useDecryptBalanceAs) -- decrypt a balance as the delegate
-- [Delegated Decryption](/reference/sdk/delegation) -- SDK reference
+- [`useRevokeDelegation`](./useRevokeDelegation.md) -- revoke a previously granted delegation
+- [`useDelegationStatus`](./useDelegationStatus.md) -- check whether a delegation is active
+- [`useDecryptBalanceAs`](./useDecryptBalanceAs.md) -- decrypt a balance as the delegate
+- [Delegated Decryption](../sdk/delegation.md) -- SDK reference

--- a/docs/gitbook/src/reference/react/useDelegationStatus.md
+++ b/docs/gitbook/src/reference/react/useDelegationStatus.md
@@ -103,6 +103,6 @@ import { type DelegationStatusData } from "@zama-fhe/sdk/query";
 
 ## Related
 
-- [`useDelegateDecryption`](/reference/react/useDelegateDecryption) -- grant delegation
-- [`useRevokeDelegation`](/reference/react/useRevokeDelegation) -- revoke delegation
-- [Delegated Decryption](/reference/sdk/delegation) -- SDK reference
+- [`useDelegateDecryption`](./useDelegateDecryption.md) -- grant delegation
+- [`useRevokeDelegation`](./useRevokeDelegation.md) -- revoke delegation
+- [Delegated Decryption](../sdk/delegation.md) -- SDK reference

--- a/docs/gitbook/src/reference/react/useEncrypt.md
+++ b/docs/gitbook/src/reference/react/useEncrypt.md
@@ -8,7 +8,7 @@ description: Low-level mutation hook that encrypts a plaintext value using the r
 Low-level mutation hook that encrypts plaintext values using the relayer's FHE engine. Returns encrypted handles and an input proof for on-chain submission.
 
 {% hint style="warning" %}
-For **confidential ERC-20 tokens**, use [`useShield`](/reference/react/useShield) or [`useConfidentialTransfer`](/reference/react/useConfidentialTransfer) — they handle encryption automatically.
+For **confidential ERC-20 tokens**, use [`useShield`](./useShield.md) or [`useConfidentialTransfer`](./useConfidentialTransfer.md) — they handle encryption automatically.
 
 Use `useEncrypt` when your smart contract uses FHE types directly (e.g. a confidential voting contract, a sealed-bid auction, or any non-token contract that accepts encrypted parameters).
 {% endhint %}
@@ -108,7 +108,7 @@ import { type EncryptResult } from "@zama-fhe/sdk";
 
 ## Related
 
-- [`useShield`](/reference/react/useShield) — high-level hook that encrypts and shields in one step
-- [`useConfidentialTransfer`](/reference/react/useConfidentialTransfer) — high-level hook that encrypts and transfers
-- [`useUserDecrypt`](/reference/react/useUserDecrypt) — reverse operation, decrypt handles back to plaintext
-- [Encrypt & Decrypt guide](/guides/encrypt-decrypt) — full walkthrough with examples
+- [`useShield`](./useShield.md) — high-level hook that encrypts and shields in one step
+- [`useConfidentialTransfer`](./useConfidentialTransfer.md) — high-level hook that encrypts and transfers
+- [`useUserDecrypt`](./useUserDecrypt.md) — reverse operation, decrypt handles back to plaintext
+- [Encrypt & Decrypt guide](../../guides/encrypt-decrypt.md) — full walkthrough with examples

--- a/docs/gitbook/src/reference/react/useFinalizeUnwrap.md
+++ b/docs/gitbook/src/reference/react/useFinalizeUnwrap.md
@@ -5,10 +5,10 @@ description: Low-level mutation hook that finalizes an unwrap with the decryptio
 
 # useFinalizeUnwrap
 
-Low-level mutation hook that finalizes an unwrap with the decryption proof. Call this after [`useUnwrap`](/reference/react/useUnwrap) or [`useUnwrapAll`](/reference/react/useUnwrapAll) has submitted the initial unwrap transaction.
+Low-level mutation hook that finalizes an unwrap with the decryption proof. Call this after [`useUnwrap`](./useUnwrap.md) or [`useUnwrapAll`](./useUnwrapAll.md) has submitted the initial unwrap transaction.
 
 {% hint style="info" %}
-Most apps should use [`useUnshield`](/reference/react/useUnshield) instead, which orchestrates both steps (unwrap + finalize) in a single call. Use this hook for custom multi-step flows where you need control over each phase.
+Most apps should use [`useUnshield`](./useUnshield.md) instead, which orchestrates both steps (unwrap + finalize) in a single call. Use this hook for custom multi-step flows where you need control over each phase.
 {% endhint %}
 
 ## Import
@@ -74,7 +74,7 @@ const { mutateAsync: finalize } = useFinalizeUnwrap({
 
 `Hex`
 
-The transaction hash returned by [`useUnwrap`](/reference/react/useUnwrap) or [`useUnwrapAll`](/reference/react/useUnwrapAll). The SDK uses this to locate and verify the decryption proof on-chain.
+The transaction hash returned by [`useUnwrap`](./useUnwrap.md) or [`useUnwrapAll`](./useUnwrapAll.md). The SDK uses this to locate and verify the decryption proof on-chain.
 
 ```tsx
 await finalize({ unwrapTxHash: "0xabc..." });
@@ -90,7 +90,7 @@ import { type UseFinalizeUnwrapReturnType } from "@zama-fhe/react-sdk";
 
 ## Related
 
-- [`useUnwrap`](/reference/react/useUnwrap) -- request unwrap for a specific amount
-- [`useUnwrapAll`](/reference/react/useUnwrapAll) -- request unwrap for the full balance
-- [`useResumeUnshield`](/reference/react/useResumeUnshield) -- resume an interrupted unshield
-- [`useUnshield`](/reference/react/useUnshield) -- high-level hook that handles both steps
+- [`useUnwrap`](./useUnwrap.md) -- request unwrap for a specific amount
+- [`useUnwrapAll`](./useUnwrapAll.md) -- request unwrap for the full balance
+- [`useResumeUnshield`](./useResumeUnshield.md) -- resume an interrupted unshield
+- [`useUnshield`](./useUnshield.md) -- high-level hook that handles both steps

--- a/docs/gitbook/src/reference/react/useGenerateKeypair.md
+++ b/docs/gitbook/src/reference/react/useGenerateKeypair.md
@@ -8,7 +8,7 @@ description: Low-level mutation hook that generates a fresh FHE keypair via the 
 Low-level mutation hook that generates a fresh FHE keypair via the relayer. Returns a public/private key pair for use in decrypt authorization.
 
 {% hint style="warning" %}
-[`useUserDecrypt`](/reference/react/useUserDecrypt), [`useAllow`](/reference/react/useAllow), and [`useConfidentialBalance`](/reference/react/useConfidentialBalance) handle keypair generation automatically. Call `useGenerateKeypair` only when managing FHE credentials manually.
+[`useUserDecrypt`](./useUserDecrypt.md), [`useAllow`](./useAllow.md), and [`useConfidentialBalance`](./useConfidentialBalance.md) handle keypair generation automatically. Call `useGenerateKeypair` only when managing FHE credentials manually.
 {% endhint %}
 
 ## Import
@@ -64,12 +64,12 @@ import { type KeypairType } from "@zama-fhe/sdk";
 - **`publicKey`** — the FHE public key (string-encoded).
 - **`privateKey`** — the FHE private key (string-encoded).
 
-Pass these to [`useUserDecrypt`](/reference/react/useUserDecrypt) when decrypting handles manually.
+Pass these to [`useUserDecrypt`](./useUserDecrypt.md) when decrypting handles manually.
 
 {% include ".gitbook/includes/mutation-result.md" %}
 
 ## Related
 
-- [`useAllow`](/reference/react/useAllow) — high-level hook that generates a keypair and caches the session signature
-- [`useUserDecrypt`](/reference/react/useUserDecrypt) — uses the generated keypair to decrypt handles
-- [`useEncrypt`](/reference/react/useEncrypt) — encrypt values (does not require a keypair)
+- [`useAllow`](./useAllow.md) — high-level hook that generates a keypair and caches the session signature
+- [`useUserDecrypt`](./useUserDecrypt.md) — uses the generated keypair to decrypt handles
+- [`useEncrypt`](./useEncrypt.md) — encrypt values (does not require a keypair)

--- a/docs/gitbook/src/reference/react/useIsAllowed.md
+++ b/docs/gitbook/src/reference/react/useIsAllowed.md
@@ -98,12 +98,12 @@ const { data: allowed } = useIsAllowed({
 `data` is a `boolean`:
 
 - `true` -- a valid session signature is cached; decrypts will not prompt the wallet.
-- `false` -- no cached signature, or the `sessionTTL` has expired. Call [`useAllow`](/reference/react/useAllow) to re-authorize.
+- `false` -- no cached signature, or the `sessionTTL` has expired. Call [`useAllow`](./useAllow.md) to re-authorize.
 
 {% include ".gitbook/includes/query-result.md" %}
 
 ## Related
 
-- [`useAllow`](/reference/react/useAllow) -- pre-authorize contracts with one wallet signature
-- [`useRevoke`](/reference/react/useRevoke) -- revoke session credentials
-- [Session Model](/concepts/session-model) -- security model and TTL configuration
+- [`useAllow`](./useAllow.md) -- pre-authorize contracts with one wallet signature
+- [`useRevoke`](./useRevoke.md) -- revoke session credentials
+- [Session Model](../../concepts/session-model.md) -- security model and TTL configuration

--- a/docs/gitbook/src/reference/react/useIsConfidentialTokenValid.md
+++ b/docs/gitbook/src/reference/react/useIsConfidentialTokenValid.md
@@ -67,6 +67,6 @@ The `data` field resolves to `boolean`:
 
 ## Related
 
-- [useConfidentialTokenAddress](/reference/react/useConfidentialTokenAddress) -- look up the wrapper for an ERC-20
-- [useTokenAddress](/reference/react/useTokenAddress) -- reverse lookup (confidential &rarr; plain)
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `isConfidentialTokenValid()` method
+- [useConfidentialTokenAddress](./useConfidentialTokenAddress.md) -- look up the wrapper for an ERC-20
+- [useTokenAddress](./useTokenAddress.md) -- reverse lookup (confidential &rarr; plain)
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `isConfidentialTokenValid()` method

--- a/docs/gitbook/src/reference/react/useListPairs.md
+++ b/docs/gitbook/src/reference/react/useListPairs.md
@@ -137,7 +137,7 @@ Results are cached with a TTL matching the SDK's `registryTTL` (default: 24 hour
 
 ## Related
 
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level registry class with `listPairs()` method
-- [useTokenPairsRegistry](/reference/react/useTokenPairsRegistry) -- fetch all pairs at once (no pagination)
-- [useConfidentialTokenAddress](/reference/react/useConfidentialTokenAddress) -- look up a single token's wrapper
-- [Query Keys](/reference/react/query-keys) -- manual cache control via `zamaQueryKeys.wrappersRegistry`
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level registry class with `listPairs()` method
+- [useTokenPairsRegistry](./useTokenPairsRegistry.md) -- fetch all pairs at once (no pagination)
+- [useConfidentialTokenAddress](./useConfidentialTokenAddress.md) -- look up a single token's wrapper
+- [Query Keys](./query-keys.md) -- manual cache control via `zamaQueryKeys.wrappersRegistry`

--- a/docs/gitbook/src/reference/react/useMetadata.md
+++ b/docs/gitbook/src/reference/react/useMetadata.md
@@ -87,6 +87,6 @@ function TokenHeader({ tokenAddress }: { tokenAddress: `0x${string}` }) {
 
 ## Related
 
-- [useWrapperDiscovery](/reference/react/useWrapperDiscovery) -- find the wrapper address for a token
-- [useConfidentialBalance](/reference/react/useConfidentialBalance) -- read the decrypted confidential balance
-- [Hooks overview](/reference/react/query-keys) -- all available hooks
+- [useWrapperDiscovery](./useWrapperDiscovery.md) -- find the wrapper address for a token
+- [useConfidentialBalance](./useConfidentialBalance.md) -- read the decrypted confidential balance
+- [Hooks overview](./query-keys.md) -- all available hooks

--- a/docs/gitbook/src/reference/react/useReadonlyToken.md
+++ b/docs/gitbook/src/reference/react/useReadonlyToken.md
@@ -96,6 +96,6 @@ A memoized `ReadonlyToken` instance. The reference stays the same as long as the
 
 ## Related
 
-- [useToken](/reference/react/useToken) — full read/write `Token` instance
-- [useZamaSDK](/reference/react/useZamaSDK) — access the underlying SDK instance directly
-- [ReadonlyToken](/reference/sdk/ReadonlyToken) — full API reference for the `ReadonlyToken` class
+- [useToken](./useToken.md) — full read/write `Token` instance
+- [useZamaSDK](./useZamaSDK.md) — access the underlying SDK instance directly
+- [ReadonlyToken](../sdk/ReadonlyToken.md) — full API reference for the `ReadonlyToken` class

--- a/docs/gitbook/src/reference/react/useResumeUnshield.md
+++ b/docs/gitbook/src/reference/react/useResumeUnshield.md
@@ -142,6 +142,6 @@ Auto-invalidates the `confidentialBalance` cache on success.
 
 ## Related
 
-- [useUnshield](/reference/react/useUnshield) — standard unshield (handles both steps automatically)
-- [useUnshieldAll](/reference/react/useUnshieldAll) — unshield the entire balance
-- [Token.resumeUnshield](/reference/sdk/Token#resumeunshield) — imperative equivalent on the `Token` class
+- [useUnshield](./useUnshield.md) — standard unshield (handles both steps automatically)
+- [useUnshieldAll](./useUnshieldAll.md) — unshield the entire balance
+- [Token.resumeUnshield](../sdk/Token.md#resumeunshield) — imperative equivalent on the `Token` class

--- a/docs/gitbook/src/reference/react/useRevoke.md
+++ b/docs/gitbook/src/reference/react/useRevoke.md
@@ -60,16 +60,16 @@ revoke(["0xContractA", "0xContractB"]);
 ## Behavior
 
 - Clears the cached session signature for each contract in the array.
-- Auto-invalidates all [`useIsAllowed`](/reference/react/useIsAllowed) queries on success.
+- Auto-invalidates all [`useIsAllowed`](./useIsAllowed.md) queries on success.
 - Does **not** delete stored FHE credentials — only the session-level signature is cleared.
 
 {% hint style="info" %}
-If you use [`WagmiSigner`](/reference/sdk/WagmiSigner), the SDK auto-revokes on wallet disconnect or account change. Manual revoke is for [`ViemSigner`](/reference/sdk/ViemSigner) and [`EthersSigner`](/reference/sdk/EthersSigner) users.
+If you use [`WagmiSigner`](../sdk/WagmiSigner.md), the SDK auto-revokes on wallet disconnect or account change. Manual revoke is for [`ViemSigner`](../sdk/ViemSigner.md) and [`EthersSigner`](../sdk/EthersSigner.md) users.
 {% endhint %}
 
 ## Related
 
-- [`useRevokeSession`](/reference/react/useRevokeSession) — revoke the entire session instead of specific contracts
-- [`useAllow`](/reference/react/useAllow) — authorize decryption for contracts with a single wallet signature
-- [`useIsAllowed`](/reference/react/useIsAllowed) — check whether a session signature is valid
-- [`Token.revoke()`](/reference/sdk/Token#revoke) — imperative equivalent on the SDK class
+- [`useRevokeSession`](./useRevokeSession.md) — revoke the entire session instead of specific contracts
+- [`useAllow`](./useAllow.md) — authorize decryption for contracts with a single wallet signature
+- [`useIsAllowed`](./useIsAllowed.md) — check whether a session signature is valid
+- [`Token.revoke()`](../sdk/Token.md#revoke) — imperative equivalent on the SDK class

--- a/docs/gitbook/src/reference/react/useRevokeDelegation.md
+++ b/docs/gitbook/src/reference/react/useRevokeDelegation.md
@@ -5,7 +5,7 @@ description: Mutation hook that revokes FHE decryption delegation for a token.
 
 # useRevokeDelegation
 
-Mutation hook that revokes a previously granted FHE decryption delegation for a token. Automatically invalidates [`useDelegationStatus`](/reference/react/useDelegationStatus) queries on success.
+Mutation hook that revokes a previously granted FHE decryption delegation for a token. Automatically invalidates [`useDelegationStatus`](./useDelegationStatus.md) queries on success.
 
 ## Import
 
@@ -84,6 +84,6 @@ await revoke({ delegateAddress: "0xDelegate" });
 
 ## Related
 
-- [`useDelegateDecryption`](/reference/react/useDelegateDecryption) -- grant delegation
-- [`useDelegationStatus`](/reference/react/useDelegationStatus) -- check whether a delegation is active
-- [Delegated Decryption](/reference/sdk/delegation) -- SDK reference
+- [`useDelegateDecryption`](./useDelegateDecryption.md) -- grant delegation
+- [`useDelegationStatus`](./useDelegationStatus.md) -- check whether a delegation is active
+- [Delegated Decryption](../sdk/delegation.md) -- SDK reference

--- a/docs/gitbook/src/reference/react/useRevokeSession.md
+++ b/docs/gitbook/src/reference/react/useRevokeSession.md
@@ -5,7 +5,7 @@ description: Revoke the entire session for the connected wallet.
 
 # useRevokeSession
 
-Revoke the entire session for the connected wallet. Unlike [`useRevoke`](/reference/react/useRevoke) which targets specific contract addresses, this clears the session-level signature.
+Revoke the entire session for the connected wallet. Unlike [`useRevoke`](./useRevoke.md) which targets specific contract addresses, this clears the session-level signature.
 
 ## Import
 
@@ -56,15 +56,15 @@ revokeSession();
 ## Behavior
 
 - Clears the session-level signature for the connected wallet.
-- Auto-invalidates all [`useIsAllowed`](/reference/react/useIsAllowed) queries on success.
+- Auto-invalidates all [`useIsAllowed`](./useIsAllowed.md) queries on success.
 - After revoking, any balance decrypt or FHE operation will prompt a new wallet signature.
 
 {% hint style="info" %}
-If you use [`WagmiSigner`](/reference/sdk/WagmiSigner), the SDK auto-revokes on wallet disconnect or account change — you do not need to call this hook manually for that case.
+If you use [`WagmiSigner`](../sdk/WagmiSigner.md), the SDK auto-revokes on wallet disconnect or account change — you do not need to call this hook manually for that case.
 {% endhint %}
 
 ## Related
 
-- [`useRevoke`](/reference/react/useRevoke) — revoke specific contract addresses instead of the full session
-- [`useAllow`](/reference/react/useAllow) — pre-authorize contracts with a single wallet signature
-- [`useIsAllowed`](/reference/react/useIsAllowed) — check whether a session signature is valid
+- [`useRevoke`](./useRevoke.md) — revoke specific contract addresses instead of the full session
+- [`useAllow`](./useAllow.md) — pre-authorize contracts with a single wallet signature
+- [`useIsAllowed`](./useIsAllowed.md) — check whether a session signature is valid

--- a/docs/gitbook/src/reference/react/useShield.md
+++ b/docs/gitbook/src/reference/react/useShield.md
@@ -160,5 +160,5 @@ Auto-invalidates the `confidentialBalance` cache on success.
 
 ## Related
 
-- [useUnshield](/reference/react/useUnshield) — reverse operation, unshield back to public ERC-20
-- [Token.shield](/reference/sdk/Token#shield) — imperative equivalent on the `Token` class
+- [useUnshield](./useUnshield.md) — reverse operation, unshield back to public ERC-20
+- [Token.shield](../sdk/Token.md#shield) — imperative equivalent on the `Token` class

--- a/docs/gitbook/src/reference/react/useToken.md
+++ b/docs/gitbook/src/reference/react/useToken.md
@@ -113,6 +113,6 @@ A memoized `Token` instance with full read and write access. The reference stays
 
 ## Related
 
-- [useReadonlyToken](/reference/react/useReadonlyToken) — read-only variant (no signing required)
-- [useZamaSDK](/reference/react/useZamaSDK) — access the underlying SDK instance directly
-- [Token](/reference/sdk/Token) — full API reference for the `Token` class
+- [useReadonlyToken](./useReadonlyToken.md) — read-only variant (no signing required)
+- [useZamaSDK](./useZamaSDK.md) — access the underlying SDK instance directly
+- [Token](../sdk/Token.md) — full API reference for the `Token` class

--- a/docs/gitbook/src/reference/react/useTokenAddress.md
+++ b/docs/gitbook/src/reference/react/useTokenAddress.md
@@ -64,6 +64,6 @@ The `data` field resolves to `readonly [boolean, Address]`:
 
 ## Related
 
-- [useConfidentialTokenAddress](/reference/react/useConfidentialTokenAddress) -- forward lookup (plain &rarr; confidential)
-- [useIsConfidentialTokenValid](/reference/react/useIsConfidentialTokenValid) -- check if a confidential token is valid
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getTokenAddress()` method
+- [useConfidentialTokenAddress](./useConfidentialTokenAddress.md) -- forward lookup (plain &rarr; confidential)
+- [useIsConfidentialTokenValid](./useIsConfidentialTokenValid.md) -- check if a confidential token is valid
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getTokenAddress()` method

--- a/docs/gitbook/src/reference/react/useTokenPair.md
+++ b/docs/gitbook/src/reference/react/useTokenPair.md
@@ -69,6 +69,6 @@ interface TokenWrapperPair {
 
 ## Related
 
-- [useTokenPairsLength](/reference/react/useTokenPairsLength) -- get total count to know valid indices
-- [useTokenPairsSlice](/reference/react/useTokenPairsSlice) -- fetch a range of pairs
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getTokenPair()` method
+- [useTokenPairsLength](./useTokenPairsLength.md) -- get total count to know valid indices
+- [useTokenPairsSlice](./useTokenPairsSlice.md) -- fetch a range of pairs
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getTokenPair()` method

--- a/docs/gitbook/src/reference/react/useTokenPairsLength.md
+++ b/docs/gitbook/src/reference/react/useTokenPairsLength.md
@@ -47,6 +47,6 @@ The `data` field resolves to `bigint` -- the total number of registered pairs.
 
 ## Related
 
-- [useListPairs](/reference/react/useListPairs) -- paginated pair listing
-- [useTokenPairsSlice](/reference/react/useTokenPairsSlice) -- fetch a range of pairs by index
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getTokenPairsLength()` method
+- [useListPairs](./useListPairs.md) -- paginated pair listing
+- [useTokenPairsSlice](./useTokenPairsSlice.md) -- fetch a range of pairs by index
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getTokenPairsLength()` method

--- a/docs/gitbook/src/reference/react/useTokenPairsRegistry.md
+++ b/docs/gitbook/src/reference/react/useTokenPairsRegistry.md
@@ -7,7 +7,7 @@ description: Fetch all token wrapper pairs from the on-chain registry.
 
 Fetches all token wrapper pairs from the `ConfidentialTokenWrappersRegistry` contract on the current chain in a single call.
 
-For large registries, prefer [`useListPairs`](/reference/react/useListPairs) with pagination.
+For large registries, prefer [`useListPairs`](./useListPairs.md) with pagination.
 
 ## Import
 
@@ -65,6 +65,6 @@ interface TokenWrapperPair {
 
 ## Related
 
-- [useListPairs](/reference/react/useListPairs) -- paginated listing with optional metadata
-- [useTokenPairsLength](/reference/react/useTokenPairsLength) -- get total count without fetching pairs
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getTokenPairs()` method
+- [useListPairs](./useListPairs.md) -- paginated listing with optional metadata
+- [useTokenPairsLength](./useTokenPairsLength.md) -- get total count without fetching pairs
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getTokenPairs()` method

--- a/docs/gitbook/src/reference/react/useTokenPairsSlice.md
+++ b/docs/gitbook/src/reference/react/useTokenPairsSlice.md
@@ -5,7 +5,7 @@ description: Fetch a range of token wrapper pairs from the registry by index.
 
 # useTokenPairsSlice
 
-Fetches a range of token wrapper pairs from the registry using start and end indices. This is the low-level pagination primitive — for page-based pagination, use [`useListPairs`](/reference/react/useListPairs) instead.
+Fetches a range of token wrapper pairs from the registry using start and end indices. This is the low-level pagination primitive — for page-based pagination, use [`useListPairs`](./useListPairs.md) instead.
 
 ## Import
 
@@ -87,7 +87,7 @@ interface TokenWrapperPair {
 
 ## Related
 
-- [useListPairs](/reference/react/useListPairs) -- page-based pagination with metadata support
-- [useTokenPairsLength](/reference/react/useTokenPairsLength) -- get total count for pagination bounds
-- [useTokenPair](/reference/react/useTokenPair) -- fetch a single pair by index
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level `getTokenPairsSlice()` method
+- [useListPairs](./useListPairs.md) -- page-based pagination with metadata support
+- [useTokenPairsLength](./useTokenPairsLength.md) -- get total count for pagination bounds
+- [useTokenPair](./useTokenPair.md) -- fetch a single pair by index
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level `getTokenPairsSlice()` method

--- a/docs/gitbook/src/reference/react/useUnderlyingAllowance.md
+++ b/docs/gitbook/src/reference/react/useUnderlyingAllowance.md
@@ -110,5 +110,5 @@ function App() {
 
 ## Related
 
-- [`useShield`](/reference/react/useShield) — shield tokens (handles approval automatically)
-- [`zamaQueryKeys.underlyingAllowance`](/reference/react/query-keys) — cache keys for manual invalidation
+- [`useShield`](./useShield.md) — shield tokens (handles approval automatically)
+- [`zamaQueryKeys.underlyingAllowance`](./query-keys.md) — cache keys for manual invalidation

--- a/docs/gitbook/src/reference/react/useUnshield.md
+++ b/docs/gitbook/src/reference/react/useUnshield.md
@@ -164,7 +164,7 @@ Auto-invalidates the `confidentialBalance` cache on success.
 
 ## Related
 
-- [useUnshieldAll](/reference/react/useUnshieldAll) — unshield the entire confidential balance
-- [useResumeUnshield](/reference/react/useResumeUnshield) — resume an interrupted unshield
-- [useShield](/reference/react/useShield) — reverse operation, shield public tokens
-- [Token.unshield](/reference/sdk/Token#unshield) — imperative equivalent on the `Token` class
+- [useUnshieldAll](./useUnshieldAll.md) — unshield the entire confidential balance
+- [useResumeUnshield](./useResumeUnshield.md) — resume an interrupted unshield
+- [useShield](./useShield.md) — reverse operation, shield public tokens
+- [Token.unshield](../sdk/Token.md#unshield) — imperative equivalent on the `Token` class

--- a/docs/gitbook/src/reference/react/useUnshieldAll.md
+++ b/docs/gitbook/src/reference/react/useUnshieldAll.md
@@ -141,7 +141,7 @@ Auto-invalidates the `confidentialBalance` cache on success.
 
 ## Related
 
-- [useUnshield](/reference/react/useUnshield) — unshield a specific amount
-- [useResumeUnshield](/reference/react/useResumeUnshield) — resume an interrupted unshield
-- [useShield](/reference/react/useShield) — reverse operation, shield public tokens
-- [Token.unshieldAll](/reference/sdk/Token#unshieldall) — imperative equivalent on the `Token` class
+- [useUnshield](./useUnshield.md) — unshield a specific amount
+- [useResumeUnshield](./useResumeUnshield.md) — resume an interrupted unshield
+- [useShield](./useShield.md) — reverse operation, shield public tokens
+- [Token.unshieldAll](../sdk/Token.md#unshieldall) — imperative equivalent on the `Token` class

--- a/docs/gitbook/src/reference/react/useUnwrap.md
+++ b/docs/gitbook/src/reference/react/useUnwrap.md
@@ -5,10 +5,10 @@ description: Low-level mutation hook that requests an unwrap for a specific amou
 
 # useUnwrap
 
-Low-level mutation hook that requests an unwrap for a specific amount. You must finalize manually with [`useFinalizeUnwrap`](/reference/react/useFinalizeUnwrap).
+Low-level mutation hook that requests an unwrap for a specific amount. You must finalize manually with [`useFinalizeUnwrap`](./useFinalizeUnwrap.md).
 
 {% hint style="info" %}
-Most apps should use [`useUnshield`](/reference/react/useUnshield) instead, which orchestrates both steps (unwrap + finalize) in a single call.
+Most apps should use [`useUnshield`](./useUnshield.md) instead, which orchestrates both steps (unwrap + finalize) in a single call.
 {% endhint %}
 
 ## Import
@@ -89,6 +89,6 @@ The mutation resolves with a transaction hash (`Hex`).
 
 ## Related
 
-- [`useFinalizeUnwrap`](/reference/react/useFinalizeUnwrap) -- finalize the unwrap with a decryption proof
-- [`useUnwrapAll`](/reference/react/useUnwrapAll) -- unwrap the full balance
-- [`useUnshield`](/reference/react/useUnshield) -- high-level hook that handles both steps
+- [`useFinalizeUnwrap`](./useFinalizeUnwrap.md) -- finalize the unwrap with a decryption proof
+- [`useUnwrapAll`](./useUnwrapAll.md) -- unwrap the full balance
+- [`useUnshield`](./useUnshield.md) -- high-level hook that handles both steps

--- a/docs/gitbook/src/reference/react/useUnwrapAll.md
+++ b/docs/gitbook/src/reference/react/useUnwrapAll.md
@@ -5,10 +5,10 @@ description: Low-level mutation hook that requests an unwrap for the full confid
 
 # useUnwrapAll
 
-Low-level mutation hook that requests an unwrap for the full confidential balance. You must finalize manually with [`useFinalizeUnwrap`](/reference/react/useFinalizeUnwrap).
+Low-level mutation hook that requests an unwrap for the full confidential balance. You must finalize manually with [`useFinalizeUnwrap`](./useFinalizeUnwrap.md).
 
 {% hint style="info" %}
-Most apps should use [`useUnshieldAll`](/reference/react/useUnshieldAll) instead, which orchestrates both steps in a single call.
+Most apps should use [`useUnshieldAll`](./useUnshieldAll.md) instead, which orchestrates both steps in a single call.
 {% endhint %}
 
 ## Import
@@ -77,6 +77,6 @@ The mutation resolves with a transaction hash (`Hex`).
 
 ## Related
 
-- [`useFinalizeUnwrap`](/reference/react/useFinalizeUnwrap) -- finalize the unwrap with a decryption proof
-- [`useUnwrap`](/reference/react/useUnwrap) -- unwrap a specific amount
-- [`useUnshieldAll`](/reference/react/useUnshieldAll) -- high-level hook that handles both steps
+- [`useFinalizeUnwrap`](./useFinalizeUnwrap.md) -- finalize the unwrap with a decryption proof
+- [`useUnwrap`](./useUnwrap.md) -- unwrap a specific amount
+- [`useUnshieldAll`](./useUnshieldAll.md) -- high-level hook that handles both steps

--- a/docs/gitbook/src/reference/react/useUserDecrypt.md
+++ b/docs/gitbook/src/reference/react/useUserDecrypt.md
@@ -5,10 +5,10 @@ description: Query hook that automatically decrypts FHE handles once credentials
 
 # useUserDecrypt
 
-Query hook for user decryption. Automatically fires when credentials are available (acquired via [`useAllow`](/reference/react/useAllow)) and handles are provided. Checks the persistent decrypt cache first and only hits the relayer for uncached handles.
+Query hook for user decryption. Automatically fires when credentials are available (acquired via [`useAllow`](./useAllow.md)) and handles are provided. Checks the persistent decrypt cache first and only hits the relayer for uncached handles.
 
 {% hint style="info" %}
-**This is the recommended way to decrypt.** For token balances, prefer [`useConfidentialBalance`](/reference/react/useConfidentialBalance) which handles decryption and caching automatically. Use `useUserDecrypt` when your smart contract uses FHE types directly (e.g. a confidential voting contract, a sealed-bid auction, or any non-token contract).
+**This is the recommended way to decrypt.** For token balances, prefer [`useConfidentialBalance`](./useConfidentialBalance.md) which handles decryption and caching automatically. Use `useUserDecrypt` when your smart contract uses FHE types directly (e.g. a confidential voting contract, a sealed-bid auction, or any non-token contract).
 {% endhint %}
 
 ## Import
@@ -112,7 +112,7 @@ When all requested handles are already cached, `data` contains the cached values
 2. **Decrypt** — calls `sdk.userDecrypt(handles)` which checks the persistent cache, then hits the relayer for any uncached handles.
 
 {% hint style="warning" %}
-**`useUserDecrypt` does not automatically gate on credentials.** If credentials are not cached when the query fires, the SDK will prompt the user's wallet for a signature. To avoid unexpected popups, gate the query yourself using [`useIsAllowed`](/reference/react/useIsAllowed):
+**`useUserDecrypt` does not automatically gate on credentials.** If credentials are not cached when the query fires, the SDK will prompt the user's wallet for a signature. To avoid unexpected popups, gate the query yourself using [`useIsAllowed`](./useIsAllowed.md):
 
 ```tsx
 const { data: allowed } = useIsAllowed({ contractAddresses: ["0xContract"] });
@@ -127,7 +127,7 @@ This ensures the decrypt query only fires after `useAllow` has been called.
 
 ## Credential caching
 
-`useUserDecrypt` relies on credentials acquired via [`useAllow`](/reference/react/useAllow):
+`useUserDecrypt` relies on credentials acquired via [`useAllow`](./useAllow.md):
 
 - **First `allow()` call** — generates a new FHE keypair, creates EIP-712 typed data, and requests a wallet signature. The credentials are then cached.
 - **Subsequent queries** — reuse the cached credentials if they are still valid (not expired).
@@ -137,8 +137,8 @@ This means users only see a wallet signature prompt once per session (or per TTL
 
 ## Related
 
-- [`useAllow`](/reference/react/useAllow) — pre-authorize contracts with one wallet signature (required before `useUserDecrypt` fires)
-- [`useIsAllowed`](/reference/react/useIsAllowed) — check whether credentials are cached and cover specific contracts
-- [`useConfidentialBalance`](/reference/react/useConfidentialBalance) — high-level hook that decrypts token balances with automatic caching
-- [`useEncrypt`](/reference/react/useEncrypt) — reverse operation, encrypt a plaintext value for on-chain submission
-- [Encrypt & Decrypt guide](/guides/encrypt-decrypt) — full walkthrough with end-to-end examples
+- [`useAllow`](./useAllow.md) — pre-authorize contracts with one wallet signature (required before `useUserDecrypt` fires)
+- [`useIsAllowed`](./useIsAllowed.md) — check whether credentials are cached and cover specific contracts
+- [`useConfidentialBalance`](./useConfidentialBalance.md) — high-level hook that decrypts token balances with automatic caching
+- [`useEncrypt`](./useEncrypt.md) — reverse operation, encrypt a plaintext value for on-chain submission
+- [Encrypt & Decrypt guide](../../guides/encrypt-decrypt.md) — full walkthrough with end-to-end examples

--- a/docs/gitbook/src/reference/react/useWrapperDiscovery.md
+++ b/docs/gitbook/src/reference/react/useWrapperDiscovery.md
@@ -91,5 +91,5 @@ function WrapperInfo({ tokenAddress }: { tokenAddress: `0x${string}` }) {
 
 ## Related
 
-- [useMetadata](/reference/react/useMetadata) -- read token name, symbol, and decimals
-- [Hooks overview](/reference/react/query-keys) -- all available hooks
+- [useMetadata](./useMetadata.md) -- read token name, symbol, and decimals
+- [Hooks overview](./query-keys.md) -- all available hooks

--- a/docs/gitbook/src/reference/react/useWrappersRegistryAddress.md
+++ b/docs/gitbook/src/reference/react/useWrappersRegistryAddress.md
@@ -51,6 +51,6 @@ The underlying chain ID query uses `staleTime: 30000` (30 seconds). Chain switch
 
 ## Related
 
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) -- SDK-level registry class
-- [Network Presets](/reference/sdk/network-presets) -- built-in chain configurations and `DefaultRegistryAddresses`
-- [useListPairs](/reference/react/useListPairs) -- paginated pair listing (depends on this hook internally)
+- [WrappersRegistry](../sdk/WrappersRegistry.md) -- SDK-level registry class
+- [Network Presets](../sdk/network-presets.md) -- built-in chain configurations and `DefaultRegistryAddresses`
+- [useListPairs](./useListPairs.md) -- paginated pair listing (depends on this hook internally)

--- a/docs/gitbook/src/reference/react/useZamaSDK.md
+++ b/docs/gitbook/src/reference/react/useZamaSDK.md
@@ -79,6 +79,6 @@ The configured SDK instance. Throws if called outside a `ZamaProvider`.
 
 ## Related
 
-- [useToken](/reference/react/useToken) — memoized `Token` instance for a given address
-- [useReadonlyToken](/reference/react/useReadonlyToken) — memoized `ReadonlyToken` instance (no write access)
-- [ZamaSDK](/reference/sdk/ZamaSDK) — full API reference for the SDK class
+- [useToken](./useToken.md) — memoized `Token` instance for a given address
+- [useReadonlyToken](./useReadonlyToken.md) — memoized `ReadonlyToken` instance (no write access)
+- [ZamaSDK](../sdk/ZamaSDK.md) — full API reference for the SDK class

--- a/docs/gitbook/src/reference/sdk/EthersSigner.md
+++ b/docs/gitbook/src/reference/sdk/EthersSigner.md
@@ -5,7 +5,7 @@ description: Signer adapter that wraps ethers providers and signers for the SDK.
 
 # EthersSigner
 
-Signer adapter that wraps ethers providers and signers for the SDK. Implements [GenericSigner](/reference/sdk/GenericSigner).
+Signer adapter that wraps ethers providers and signers for the SDK. Implements [GenericSigner](./GenericSigner.md).
 
 ## Import
 
@@ -103,7 +103,7 @@ const signer = new EthersSigner({
 
 ## Methods
 
-All methods are inherited from [GenericSigner](/reference/sdk/GenericSigner).
+All methods are inherited from [GenericSigner](./GenericSigner.md).
 
 | Method                        | Browser | Node.js | Read-only |
 | ----------------------------- | ------- | ------- | --------- |
@@ -121,7 +121,7 @@ Only the browser mode (passing `ethereum`) supports `subscribe()`. In Node.js mo
 
 ## Related
 
-- [GenericSigner](/reference/sdk/GenericSigner) -- interface this class implements
-- [ViemSigner](/reference/sdk/ViemSigner) -- viem alternative
-- [WagmiSigner](/reference/sdk/WagmiSigner) -- React adapter with auto-revoke
-- [Configuration guide](/guides/configuration) -- full setup walkthrough
+- [GenericSigner](./GenericSigner.md) -- interface this class implements
+- [ViemSigner](./ViemSigner.md) -- viem alternative
+- [WagmiSigner](./WagmiSigner.md) -- React adapter with auto-revoke
+- [Configuration guide](../../guides/configuration.md) -- full setup walkthrough

--- a/docs/gitbook/src/reference/sdk/FheArtifactCache.md
+++ b/docs/gitbook/src/reference/sdk/FheArtifactCache.md
@@ -230,7 +230,7 @@ Cache entries are scoped by chain ID:
 
 ## Related
 
-- [RelayerWeb](/reference/sdk/RelayerWeb) — browser relayer that creates an `FheArtifactCache` internally
-- [RelayerNode](/reference/sdk/RelayerNode) — Node.js relayer variant
-- [GenericStorage](/reference/sdk/GenericStorage) — storage interface used by the cache
-- [Configuration guide](/guides/configuration) — network presets and relayer setup
+- [RelayerWeb](./RelayerWeb.md) — browser relayer that creates an `FheArtifactCache` internally
+- [RelayerNode](./RelayerNode.md) — Node.js relayer variant
+- [GenericStorage](./GenericStorage.md) — storage interface used by the cache
+- [Configuration guide](../../guides/configuration.md) — network presets and relayer setup

--- a/docs/gitbook/src/reference/sdk/GenericSigner.md
+++ b/docs/gitbook/src/reference/sdk/GenericSigner.md
@@ -5,7 +5,7 @@ description: Interface that all signer adapters must implement for the SDK to in
 
 # GenericSigner
 
-Interface that all signer adapters must implement for the SDK to interact with wallets. You only need this if you are building a custom signer -- otherwise use [ViemSigner](/reference/sdk/ViemSigner), [EthersSigner](/reference/sdk/EthersSigner), or [WagmiSigner](/reference/sdk/WagmiSigner).
+Interface that all signer adapters must implement for the SDK to interact with wallets. You only need this if you are building a custom signer -- otherwise use [ViemSigner](./ViemSigner.md), [EthersSigner](./EthersSigner.md), or [WagmiSigner](./WagmiSigner.md).
 
 ## Import
 
@@ -124,7 +124,7 @@ Implementing `subscribe()` is optional but recommended. Without it, stale sessio
 
 ## Related
 
-- [ViemSigner](/reference/sdk/ViemSigner) -- viem implementation
-- [EthersSigner](/reference/sdk/EthersSigner) -- ethers implementation
-- [WagmiSigner](/reference/sdk/WagmiSigner) -- wagmi implementation with auto-revoke
-- [Configuration guide](/guides/configuration) -- full setup walkthrough
+- [ViemSigner](./ViemSigner.md) -- viem implementation
+- [EthersSigner](./EthersSigner.md) -- ethers implementation
+- [WagmiSigner](./WagmiSigner.md) -- wagmi implementation with auto-revoke
+- [Configuration guide](../../guides/configuration.md) -- full setup walkthrough

--- a/docs/gitbook/src/reference/sdk/GenericStorage.md
+++ b/docs/gitbook/src/reference/sdk/GenericStorage.md
@@ -148,5 +148,5 @@ const sdk = new ZamaSDK({
 
 ## Related
 
-- [ZamaSDK](/reference/sdk/ZamaSDK) -- accepts `storage` and `sessionStorage` parameters
-- [Configuration guide](/guides/configuration) -- storage selection guidance
+- [ZamaSDK](./ZamaSDK.md) -- accepts `storage` and `sessionStorage` parameters
+- [Configuration guide](../../guides/configuration.md) -- storage selection guidance

--- a/docs/gitbook/src/reference/sdk/ReadonlyToken.md
+++ b/docs/gitbook/src/reference/sdk/ReadonlyToken.md
@@ -13,7 +13,7 @@ Read-only interface for confidential token queries and batch operations — bala
 import { ReadonlyToken } from "@zama-fhe/sdk";
 ```
 
-Instance creation via [`ZamaSDK.createReadonlyToken()`](/reference/sdk/ZamaSDK#createreadonlytoken).
+Instance creation via [`ZamaSDK.createReadonlyToken()`](./ZamaSDK.md#createreadonlytoken).
 
 ## Usage
 
@@ -233,6 +233,6 @@ if (readonlyToken.isZeroHandle(handle)) {
 
 ## Related
 
-- [ZamaSDK](/reference/sdk/ZamaSDK) — creates `ReadonlyToken` via `createReadonlyToken()`
-- [Token](/reference/sdk/Token) — read/write variant with shielding and transfers
-- [Check Balances guide](/guides/check-balances) — step-by-step balance decryption walkthrough
+- [ZamaSDK](./ZamaSDK.md) — creates `ReadonlyToken` via `createReadonlyToken()`
+- [Token](./Token.md) — read/write variant with shielding and transfers
+- [Check Balances guide](../../guides/check-balances.md) — step-by-step balance decryption walkthrough

--- a/docs/gitbook/src/reference/sdk/RelayerCleartext.md
+++ b/docs/gitbook/src/reference/sdk/RelayerCleartext.md
@@ -152,7 +152,7 @@ The cleartext relayer implements the full `RelayerSDK` interface:
 
 ## Related
 
-- [Local Development guide](/guides/local-development) — when and how to use cleartext mode
-- [RelayerWeb](/reference/sdk/RelayerWeb) — browser relayer with real FHE
-- [RelayerNode](/reference/sdk/RelayerNode) — Node.js relayer with real FHE
-- [Network Presets](/reference/sdk/network-presets) — production network configs
+- [Local Development guide](../../guides/local-development.md) — when and how to use cleartext mode
+- [RelayerWeb](./RelayerWeb.md) — browser relayer with real FHE
+- [RelayerNode](./RelayerNode.md) — Node.js relayer with real FHE
+- [Network Presets](./network-presets.md) — production network configs

--- a/docs/gitbook/src/reference/sdk/RelayerNode.md
+++ b/docs/gitbook/src/reference/sdk/RelayerNode.md
@@ -138,6 +138,6 @@ The default of `min(CPU cores, 4)` works well for most server deployments. Incre
 
 ## Related
 
-- [ZamaSDK](/reference/sdk/ZamaSDK) — pass the relayer to the SDK constructor
-- [RelayerWeb](/reference/sdk/RelayerWeb) — browser variant using Web Workers and WASM
-- [Configuration guide](/guides/configuration) — authentication and network presets
+- [ZamaSDK](./ZamaSDK.md) — pass the relayer to the SDK constructor
+- [RelayerWeb](./RelayerWeb.md) — browser variant using Web Workers and WASM
+- [Configuration guide](../../guides/configuration.md) — authentication and network presets

--- a/docs/gitbook/src/reference/sdk/RelayerWeb.md
+++ b/docs/gitbook/src/reference/sdk/RelayerWeb.md
@@ -165,6 +165,6 @@ const relayer = new RelayerWeb({
 
 ## Related
 
-- [ZamaSDK](/reference/sdk/ZamaSDK) — pass the relayer to the SDK constructor
-- [RelayerNode](/reference/sdk/RelayerNode) — Node.js variant using worker threads
-- [Configuration guide](/guides/configuration) — authentication and network presets
+- [ZamaSDK](./ZamaSDK.md) — pass the relayer to the SDK constructor
+- [RelayerNode](./RelayerNode.md) — Node.js variant using worker threads
+- [Configuration guide](../../guides/configuration.md) — authentication and network presets

--- a/docs/gitbook/src/reference/sdk/Token.md
+++ b/docs/gitbook/src/reference/sdk/Token.md
@@ -9,7 +9,7 @@ Read/write interface for confidential ERC-20 operations — shielding, transferr
 
 ## Import
 
-Created via [`ZamaSDK.createToken()`](/reference/sdk/ZamaSDK#createtoken). Not imported directly.
+Created via [`ZamaSDK.createToken()`](./ZamaSDK.md#createtoken). Not imported directly.
 
 ## Usage
 
@@ -324,6 +324,6 @@ await token.finalizeUnwrap(burnAmountHandle);
 
 ## Related
 
-- [ZamaSDK](/reference/sdk/ZamaSDK) — creates `Token` via `createToken()`
-- [ReadonlyToken](/reference/sdk/ReadonlyToken) — read-only variant with batch operations
-- [Shield Tokens guide](/guides/shield-tokens) — step-by-step shielding walkthrough
+- [ZamaSDK](./ZamaSDK.md) — creates `Token` via `createToken()`
+- [ReadonlyToken](./ReadonlyToken.md) — read-only variant with batch operations
+- [Shield Tokens guide](../../guides/shield-tokens.md) — step-by-step shielding walkthrough

--- a/docs/gitbook/src/reference/sdk/ViemSigner.md
+++ b/docs/gitbook/src/reference/sdk/ViemSigner.md
@@ -5,7 +5,7 @@ description: Signer adapter that wraps viem wallet and public clients for the SD
 
 # ViemSigner
 
-Signer adapter that wraps viem wallet and public clients for the SDK. Implements [GenericSigner](/reference/sdk/GenericSigner).
+Signer adapter that wraps viem wallet and public clients for the SDK. Implements [GenericSigner](./GenericSigner.md).
 
 ## Import
 
@@ -98,7 +98,7 @@ const signer = new ViemSigner({
 
 ## Methods
 
-All methods are inherited from [GenericSigner](/reference/sdk/GenericSigner).
+All methods are inherited from [GenericSigner](./GenericSigner.md).
 
 | Method                        | Read-only | Full                        |
 | ----------------------------- | --------- | --------------------------- |
@@ -111,12 +111,12 @@ All methods are inherited from [GenericSigner](/reference/sdk/GenericSigner).
 | `subscribe()`                 | N/A       | Works (requires `ethereum`) |
 
 {% hint style="info" %}
-`subscribe()` is only available when you pass the `ethereum` option. Without it, wire wallet lifecycle events manually to `sdk.revokeSession()`. See the [Configuration guide](/guides/configuration).
+`subscribe()` is only available when you pass the `ethereum` option. Without it, wire wallet lifecycle events manually to `sdk.revokeSession()`. See the [Configuration guide](../../guides/configuration.md).
 {% endhint %}
 
 ## Related
 
-- [GenericSigner](/reference/sdk/GenericSigner) -- interface this class implements
-- [EthersSigner](/reference/sdk/EthersSigner) -- ethers alternative
-- [WagmiSigner](/reference/sdk/WagmiSigner) -- React adapter with auto-revoke
-- [Configuration guide](/guides/configuration) -- full setup walkthrough
+- [GenericSigner](./GenericSigner.md) -- interface this class implements
+- [EthersSigner](./EthersSigner.md) -- ethers alternative
+- [WagmiSigner](./WagmiSigner.md) -- React adapter with auto-revoke
+- [Configuration guide](../../guides/configuration.md) -- full setup walkthrough

--- a/docs/gitbook/src/reference/sdk/WagmiSigner.md
+++ b/docs/gitbook/src/reference/sdk/WagmiSigner.md
@@ -5,7 +5,7 @@ description: React-only signer adapter that wraps a wagmi config with automatic 
 
 # WagmiSigner
 
-React-only signer adapter that wraps a wagmi config with automatic session revocation. Implements [GenericSigner](/reference/sdk/GenericSigner).
+React-only signer adapter that wraps a wagmi config with automatic session revocation. Implements [GenericSigner](./GenericSigner.md).
 
 ## Import
 
@@ -50,7 +50,7 @@ const signer = new WagmiSigner({
 
 ## Methods
 
-All methods are inherited from [GenericSigner](/reference/sdk/GenericSigner).
+All methods are inherited from [GenericSigner](./GenericSigner.md).
 
 ### subscribe()
 
@@ -67,7 +67,7 @@ Chain switches do **not** trigger revocation. Credentials are keyed by `address 
 
 ## Related
 
-- [GenericSigner](/reference/sdk/GenericSigner) -- interface this class implements
-- [ViemSigner](/reference/sdk/ViemSigner) -- viem alternative (manual lifecycle wiring)
-- [EthersSigner](/reference/sdk/EthersSigner) -- ethers alternative
-- [Configuration guide](/guides/configuration) -- full setup walkthrough
+- [GenericSigner](./GenericSigner.md) -- interface this class implements
+- [ViemSigner](./ViemSigner.md) -- viem alternative (manual lifecycle wiring)
+- [EthersSigner](./EthersSigner.md) -- ethers alternative
+- [Configuration guide](../../guides/configuration.md) -- full setup walkthrough

--- a/docs/gitbook/src/reference/sdk/WrappersRegistry.md
+++ b/docs/gitbook/src/reference/sdk/WrappersRegistry.md
@@ -248,10 +248,10 @@ console.log(DefaultRegistryAddresses[1]); // "0xeb5015fF021DB115aCe010f23F55C259
 
 ## Related
 
-- [ZamaSDK](/reference/sdk/ZamaSDK) — `sdk.registry` shared instance and `createWrappersRegistry()` factory
-- [useListPairs](/reference/react/useListPairs) — React hook for paginated pair listing
-- [useConfidentialTokenAddress](/reference/react/useConfidentialTokenAddress) — React hook for forward lookup
-- [useTokenAddress](/reference/react/useTokenAddress) — React hook for reverse lookup
-- [useIsConfidentialTokenValid](/reference/react/useIsConfidentialTokenValid) — React hook for validity check
-- [Contract Builders](/reference/sdk/contract-builders) — low-level registry builders
-- [Network Presets](/reference/sdk/network-presets) — built-in chain configurations
+- [ZamaSDK](./ZamaSDK.md) — `sdk.registry` shared instance and `createWrappersRegistry()` factory
+- [useListPairs](../react/useListPairs.md) — React hook for paginated pair listing
+- [useConfidentialTokenAddress](../react/useConfidentialTokenAddress.md) — React hook for forward lookup
+- [useTokenAddress](../react/useTokenAddress.md) — React hook for reverse lookup
+- [useIsConfidentialTokenValid](../react/useIsConfidentialTokenValid.md) — React hook for validity check
+- [Contract Builders](./contract-builders.md) — low-level registry builders
+- [Network Presets](./network-presets.md) — built-in chain configurations

--- a/docs/gitbook/src/reference/sdk/ZamaSDK.md
+++ b/docs/gitbook/src/reference/sdk/ZamaSDK.md
@@ -387,7 +387,7 @@ emitter.on(ZamaSDKEvents.DecryptError, ({ error, durationMs, handles }: DecryptE
 {% endtabs %}
 
 {% hint style="info" %}
-This is the SDK-level entry point for user decryption. The method is named `userDecrypt` (not `decrypt`) because it requires the connected wallet's credentials — distinguishing it from gateway-level decryption that happens on-chain without user authentication. In React, use [`useUserDecrypt`](/reference/react/useUserDecrypt) which wraps this method with TanStack Query semantics.
+This is the SDK-level entry point for user decryption. The method is named `userDecrypt` (not `decrypt`) because it requires the connected wallet's credentials — distinguishing it from gateway-level decryption that happens on-chain without user authentication. In React, use [`useUserDecrypt`](../react/useUserDecrypt.md) which wraps this method with TanStack Query semantics.
 {% endhint %}
 
 ### revokeSession
@@ -422,7 +422,7 @@ sdk.terminate();
 
 ## Related
 
-- [Token](/reference/sdk/Token) — read/write token operations
-- [ReadonlyToken](/reference/sdk/ReadonlyToken) — read-only token operations
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) — on-chain token wrappers registry
-- [Configuration guide](/guides/configuration) — relayer, signer, and storage setup
+- [Token](./Token.md) — read/write token operations
+- [ReadonlyToken](./ReadonlyToken.md) — read-only token operations
+- [WrappersRegistry](./WrappersRegistry.md) — on-chain token wrappers registry
+- [Configuration guide](../../guides/configuration.md) — relayer, signer, and storage setup

--- a/docs/gitbook/src/reference/sdk/contract-builders.md
+++ b/docs/gitbook/src/reference/sdk/contract-builders.md
@@ -22,7 +22,7 @@ type WriteContractConfig = ReadContractConfig & {
 ```
 
 {% hint style="warning" %}
-The [Token API](/reference/sdk/Token) (`shield`, `unshield`, `confidentialTransfer`, etc.) handles contract calls, encryption, and multi-step flows for you. Use builders only when you need raw contract-level control — custom transaction pipelines, batching, or integrating with systems that expect ABI-encoded call data.
+The [Token API](./Token.md) (`shield`, `unshield`, `confidentialTransfer`, etc.) handles contract calls, encryption, and multi-step flows for you. Use builders only when you need raw contract-level control — custom transaction pipelines, batching, or integrating with systems that expect ABI-encoded call data.
 {% endhint %}
 
 ## Import
@@ -122,7 +122,7 @@ import {
 | `isConfidentialTokenValidContract(registry, confidentialToken)` | Check if a confidential token is valid in the registry |
 
 {% hint style="info" %}
-The [WrappersRegistry class](/reference/sdk/WrappersRegistry) wraps these builders with automatic address resolution. Use builders only when you need raw contract-level control.
+The [WrappersRegistry class](./WrappersRegistry.md) wraps these builders with automatic address resolution. Use builders only when you need raw contract-level control.
 {% endhint %}
 
 ## Delegation
@@ -182,5 +182,5 @@ All builders validate addresses at call time. A malformed address throws immedia
 
 ## Related
 
-- [Token](/reference/sdk/Token) — high-level API that wraps these builders
-- [Event Decoders](/reference/sdk/event-decoders) — decode on-chain logs into typed events
+- [Token](./Token.md) — high-level API that wraps these builders
+- [Event Decoders](./event-decoders.md) — decode on-chain logs into typed events

--- a/docs/gitbook/src/reference/sdk/delegation.md
+++ b/docs/gitbook/src/reference/sdk/delegation.md
@@ -222,7 +222,7 @@ A delegation between `(delegator, delegate, contract)` can be in one of four sta
 | **Expired**   | Past non-zero timestamp  | `isDelegated()` returns `false`, `getDelegationExpiry()` returns a non-zero past value                                  |
 | **Revoked**   | `0n` (reset by contract) | Indistinguishable from **never set** via state reads — use `RevokedDelegationForUserDecryption` events to differentiate |
 
-Because the ACL contract resets the expiry to `0n` on revocation, `DelegationNotFoundError` covers both the never-set and revoked cases. To distinguish them, query `RevokedDelegationForUserDecryption` events using the [ACL event decoders](/reference/sdk/event-decoders#acl-delegation-events).
+Because the ACL contract resets the expiry to `0n` on revocation, `DelegationNotFoundError` covers both the never-set and revoked cases. To distinguish them, query `RevokedDelegationForUserDecryption` events using the [ACL event decoders](./event-decoders.md#acl-delegation-events).
 
 ## Error handling
 
@@ -345,13 +345,13 @@ if (delegated) {
 }
 ```
 
-See [Event Decoders](/reference/sdk/event-decoders#acl-delegation-events) for the full list of ACL event decoders and types.
+See [Event Decoders](./event-decoders.md#acl-delegation-events) for the full list of ACL event decoders and types.
 
 ## Related
 
-- [Contract Builders](/reference/sdk/contract-builders#delegation) — low-level ACL delegation builders
-- [useDelegateDecryption](/reference/react/useDelegateDecryption) — React hook to grant delegation
-- [useRevokeDelegation](/reference/react/useRevokeDelegation) — React hook to revoke delegation
-- [useDelegationStatus](/reference/react/useDelegationStatus) — React hook to query delegation status
-- [useDecryptBalanceAs](/reference/react/useDecryptBalanceAs) — React hook to decrypt as a delegate
-- [useBatchDecryptBalancesAs](/reference/react/useBatchDecryptBalancesAs) — React hook for batch delegation decryption
+- [Contract Builders](./contract-builders.md#delegation) — low-level ACL delegation builders
+- [useDelegateDecryption](../react/useDelegateDecryption.md) — React hook to grant delegation
+- [useRevokeDelegation](../react/useRevokeDelegation.md) — React hook to revoke delegation
+- [useDelegationStatus](../react/useDelegationStatus.md) — React hook to query delegation status
+- [useDecryptBalanceAs](../react/useDecryptBalanceAs.md) — React hook to decrypt as a delegate
+- [useBatchDecryptBalancesAs](../react/useBatchDecryptBalancesAs.md) — React hook for batch delegation decryption

--- a/docs/gitbook/src/reference/sdk/errors.md
+++ b/docs/gitbook/src/reference/sdk/errors.md
@@ -510,7 +510,7 @@ matchZamaError(error, {
 **How to handle:** Wait for the ACL contract to be unpaused. This is an operator-level action — contact the protocol team if this persists.
 
 {% hint style="info" %}
-The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses via `matchAclRevert()`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation error reference](/reference/sdk/delegation#on-chain-revert-errors) for the full mapping.
+The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError` subclasses via `matchAclRevert()`. Unmapped reverts fall through to `TransactionRevertedError`. See the [delegation error reference](./delegation.md#on-chain-revert-errors) for the full mapping.
 {% endhint %}
 
 ## Common problems
@@ -531,5 +531,5 @@ The SDK automatically maps known ACL Solidity revert reasons to typed `ZamaError
 
 ## Related
 
-- [Error handling guide](/guides/handle-errors) — practical patterns for catching and displaying errors
-- [ZamaSDK](/reference/sdk/ZamaSDK) — SDK constructor and session management
+- [Error handling guide](../../guides/handle-errors.md) — practical patterns for catching and displaying errors
+- [ZamaSDK](./ZamaSDK.md) — SDK constructor and session management

--- a/docs/gitbook/src/reference/sdk/event-decoders.md
+++ b/docs/gitbook/src/reference/sdk/event-decoders.md
@@ -321,6 +321,6 @@ const feed = sortByBlockNumber(enrichedItems);
 
 ## Related
 
-- [Activity Feeds guide](/guides/activity-feeds) — activity feed usage in context
-- [Delegated Decryption](/reference/sdk/delegation) — delegation API with on-chain event examples
-- [Token](/reference/sdk/Token) — high-level API for token operations
+- [Activity Feeds guide](../../guides/activity-feeds.md) — activity feed usage in context
+- [Delegated Decryption](./delegation.md) — delegation API with on-chain event examples
+- [Token](./Token.md) — high-level API for token operations

--- a/docs/gitbook/src/reference/sdk/network-presets.md
+++ b/docs/gitbook/src/reference/sdk/network-presets.md
@@ -129,7 +129,7 @@ The relayer selects the correct transport based on the chain ID returned by `get
 
 ## DefaultRegistryAddresses
 
-A convenience export of built-in registry addresses for known chains (Mainnet, Sepolia, Hoodi) as a `Record<number, Address>` map. Used internally by the [WrappersRegistry](/reference/sdk/WrappersRegistry) class.
+A convenience export of built-in registry addresses for known chains (Mainnet, Sepolia, Hoodi) as a `Record<number, Address>` map. Used internally by the [WrappersRegistry](./WrappersRegistry.md) class.
 
 ```ts
 import { DefaultRegistryAddresses } from "@zama-fhe/sdk";
@@ -139,11 +139,11 @@ console.log(DefaultRegistryAddresses);
 ```
 
 {% hint style="info" %}
-`HardhatConfig` has no registry address by default. Pass one explicitly via `registryAddresses` when creating a [WrappersRegistry](/reference/sdk/WrappersRegistry).
+`HardhatConfig` has no registry address by default. Pass one explicitly via `registryAddresses` when creating a [WrappersRegistry](./WrappersRegistry.md).
 {% endhint %}
 
 ## Related
 
-- [WrappersRegistry](/reference/sdk/WrappersRegistry) — high-level registry query API
-- [Configuration guide](/guides/configuration) — full relayer, signer, and storage setup
-- [ZamaSDK](/reference/sdk/ZamaSDK) — SDK constructor reference
+- [WrappersRegistry](./WrappersRegistry.md) — high-level registry query API
+- [Configuration guide](../../guides/configuration.md) — full relayer, signer, and storage setup
+- [ZamaSDK](./ZamaSDK.md) — SDK constructor reference

--- a/docs/gitbook/src/tutorials/first-confidential-dapp.md
+++ b/docs/gitbook/src/tutorials/first-confidential-dapp.md
@@ -82,7 +82,7 @@ export const WRAPPER_ADDRESS = "0xYourWrapperAddress" as const;
 {% endtab %}
 {% endtabs %}
 
-Replace `YOUR_KEY` with your Infura (or Alchemy) project ID, and update the relayer URL to point at your backend proxy. See the [Authentication guide](/guides/authentication) for proxy setup details.
+Replace `YOUR_KEY` with your Infura (or Alchemy) project ID, and update the relayer URL to point at your backend proxy. See the [Authentication guide](../guides/authentication.md) for proxy setup details.
 
 ## 4. Create the App layout with providers
 
@@ -298,11 +298,11 @@ export function UnshieldForm() {
 {% endtab %}
 {% endtabs %}
 
-See [Hooks > useUnshield](/reference/react/useUnshield) for the full callback reference.
+See [Hooks > useUnshield](../reference/react/useUnshield.md) for the full callback reference.
 
 ## 9. Add error handling
 
-Create `src/ErrorMessage.tsx`. The `matchZamaError` utility maps SDK error codes to user-friendly messages without long `instanceof` chains. See [Error Handling](/guides/handle-errors) for the full list of error codes.
+Create `src/ErrorMessage.tsx`. The `matchZamaError` utility maps SDK error codes to user-friendly messages without long `instanceof` chains. See [Error Handling](../guides/handle-errors.md) for the full list of error codes.
 
 {% tabs %}
 {% tab title="src/ErrorMessage.tsx" %}
@@ -382,7 +382,7 @@ Open the app in your browser, connect your wallet, and try the full flow: shield
 
 ## Next steps
 
-- [Configuration](/guides/configuration) -- customize authentication, storage backends, and network presets
-- [Error Handling](/guides/handle-errors) -- handle every SDK error type
-- [React Hooks](/reference/react/query-keys) -- explore all available hooks
-- [Core SDK](/reference/sdk/ZamaSDK) -- use the imperative API for non-React apps
+- [Configuration](../guides/configuration.md) -- customize authentication, storage backends, and network presets
+- [Error Handling](../guides/handle-errors.md) -- handle every SDK error type
+- [React Hooks](../reference/react/query-keys.md) -- explore all available hooks
+- [Core SDK](../reference/sdk/ZamaSDK.md) -- use the imperative API for non-React apps

--- a/docs/gitbook/src/tutorials/quick-start.md
+++ b/docs/gitbook/src/tutorials/quick-start.md
@@ -29,7 +29,7 @@ relayerUrl: "https://your-app.com/api/relayer/11155111"
 auth: { __type: "ApiKeyHeader", value: "your-api-key" }
 ```
 
-See [Authentication](/guides/authentication) for a backend proxy example.
+See [Authentication](../guides/authentication.md) for a backend proxy example.
 
 ## Install
 
@@ -247,7 +247,7 @@ const sdk = new ZamaSDK({
 {% endtabs %}
 
 {% hint style="info" %}
-**FHE artifact caching** — Both `RelayerWeb` and `RelayerNode` automatically cache the multi-MB FHE public key and parameters so they are not re-downloaded on every startup. `RelayerWeb` uses IndexedDB (persists across reloads), `RelayerNode` uses in-memory storage (lost on restart). The cache revalidates against the CDN every 24 hours. Configure via `fheArtifactStorage` and `fheArtifactCacheTTL`. See [FheArtifactCache](/reference/sdk/FheArtifactCache) for details.
+**FHE artifact caching** — Both `RelayerWeb` and `RelayerNode` automatically cache the multi-MB FHE public key and parameters so they are not re-downloaded on every startup. `RelayerWeb` uses IndexedDB (persists across reloads), `RelayerNode` uses in-memory storage (lost on restart). The cache revalidates against the CDN every 24 hours. Configure via `fheArtifactStorage` and `fheArtifactCacheTTL`. See [FheArtifactCache](../reference/sdk/FheArtifactCache.md) for details.
 {% endhint %}
 
 ## Your first confidential transfer
@@ -427,8 +427,8 @@ The hooks and SDK methods handle FHE encryption, wallet signing, ERC-20 approval
 
 ## Next steps
 
-- [Configuration](/guides/configuration) -- relayer, signer, storage, and authentication setup
-- [Shield Tokens](/guides/shield-tokens) -- move tokens into confidential form
-- [Network Presets](/reference/sdk/network-presets) -- pre-configured contract addresses for Sepolia, Mainnet, and Hardhat
-- [React Hooks](/reference/react/ZamaProvider) -- provider setup and all available hooks
-- [Security Model](/concepts/security-model) -- understand the cryptography and trust assumptions
+- [Configuration](../guides/configuration.md) -- relayer, signer, storage, and authentication setup
+- [Shield Tokens](../guides/shield-tokens.md) -- move tokens into confidential form
+- [Network Presets](../reference/sdk/network-presets.md) -- pre-configured contract addresses for Sepolia, Mainnet, and Hardhat
+- [React Hooks](../reference/react/ZamaProvider.md) -- provider setup and all available hooks
+- [Security Model](../concepts/security-model.md) -- understand the cryptography and trust assumptions

--- a/docs/gitbook/src/tutorials/wallet-exchange-integration.md
+++ b/docs/gitbook/src/tutorials/wallet-exchange-integration.md
@@ -17,7 +17,7 @@ By the end of this guide, you will be able to:
 
 ## Core concepts
 
-While building support for [ERC-7984 confidential tokens](https://eips.ethereum.org/EIPS/eip-7984) you will encounter the following terminology. For a deeper architectural overview, see [Architecture](/concepts/architecture).
+While building support for [ERC-7984 confidential tokens](https://eips.ethereum.org/EIPS/eip-7984) you will encounter the following terminology. For a deeper architectural overview, see [Architecture](../concepts/architecture.md).
 
 - **FHEVM** — Zama's library for computations on encrypted values. Encrypted values are represented on-chain as **ciphertext handles** (`bytes32`).
 - **Host chain** — the EVM network your users connect to (e.g. Ethereum mainnet, Sepolia).
@@ -32,15 +32,15 @@ While building support for [ERC-7984 confidential tokens](https://eips.ethereum.
 
 You do **not** need to run FHE infrastructure to integrate. Wallets and exchanges interact with the protocol entirely through the Zama SDK:
 
-1. Install and configure `@zama-fhe/sdk` (or `@zama-fhe/react-sdk` for React apps). See [Quick start](/tutorials/quick-start) for stack-by-stack setup.
-2. Initialize a `ZamaSDK` instance with a relayer, signer, and storage. See the [`ZamaSDK` reference](/reference/sdk/ZamaSDK).
+1. Install and configure `@zama-fhe/sdk` (or `@zama-fhe/react-sdk` for React apps). See [Quick start](./quick-start.md) for stack-by-stack setup.
+2. Initialize a `ZamaSDK` instance with a relayer, signer, and storage. See the [`ZamaSDK` reference](../reference/sdk/ZamaSDK.md).
 3. For each confidential token contract, build a `Token` handle via `sdk.createToken(address)`.
 4. Read encrypted balances, build transfers, and manage operators using the `Token` API or React hooks.
 
 ## What wallets and exchanges should support
 
-- **Transfers**: Support the ERC-7984 transfer variants documented by OpenZeppelin, including forms that use an input proof and optional receiver callbacks. The SDK's [`Token.confidentialTransfer`](/reference/sdk/Token) and [`useConfidentialTransfer`](/reference/react/useConfidentialTransfer) handle the encrypted input pipeline for you. See [Transfer privately](/guides/transfer-privately).
-- **Operators**: Operators can move any amount during an active window. UX must capture an expiry, show risk clearly, and make revoke easy. See [Operator approvals](/guides/operator-approvals).
+- **Transfers**: Support the ERC-7984 transfer variants documented by OpenZeppelin, including forms that use an input proof and optional receiver callbacks. The SDK's [`Token.confidentialTransfer`](../reference/sdk/Token.md) and [`useConfidentialTransfer`](../reference/react/useConfidentialTransfer.md) handle the encrypted input pipeline for you. See [Transfer privately](../guides/transfer-privately.md).
+- **Operators**: Operators can move any amount during an active window. UX must capture an expiry, show risk clearly, and make revoke easy. See [Operator approvals](../guides/operator-approvals.md).
 - **Events and metadata**: Names and symbols behave like conventional ERC-20s, but on-chain amounts remain encrypted. Render user-specific amounts only after user-decrypting them.
 
 ## Display confidential balances
@@ -99,7 +99,7 @@ function Balance() {
 {% endtab %}
 {% endtabs %}
 
-A common pattern is to call `useAllow` once when the user first connects (covering every confidential contract you'll touch), then read balances anywhere in the app without further prompts. Credentials persist in IndexedDB and survive page reloads. See [Encrypt & decrypt](/guides/encrypt-decrypt) for the full pre-authorization pattern, and [Check balances](/guides/check-balances) for batch decryption across multiple tokens.
+A common pattern is to call `useAllow` once when the user first connects (covering every confidential contract you'll touch), then read balances anywhere in the app without further prompts. Credentials persist in IndexedDB and survive page reloads. See [Encrypt & decrypt](../guides/encrypt-decrypt.md) for the full pre-authorization pattern, and [Check balances](../guides/check-balances.md) for batch decryption across multiple tokens.
 
 ## Send a confidential transfer
 
@@ -125,7 +125,7 @@ mutate({ to: "0xRecipient", amount: 500n });
 {% endtab %}
 {% endtabs %}
 
-For operator transfers (`transferFrom`-style with delegated authority), see [`useConfidentialTransferFrom`](/reference/react/useConfidentialTransferFrom) and [Operator approvals](/guides/operator-approvals).
+For operator transfers (`transferFrom`-style with delegated authority), see [`useConfidentialTransferFrom`](../reference/react/useConfidentialTransferFrom.md) and [Operator approvals](../guides/operator-approvals.md).
 
 ## Wrapping and unwrapping
 
@@ -175,7 +175,7 @@ mutate({ amount: 1000n });
 {% endtab %}
 {% endtabs %}
 
-See [Shield tokens](/guides/shield-tokens) for the full options surface, including custom approval strategies and progress callbacks.
+See [Shield tokens](../guides/shield-tokens.md) for the full options surface, including custom approval strategies and progress callbacks.
 
 ### Unshield (unwrap)
 
@@ -211,7 +211,7 @@ mutate({ amount: 500n });
 {% endtab %}
 {% endtabs %}
 
-If the user closes the page between unwrap and finalize, resume with `Token.resumeUnshield` / [`useResumeUnshield`](/reference/react/useResumeUnshield). See [Unshield tokens](/guides/unshield-tokens) for the full flow.
+If the user closes the page between unwrap and finalize, resume with `Token.resumeUnshield` / [`useResumeUnshield`](../reference/react/useResumeUnshield.md). See [Unshield tokens](../guides/unshield-tokens.md) for the full flow.
 
 ### Decimal conversion in your UI
 
@@ -229,7 +229,7 @@ Display balances in the underlying asset's decimals when possible — your users
 
 The Confidential Token Wrappers Registry is an on-chain contract that maps ERC-20s to their ERC-7984 wrappers. It's the canonical directory for wallets and exchanges to discover which underlying tokens have official confidential wrappers.
 
-The SDK exposes it via `sdk.registry`. See the [`WrappersRegistry` reference](/reference/sdk/WrappersRegistry) for the full surface.
+The SDK exposes it via `sdk.registry`. See the [`WrappersRegistry` reference](../reference/sdk/WrappersRegistry.md) for the full surface.
 
 {% hint style="warning" %}
 **Always check validity.** A non-zero wrapper address may have been revoked. Treat `isValid: false` as no wrapper for that token.
@@ -326,26 +326,26 @@ Look up the underlying ERC-20 for each via `sdk.registry.getUnderlyingToken(addr
 
 ## End-to-end example
 
-For a runnable React dApp using these APIs end-to-end, follow [Build your first confidential dApp](/tutorials/first-confidential-dapp).
+For a runnable React dApp using these APIs end-to-end, follow [Build your first confidential dApp](./first-confidential-dapp.md).
 
 ## UI and UX recommendations
 
 - **Caching**: Decrypted values are cached client-side for the session lifetime. Offer a refresh action that repeats the decrypt flow.
-- **Permissions**: Treat user decryption as a permission grant with scope and duration. Show which contracts are included and when access expires. The SDK's session model is described in [Session model](/concepts/session-model).
+- **Permissions**: Treat user decryption as a permission grant with scope and duration. Show which contracts are included and when access expires. The SDK's session model is described in [Session model](../concepts/session-model.md).
 - **Indicators**: Use distinct icons or badges for encrypted amounts. Avoid showing zero when a value is simply undisclosed.
-- **Operator visibility**: Always show current operator approvals with expiry and a one-tap revoke. See [`useConfidentialIsApproved`](/reference/react/useConfidentialIsApproved) and [`useRevoke`](/reference/react/useRevoke).
+- **Operator visibility**: Always show current operator approvals with expiry and a one-tap revoke. See [`useConfidentialIsApproved`](../reference/react/useConfidentialIsApproved.md) and [`useRevoke`](../reference/react/useRevoke.md).
 - **Wrapping/unwrapping**: Clearly indicate which token a user is converting between. Show the underlying ERC-20's name and symbol alongside the confidential token.
-- **Failure modes**: Differentiate between decryption denied, missing ACL grant, and expired session. Offer guided recovery actions. See [Handle errors](/guides/handle-errors).
+- **Failure modes**: Differentiate between decryption denied, missing ACL grant, and expired session. Offer guided recovery actions. See [Handle errors](../guides/handle-errors.md).
 
 ## Testing and environments
 
-- For local development against a Hardhat chain with no relayer, use [`RelayerCleartext`](/reference/sdk/RelayerCleartext). See [Local development](/guides/local-development).
-- For testnet, use the SDK's built-in Sepolia config or any other supported network — see [Network presets](/reference/sdk/network-presets).
+- For local development against a Hardhat chain with no relayer, use [`RelayerCleartext`](../reference/sdk/RelayerCleartext.md). See [Local development](../guides/local-development.md).
+- For testnet, use the SDK's built-in Sepolia config or any other supported network — see [Network presets](../reference/sdk/network-presets.md).
 - Keep chain selection in a single source of truth in your app.
 
 ## Further reading
 
 - [OpenZeppelin Confidential Contracts documentation](https://docs.openzeppelin.com/confidential-contracts) — ERC-7984 transfer variants, receiver callbacks, and operator semantics.
-- [`Token` reference](/reference/sdk/Token) — full method surface for shield, unshield, transfer, approve, and balance operations.
-- [`WrappersRegistry` reference](/reference/sdk/WrappersRegistry) — registry construction, caching, and pagination.
-- [Architecture](/concepts/architecture) — how the SDK, relayer, and gateway fit together.
+- [`Token` reference](../reference/sdk/Token.md) — full method surface for shield, unshield, transfer, approve, and balance operations.
+- [`WrappersRegistry` reference](../reference/sdk/WrappersRegistry.md) — registry construction, caching, and pagination.
+- [Architecture](../concepts/architecture.md) — how the SDK, relayer, and gateway fit together.


### PR DESCRIPTION
## Root cause

GitBook publishes each docs space under a sub-path (`docs.zama.org/protocol/sdk/...`). Host-absolute internal links like `[X](/reference/sdk/RelayerWeb)` resolve against the **site** root there, miss the space, and render as broken external GitHub URLs that 404. The fix is to convert them to **relative `.md` paths** (e.g. `../reference/sdk/RelayerWeb.md`, `./configuration.md`), which resolve natively on GitBook.

## What changed

- **363 links rewritten** across **81 files** under `docs/gitbook/src/`.
- Same-directory links use `./name.md`; cross-directory links use `../path/name.md`.
- `#anchor` fragments preserved on every rewritten link, and all of them were validated against the actual headings in their target files — all resolve.
- The rewrite was **fence-aware**: fenced code blocks were skipped so example code was not touched. A final grep confirms **zero** `](/...)` host-absolute internal links remain anywhere (including code samples); protocol-relative `](//` and `](http...)` links were left alone.

## Stale / unresolved targets

- **None.** Every host-absolute link pointed to a page that exists on disk, so all 363 were rewritten — nothing needed manual retargeting and nothing was dropped.

## Notes

- The only non-link diff lines are markdown table column-width realignments in `overview.md`, produced by oxfmt because the relative `.md` targets are slightly longer than the originals. No prose or code content changed.
- `main` has no `llm:build` script and no `llms-full.txt`, so there was nothing to regenerate (unlike `prerelease`).
- Verified with `pnpm install`, `pnpm format docs/gitbook/src`, and `pnpm format:check docs/gitbook/src` (all clean).
- No link-checking tooling was added — that is a separate ticket.

This is the `main`-branch sibling of the prerelease fix (PR #437) under SDK-224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)