### PR TITLE
fix(chains): add ingenTestnet + bscTestnet presets

### DIFF
--- a/docs/gitbook/src/guides/configuration.md
+++ b/docs/gitbook/src/guides/configuration.md
@@ -17,12 +17,14 @@ Import pre-configured chain objects from `@zama-fhe/sdk/chains`. Each chain incl
 import { sepolia, mainnet, hoodi } from "@zama-fhe/sdk/chains";
 ```
 
-| Chain     | Chain ID   | Description        |
-| --------- | ---------- | ------------------ |
-| `mainnet` | `1`        | Ethereum Mainnet   |
-| `sepolia` | `11155111` | Sepolia Testnet    |
-| `hoodi`   | `560048`   | Hoodi Testnet      |
-| `hardhat` | `31337`    | Local Hardhat node |
+| Chain        | Chain ID   | Description         |
+| ------------ | ---------- | ------------------- |
+| `mainnet`    | `1`        | Ethereum Mainnet    |
+| `sepolia`    | `11155111` | Sepolia Testnet     |
+| `hoodi`      | `560048`   | Hoodi Testnet       |
+| `ingen`      | `364301`   | T-Rex InGen Testnet |
+| `bscTestnet` | `97`       | BNB Smart Chain Testnet |
+| `hardhat`    | `31337`    | Local Hardhat node  |
 
 ### 2. Pick a relayer
 

--- a/docs/gitbook/src/guides/configuration.md
+++ b/docs/gitbook/src/guides/configuration.md
@@ -17,14 +17,14 @@ Import pre-configured chain objects from `@zama-fhe/sdk/chains`. Each chain incl
 import { sepolia, mainnet, hoodi } from "@zama-fhe/sdk/chains";
 ```
 
-| Chain        | Chain ID   | Description         |
-| ------------ | ---------- | ------------------- |
-| `mainnet`    | `1`        | Ethereum Mainnet    |
-| `sepolia`    | `11155111` | Sepolia Testnet     |
-| `hoodi`      | `560048`   | Hoodi Testnet       |
-| `ingen`      | `364301`   | T-Rex InGen Testnet |
-| `bscTestnet` | `97`       | BNB Smart Chain Testnet |
-| `hardhat`    | `31337`    | Local Hardhat node  |
+| Chain          | Chain ID   | Description             |
+| -------------- | ---------- | ----------------------- |
+| `mainnet`      | `1`        | Ethereum Mainnet        |
+| `sepolia`      | `11155111` | Sepolia Testnet         |
+| `hoodi`        | `560048`   | Hoodi Testnet           |
+| `ingenTestnet` | `364301`   | InGen Testnet           |
+| `bscTestnet`   | `97`       | BNB Smart Chain Testnet |
+| `hardhat`      | `31337`    | Local Hardhat node      |
 
 ### 2. Pick a relayer
 

--- a/docs/gitbook/src/guides/configuration.md
+++ b/docs/gitbook/src/guides/configuration.md
@@ -26,6 +26,8 @@ import { sepolia, mainnet, hoodi } from "@zama-fhe/sdk/chains";
 | `bscTestnet`   | `97`       | BNB Smart Chain Testnet |
 | `hardhat`      | `31337`    | Local Hardhat node      |
 
+`anvil` is also exported as an alias for `hardhat` (both target chain ID `31337`), for Foundry users.
+
 ### 2. Pick a relayer
 
 Relayers tell the SDK how to run FHE operations on each chain.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1466,6 +1466,8 @@ import { sepolia, mainnet, hoodi } from "@zama-fhe/sdk/chains";
 | `bscTestnet`   | `97`       | BNB Smart Chain Testnet |
 | `hardhat`      | `31337`    | Local Hardhat node      |
 
