### PR TITLE
refactor(examples): upgrade node-ethers & node-viem to @zama-fhe/sdk 3.1.0

### DIFF
--- a/examples/node-ethers/package.json
+++ b/examples/node-ethers/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@zama-fhe/sdk": "3.0.0-alpha.34",
+    "@zama-fhe/sdk": "3.1.0",
     "ethers": "^6.13.0"
   },
   "devDependencies": {

--- a/examples/node-ethers/src/index.ts
+++ b/examples/node-ethers/src/index.ts
@@ -99,9 +99,10 @@ async function main() {
   console.log("ERC-20 token:        ", TOKEN_ADDRESS);
   console.log("Confidential wrapper:", confidentialTokenAddress);
 
-  // createToken() takes the confidential token address. The SDK resolves the
-  // underlying ERC-20 automatically via underlyingContract(this.wrapper).
-  const tokenA = sdkA.createToken(confidentialTokenAddress);
+  // tokenA shields/unshields, so it needs a WrappedToken (createWrappedToken) — the
+  // SDK resolves the underlying ERC-20 automatically. tokenB only reads and decrypts
+  // balances, so a plain Token (createToken) is enough.
+  const tokenA = sdkA.createWrappedToken(confidentialTokenAddress);
   const tokenB = sdkB.createToken(confidentialTokenAddress);
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -191,9 +192,13 @@ async function main() {
 
   // 4a. Grant: A delegates decrypt rights to B
   console.log("── 4a. Grant delegation: A → B ──");
-  await tokenA.delegateDecryption({ delegateAddress: walletB.address as Address });
+  await sdkA.delegations.delegateDecryption({
+    contractAddress: confidentialTokenAddress,
+    delegateAddress: walletB.address as Address,
+  });
 
-  const isDelegated = await tokenA.isDelegated({
+  const isDelegated = await sdkA.delegations.isActive({
+    contractAddress: confidentialTokenAddress,
     delegatorAddress: walletA.address as Address,
     delegateAddress: walletB.address as Address,
   });
@@ -234,9 +239,13 @@ async function main() {
 
   // 4c. Revoke: A removes B's decrypt rights
   console.log("\n── 4c. Revoke delegation ──");
-  await tokenA.revokeDelegation({ delegateAddress: walletB.address as Address });
+  await sdkA.delegations.revokeDelegation({
+    contractAddress: confidentialTokenAddress,
+    delegateAddress: walletB.address as Address,
+  });
 
-  const isDelegatedAfter = await tokenA.isDelegated({
+  const isDelegatedAfter = await sdkA.delegations.isActive({
+    contractAddress: confidentialTokenAddress,
     delegatorAddress: walletA.address as Address,
     delegateAddress: walletB.address as Address,
   });

--- a/examples/node-viem/package.json
+++ b/examples/node-viem/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@zama-fhe/sdk": "3.0.0-alpha.34",
+    "@zama-fhe/sdk": "3.1.0",
     "viem": "^2.30.0"
   },
   "devDependencies": {

--- a/examples/node-viem/src/index.ts
+++ b/examples/node-viem/src/index.ts
@@ -110,9 +110,10 @@ async function main() {
   console.log("ERC-20 token:        ", TOKEN_ADDRESS);
   console.log("Confidential wrapper:", confidentialTokenAddress);
 
-  // createToken() takes the confidential token address. The SDK resolves the
-  // underlying ERC-20 automatically via underlyingContract(this.wrapper).
-  const tokenA = sdkA.createToken(confidentialTokenAddress);
+  // tokenA shields/unshields, so it needs a WrappedToken (createWrappedToken) — the
+  // SDK resolves the underlying ERC-20 automatically. tokenB only reads and decrypts
+  // balances, so a plain Token (createToken) is enough.
+  const tokenA = sdkA.createWrappedToken(confidentialTokenAddress);
   const tokenB = sdkB.createToken(confidentialTokenAddress);
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -218,9 +219,13 @@ async function main() {
 
   // 4a. Grant: A delegates decrypt rights to B
   console.log("── 4a. Grant delegation: A → B ──");
-  await tokenA.delegateDecryption({ delegateAddress: accountB.address as Address });
+  await sdkA.delegations.delegateDecryption({
+    contractAddress: confidentialTokenAddress,
+    delegateAddress: accountB.address as Address,
+  });
 
-  const isDelegated = await tokenA.isDelegated({
+  const isDelegated = await sdkA.delegations.isActive({
+    contractAddress: confidentialTokenAddress,
     delegatorAddress: accountA.address as Address,
     delegateAddress: accountB.address as Address,
   });
@@ -261,9 +266,13 @@ async function main() {
 
   // 4c. Revoke: A removes B's decrypt rights
   console.log("\n── 4c. Revoke delegation ──");
-  await tokenA.revokeDelegation({ delegateAddress: accountB.address as Address });
+  await sdkA.delegations.revokeDelegation({
+    contractAddress: confidentialTokenAddress,
+    delegateAddress: accountB.address as Address,
+  });
 
-  const isDelegatedAfter = await tokenA.isDelegated({
+  const isDelegatedAfter = await sdkA.delegations.isActive({
+    contractAddress: confidentialTokenAddress,
     delegatorAddress: accountA.address as Address,
     delegateAddress: accountB.address as Address,
   });


### PR DESCRIPTION
## What

Upgrades the two Node examples — `node-ethers` and `node-viem` — to `@zama-fhe/sdk` **3.1.0**, completing the example-app coverage (the React apps shipped in #451). One commit per app.

## Codemod is a no-op here (expected)

The `sdk-upgrade-v3-1-0` codemod (#447) was run on both apps and made **0 changes**: they use zero React hooks and none of the renamed core symbols (`createZamaConfig`, `Handle`, `UseZamaConfig`, …). So this PR is the **manual tail** the codemod can't cover.

## Manual changes (identical in both files)

- **`createToken` → `createWrappedToken`** for the shielding token (`tokenA`). In 3.1.x the wrapper methods (`shield` / `unshield`) live on `WrappedToken`, not `Token`. This is data-flow dependent (a `createToken` result must become `createWrappedToken` only when later used for wrapper ops), which is why it's a documented known limitation of the codemod rather than a rule. `tokenB` stays a plain `Token` (read/decrypt only).
- **Delegation API moved off `Token` to the `sdk.delegations.*` namespace**: `token.delegateDecryption` / `revokeDelegation` / `isDelegated` → `sdk.delegations.delegateDecryption` / `revokeDelegation` / `isActive`, which now take an explicit `contractAddress`.

## Validation

Both apps `tsc --noEmit` **green** against the published 3.1.0 (the break list came from typechecking against it). No runtime smoke test exists for these apps (typecheck is the gate). oxfmt clean.

> Standalone install needs `--config.minimumReleaseAge=0` until ~2026-06-25 (3.1.0 release-age window); the merge itself is unaffected — examples aren't workspace members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