+`anvil` is also exported as an alias for `hardhat` (both target chain ID `31337`), for Foundry users.
+
 ### 2. Pick a relayer
 
 Relayers tell the SDK how to run FHE operations on each chain.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1457,14 +1457,14 @@ Import pre-configured chain objects from `@zama-fhe/sdk/chains`. Each chain incl
 import { sepolia, mainnet, hoodi } from "@zama-fhe/sdk/chains";
 ```
 
-| Chain        | Chain ID   | Description         |
-| ------------ | ---------- | ------------------- |
-| `mainnet`    | `1`        | Ethereum Mainnet    |
-| `sepolia`    | `11155111` | Sepolia Testnet     |
-| `hoodi`      | `560048`   | Hoodi Testnet       |
-| `ingen`      | `364301`   | T-Rex InGen Testnet |
-| `bscTestnet` | `97`       | BNB Smart Chain Testnet |
-| `hardhat`    | `31337`    | Local Hardhat node  |
+| Chain          | Chain ID   | Description             |
+| -------------- | ---------- | ----------------------- |
+| `mainnet`      | `1`        | Ethereum Mainnet        |
+| `sepolia`      | `11155111` | Sepolia Testnet         |
+| `hoodi`        | `560048`   | Hoodi Testnet           |
+| `ingenTestnet` | `364301`   | InGen Testnet           |
+| `bscTestnet`   | `97`       | BNB Smart Chain Testnet |
+| `hardhat`      | `31337`    | Local Hardhat node      |
 
 ### 2. Pick a relayer
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1457,12 +1457,14 @@ Import pre-configured chain objects from `@zama-fhe/sdk/chains`. Each chain incl
 import { sepolia, mainnet, hoodi } from "@zama-fhe/sdk/chains";
 ```
 
-| Chain     | Chain ID   | Description        |
-| --------- | ---------- | ------------------ |
-| `mainnet` | `1`        | Ethereum Mainnet   |
-| `sepolia` | `11155111` | Sepolia Testnet    |
-| `hoodi`   | `560048`   | Hoodi Testnet      |
-| `hardhat` | `31337`    | Local Hardhat node |
+| Chain        | Chain ID   | Description         |
+| ------------ | ---------- | ------------------- |
+| `mainnet`    | `1`        | Ethereum Mainnet    |
+| `sepolia`    | `11155111` | Sepolia Testnet     |
+| `hoodi`      | `560048`   | Hoodi Testnet       |
+| `ingen`      | `364301`   | T-Rex InGen Testnet |
+| `bscTestnet` | `97`       | BNB Smart Chain Testnet |
+| `hardhat`    | `31337`    | Local Hardhat node  |
 
 ### 2. Pick a relayer
 

--- a/packages/sdk/etc/sdk-node.api.md
+++ b/packages/sdk/etc/sdk-node.api.md
@@ -115,6 +115,21 @@ export abstract class BaseWorkerClient<TWorker, TConfig> {
 }
 
 // @public
+export const bscTestnet: {
+    readonly id: 97;
+    readonly gatewayChainId: 10901;
+    readonly relayerUrl: "";
+    readonly network: "https://bsc-testnet-rpc.publicnode.com";
+    readonly aclContractAddress: "0x52470e945521E247Cb4754088a836Dc4b838AFBE";
+    readonly kmsContractAddress: "0x788F5BB2d93aB4Cb67Fe2277757aE95006504F6F";
+    readonly inputVerifierContractAddress: "0x49e0BAB39904E4192c30CFB58573Cbe27B7E398E";
+    readonly verifyingContractAddressDecryption: "0x5ffdaAB0373E62E2ea2944776209aEf29E631A64";
+    readonly verifyingContractAddressInputVerification: "0x812b06e1CDCE800494b79fFE4f925A504a9A9810";
+    readonly registryAddress: "0xc0E8B73b1C58D846e1d4f8fAE2E1466C85BCeAeC";
+    readonly executorAddress: "0x5985e48689550c1b2893ABfBbe4cc0eE3A22cc54";
+};
+
+// @public
 export const chains: Record<number, FheChain>;
 
 // @public
@@ -385,6 +400,21 @@ export const hoodi: {
     readonly verifyingContractAddressInputVerification: "0x812b06e1CDCE800494b79fFE4f925A504a9A9810";
     readonly registryAddress: "0x1807aE2f693F8530DFB126D0eF98F2F2518F292f";
     readonly executorAddress: "0xC316692627de536368d82e9121F1D44a550894E6";
+};
+
+// @public
+export const ingen: {
+    readonly id: 364301;
+    readonly gatewayChainId: 10901;
+    readonly relayerUrl: "";
+    readonly network: "https://rpc.ingen.t-rex.network";
+    readonly aclContractAddress: "0x09a4710BfBe7B557cD5CFE88BB31e9b5b85C419b";
+    readonly kmsContractAddress: "0xd885DEa6a924785fCcdf9CE993FEe27EA11832e6";
+    readonly inputVerifierContractAddress: "0x90f05B10db153365D8cB143EA17f5E5714D0bCD5";
+    readonly verifyingContractAddressDecryption: "0x5ffdaAB0373E62E2ea2944776209aEf29E631A64";
+    readonly verifyingContractAddressInputVerification: "0x812b06e1CDCE800494b79fFE4f925A504a9A9810";
+    readonly registryAddress: "0x7FC3D79EF9d01fA318CF2Aa5D91dDC492383Be0F";
+    readonly executorAddress: "0x1B05DE5b67b8f8363DC04E3a5996a616f11f8C7B";
 };
 
 // @public (undocumented)

--- a/packages/sdk/etc/sdk-node.api.md
+++ b/packages/sdk/etc/sdk-node.api.md
@@ -403,7 +403,7 @@ export const hoodi: {
 };
 
 // @public
-export const ingen: {
+export const ingenTestnet: {
     readonly id: 364301;
     readonly gatewayChainId: 10901;
     readonly relayerUrl: "";

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -583,6 +583,21 @@ export interface BatchDecryptResult {
 }
 
 // @public
+export const bscTestnet: {
+    readonly id: 97;
+    readonly gatewayChainId: 10901;
+    readonly relayerUrl: "";
+    readonly network: "https://bsc-testnet-rpc.publicnode.com";
+    readonly aclContractAddress: "0x52470e945521E247Cb4754088a836Dc4b838AFBE";
+    readonly kmsContractAddress: "0x788F5BB2d93aB4Cb67Fe2277757aE95006504F6F";
+    readonly inputVerifierContractAddress: "0x49e0BAB39904E4192c30CFB58573Cbe27B7E398E";
+    readonly verifyingContractAddressDecryption: "0x5ffdaAB0373E62E2ea2944776209aEf29E631A64";
+    readonly verifyingContractAddressInputVerification: "0x812b06e1CDCE800494b79fFE4f925A504a9A9810";
+    readonly registryAddress: "0xc0E8B73b1C58D846e1d4f8fAE2E1466C85BCeAeC";
+    readonly executorAddress: "0x5985e48689550c1b2893ABfBbe4cc0eE3A22cc54";
+};
+
+// @public
 export class ChainMismatchError extends ZamaError {
     constructor(input: {
         operation: string;
@@ -9796,6 +9811,21 @@ export function inferredTotalSupplyContract(wrapperAddress: Address): {
     }];
     readonly functionName: "inferredTotalSupply";
     readonly args: readonly [];
+};
+
+// @public
+export const ingen: {
+    readonly id: 364301;
+    readonly gatewayChainId: 10901;
+    readonly relayerUrl: "";
+    readonly network: "https://rpc.ingen.t-rex.network";
+    readonly aclContractAddress: "0x09a4710BfBe7B557cD5CFE88BB31e9b5b85C419b";
+    readonly kmsContractAddress: "0xd885DEa6a924785fCcdf9CE993FEe27EA11832e6";
+    readonly inputVerifierContractAddress: "0x90f05B10db153365D8cB143EA17f5E5714D0bCD5";
+    readonly verifyingContractAddressDecryption: "0x5ffdaAB0373E62E2ea2944776209aEf29E631A64";
+    readonly verifyingContractAddressInputVerification: "0x812b06e1CDCE800494b79fFE4f925A504a9A9810";
+    readonly registryAddress: "0x7FC3D79EF9d01fA318CF2Aa5D91dDC492383Be0F";
+    readonly executorAddress: "0x1B05DE5b67b8f8363DC04E3a5996a616f11f8C7B";
 };
 
 export { InputProofBytesType }

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -9814,7 +9814,7 @@ export function inferredTotalSupplyContract(wrapperAddress: Address): {
 };
 
 // @public
-export const ingen: {
+export const ingenTestnet: {
     readonly id: 364301;
     readonly gatewayChainId: 10901;
     readonly relayerUrl: "";

--- a/packages/sdk/src/chains/configs.ts
+++ b/packages/sdk/src/chains/configs.ts
@@ -64,7 +64,7 @@ export const hoodi = {
  * InGen does not have full FHE infrastructure — use with `cleartext()` transport.
  * Contract addresses match the cleartext deployment.
  */
-export const ingen = {
+export const ingenTestnet = {
   id: 364301,
   gatewayChainId: 10901,
   relayerUrl: "",
@@ -127,7 +127,7 @@ export const chains: Record<number, FheChain> = {
   [mainnet.id]: mainnet,
   [sepolia.id]: sepolia,
   [hoodi.id]: hoodi,
-  [ingen.id]: ingen,
+  [ingenTestnet.id]: ingenTestnet,
   [bscTestnet.id]: bscTestnet,
   [hardhat.id]: hardhat,
 } as const;

--- a/packages/sdk/src/chains/configs.ts
+++ b/packages/sdk/src/chains/configs.ts
@@ -59,6 +59,46 @@ export const hoodi = {
 } as const satisfies FheChain;
 
 /**
+ * T-Rex InGen testnet configuration (chainId 364301).
+ *
+ * InGen does not have full FHE infrastructure — use with `cleartext()` transport.
+ * Contract addresses match the cleartext deployment.
+ */
+export const ingen = {
+  id: 364301,
+  gatewayChainId: 10901,
+  relayerUrl: "",
+  network: "https://rpc.ingen.t-rex.network",
+  aclContractAddress: "0x09a4710BfBe7B557cD5CFE88BB31e9b5b85C419b",
+  kmsContractAddress: "0xd885DEa6a924785fCcdf9CE993FEe27EA11832e6",
+  inputVerifierContractAddress: "0x90f05B10db153365D8cB143EA17f5E5714D0bCD5",
+  verifyingContractAddressDecryption: "0x5ffdaAB0373E62E2ea2944776209aEf29E631A64",
+  verifyingContractAddressInputVerification: "0x812b06e1CDCE800494b79fFE4f925A504a9A9810",
+  registryAddress: "0x7FC3D79EF9d01fA318CF2Aa5D91dDC492383Be0F",
+  executorAddress: "0x1B05DE5b67b8f8363DC04E3a5996a616f11f8C7B",
+} as const satisfies FheChain;
+
+/**
+ * BNB Smart Chain testnet configuration (chainId 97, Chapel).
+ *
+ * BSC testnet does not have full FHE infrastructure — use with `cleartext()` transport.
+ * Contract addresses match the cleartext deployment.
+ */
+export const bscTestnet = {
+  id: 97,
+  gatewayChainId: 10901,
+  relayerUrl: "",
+  network: "https://bsc-testnet-rpc.publicnode.com",
+  aclContractAddress: "0x52470e945521E247Cb4754088a836Dc4b838AFBE",
+  kmsContractAddress: "0x788F5BB2d93aB4Cb67Fe2277757aE95006504F6F",
+  inputVerifierContractAddress: "0x49e0BAB39904E4192c30CFB58573Cbe27B7E398E",
+  verifyingContractAddressDecryption: "0x5ffdaAB0373E62E2ea2944776209aEf29E631A64",
+  verifyingContractAddressInputVerification: "0x812b06e1CDCE800494b79fFE4f925A504a9A9810",
+  registryAddress: "0xc0E8B73b1C58D846e1d4f8fAE2E1466C85BCeAeC",
+  executorAddress: "0x5985e48689550c1b2893ABfBbe4cc0eE3A22cc54",
+} as const satisfies FheChain;
+
+/**
  * Hardhat local network configuration (chainId 31337).
  *
  * The addresses in this configuration must match those of your deployment.
@@ -87,5 +127,7 @@ export const chains: Record<number, FheChain> = {
   [mainnet.id]: mainnet,
   [sepolia.id]: sepolia,
   [hoodi.id]: hoodi,
+  [ingen.id]: ingen,
+  [bscTestnet.id]: bscTestnet,
   [hardhat.id]: hardhat,
 } as const;

--- a/packages/sdk/src/chains/index.ts
+++ b/packages/sdk/src/chains/index.ts
@@ -1,2 +1,11 @@
-export { mainnet, sepolia, hoodi, ingen, bscTestnet, hardhat, anvil, chains } from "./configs";
+export {
+  mainnet,
+  sepolia,
+  hoodi,
+  ingenTestnet,
+  bscTestnet,
+  hardhat,
+  anvil,
+  chains,
+} from "./configs";
 export type { FheChain, AtLeastOneChain } from "./types";

--- a/packages/sdk/src/chains/index.ts
+++ b/packages/sdk/src/chains/index.ts
@@ -1,2 +1,2 @@
-export { mainnet, sepolia, hoodi, hardhat, anvil, chains } from "./configs";
+export { mainnet, sepolia, hoodi, ingen, bscTestnet, hardhat, anvil, chains } from "./configs";
 export type { FheChain, AtLeastOneChain } from "./types";

--- a/packages/sdk/src/chains/types.ts
+++ b/packages/sdk/src/chains/types.ts
@@ -5,7 +5,7 @@ import type { Address, EIP1193Provider, Hex } from "viem";
  * Complete chain configuration — the single source of truth for
  * per-chain FHE contract addresses and network settings.
  *
- * All built-in presets (`mainnet`, `sepolia`, `hoodi`, `ingen`,
+ * All built-in presets (`mainnet`, `sepolia`, `hoodi`, `ingenTestnet`,
  * `bscTestnet`, `hardhat`) are `FheChain` objects exported from
  * `@zama-fhe/sdk/chains`.
  */

--- a/packages/sdk/src/chains/types.ts
+++ b/packages/sdk/src/chains/types.ts
@@ -5,8 +5,9 @@ import type { Address, EIP1193Provider, Hex } from "viem";
  * Complete chain configuration — the single source of truth for
  * per-chain FHE contract addresses and network settings.
  *
- * All built-in presets (`mainnet`, `sepolia`, `hardhat`, `hoodi`)
- * are `FheChain` objects exported from `@zama-fhe/sdk/chains`.
+ * All built-in presets (`mainnet`, `sepolia`, `hoodi`, `ingen`,
+ * `bscTestnet`, `hardhat`) are `FheChain` objects exported from
+ * `@zama-fhe/sdk/chains`.
  */
 export interface FheChain<TId extends number = number> {
   readonly id: TId;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -55,7 +55,16 @@ export type { KmsDelegatedUserDecryptEIP712Type as KmsDelegatedDecryptEIP712Type
 export type { GenericLogger } from "./worker/worker.types";
 
 // Chain presets and types
-export { mainnet, sepolia, hoodi, ingen, bscTestnet, hardhat, anvil, chains } from "./chains";
+export {
+  mainnet,
+  sepolia,
+  hoodi,
+  ingenTestnet,
+  bscTestnet,
+  hardhat,
+  anvil,
+  chains,
+} from "./chains";
 export type { FheChain } from "./chains/types";
 
 // ERC-165 interface IDs

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -55,7 +55,7 @@ export type { KmsDelegatedUserDecryptEIP712Type as KmsDelegatedDecryptEIP712Type
 export type { GenericLogger } from "./worker/worker.types";
 
 // Chain presets and types
-export { mainnet, sepolia, hoodi, hardhat, anvil, chains } from "./chains";
+export { mainnet, sepolia, hoodi, ingen, bscTestnet, hardhat, anvil, chains } from "./chains";
 export type { FheChain } from "./chains/types";
 
 // ERC-165 interface IDs

--- a/packages/sdk/src/node/index.ts
+++ b/packages/sdk/src/node/index.ts
@@ -74,4 +74,4 @@ export type {
 export { asyncLocalStorage, AsyncLocalMapStorage } from "../storage/async-local-storage";
 
 // Chain presets
-export { mainnet, sepolia, hoodi, hardhat, anvil, chains } from "../chains";
+export { mainnet, sepolia, hoodi, ingen, bscTestnet, hardhat, anvil, chains } from "../chains";

--- a/packages/sdk/src/node/index.ts
+++ b/packages/sdk/src/node/index.ts
@@ -74,4 +74,13 @@ export type {
 export { asyncLocalStorage, AsyncLocalMapStorage } from "../storage/async-local-storage";
 
 // Chain presets
-export { mainnet, sepolia, hoodi, ingen, bscTestnet, hardhat, anvil, chains } from "../chains";
+export {
+  mainnet,
+  sepolia,
+  hoodi,
+  ingenTestnet,
+  bscTestnet,
+  hardhat,
+  anvil,
+  chains,
+} from "../chains";

--- a/packages/sdk/src/relayer/__tests__/relayer-utils.test.ts
+++ b/packages/sdk/src/relayer/__tests__/relayer-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "../../test-fixtures";
-import { mainnet, sepolia, hardhat, hoodi, ingen, bscTestnet, chains } from "../../chains";
+import { mainnet, sepolia, hardhat, hoodi, ingenTestnet, bscTestnet, chains } from "../../chains";
 
 describe("Chain presets", () => {
   test("mainnet has id 1", () => {
@@ -18,8 +18,8 @@ describe("Chain presets", () => {
     expect(hoodi.id).toBe(560048);
   });
 
-  test("ingen has id 364301", () => {
-    expect(ingen.id).toBe(364301);
+  test("ingenTestnet has id 364301", () => {
+    expect(ingenTestnet.id).toBe(364301);
   });
 
   test("bscTestnet has id 97", () => {
@@ -29,7 +29,7 @@ describe("Chain presets", () => {
   test("cleartext testnets have executorAddress", () => {
     expect(hardhat.executorAddress).toBe("0xe3a9105a3a932253A70F126eb1E3b589C643dD24");
     expect(hoodi.executorAddress).toBe("0xC316692627de536368d82e9121F1D44a550894E6");
-    expect(ingen.executorAddress).toBe("0x1B05DE5b67b8f8363DC04E3a5996a616f11f8C7B");
+    expect(ingenTestnet.executorAddress).toBe("0x1B05DE5b67b8f8363DC04E3a5996a616f11f8C7B");
     expect(bscTestnet.executorAddress).toBe("0x5985e48689550c1b2893ABfBbe4cc0eE3A22cc54");
   });
 
@@ -43,7 +43,7 @@ describe("Chain presets", () => {
     expect(chains[11155111]).toBe(sepolia);
     expect(chains[31337]).toBe(hardhat);
     expect(chains[560048]).toBe(hoodi);
-    expect(chains[364301]).toBe(ingen);
+    expect(chains[364301]).toBe(ingenTestnet);
     expect(chains[97]).toBe(bscTestnet);
   });
 });

--- a/packages/sdk/src/relayer/__tests__/relayer-utils.test.ts
+++ b/packages/sdk/src/relayer/__tests__/relayer-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "../../test-fixtures";
-import { mainnet, sepolia, hardhat, hoodi, chains } from "../../chains";
+import { mainnet, sepolia, hardhat, hoodi, ingen, bscTestnet, chains } from "../../chains";
 
 describe("Chain presets", () => {
   test("mainnet has id 1", () => {
@@ -18,9 +18,19 @@ describe("Chain presets", () => {
     expect(hoodi.id).toBe(560048);
   });
 
-  test("hardhat and hoodi have executorAddress", () => {
+  test("ingen has id 364301", () => {
+    expect(ingen.id).toBe(364301);
+  });
+
+  test("bscTestnet has id 97", () => {
+    expect(bscTestnet.id).toBe(97);
+  });
+
+  test("cleartext testnets have executorAddress", () => {
     expect(hardhat.executorAddress).toBe("0xe3a9105a3a932253A70F126eb1E3b589C643dD24");
     expect(hoodi.executorAddress).toBe("0xC316692627de536368d82e9121F1D44a550894E6");
+    expect(ingen.executorAddress).toBe("0x1B05DE5b67b8f8363DC04E3a5996a616f11f8C7B");
+    expect(bscTestnet.executorAddress).toBe("0x5985e48689550c1b2893ABfBbe4cc0eE3A22cc54");
   });
 
   test("mainnet and sepolia have no executorAddress", () => {
@@ -33,5 +43,7 @@ describe("Chain presets", () => {
     expect(chains[11155111]).toBe(sepolia);
     expect(chains[31337]).toBe(hardhat);
     expect(chains[560048]).toBe(hoodi);
+    expect(chains[364301]).toBe(ingen);
+    expect(chains[97]).toBe(bscTestnet);
   });
 });

--- a/packages/sdk/src/wrappers-registry.ts
+++ b/packages/sdk/src/wrappers-registry.ts
@@ -15,7 +15,7 @@ import {
   symbolContract,
 } from "./contracts";
 import { ConfigurationError } from "./errors/relayer";
-import { mainnet, sepolia, hoodi } from "./chains";
+import { mainnet, sepolia, hoodi, ingen, bscTestnet } from "./chains";
 import { checksummedAddress, nonNegativeSeconds } from "./schemas/primitives";
 import type { GenericProvider } from "./types/provider";
 import { parseConfiguration } from "./validation";
@@ -28,6 +28,8 @@ export const DefaultRegistryAddresses: Record<number, Address> = {
   [mainnet.id]: mainnet.registryAddress,
   [sepolia.id]: sepolia.registryAddress,
   [hoodi.id]: hoodi.registryAddress,
+  [ingen.id]: ingen.registryAddress,
+  [bscTestnet.id]: bscTestnet.registryAddress,
 };
 
 /** Default registry TTL in seconds (24 hours). */

--- a/packages/sdk/src/wrappers-registry.ts
+++ b/packages/sdk/src/wrappers-registry.ts
@@ -15,7 +15,7 @@ import {
   symbolContract,
 } from "./contracts";
 import { ConfigurationError } from "./errors/relayer";
-import { mainnet, sepolia, hoodi, ingen, bscTestnet } from "./chains";
+import { mainnet, sepolia, hoodi, ingenTestnet, bscTestnet } from "./chains";
 import { checksummedAddress, nonNegativeSeconds } from "./schemas/primitives";
 import type { GenericProvider } from "./types/provider";
 import { parseConfiguration } from "./validation";
@@ -28,7 +28,7 @@ export const DefaultRegistryAddresses: Record<number, Address> = {
   [mainnet.id]: mainnet.registryAddress,
   [sepolia.id]: sepolia.registryAddress,
   [hoodi.id]: hoodi.registryAddress,
-  [ingen.id]: ingen.registryAddress,
+  [ingenTestnet.id]: ingenTestnet.registryAddress,
   [bscTestnet.id]: bscTestnet.registryAddress,
 };
 


### PR DESCRIPTION
## What

Promotes two cleartext deployments to first-class `FheChain` presets in `@zama-fhe/sdk/chains`, alongside `mainnet` / `sepolia` / `hoodi`:

| Preset | Chain ID | Network |
| --- | --- | --- |
| `ingenTestnet` | `364301` | InGen Testnet |
| `bscTestnet` | `97` | BNB Smart Chain Testnet (Chapel) |

Until now these chains existed only as inline config inside `example-ingen` / `example-bnb`. This makes the SDK able to talk to them out of the box (registry address auto-resolved), at the same tier as the other presets.

**Naming convention:** network-specific chains that can grow a mainnet sibling carry the `Testnet` suffix (`bscTestnet`, `ingenTestnet`), reserving the bare name for a future mainnet preset. The Ethereum testnets `sepolia` / `hoodi` stay bare since their mainnet is just `mainnet`.

## Why

Follow-up to the SDK-211 (Ingen) / SDK-212 (BNB) wrapper-upgrade verification. Both deployments' wrappers already expose the post-mainnet `IERC7984ERC20Wrapper` interface — verified on-chain:

- `supportsInterface(0x1f1c62b2) == true`, `inferredTotalSupply()` present, legacy `totalSupply()` reverts
- A full shield → transfer → **unshield (unwrap + finalize)** cycle was run end-to-end against the current SDK on **both** chains; the emitted log topics match the canonical `UnwrapRequested(address,bytes32,bytes32)` / `UnwrapFinalized(address,bytes32,bytes32,uint64)` signatures.

The e2e runs also confirmed both deployments use the default mock cleartext signers, so **no private keys are needed in the presets**.

## Changes

- `chains/configs.ts`: add `ingenTestnet` and `bscTestnet`, register both in the `chains` map
- Re-export from `chains`, the root `index`, and the `node` entrypoint
- `DefaultRegistryAddresses`: map both registries so discovery resolves from the connected chain
- Preset enumeration tests (`relayer-utils.test.ts`)
- `configuration.md` network table + regenerated API reports and llms artifacts

## Notes

- The example apps (`example-ingen` / `example-bnb`) are **not** migrated to import these presets here — they're pinned to published SDK versions and will switch over at the next stable release once the presets ship.
- Hoodi is intentionally out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
