### PR TITLE
refactor(examples): upgrade example-hoodi to @zama-fhe/sdk 3.1.0

### DIFF
--- a/examples/example-hoodi/WALKTHROUGH.md
+++ b/examples/example-hoodi/WALKTHROUGH.md
@@ -12,9 +12,9 @@
 
 ERC-7984 is a token standard that adds **confidential balances and transfer amounts** to ERC-20 tokens. Instead of storing plaintext balances on-chain, balances are stored as encrypted handles. Only the token owner can decrypt their own balance.
 
-The **Zama SDK** (`@zama-fhe/sdk`, `@zama-fhe/react-sdk`) handles all cryptographic operations — encryption, decryption, EIP-712 signing — behind simple React hooks (`useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`) and the `Token` API (`sdk.createToken().shield()`).
+The **Zama SDK** (`@zama-fhe/sdk`, `@zama-fhe/react-sdk`) handles all cryptographic operations — encryption, decryption, EIP-712 signing — behind simple React hooks (`useShield`, `useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`).
 
-This example uses the **cleartext stack** (`RelayerCleartext`), which is Zama's lightweight backend for chains where the full FHE co-processor is not deployed (including Hoodi). See [How the cleartext stack works](#how-the-cleartext-stack-works) below.
+This example uses the **cleartext stack** (`cleartext()`), which is Zama's lightweight backend for chains where the full FHE co-processor is not deployed (including Hoodi). See [How the cleartext stack works](#how-the-cleartext-stack-works) below.
 
 ---
 
@@ -35,7 +35,7 @@ Specifically:
 | Operation                    | SDK API                                                      | Source file                                            | Transactions          |
 | ---------------------------- | ------------------------------------------------------------ | ------------------------------------------------------ | --------------------- |
 | Decrypt confidential balance | `useHasPermit` + `useGrantPermit` + `useConfidentialBalance` | `src/app/page.tsx` + `src/components/BalancesCard.tsx` | 0 (read)              |
-| Shield (ERC-20 → cToken)     | `sdk.createToken().shield()`                                 | `src/components/ShieldCard.tsx`                        | 1–3 (wrap, ± approve) |
+| Shield (ERC-20 → cToken)     | `useShield`                                                  | `src/components/ShieldCard.tsx`                        | 1–3 (wrap, ± approve) |
 | Confidential transfer        | `useConfidentialTransfer`                                    | `src/components/TransferCard.tsx`                      | 1                     |
 | Unshield (cToken → ERC-20)   | `useUnshield`                                                | `src/components/UnshieldCard.tsx`                      | 2 (unwrap + finalize) |
 | Grant decryption access      | `useDelegateDecryption`                                      | `src/components/DelegateDecryptionCard.tsx`            | 1                     |
@@ -63,15 +63,15 @@ The full Zama FHE stack (used on Sepolia and Mainnet) relies on:
 **Hoodi uses the cleartext stack.** In cleartext mode:
 
 - Values are stored as **plaintexts** in the `CleartextFHEVMExecutor` contract on-chain (no actual FHE encryption)
-- The `RelayerCleartext` class acts as a local relayer: it reads plaintexts directly from the executor contract and produces mock KMS signatures locally
+- The `cleartext()` transport acts as a local relayer: it reads plaintexts directly from the executor contract and produces mock KMS signatures locally
 - **No external service** is required — no relayer URL, no API key
 
-The SDK interface is identical in both modes. From the application developer's perspective, you swap `RelayerWeb` (or `RelayerNode`) for `RelayerCleartext` and point it at the Hoodi preset config. All hooks behave the same way.
+The SDK interface is identical in both modes. From the application developer's perspective, you swap `web()` (or `node()`) for `cleartext()` and point it at the Hoodi preset config. All hooks behave the same way.
 
 ```
 Full FHE stack (Sepolia / Mainnet)      Cleartext stack (Hoodi)
 ──────────────────────────────────      ──────────────────────────────────────
-RelayerWeb → external HTTP service      RelayerCleartext → on-chain executor
+web() → external HTTP service      cleartext() → on-chain executor
   └─ FHE co-processor (on-chain)          └─ plaintexts(handle) → plaintext
   └─ KMS decryption (server-side)         └─ mock KMS signature (local)
   └─ Zama relayer API key required        └─ No API key, no external service
@@ -85,18 +85,18 @@ RelayerWeb → external HTTP service      RelayerCleartext → on-chain executor
 User (browser wallet)
   │
   ▼
-page.tsx — sdk.createToken().shield() / useConfidentialTransfer / useUnshield / useConfidentialBalance
+page.tsx — useShield / useConfidentialTransfer / useUnshield / useConfidentialBalance
   │
   ▼
 @zama-fhe/react-sdk (React hooks + ZamaProvider)
   │
   ▼
 @zama-fhe/sdk (ZamaSDK)
-  ├─ EthersSigner   → hybrid EIP-1193 provider
+  ├─ ethers adapter   → hybrid EIP-1193 provider
   │    ├─ reads (eth_call, eth_estimateGas) → JsonRpcProvider(HOODI_RPC_URL)
   │    └─ writes + polling (signing, eth_sendTransaction,
   │         eth_blockNumber, eth_getTransactionReceipt) → injected wallet
-  └─ RelayerCleartext → hoodiCleartextConfig
+  └─ cleartext() → the hoodi preset
        └─ reads plaintexts from CleartextFHEVMExecutor (on-chain, Hoodi)
        └─ produces mock KMS signatures locally (no external call)
 ```
@@ -110,7 +110,7 @@ page.tsx — sdk.createToken().shield() / useConfidentialTransfer / useUnshield 
 
 To ensure ethers' `PollingBlockSubscriber` checks for new receipts on every poll interval (4 s rather than once per block at ~12 s), `eth_blockNumber` responses are adjusted to always be strictly increasing — if the returned block number has not advanced, the counter increments by 1.
 
-**Wallet-switch lifecycle:** on every account change, `ZamaProvider` remounts with a fresh `EthersSigner` so the new account's address is used immediately. The `accountsChanged` listener ignores events that fire before the initial `eth_accounts` call resolves (some wallets emit it on page load before the ref is seeded), preventing spurious remounts that would clear the in-memory credential cache. First connection is handled correctly: once `eth_accounts` resolves and the user connects, `walletKey` increments and a new `EthersSigner` is created with the live account ref already populated. An EIP-712 session credential is persisted in IndexedDB and survives page reloads within the 30-day TTL.
+**Wallet-switch lifecycle:** on every account change, `ZamaProvider` remounts with a fresh `ethers adapter` so the new account's address is used immediately. The `accountsChanged` listener ignores events that fire before the initial `eth_accounts` call resolves (some wallets emit it on page load before the ref is seeded), preventing spurious remounts that would clear the in-memory credential cache. First connection is handled correctly: once `eth_accounts` resolves and the user connects, `walletKey` increments and a new `ethers adapter` is created with the live account ref already populated. An EIP-712 session credential is persisted in IndexedDB and survives page reloads within the 30-day TTL.
 
 ---
 
@@ -221,7 +221,7 @@ If your ERC-20 balance shows `0`, click **Mint** next to the ERC-20 balance, or 
 Two balances are displayed:
 
 - **ERC-20 balance** — your public on-chain balance of the underlying token. Read via a standard `balanceOf` call.
-- **Confidential balance** — your confidential cToken balance, read via `useConfidentialBalance`. The SDK reads the encrypted handle on-chain (Phase 1), then decrypts it via `RelayerCleartext` (Phase 2).
+- **Confidential balance** — your confidential cToken balance, read via `useConfidentialBalance`. The SDK reads the encrypted handle on-chain (Phase 1), then decrypts it via `cleartext()` (Phase 2).
 
 **Explicit decrypt pattern:** the confidential balance is not queried until you explicitly authorize FHE decryption. The Balances card shows a **Decrypt Balance** button instead of a balance value until you sign. This avoids blind EIP-712 prompts on mount.
 
@@ -233,18 +233,15 @@ If you have never shielded any tokens, the confidential balance shows **—** af
 
 Enter a human-readable amount (e.g., `1.5`) and click **Shield**. This converts public ERC-20 tokens into confidential cTokens.
 
-The app manages ERC-20 allowances automatically. The spend cap is set to your **full ERC-20 balance** (not the exact shield amount), so once approved, subsequent shields within the remaining cap need only the wrap transaction — no re-approval. The number of wallet confirmations depends on the current allowance:
+The app delegates the entire approve + wrap flow to `useShield` — it does not read ERC-20 allowances, submit approvals, or call wrapper contracts directly. With `approvalStrategy: "exact"` the SDK approves exactly the shielded amount, performing a USDT-style allowance reset first when an existing non-zero allowance would block the approval. The number of wallet confirmations depends on the underlying token and current allowance:
 
-| Situation                                          | Transactions                                       | Confirmations |
-| -------------------------------------------------- | -------------------------------------------------- | ------------- |
-| Allowance already covers the amount                | `wrap` only                                        | 1             |
-| No existing allowance (or zero)                    | `approve(fullBalance)` → `wrap`                    | 2             |
-| Non-zero allowance insufficient — standard token   | `approve(fullBalance)` → `wrap` (direct overwrite) | 2             |
-| Non-zero allowance insufficient — USDT-style token | `approve(0)` → `approve(fullBalance)` → `wrap`     | 3 _(rare)_    |
+| Situation                                          | Transactions                              | Confirmations |
+| -------------------------------------------------- | ----------------------------------------- | ------------- |
+| Allowance already covers the amount                | `wrap` only                               | 1             |
+| No existing allowance (or zero)                    | `approve(amount)` → `wrap`                | 2             |
+| Non-zero allowance insufficient — USDT-style token | `approve(0)` → `approve(amount)` → `wrap` | 3 _(rare)_    |
 
-When re-approving (non-zero insufficient allowance), the app optimistically tries `approve(fullBalance)` directly. `writeContract` goes through the signer, so `eth_estimateGas` is called with `from = userAddress` — correctly simulating the allowance check. For standard ERC-20 tokens, gas estimation succeeds and the wallet is prompted once. For USDT-style tokens (which revert when `approve(nonZero)` is called with a non-zero existing allowance), gas estimation fails **before the wallet is prompted** — the app silently falls back to the reset path. User rejections are re-thrown immediately and never misidentified as USDT-style.
-
-The button shows **Shielding… (1/2 approve)** during approval and **Shielding… (2/2 wrap)** once the approval is confirmed. Gas fees on Hoodi are effectively zero. The ERC-20 balance refreshes automatically on success.
+The button shows **Shielding… (approving)** during approval and **Shielding… (wrapping)** once the approval is confirmed. Gas fees on Hoodi are effectively zero. The ERC-20 balance refreshes automatically on success.
 
 ### Step 6 — Confidential transfer
 
@@ -262,7 +259,7 @@ Enter an amount and click **Unshield**. This converts cTokens back into public E
 Unshield is a two-phase operation:
 
 1. **Unwrap** — a transaction that burns the cTokens and emits an `UnwrapRequested` event containing the encrypted amount handle. The button shows **Unshielding… (1/2)**. One wallet confirmation.
-2. **Finalize** — the `RelayerCleartext` decrypts the amount locally (no external call, no wallet prompt), then submits a `finalizeUnwrap` transaction that releases the ERC-20 tokens. The button shows **Unshielding… (2/2)**. One wallet confirmation.
+2. **Finalize** — the `cleartext()` decrypts the amount locally (no external call, no wallet prompt), then submits a `finalizeUnwrap` transaction that releases the ERC-20 tokens. The button shows **Unshielding… (2/2)**. One wallet confirmation.
 
 Both phases complete within seconds on Hoodi. The ERC-20 balance refreshes automatically on success.
 
@@ -312,55 +309,52 @@ Switch back to the owner wallet. In the **Revoke Decryption Access** card, enter
 
 ```tsx
 // src/providers.tsx
-import { RelayerCleartext, hoodiCleartextConfig } from "@zama-fhe/sdk/cleartext";
-import { EthersSigner } from "@zama-fhe/sdk/ethers";
-import { ZamaProvider, IndexedDBStorage, indexedDBStorage } from "@zama-fhe/react-sdk";
+import { createConfig } from "@zama-fhe/sdk/ethers";
+import { cleartext, IndexedDBStorage, indexedDBStorage } from "@zama-fhe/sdk";
+import { hoodi } from "@zama-fhe/sdk/chains";
+import { ZamaProvider } from "@zama-fhe/react-sdk";
+import { JsonRpcProvider } from "ethers";
 import { HOODI_RPC_URL } from "@/lib/config"; // process.env.NEXT_PUBLIC_HOODI_RPC_URL || fallback
 
-// getEthereumProvider() prefers window.phantom.ethereum when Phantom is detected,
-// falling back to window.ethereum for MetaMask and other EIP-1193 wallets.
-// Route read-only RPC calls to a direct JsonRpcProvider for fast receipt polling.
-// Wallet calls (signing, account management) are forwarded to the injected wallet.
-// See providers.tsx for the full implementation — createHybridEthereum also takes a
-// liveAccountsRef cache to resolve accounts immediately on wallet switch.
-const hybridEthereum = createHybridEthereum(getEthereumProvider(), liveAccountsRef);
-const signer = new EthersSigner({ ethereum: hybridEthereum });
+// The hybrid EIP-1193 provider routes reads to a direct JsonRpcProvider and wallet calls
+// (signing, nonce, receipt polling) to the injected wallet — see providers.tsx for
+// createHybridEthereum and its liveAccountsRef cache. It is passed as `ethereum`; SDK reads
+// also use `provider` (the direct Hoodi RPC).
+const ethereum = createHybridEthereum(getEthereumProvider(), liveAccountsRef);
+const provider = new JsonRpcProvider(HOODI_RPC_URL);
 
-// hoodiCleartextConfig contains the chainId, executor address, and ACL address for Hoodi.
-// Override `network` to use a custom RPC endpoint.
-const relayer = new RelayerCleartext({ ...hoodiCleartextConfig, network: HOODI_RPC_URL });
+// IMPORTANT: use a separate IndexedDBStorage instance for permitStorage.
+// Both storage and permitStorage use the same key internally — sharing one database
+// overwrites the encrypted keypair and forces the user to re-sign on every decryption.
+const permitDBStorage = new IndexedDBStorage("PermitStore");
 
-// IMPORTANT: use a separate IndexedDBStorage instance for sessionStorage.
-// Both storage and sessionStorage use the same key internally — if they share the same
-// database, the session entry overwrites the encrypted keypair, which corrupts credentials
-// and forces the user to re-sign on every balance decryption.
-const sessionDBStorage = new IndexedDBStorage("SessionStore");
+// `hoodi` is the shipped Hoodi cleartext chain preset (chain 560048). cleartext() is the
+// relayer transport — Hoodi runs the cleartext FHEVM host stack, so there is no real
+// relayer/KMS network to call.
+const config = createConfig({
+  chains: [hoodi],
+  ethereum,
+  provider,
+  storage: indexedDBStorage, // "CredentialStore" DB — encrypted FHE keypair
+  permitStorage: permitDBStorage, // "PermitStore" DB — EIP-712 permit signatures
+  relayers: { [hoodi.id]: cleartext() },
+});
 
-<ZamaProvider
-  relayer={relayer}
-  signer={signer}
-  storage={indexedDBStorage} // "CredentialStore" DB — encrypted FHE keypair
-  sessionStorage={sessionDBStorage} // "SessionStore" DB — EIP-712 session signatures
->
-  ...
-</ZamaProvider>;
+<ZamaProvider config={config}>...</ZamaProvider>;
 ```
 
 ### Hook usage
 
 ```tsx
-import { parseUnits, isError } from "ethers";
+import { parseUnits } from "ethers";
 import {
-  useZamaSDK,
+  useShield,
   useListPairs,
   useHasPermit,
   useGrantPermit,
   useConfidentialTransfer,
   useUnshield,
   useConfidentialBalance,
-  allowanceContract,
-  approveContract,
-  balanceOfContract,
 } from "@zama-fhe/react-sdk";
 
 // Fetch all valid token pairs from the on-chain WrappersRegistry.
@@ -377,10 +371,10 @@ const erc20Decimals = pair?.underlying.decimals ?? 0;
 
 // Explicit decrypt pattern: check credentials before enabling the balance display.
 // useHasPermit returns true only when cached credentials cover the selected token.
-const { data: hasPermit } = useHasPermit({
-  contractAddresses: cTokenAddress ? [cTokenAddress] : [],
-  query: { enabled: Boolean(cTokenAddress) },
-});
+const { data: hasPermit } = useHasPermit(
+  { contractAddresses: cTokenAddress ? [cTokenAddress] : [] },
+  { enabled: Boolean(cTokenAddress) },
+);
 
 // useGrantPermit triggers the EIP-712 wallet signature that authorizes decryption.
 // Pass all confidential token addresses at once — a single signature covers all tokens.
@@ -390,74 +384,30 @@ function handleDecrypt() {
   if (addresses.length > 0) grantPermits.mutate(addresses);
 }
 
-const transfer = useConfidentialTransfer({ tokenAddress: cTokenAddress });
-const unshield = useUnshield({ tokenAddress: cTokenAddress, wrapperAddress: cTokenAddress });
+const transfer = useConfidentialTransfer({ address: cTokenAddress });
+const unshield = useUnshield(cTokenAddress);
 
 // Pass enabled: false until the user has authorized decrypt (hasPermit).
 // This prevents the hook from firing an EIP-712 prompt on mount.
 const balance = useConfidentialBalance(
-  { tokenAddress: cTokenAddress ?? "0x0000000000000000000000000000000000000000" },
+  // `account` (the balance holder) is optional — it defaults to the connected signer.
+  // page.tsx passes it explicitly; omit it for the connected wallet's own balance.
+  { address: cTokenAddress ?? "0x0000000000000000000000000000000000000000" },
   { enabled: !!hasPermit && !!cTokenAddress },
 );
 
-// Shield: manual approval + wrap.
-// Spend cap strategy: approve for the user's full ERC-20 balance (not the exact shield amount).
-// This avoids re-approval on every shield — subsequent shields within the remaining cap
-// need only the wrap transaction. Re-approval is only triggered when the cap is exceeded.
-//
-// USDT-style detection (non-zero insufficient allowance): writeContract uses the signer,
-// so eth_estimateGas runs with from=userAddress. For USDT-style tokens, gas estimation
-// reverts before the wallet is prompted. We catch this and fall back to reset(0) + approve.
-// User rejections (ACTION_REJECTED) are re-thrown immediately.
-//
-// The shield logic runs inside an async function (e.g., a TanStack Query mutationFn):
-const sdk = useZamaSDK();
-const shieldAmount = parseUnits("10", erc20Decimals);
-const token = sdk.createToken(cTokenAddress);
-const userAddress = await sdk.signer.getAddress();
-
-const currentAllowance = (await sdk.signer.readContract(
-  allowanceContract(erc20Address, userAddress, cTokenAddress),
-)) as bigint;
-
-if (currentAllowance < shieldAmount) {
-  const erc20Balance = (await sdk.signer.readContract(
-    balanceOfContract(erc20Address, userAddress),
-  )) as bigint;
-
-  if (currentAllowance > 0n) {
-    // Try direct overwrite — works for standard ERC-20s (2 txs total: approve + wrap).
-    // USDT-style: gas estimation fails pre-wallet → fall back to reset + approve (3 txs).
-    let needsReset = false;
-    try {
-      const approveHash = await sdk.signer.writeContract(
-        approveContract(erc20Address, cTokenAddress, erc20Balance),
-      );
-      await sdk.signer.waitForTransactionReceipt(approveHash);
-    } catch (err) {
-      if (isError(err, "ACTION_REJECTED")) throw err; // user rejected — stop here
-      needsReset = true; // gas estimation reverted → USDT-style token
-    }
-    if (needsReset) {
-      const resetHash = await sdk.signer.writeContract(
-        approveContract(erc20Address, cTokenAddress, 0n),
-      );
-      await sdk.signer.waitForTransactionReceipt(resetHash);
-      const approveHash = await sdk.signer.writeContract(
-        approveContract(erc20Address, cTokenAddress, erc20Balance),
-      );
-      await sdk.signer.waitForTransactionReceipt(approveHash);
-    }
-  } else {
-    // Zero allowance: direct approve — no reset needed for any token.
-    const approveHash = await sdk.signer.writeContract(
-      approveContract(erc20Address, cTokenAddress, erc20Balance),
-    );
-    await sdk.signer.waitForTransactionReceipt(approveHash);
-  }
-}
-// approvalStrategy: 'skip' — allowance is confirmed above (or was already sufficient).
-await token.shield(shieldAmount, { approvalStrategy: "skip" });
+// Shield: useShield owns the entire approve + wrap flow — the app does not read ERC-20
+// allowances, submit approvals, or call wrapper contracts. approvalStrategy "exact" approves
+// exactly the shielded amount; the SDK performs the USDT-style allowance reset when an
+// existing non-zero allowance would otherwise block the approval, and routes through ERC-1363
+// transferAndCall when the underlying ERC-20 supports it.
+const shield = useShield({ address: cTokenAddress });
+shield.mutate({
+  amount: parseUnits("10", erc20Decimals),
+  approvalStrategy: "exact",
+  onApprovalSubmitted: () => setPhase("approve"),
+  onShieldSubmitted: () => setPhase("wrap"),
+});
 
 // Transfer: FHE encryption (local) + 1 transaction.
 // Amount is in confidential token units — use cTokenDecimals.
@@ -465,7 +415,7 @@ await token.shield(shieldAmount, { approvalStrategy: "skip" });
 transfer.mutate({
   to: "0xRecipient",
   amount: parseUnits("5", cTokenDecimals),
-  callbacks: { onEncryptComplete: () => setStep(2) },
+  onEncryptComplete: () => setStep(2),
 });
 
 // Unshield: 2 transactions (unwrap + finalizeUnwrap).
@@ -473,7 +423,7 @@ transfer.mutate({
 // onFinalizing fires between the two transactions — use it to update the progress UI.
 unshield.mutate({
   amount: parseUnits("2", cTokenDecimals),
-  callbacks: { onFinalizing: () => setStep(2) },
+  onFinalizing: () => setStep(2),
 });
 ```
 
@@ -490,21 +440,21 @@ import { DelegationNotFoundError, DelegationExpiredError } from "@zama-fhe/sdk";
 
 // Grant decryption access — 1 transaction.
 // expirationDate: undefined → SDK sends MAX_UINT64 on-chain (permanent delegation).
-const delegate = useDelegateDecryption({ tokenAddress: cTokenAddress });
+const delegate = useDelegateDecryption(cTokenAddress);
 // Permanent delegation (no expiry):
 delegate.mutate({ delegateAddress: "0xDelegate" });
 // With expiry (must be at least 1 hour in the future):
 delegate.mutate({ delegateAddress: "0xDelegate", expirationDate: new Date("2027-01-01") });
 
 // Revoke decryption access — 1 transaction.
-const revoke = useRevokeDelegation({ tokenAddress: cTokenAddress });
+const revoke = useRevokeDelegation(cTokenAddress);
 revoke.mutate({ delegateAddress: "0xDelegate" });
 
 // Query delegation status — fires automatically when both addresses are valid.
 // Pass undefined for either address to disable the query (useful before the user
 // has entered an address).
 const { data: status } = useDelegationStatus({
-  tokenAddress: cTokenAddress,
+  contractAddress: cTokenAddress,
   delegatorAddress: "0xOwner", // the wallet that granted the delegation
   delegateAddress: "0xDelegate", // the wallet that received it (usually the connected wallet)
 });
@@ -513,8 +463,8 @@ const { data: status } = useDelegationStatus({
 
 // Decrypt owner's balance as a delegate — 0 transactions (read + local cache).
 // Throws DelegationNotFoundError / DelegationExpiredError if the ACL check fails.
-// Note: useDecryptBalanceAs takes a positional tokenAddress argument (unlike
-// useDelegateDecryption / useRevokeDelegation which use a config object { tokenAddress }).
+// Note: useDecryptBalanceAs, useDelegateDecryption, and useRevokeDelegation all take a
+// positional tokenAddress as their first argument.
 const decryptAs = useDecryptBalanceAs(cTokenAddress);
 decryptAs.mutate({ delegatorAddress: "0xOwner" });
 // decryptAs.data → bigint (raw balance)
@@ -553,10 +503,10 @@ Copy `.env.example` to `.env.local` and fill in `NEXT_PUBLIC_HOODI_RPC_URL` if y
 | ERC-20 balance shows `0`                                  | Tokens not yet minted                                                                                                                                    | Click the **Mint** button or use one of the methods in [Minting test tokens](#minting-test-tokens)                                                                                                                                                                                                                                                               |
 | Confidential balance shows `—` immediately after connect  | No shielded balance yet — no encrypted handle to read                                                                                                    | Shield some tokens first; the balance will display once there is something to decrypt                                                                                                                                                                                                                                                                            |
 | "Decrypting…" stays indefinitely                          | Wallet EIP-712 signature request was missed (small notification badge)                                                                                   | Open your wallet and approve the pending signature request; balance will update immediately                                                                                                                                                                                                                                                                      |
-| Asked to sign an EIP-712 message after each action        | Session not yet cached (first use — expected)                                                                                                            | Approve once — subsequent decryptions reuse the IndexedDB-persisted session credential (30-day TTL). If the prompt recurs every time, make sure `storage` and `sessionStorage` in `ZamaProvider` point to **different** `IndexedDBStorage` instances — sharing the same instance corrupts the stored credentials (see Providers setup)                           |
-| Shield fails immediately after approving spend cap        | Approval transaction not yet confirmed on Hoodi when wrap was attempted                                                                                  | Wait for the approval confirmation and retry — the app detects this and shows a hint                                                                                                                                                                                                                                                                             |
+| Asked to sign an EIP-712 message after each action        | Session not yet cached (first use — expected)                                                                                                            | Approve once — subsequent decryptions reuse the IndexedDB-persisted session credential (30-day TTL). If the prompt recurs every time, make sure `storage` and `permitStorage` in `ZamaProvider` point to **different** `IndexedDBStorage` instances — sharing the same instance corrupts the stored credentials (see Providers setup)                            |
+| Shield fails right after the approval transaction         | The approval reverted or was rejected before the wrap step                                                                                               | Retry — useShield re-reads the allowance and re-approves only if needed                                                                                                                                                                                                                                                                                          |
 | Shield fails after a recent transfer or other operation   | Pending transaction in the mempool caused a nonce conflict                                                                                               | Wait for all pending transactions to confirm, then retry                                                                                                                                                                                                                                                                                                         |
-| Shield stuck on "Shielding… (1/2)"                        | Ran out of Hoodi ETH after the approval transaction                                                                                                      | Top up your wallet with Hoodi ETH and try again                                                                                                                                                                                                                                                                                                                  |
+| Shield stuck on "Shielding… (approving)"                  | Ran out of Hoodi ETH after the approval transaction                                                                                                      | Top up your wallet with Hoodi ETH and try again                                                                                                                                                                                                                                                                                                                  |
 | Shield completes but balances unchanged                   | Decimal mismatch — wrong number of decimals used to parse the amount                                                                                     | Ensure the amount input uses the ERC-20 contract's decimals (not the ERC-7984 token's); decimals are available as `pair.underlying.decimals` and `pair.confidential.decimals` from `useListPairs`                                                                                                                                                                |
 | "nonce too low: next nonce X, tx nonce Y"                 | The Hoodi public RPC returned a stale nonce; ethers built the tx with an outdated value                                                                  | This is fixed by routing `eth_getTransactionCount` through the wallet in the hybrid provider. If you see this in your own integration, ensure `eth_getTransactionCount` is NOT routed to a load-balanced RPC — it must go through the same node that will receive your `eth_sendTransaction`                                                                     |
 | "Transaction reverted" on any operation                   | Insufficient token balance, or wrong network                                                                                                             | Verify you are on Hoodi (chainId 560048) and have sufficient tokens                                                                                                                                                                                                                                                                                              |
@@ -597,7 +547,7 @@ Tests run automatically on CI for every pull request that touches `examples/exam
 ## Going further
 
 - **Additional tokens** — register new ERC-7984 pairs in the on-chain WrappersRegistry at `0x1807aE2f693F8530DFB126D0eF98F2F2518F292f`. The app picks them up automatically via `useListPairs` on the next load — no code change required.
-- **Production use** — replace `RelayerCleartext` with `RelayerWeb` (browser) or `RelayerNode` (server) when targeting a chain with the full FHE co-processor (Sepolia, Mainnet).
+- **Production use** — replace `cleartext()` with `web()` (browser) or `node()` (server) when targeting a chain with the full FHE co-processor (Sepolia, Mainnet).
 - **Batch balance decryption** — for multiple tokens, use `useConfidentialBalances` (batch hook) to decrypt all balances in a single relayer call.
 - **Optimistic balance updates** — for `useConfidentialTransfer`, pass `optimistic: true` to immediately update the cached confidential balance while the transaction confirms, then roll back automatically on error. Improves perceived responsiveness in production UIs.
 
@@ -607,9 +557,9 @@ Tests run automatically on CI for every pull request that touches `examples/exam
 
 | Package                 | Version            | Role                                                                                                                                                                                                                             |
 | ----------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@zama-fhe/sdk`         | see `package.json` | FHE core — `RelayerCleartext`, `EthersSigner`, contract builders                                                                                                                                                                 |
+| `@zama-fhe/sdk`         | see `package.json` | FHE core — `cleartext()`, `createConfig`, contract builders                                                                                                                                                                      |
 | `@zama-fhe/react-sdk`   | see `package.json` | React hooks — `useListPairs`, `useHasPermit`, `useGrantPermit`, `useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`, `useDelegateDecryption`, `useRevokeDelegation`, `useDelegationStatus`, `useDecryptBalanceAs` |
-| `ethers`                | ^6.13.0            | Ethereum client (via `EthersSigner`)                                                                                                                                                                                             |
+| `ethers`                | ^6.13.0            | Ethereum client (via `ethers adapter`)                                                                                                                                                                                           |
 | `@tanstack/react-query` | ^5.90.0            | Async state management                                                                                                                                                                                                           |
 | `next`                  | ^16.0.0            | React framework (App Router)                                                                                                                                                                                                     |
 | **Chain**               | Hoodi testnet      | chainId 560048                                                                                                                                                                                                                   |

--- a/examples/example-hoodi/package-lock.json
+++ b/examples/example-hoodi/package-lock.json
@@ -7,8 +7,8 @@
       "name": "hoodi-example",
       "dependencies": {
         "@tanstack/react-query": "^5.90.0",
-        "@zama-fhe/react-sdk": "2.2.0-alpha.4",
-        "@zama-fhe/sdk": "2.2.0-alpha.4",
+        "@zama-fhe/react-sdk": "3.1.0",
+        "@zama-fhe/sdk": "3.1.0",
         "ethers": "^6.13.0",
         "next": "^16.2.6",
         "react": "^19.2.0",
@@ -679,7 +679,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -795,7 +794,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
       "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -827,18 +825,18 @@
       }
     },
     "node_modules/@zama-fhe/react-sdk": {
-      "version": "2.2.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-2.2.0-alpha.4.tgz",
-      "integrity": "sha512-b6v8Yl4K4w5croL8WCjsFPdTRfdaXWtYis+lzIHkmXtaXdAjlN4GvUNywYeZHly2MYZ271x7xGRXU8FGYwSYUA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.1.0.tgz",
+      "integrity": "sha512-RpFrGS+pG+Z4kiw9PWAiNij8cbntFWqA1Lz5VLBdu0KPEtoU5LByY2pniMI6fXMZikoN3RW0FPbuQSMGWgzLoQ==",
       "license": "BSD-3-Clause-Clear",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5",
-        "@zama-fhe/sdk": "^2.2.0-alpha.4",
+        "@zama-fhe/sdk": "^3.1.0",
         "react": ">=18",
-        "viem": "^2.47.0",
+        "viem": ">=2",
         "wagmi": ">=2"
       },
       "peerDependenciesMeta": {
@@ -848,9 +846,9 @@
       }
     },
     "node_modules/@zama-fhe/relayer-sdk": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.4.2.tgz",
-      "integrity": "sha512-3Q0tINKxz6YseaDxOrNP/648j5Wr2C4Utnjx5npZESjLAc20tWgWFE7BOfx0Kjhs8cx/ykU+tMZBq40+DsiUvA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.4.4.tgz",
+      "integrity": "sha512-N+ateFbi7Fu9JsxExapfn/SdU3Bye3tvCfIaZQsRNXsZ7ep39S0BUnmljh+JhalUKT11xlMoA4+1TKLx72amcw==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^14.0.0",
@@ -871,14 +869,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "2.2.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-2.2.0-alpha.4.tgz",
-      "integrity": "sha512-rczGMP1jkay7PpFNXl1hb6ttoqLZjnGrwMFHK4iBuBA7lqBtPu2xzkfAOec1JMaafTTF/dZHWGGdvc4mb6+8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0.tgz",
+      "integrity": "sha512-OTZxMLHOUhapGVkqnslLF9ENQfJmzU/lvI5nfvAjBzJXvQgTf+IUC2JRXpnifojFV+RFhmW12TYOuE8spUbpFw==",
       "license": "BSD-3-Clause-Clear",
-      "peer": true,
       "dependencies": {
-        "@zama-fhe/relayer-sdk": "~0.4.2",
-        "viem": "^2.47.6"
+        "@zama-fhe/relayer-sdk": "~0.4.4",
+        "viem": "^2.52.2",
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22"
@@ -1035,7 +1033,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1183,9 +1180,9 @@
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/ox": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.7.tgz",
-      "integrity": "sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==",
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
       "funding": [
         {
           "type": "github",
@@ -1316,7 +1313,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1326,7 +1322,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -1497,7 +1492,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1519,9 +1513,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.47.6",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.6.tgz",
-      "integrity": "sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==",
+      "version": "2.53.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.53.1.tgz",
+      "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
       "funding": [
         {
           "type": "github",
@@ -1529,7 +1523,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -1537,8 +1530,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.7",
-        "ws": "8.18.3"
+        "ox": "0.14.29",
+        "ws": "8.20.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -1577,9 +1570,9 @@
       }
     },
     "node_modules/viem/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -1608,7 +1601,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1623,6 +1615,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/examples/example-hoodi/package.json
+++ b/examples/example-hoodi/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "2.2.0-alpha.4",
-    "@zama-fhe/sdk": "2.2.0-alpha.4",
+    "@zama-fhe/react-sdk": "3.1.0",
+    "@zama-fhe/sdk": "3.1.0",
     "ethers": "^6.13.0",
     "next": "^16.2.6",
     "react": "^19.2.0",

--- a/examples/example-hoodi/src/app/page.tsx
+++ b/examples/example-hoodi/src/app/page.tsx
@@ -5,15 +5,15 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatEther, formatUnits, parseUnits, JsonRpcProvider } from "ethers";
 import {
   useConfidentialBalance,
-  useIsAllowed,
-  useAllow,
+  useHasPermit,
+  useGrantPermit,
   useListPairs,
   useZamaSDK,
-  balanceOfContract,
 } from "@zama-fhe/react-sdk";
+import { balanceOfContract } from "@zama-fhe/sdk";
 import type { TokenWrapperPair, TokenWrapperPairWithMetadata } from "@zama-fhe/sdk";
 import { zamaQueryKeys } from "@zama-fhe/sdk/query"; // query key builders for SDK-managed caches — /query subpath export
-import type { Address } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { BalancesCard } from "@/components/BalancesCard";
 import { ShieldCard } from "@/components/ShieldCard";
 import { TransferCard } from "@/components/TransferCard";
@@ -149,10 +149,10 @@ export default function Home() {
   const token = validPairs.find((p) => p.confidentialTokenAddress === selectedTokenAddress);
 
   // Check whether cached credentials cover the currently selected confidential token.
-  const { data: isAllowed } = useIsAllowed({
-    contractAddresses: token ? [token.confidentialTokenAddress] : [],
-    query: { enabled: Boolean(token) },
-  });
+  const { data: isAllowed } = useHasPermit(
+    { contractAddresses: token ? [token.confidentialTokenAddress] : [] },
+    { enabled: Boolean(token) },
+  );
 
   // Metadata for the selected token pair — sourced directly from the registry response
   // (useListPairs with metadata: true). Defaults to safe zero values until the pair loads.
@@ -164,7 +164,7 @@ export default function Home() {
   // Triggers the EIP-712 wallet signature to create FHE decrypt credentials.
   // All registry pairs are passed at once — a single signature covers all tokens,
   // so switching tokens does not require a second wallet prompt.
-  const allowTokens = useAllow();
+  const allowTokens = useGrantPermit();
   function handleDecrypt() {
     if (validPairs.length === 0) return;
     allowTokens.mutate(validPairs.map((p) => p.confidentialTokenAddress));
@@ -282,7 +282,7 @@ export default function Home() {
   const { data: erc20Balance } = useQuery({
     queryKey: erc20BalanceKey,
     queryFn: async () =>
-      sdk.signer.readContract(
+      sdk.provider.readContract(
         balanceOfContract(token!.tokenAddress, address as Address),
       ) as Promise<bigint>,
     enabled: !!address && isHoodi && !!token,
@@ -295,7 +295,7 @@ export default function Home() {
     // any operation that changes the confidential balance (shield, unshield, transfer).
     if (token) {
       queryClient.invalidateQueries({
-        queryKey: zamaQueryKeys.confidentialHandle.token(token.confidentialTokenAddress),
+        queryKey: zamaQueryKeys.confidentialBalance.token(token.confidentialTokenAddress),
       });
     }
   };
@@ -305,20 +305,27 @@ export default function Home() {
   // ZERO_ADDRESS is used as a stable placeholder while no token pair is selected —
   // the query is disabled (enabled: false) so no actual RPC call is made.
   const balance = useConfidentialBalance(
-    { tokenAddress: token?.confidentialTokenAddress ?? ZERO_ADDRESS },
+    {
+      address: token?.confidentialTokenAddress ?? ZERO_ADDRESS,
+      account: (address ?? ZERO_ADDRESS) as Address,
+    },
     { enabled: !!address && isHoodi && !!isAllowed && !!token },
   );
 
   // Mint 10 whole tokens on the underlying ERC-20 contract.
   const mint = useMutation({
     mutationFn: async () => {
-      const txHash = await sdk.signer.writeContract({
+      const signer = sdk.signer;
+      if (!signer) {
+        throw new Error("Connect a wallet before minting tokens.");
+      }
+      const txHash = await signer.writeContract({
         address: token!.tokenAddress,
         abi: MINT_ABI,
         functionName: "mint",
         args: [address as Address, parseUnits("10", erc20Decimals)],
       });
-      await sdk.signer.waitForTransactionReceipt(txHash);
+      await sdk.provider.waitForTransactionReceipt(txHash);
       return txHash;
     },
     onSuccess: refreshBalances,
@@ -452,9 +459,9 @@ export default function Home() {
       <BalancesCard
         formattedErc20={formattedErc20}
         formattedConfidential={formattedConfidential}
-        // handleQuery.isLoading: fetching the encrypted handle from chain (Phase 1).
-        // balance.isLoading: decrypting it via RelayerCleartext (Phase 2).
-        isLoadingConfidential={balance.handleQuery.isLoading || balance.isLoading}
+        // balance.isLoading: decrypting via the cleartext relayer; balance.isFetching:
+        // re-reading the encrypted handle from chain after a balance-changing operation.
+        isLoadingConfidential={balance.isLoading || balance.isFetching}
         erc20Symbol={erc20Symbol}
         onMint={() => mint.mutate()}
         isMinting={mint.isPending}
@@ -485,7 +492,6 @@ export default function Home() {
       <ShieldCard
         key={`shield-${address}-${selectedTokenAddress}`}
         tokenAddress={token?.confidentialTokenAddress ?? ZERO_ADDRESS}
-        underlyingAddress={token?.tokenAddress ?? ZERO_ADDRESS}
         decimals={erc20Decimals}
         symbol={erc20Symbol}
         disabled={actionsDisabled}

--- a/examples/example-hoodi/src/components/DecryptAsCard.tsx
+++ b/examples/example-hoodi/src/components/DecryptAsCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { isAddress, formatUnits } from "ethers";
 import { useDelegationStatus, useDecryptBalanceAs } from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { DelegationNotFoundError, DelegationExpiredError } from "@zama-fhe/sdk";
 
 // Matches the SDK's internal sentinel value for permanent (no-expiry) delegations.

--- a/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
+++ b/examples/example-hoodi/src/components/DelegateDecryptionCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { isAddress } from "ethers";
 import { useDelegateDecryption } from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 
 interface DelegateDecryptionCardProps {
@@ -17,16 +17,13 @@ export function DelegateDecryptionCard({ tokenAddress, disabled }: DelegateDecry
   const [noExpiry, setNoExpiry] = useState(true);
   const [expirationInput, setExpirationInput] = useState("");
 
-  const delegate = useDelegateDecryption(
-    { tokenAddress },
-    {
-      onSuccess: () => {
-        setDelegateAddress("");
-        setNoExpiry(true);
-        setExpirationInput("");
-      },
+  const delegate = useDelegateDecryption(tokenAddress, {
+    onSuccess: () => {
+      setDelegateAddress("");
+      setNoExpiry(true);
+      setExpirationInput("");
     },
-  );
+  });
 
   const isExpiryValid = noExpiry || (!!expirationInput && new Date(expirationInput) > new Date());
   const canSubmit = isAddress(delegateAddress) && isExpiryValid;

--- a/examples/example-hoodi/src/components/PendingUnshieldCard.tsx
+++ b/examples/example-hoodi/src/components/PendingUnshieldCard.tsx
@@ -1,13 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import {
-  useZamaSDK,
-  useResumeUnshield,
-  loadPendingUnshield,
-  clearPendingUnshield,
-} from "@zama-fhe/react-sdk";
-import type { Address, Hex } from "@zama-fhe/react-sdk";
+import { useZamaSDK, useResumeUnshield } from "@zama-fhe/react-sdk";
+import { loadPendingUnshield, clearPendingUnshield } from "@zama-fhe/sdk";
+import type { Address, Hex } from "@zama-fhe/sdk";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 
 interface PendingUnshieldCardProps {
@@ -26,19 +22,15 @@ export function PendingUnshieldCard({ tokenAddress, label, onSuccess }: PendingU
       .catch((err) => console.error("[PendingUnshieldCard] loadPendingUnshield failed:", err));
   }, [storage, tokenAddress]);
 
-  const resume = useResumeUnshield(
-    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
-    { tokenAddress, wrapperAddress: tokenAddress },
-    {
-      onSuccess: () => {
-        clearPendingUnshield(storage, tokenAddress).catch((err) =>
-          console.error("[PendingUnshieldCard] Failed to clear pending unshield:", err),
-        );
-        setPendingTxHash(null);
-        onSuccess?.();
-      },
+  const resume = useResumeUnshield(tokenAddress, {
+    onSuccess: () => {
+      clearPendingUnshield(storage, tokenAddress).catch((err) =>
+        console.error("[PendingUnshieldCard] Failed to clear pending unshield:", err),
+      );
+      setPendingTxHash(null);
+      onSuccess?.();
     },
-  );
+  });
 
   if (!pendingTxHash) return null;
 

--- a/examples/example-hoodi/src/components/RevokeDelegationCard.tsx
+++ b/examples/example-hoodi/src/components/RevokeDelegationCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { isAddress } from "ethers";
 import { useRevokeDelegation } from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 
 interface RevokeDelegationCardProps {
@@ -14,12 +14,9 @@ interface RevokeDelegationCardProps {
 export function RevokeDelegationCard({ tokenAddress, disabled }: RevokeDelegationCardProps) {
   const [delegateAddress, setDelegateAddress] = useState("");
 
-  const revoke = useRevokeDelegation(
-    { tokenAddress },
-    {
-      onSuccess: () => setDelegateAddress(""),
-    },
-  );
+  const revoke = useRevokeDelegation(tokenAddress, {
+    onSuccess: () => setDelegateAddress(""),
+  });
 
   function handleRevoke() {
     revoke.mutate({ delegateAddress: delegateAddress as Address });

--- a/examples/example-hoodi/src/components/ShieldCard.tsx
+++ b/examples/example-hoodi/src/components/ShieldCard.tsx
@@ -1,22 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
-import { isError } from "ethers";
-import {
-  useZamaSDK,
-  allowanceContract,
-  approveContract,
-  balanceOfContract,
-} from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import { useShield } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { parseAmount } from "@/lib/parseAmount";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 
 interface ShieldCardProps {
   tokenAddress: Address;
-  /** ERC-20 address of the underlying token (the `erc20` side of the pair). */
-  underlyingAddress: Address;
   decimals: number;
   symbol: string;
   disabled: boolean;
@@ -25,103 +16,34 @@ interface ShieldCardProps {
 
 export function ShieldCard({
   tokenAddress,
-  underlyingAddress,
   decimals,
   symbol,
   disabled,
   onSuccess,
 }: ShieldCardProps) {
   const [amount, setAmount] = useState("");
-  // "wrap"               = checking allowance or waiting for the wrap tx (no approval in progress)
-  // "approve"            = waiting for the ERC-20 approval transaction
-  // "wrap-after-approve" = approval confirmed, waiting for the wrap transaction
-  const [phase, setPhase] = useState<"wrap" | "approve" | "wrap-after-approve">("wrap");
+  const [phase, setPhase] = useState<"prepare" | "approve" | "wrap">("prepare");
 
-  const sdk = useZamaSDK();
+  const shield = useShield({ address: tokenAddress }, { onSuccess });
 
   const parsedAmount = parseAmount(amount, decimals);
   const pendingLabel =
     phase === "approve"
-      ? "Shielding… (1/2 approve)"
-      : phase === "wrap-after-approve"
-        ? "Shielding… (2/2 wrap)"
+      ? "Shielding… (approving)"
+      : phase === "wrap"
+        ? "Shielding… (wrapping)"
         : "Shielding…";
 
-  // Spend cap strategy: approve for the user's full ERC-20 balance (not the exact shield amount).
-  // This avoids re-approval on every shield — subsequent shields within the remaining cap
-  // need only the wrap transaction (1 wallet confirmation). Re-approval is only triggered
-  // when the requested amount exceeds the current spend cap.
-  //
-  // USDT-style detection (non-zero insufficient allowance case):
-  // We try approve(fullBalance) directly via writeContract. writeContract uses the signer,
-  // so eth_estimateGas is called with from=userAddress. For USDT-style tokens, the allowance
-  // check (_allowances[userAddress][spender] > 0) causes the estimation to revert before the
-  // wallet is ever prompted. We catch this and fall back to reset(0) + approve(fullBalance).
-  // User rejections (ACTION_REJECTED) are re-thrown immediately — we never silently fall back
-  // to the reset path when the user said no.
-  const shield = useMutation({
-    mutationFn: async (amount: bigint) => {
-      const token = sdk.createToken(tokenAddress);
-      const userAddress = await sdk.signer.getAddress();
-
-      // Read the current ERC-20 allowance granted to the wrapper.
-      const currentAllowance = (await sdk.signer.readContract(
-        allowanceContract(underlyingAddress, userAddress, tokenAddress),
-      )) as bigint;
-
-      if (currentAllowance < amount) {
-        // Fetch the user's full ERC-20 balance to use as the new spend cap.
-        const erc20Balance = (await sdk.signer.readContract(
-          balanceOfContract(underlyingAddress, userAddress),
-        )) as bigint;
-
-        setPhase("approve");
-
-        if (currentAllowance > 0n) {
-          // Non-zero insufficient allowance: try direct overwrite first.
-          // - Standard ERC-20: eth_estimateGas succeeds → wallet prompted → 1 confirmation.
-          // - USDT-style: eth_estimateGas reverts → caught below → reset path (2 confirmations).
-          let needsReset = false;
-          try {
-            const approveTxHash = await sdk.signer.writeContract(
-              approveContract(underlyingAddress, tokenAddress, erc20Balance),
-            );
-            await sdk.signer.waitForTransactionReceipt(approveTxHash);
-          } catch (err) {
-            if (isError(err, "ACTION_REJECTED")) throw err; // user rejected — stop here
-            needsReset = true; // eth_estimateGas reverted → USDT-style token
-          }
-
-          if (needsReset) {
-            const resetTxHash = await sdk.signer.writeContract(
-              approveContract(underlyingAddress, tokenAddress, 0n),
-            );
-            await sdk.signer.waitForTransactionReceipt(resetTxHash);
-            const approveTxHash = await sdk.signer.writeContract(
-              approveContract(underlyingAddress, tokenAddress, erc20Balance),
-            );
-            await sdk.signer.waitForTransactionReceipt(approveTxHash);
-          }
-        } else {
-          // Zero allowance: simple approve — no reset needed for any token.
-          const approveTxHash = await sdk.signer.writeContract(
-            approveContract(underlyingAddress, tokenAddress, erc20Balance),
-          );
-          await sdk.signer.waitForTransactionReceipt(approveTxHash);
-        }
-
-        setPhase("wrap-after-approve");
-      }
-
-      // approvalStrategy: 'skip' — allowance is confirmed above (or was already sufficient).
-      return token.shield(amount, { approvalStrategy: "skip" });
-    },
-    onSuccess,
-  });
-
   function handleShield() {
-    setPhase("wrap"); // reset to default; updated to "approve" inside mutation if needed
-    shield.mutate(parsedAmount);
+    setPhase("prepare");
+    shield.mutate({
+      amount: parsedAmount,
+      // Let the SDK handle ERC-20 balance checks, allowance reads, USDT-style allowance reset,
+      // approval transaction(s), shield submission, and cache invalidation.
+      approvalStrategy: "exact",
+      onApprovalSubmitted: () => setPhase("approve"),
+      onShieldSubmitted: () => setPhase("wrap"),
+    });
   }
 
   return (

--- a/examples/example-hoodi/src/components/TransferCard.tsx
+++ b/examples/example-hoodi/src/components/TransferCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { isAddress } from "ethers";
 import { useConfidentialTransfer } from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { parseAmount } from "@/lib/parseAmount";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 
@@ -28,7 +28,7 @@ export function TransferCard({
   const [recipient, setRecipient] = useState("");
   const [step, setStep] = useState<1 | 2>(1);
 
-  const transfer = useConfidentialTransfer({ tokenAddress }, { onSuccess });
+  const transfer = useConfidentialTransfer({ address: tokenAddress }, { onSuccess });
 
   const parsedAmount = parseAmount(amount, decimals);
   const pendingLabel = step === 2 ? "Submitting…" : "Encrypting…";
@@ -38,7 +38,7 @@ export function TransferCard({
     transfer.mutate({
       to: recipient as Address,
       amount: parsedAmount,
-      callbacks: { onEncryptComplete: () => setStep(2) },
+      onEncryptComplete: () => setStep(2),
     });
   }
 

--- a/examples/example-hoodi/src/components/UnshieldCard.tsx
+++ b/examples/example-hoodi/src/components/UnshieldCard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { useUnshield, useZamaSDK, clearPendingUnshield } from "@zama-fhe/react-sdk";
-import type { Address } from "@zama-fhe/react-sdk";
+import { useUnshield, useZamaSDK } from "@zama-fhe/react-sdk";
+import { clearPendingUnshield } from "@zama-fhe/sdk";
+import type { Address } from "@zama-fhe/sdk";
 import { parseAmount } from "@/lib/parseAmount";
 import { HOODI_EXPLORER_URL } from "@/lib/config";
 import { setActiveUnshieldToken } from "@/lib/activeUnshield";
@@ -29,21 +30,17 @@ export function UnshieldCard({
 
   const { storage } = useZamaSDK();
 
-  const unshield = useUnshield(
-    // For ERC-7984 tokens, the wrapper IS the token — tokenAddress and wrapperAddress are the same.
-    { tokenAddress, wrapperAddress: tokenAddress },
-    {
-      onSuccess: () => {
-        clearPendingUnshield(storage, tokenAddress).catch((err) =>
-          console.error("[UnshieldCard] Failed to clear pending unshield:", err),
-        );
-        onSuccess?.();
-      },
-      // Clear the active token ref on failure so a stale address is never used by the
-      // onEvent handler in ZamaProvider if a subsequent UnshieldPhase1Submitted fires.
-      onError: () => setActiveUnshieldToken(null),
+  const unshield = useUnshield(tokenAddress, {
+    onSuccess: () => {
+      clearPendingUnshield(storage, tokenAddress).catch((err) =>
+        console.error("[UnshieldCard] Failed to clear pending unshield:", err),
+      );
+      onSuccess?.();
     },
-  );
+    // Clear the active token ref on failure so a stale address is never used by the
+    // onEvent handler in ZamaProvider if a subsequent UnshieldPhase1Submitted fires.
+    onError: () => setActiveUnshieldToken(null),
+  });
 
   const parsedAmount = parseAmount(amount, decimals);
   const pendingLabel = step === 2 ? "Unshielding… (2/2)" : "Unshielding… (1/2)";
@@ -57,10 +54,8 @@ export function UnshieldCard({
     setActiveUnshieldToken(tokenAddress);
     unshield.mutate({
       amount: parsedAmount,
-      callbacks: {
-        // onFinalizing fires between the two on-chain transactions, marking step 2.
-        onFinalizing: () => setStep(2),
-      },
+      // onFinalizing fires between the two on-chain transactions, marking step 2.
+      onFinalizing: () => setStep(2),
     });
   }
 

--- a/examples/example-hoodi/src/lib/activeUnshield.ts
+++ b/examples/example-hoodi/src/lib/activeUnshield.ts
@@ -1,4 +1,4 @@
-import type { Address } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
 
 /**
  * Module-level bridge used to associate an in-flight unwrap transaction hash

--- a/examples/example-hoodi/src/providers.tsx
+++ b/examples/example-hoodi/src/providers.tsx
@@ -3,14 +3,16 @@
 import { useState, useEffect, useMemo, useRef, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
-  ZamaProvider,
   ZamaSDKEvents,
   IndexedDBStorage,
   indexedDBStorage,
   savePendingUnshield,
-} from "@zama-fhe/react-sdk";
-import { RelayerCleartext, hoodiCleartextConfig } from "@zama-fhe/sdk/cleartext";
-import { EthersSigner } from "@zama-fhe/sdk/ethers";
+  cleartext,
+} from "@zama-fhe/sdk";
+import { createConfig } from "@zama-fhe/sdk/ethers";
+import type { EIP1193Provider } from "@zama-fhe/sdk/ethers";
+import { ZamaProvider } from "@zama-fhe/react-sdk";
+import { hoodi } from "@zama-fhe/sdk/chains";
 import { JsonRpcProvider } from "ethers";
 import { HOODI_RPC_URL } from "@/lib/config";
 import { getActiveUnshieldToken, setActiveUnshieldToken } from "@/lib/activeUnshield";
@@ -18,12 +20,11 @@ import { getEthereumProvider } from "@/lib/ethereum";
 
 // ── What this file does ────────────────────────────────────────────────────────
 //
-// This file wires together the three SDK primitives every integration needs:
+// This file wires together the SDK config every integration needs:
 //
-//   const signer  = new EthersSigner({ ethereum });
-//   const relayer = new RelayerCleartext({ ...hoodiCleartextConfig, network: HOODI_RPC_URL });
-//   <ZamaProvider relayer={relayer} signer={signer}
-//     storage={indexedDBStorage} sessionStorage={sessionDBStorage}>
+//   const config = createConfig({ chains: [hoodi], ethereum, provider,
+//     storage: indexedDBStorage, permitStorage, relayers: { [hoodi.id]: cleartext() } });
+//   <ZamaProvider config={config}>
 //
 // That is the minimal setup. This file adds three extra layers to handle issues
 // specific to MetaMask + Hoodi — you may not need all of them in your integration:
@@ -33,22 +34,22 @@ import { getEthereumProvider } from "@/lib/ethereum";
 //    nonce (eth_getTransactionCount), and receipt polling to the injected wallet
 //    to avoid stale data from the Hoodi load balancer. See WALLET_METHODS below.
 //
-// 2. Separate IndexedDB instances for storage and sessionStorage — both use the
+// 2. Separate IndexedDB instances for storage and permitStorage — both use the
 //    same internal key; sharing one DB instance causes the session entry to
 //    overwrite the encrypted keypair, forcing re-signing on every balance decrypt.
 //
 // 3. walletKey + refSeededRef — remounts ZamaProvider on wallet switch with a
-//    fresh EthersSigner bound to the new account, while ignoring spurious
+//    fresh ethers adapter bound to the new account, while ignoring spurious
 //    accountsChanged events some wallets emit before eth_accounts resolves.
 //
 // See WALKTHROUGH.md §"Architecture at a glance" for the full rationale.
 // ──────────────────────────────────────────────────────────────────────────────
 
-// Separate IndexedDB database for session signatures (EIP-712 wallet signatures that
-// authorize decryption). Must be distinct from indexedDBStorage ("CredentialStore") because
-// both use the same storage key — storing them in the same DB would cause the session entry
-// to overwrite the encrypted keypair, corrupting credentials on the next decrypt attempt.
-const sessionDBStorage = new IndexedDBStorage("SessionStore");
+// Separate IndexedDB database for permit storage (EIP-712 wallet signatures that authorize
+// decryption). Must be distinct from indexedDBStorage ("CredentialStore") because both use
+// the same storage key — sharing one DB would overwrite the encrypted keypair and corrupt
+// credentials on the next decrypt attempt.
+const permitDBStorage = new IndexedDBStorage("PermitStore");
 
 /**
  * Methods routed to the injected wallet rather than the direct Hoodi RPC.
@@ -110,7 +111,7 @@ const WALLET_METHODS = new Set([
  * - Page refresh (wallet connected): returns the connected account immediately — getSigner() works.
  * - Fresh install (wallet not connected): returns [] silently — getSigner() fails gracefully,
  *   no unexpected popup. After the user explicitly connects via Connect Wallet, walletKey
- *   increments → ZamaProvider remounts → new EthersSigner created with the populated cache.
+ *   increments → ZamaProvider remounts → new ethers adapter created with the populated cache.
  */
 function createHybridEthereum(
   ethereum: typeof window.ethereum,
@@ -145,11 +146,11 @@ function createHybridEthereum(
     request({ method, params }: { method: string; params?: unknown[] }) {
       if (method === "eth_requestAccounts" || method === "eth_accounts") {
         if (liveAccountsRef.current.length > 0) {
-          // Cache hit — serve immediately so EthersSigner resolves without a wallet roundtrip.
+          // Cache hit — serve immediately so ethers adapter resolves without a wallet roundtrip.
           return Promise.resolve([...liveAccountsRef.current]);
         }
         // Cache empty (initial mount, not yet seeded): query eth_accounts (non-requesting).
-        // This avoids triggering an unexpected wallet popup from EthersSigner's eager
+        // This avoids triggering an unexpected wallet popup from ethers adapter's eager
         // getSigner() call. Returns the connected accounts on page refresh (no popup),
         // or [] when not yet connected (getSigner fails gracefully, balances stay "—").
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -184,7 +185,7 @@ export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
   // Updated synchronously in accountsChanged (before setWalletKey re-renders) so the
-  // next EthersSigner sees the correct accounts immediately via the hybrid provider.
+  // next ethers adapter sees the correct accounts immediately via the hybrid provider.
   const liveAccountsRef = useRef<readonly string[]>([]);
 
   // Becomes true once the initial eth_accounts call resolves. accountsChanged events
@@ -193,7 +194,7 @@ export function Providers({ children }: { children: ReactNode }) {
   // would cause a spurious ZamaProvider remount and force the user to re-sign.
   const refSeededRef = useRef(false);
 
-  // Incremented on wallet switch to remount ZamaProvider with a fresh EthersSigner
+  // Incremented on wallet switch to remount ZamaProvider with a fresh ethers adapter
   // bound to the new account.
   const [walletKey, setWalletKey] = useState(0);
 
@@ -226,43 +227,46 @@ export function Providers({ children }: { children: ReactNode }) {
     return () => ethereum.removeListener("accountsChanged", handleAccountsChanged);
   }, []);
 
-  // hoodiCleartextConfig and HOODI_RPC_URL are build-time constants — relayer never changes.
-  const relayer = useMemo(
-    () => new RelayerCleartext({ ...hoodiCleartextConfig, network: HOODI_RPC_URL }),
-    [],
-  );
+  // Recreated on wallet switch so the ethers adapter is bound to the new account address.
+  // The hybrid EIP-1193 provider (createHybridEthereum) is passed as `ethereum`, so wallet
+  // writes/signing/nonce/receipt-polling stay on the injected wallet, while SDK reads go to
+  // the direct Hoodi RPC via `provider`. cleartext() is the relayer transport — Hoodi runs the
+  // cleartext FHEVM host stack, so there is no real relayer/KMS network to call.
+  const zamaConfig = useMemo(() => {
+    const ethereum = createHybridEthereum(
+      getEthereumProvider(),
+      liveAccountsRef,
+    ) as unknown as EIP1193Provider;
+    const provider = new JsonRpcProvider(HOODI_RPC_URL);
 
-  // Recreated on wallet switch so the new EthersSigner is bound to the new account address.
-  const signer = useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const hybridEthereum = createHybridEthereum(getEthereumProvider(), liveAccountsRef) as any;
-    return new EthersSigner({ ethereum: hybridEthereum });
+    return createConfig({
+      chains: [hoodi],
+      ethereum,
+      provider,
+      storage: indexedDBStorage,
+      permitStorage: permitDBStorage,
+      relayers: { [hoodi.id]: cleartext() },
+      onEvent: (event) => {
+        // ZamaSDKEvents.UnshieldPhase1Submitted fires after Phase 1 is mined (the SDK awaits
+        // the receipt before emitting). Saving here ensures the pending state survives a tab
+        // close between Phase 1 and Phase 2. See activeUnshield.ts for why wrapperAddress is
+        // passed via a module-level ref.
+        if (event.type === ZamaSDKEvents.UnshieldPhase1Submitted) {
+          const wrapperAddress = getActiveUnshieldToken();
+          if (wrapperAddress) {
+            savePendingUnshield(indexedDBStorage, wrapperAddress, event.txHash).catch((err) =>
+              console.error("[Providers] Failed to persist pending unshield:", event.txHash, err),
+            );
+            setActiveUnshieldToken(null);
+          }
+        }
+      },
+    });
   }, [walletKey]);
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ZamaProvider
-        key={walletKey}
-        relayer={relayer}
-        storage={indexedDBStorage}
-        sessionStorage={sessionDBStorage}
-        signer={signer}
-        onEvent={(event) => {
-          // ZamaSDKEvents.UnshieldPhase1Submitted fires after Phase 1 is mined (the SDK
-          // awaits the receipt before emitting). Saving here ensures the pending state
-          // survives a tab close between Phase 1 and Phase 2.
-          // See activeUnshield.ts for why wrapperAddress is passed via a module-level ref.
-          if (event.type === ZamaSDKEvents.UnshieldPhase1Submitted) {
-            const wrapperAddress = getActiveUnshieldToken();
-            if (wrapperAddress) {
-              savePendingUnshield(indexedDBStorage, wrapperAddress, event.txHash).catch((err) =>
-                console.error("[Providers] Failed to persist pending unshield:", event.txHash, err),
-              );
-              setActiveUnshieldToken(null);
-            }
-          }
-        }}
-      >
+      <ZamaProvider key={walletKey} config={zamaConfig}>
         {children}
       </ZamaProvider>
     </QueryClientProvider>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15880,9 +15880,9 @@ For a detailed partner-facing guide including prerequisites, step-by-step flow, 
 
 ERC-7984 is a token standard that adds **confidential balances and transfer amounts** to ERC-20 tokens. Instead of storing plaintext balances on-chain, balances are stored as encrypted handles. Only the token owner can decrypt their own balance.
 
-The **Zama SDK** (`@zama-fhe/sdk`, `@zama-fhe/react-sdk`) handles all cryptographic operations — encryption, decryption, EIP-712 signing — behind simple React hooks (`useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`) and the `Token` API (`sdk.createToken().shield()`).
+The **Zama SDK** (`@zama-fhe/sdk`, `@zama-fhe/react-sdk`) handles all cryptographic operations — encryption, decryption, EIP-712 signing — behind simple React hooks (`useShield`, `useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`).
 
-This example uses the **cleartext stack** (`RelayerCleartext`), which is Zama's lightweight backend for chains where the full FHE co-processor is not deployed (including Hoodi). See [How the cleartext stack works](#how-the-cleartext-stack-works) below.
+This example uses the **cleartext stack** (`cleartext()`), which is Zama's lightweight backend for chains where the full FHE co-processor is not deployed (including Hoodi). See [How the cleartext stack works](#how-the-cleartext-stack-works) below.
 
 ---
 
@@ -15903,7 +15903,7 @@ Specifically:
 | Operation                    | SDK API                                                      | Source file                                            | Transactions          |
 | ---------------------------- | ------------------------------------------------------------ | ------------------------------------------------------ | --------------------- |
 | Decrypt confidential balance | `useHasPermit` + `useGrantPermit` + `useConfidentialBalance` | `src/app/page.tsx` + `src/components/BalancesCard.tsx` | 0 (read)              |
-| Shield (ERC-20 → cToken)     | `sdk.createToken().shield()`                                 | `src/components/ShieldCard.tsx`                        | 1–3 (wrap, ± approve) |
+| Shield (ERC-20 → cToken)     | `useShield`                                                  | `src/components/ShieldCard.tsx`                        | 1–3 (wrap, ± approve) |
 | Confidential transfer        | `useConfidentialTransfer`                                    | `src/components/TransferCard.tsx`                      | 1                     |
 | Unshield (cToken → ERC-20)   | `useUnshield`                                                | `src/components/UnshieldCard.tsx`                      | 2 (unwrap + finalize) |
 | Grant decryption access      | `useDelegateDecryption`                                      | `src/components/DelegateDecryptionCard.tsx`            | 1                     |
@@ -15931,15 +15931,15 @@ The full Zama FHE stack (used on Sepolia and Mainnet) relies on:
 **Hoodi uses the cleartext stack.** In cleartext mode:
 
 - Values are stored as **plaintexts** in the `CleartextFHEVMExecutor` contract on-chain (no actual FHE encryption)
-- The `RelayerCleartext` class acts as a local relayer: it reads plaintexts directly from the executor contract and produces mock KMS signatures locally
+- The `cleartext()` transport acts as a local relayer: it reads plaintexts directly from the executor contract and produces mock KMS signatures locally
 - **No external service** is required — no relayer URL, no API key
 
-The SDK interface is identical in both modes. From the application developer's perspective, you swap `RelayerWeb` (or `RelayerNode`) for `RelayerCleartext` and point it at the Hoodi preset config. All hooks behave the same way.
+The SDK interface is identical in both modes. From the application developer's perspective, you swap `web()` (or `node()`) for `cleartext()` and point it at the Hoodi preset config. All hooks behave the same way.
 
 ```
 Full FHE stack (Sepolia / Mainnet)      Cleartext stack (Hoodi)
 ──────────────────────────────────      ──────────────────────────────────────
-RelayerWeb → external HTTP service      RelayerCleartext → on-chain executor
+web() → external HTTP service      cleartext() → on-chain executor
   └─ FHE co-processor (on-chain)          └─ plaintexts(handle) → plaintext
   └─ KMS decryption (server-side)         └─ mock KMS signature (local)
   └─ Zama relayer API key required        └─ No API key, no external service
@@ -15953,18 +15953,18 @@ RelayerWeb → external HTTP service      RelayerCleartext → on-chain executor
 User (browser wallet)
   │
   ▼
-page.tsx — sdk.createToken().shield() / useConfidentialTransfer / useUnshield / useConfidentialBalance
+page.tsx — useShield / useConfidentialTransfer / useUnshield / useConfidentialBalance
   │
   ▼
 @zama-fhe/react-sdk (React hooks + ZamaProvider)
   │
   ▼
 @zama-fhe/sdk (ZamaSDK)
-  ├─ EthersSigner   → hybrid EIP-1193 provider
+  ├─ ethers adapter   → hybrid EIP-1193 provider
   │    ├─ reads (eth_call, eth_estimateGas) → JsonRpcProvider(HOODI_RPC_URL)
   │    └─ writes + polling (signing, eth_sendTransaction,
   │         eth_blockNumber, eth_getTransactionReceipt) → injected wallet
-  └─ RelayerCleartext → hoodiCleartextConfig
+  └─ cleartext() → the hoodi preset
        └─ reads plaintexts from CleartextFHEVMExecutor (on-chain, Hoodi)
        └─ produces mock KMS signatures locally (no external call)
 ```
@@ -15978,7 +15978,7 @@ page.tsx — sdk.createToken().shield() / useConfidentialTransfer / useUnshield 
 
 To ensure ethers' `PollingBlockSubscriber` checks for new receipts on every poll interval (4 s rather than once per block at ~12 s), `eth_blockNumber` responses are adjusted to always be strictly increasing — if the returned block number has not advanced, the counter increments by 1.
 
-**Wallet-switch lifecycle:** on every account change, `ZamaProvider` remounts with a fresh `EthersSigner` so the new account's address is used immediately. The `accountsChanged` listener ignores events that fire before the initial `eth_accounts` call resolves (some wallets emit it on page load before the ref is seeded), preventing spurious remounts that would clear the in-memory credential cache. First connection is handled correctly: once `eth_accounts` resolves and the user connects, `walletKey` increments and a new `EthersSigner` is created with the live account ref already populated. An EIP-712 session credential is persisted in IndexedDB and survives page reloads within the 30-day TTL.
+**Wallet-switch lifecycle:** on every account change, `ZamaProvider` remounts with a fresh `ethers adapter` so the new account's address is used immediately. The `accountsChanged` listener ignores events that fire before the initial `eth_accounts` call resolves (some wallets emit it on page load before the ref is seeded), preventing spurious remounts that would clear the in-memory credential cache. First connection is handled correctly: once `eth_accounts` resolves and the user connects, `walletKey` increments and a new `ethers adapter` is created with the live account ref already populated. An EIP-712 session credential is persisted in IndexedDB and survives page reloads within the 30-day TTL.
 
 ---
 
@@ -16089,7 +16089,7 @@ If your ERC-20 balance shows `0`, click **Mint** next to the ERC-20 balance, or 
 Two balances are displayed:
 
 - **ERC-20 balance** — your public on-chain balance of the underlying token. Read via a standard `balanceOf` call.
-- **Confidential balance** — your confidential cToken balance, read via `useConfidentialBalance`. The SDK reads the encrypted handle on-chain (Phase 1), then decrypts it via `RelayerCleartext` (Phase 2).
+- **Confidential balance** — your confidential cToken balance, read via `useConfidentialBalance`. The SDK reads the encrypted handle on-chain (Phase 1), then decrypts it via `cleartext()` (Phase 2).
 
 **Explicit decrypt pattern:** the confidential balance is not queried until you explicitly authorize FHE decryption. The Balances card shows a **Decrypt Balance** button instead of a balance value until you sign. This avoids blind EIP-712 prompts on mount.
 
@@ -16101,18 +16101,15 @@ If you have never shielded any tokens, the confidential balance shows **—** af
 
 Enter a human-readable amount (e.g., `1.5`) and click **Shield**. This converts public ERC-20 tokens into confidential cTokens.
 
-The app manages ERC-20 allowances automatically. The spend cap is set to your **full ERC-20 balance** (not the exact shield amount), so once approved, subsequent shields within the remaining cap need only the wrap transaction — no re-approval. The number of wallet confirmations depends on the current allowance:
+The app delegates the entire approve + wrap flow to `useShield` — it does not read ERC-20 allowances, submit approvals, or call wrapper contracts directly. With `approvalStrategy: "exact"` the SDK approves exactly the shielded amount, performing a USDT-style allowance reset first when an existing non-zero allowance would block the approval. The number of wallet confirmations depends on the underlying token and current allowance:
 
-| Situation                                          | Transactions                                       | Confirmations |
-| -------------------------------------------------- | -------------------------------------------------- | ------------- |
-| Allowance already covers the amount                | `wrap` only                                        | 1             |
-| No existing allowance (or zero)                    | `approve(fullBalance)` → `wrap`                    | 2             |
-| Non-zero allowance insufficient — standard token   | `approve(fullBalance)` → `wrap` (direct overwrite) | 2             |
-| Non-zero allowance insufficient — USDT-style token | `approve(0)` → `approve(fullBalance)` → `wrap`     | 3 _(rare)_    |
+| Situation                                          | Transactions                              | Confirmations |
+| -------------------------------------------------- | ----------------------------------------- | ------------- |
+| Allowance already covers the amount                | `wrap` only                               | 1             |
+| No existing allowance (or zero)                    | `approve(amount)` → `wrap`                | 2             |
+| Non-zero allowance insufficient — USDT-style token | `approve(0)` → `approve(amount)` → `wrap` | 3 _(rare)_    |
 
-When re-approving (non-zero insufficient allowance), the app optimistically tries `approve(fullBalance)` directly. `writeContract` goes through the signer, so `eth_estimateGas` is called with `from = userAddress` — correctly simulating the allowance check. For standard ERC-20 tokens, gas estimation succeeds and the wallet is prompted once. For USDT-style tokens (which revert when `approve(nonZero)` is called with a non-zero existing allowance), gas estimation fails **before the wallet is prompted** — the app silently falls back to the reset path. User rejections are re-thrown immediately and never misidentified as USDT-style.
-
-The button shows **Shielding… (1/2 approve)** during approval and **Shielding… (2/2 wrap)** once the approval is confirmed. Gas fees on Hoodi are effectively zero. The ERC-20 balance refreshes automatically on success.
+The button shows **Shielding… (approving)** during approval and **Shielding… (wrapping)** once the approval is confirmed. Gas fees on Hoodi are effectively zero. The ERC-20 balance refreshes automatically on success.
 
 ### Step 6 — Confidential transfer
 
@@ -16130,7 +16127,7 @@ Enter an amount and click **Unshield**. This converts cTokens back into public E
 Unshield is a two-phase operation:
 
 1. **Unwrap** — a transaction that burns the cTokens and emits an `UnwrapRequested` event containing the encrypted amount handle. The button shows **Unshielding… (1/2)**. One wallet confirmation.
-2. **Finalize** — the `RelayerCleartext` decrypts the amount locally (no external call, no wallet prompt), then submits a `finalizeUnwrap` transaction that releases the ERC-20 tokens. The button shows **Unshielding… (2/2)**. One wallet confirmation.
+2. **Finalize** — the `cleartext()` decrypts the amount locally (no external call, no wallet prompt), then submits a `finalizeUnwrap` transaction that releases the ERC-20 tokens. The button shows **Unshielding… (2/2)**. One wallet confirmation.
 
 Both phases complete within seconds on Hoodi. The ERC-20 balance refreshes automatically on success.
 
@@ -16180,55 +16177,52 @@ Switch back to the owner wallet. In the **Revoke Decryption Access** card, enter
 
 ```tsx
 // src/providers.tsx
-import { RelayerCleartext, hoodiCleartextConfig } from "@zama-fhe/sdk/cleartext";
-import { EthersSigner } from "@zama-fhe/sdk/ethers";
-import { ZamaProvider, IndexedDBStorage, indexedDBStorage } from "@zama-fhe/react-sdk";
+import { createConfig } from "@zama-fhe/sdk/ethers";
+import { cleartext, IndexedDBStorage, indexedDBStorage } from "@zama-fhe/sdk";
+import { hoodi } from "@zama-fhe/sdk/chains";
+import { ZamaProvider } from "@zama-fhe/react-sdk";
+import { JsonRpcProvider } from "ethers";
 import { HOODI_RPC_URL } from "@/lib/config"; // process.env.NEXT_PUBLIC_HOODI_RPC_URL || fallback
 
-// getEthereumProvider() prefers window.phantom.ethereum when Phantom is detected,
-// falling back to window.ethereum for MetaMask and other EIP-1193 wallets.
-// Route read-only RPC calls to a direct JsonRpcProvider for fast receipt polling.
-// Wallet calls (signing, account management) are forwarded to the injected wallet.
-// See providers.tsx for the full implementation — createHybridEthereum also takes a
-// liveAccountsRef cache to resolve accounts immediately on wallet switch.
-const hybridEthereum = createHybridEthereum(getEthereumProvider(), liveAccountsRef);
-const signer = new EthersSigner({ ethereum: hybridEthereum });
+// The hybrid EIP-1193 provider routes reads to a direct JsonRpcProvider and wallet calls
+// (signing, nonce, receipt polling) to the injected wallet — see providers.tsx for
+// createHybridEthereum and its liveAccountsRef cache. It is passed as `ethereum`; SDK reads
+// also use `provider` (the direct Hoodi RPC).
+const ethereum = createHybridEthereum(getEthereumProvider(), liveAccountsRef);
+const provider = new JsonRpcProvider(HOODI_RPC_URL);
 
-// hoodiCleartextConfig contains the chainId, executor address, and ACL address for Hoodi.
-// Override `network` to use a custom RPC endpoint.
-const relayer = new RelayerCleartext({ ...hoodiCleartextConfig, network: HOODI_RPC_URL });
+// IMPORTANT: use a separate IndexedDBStorage instance for permitStorage.
+// Both storage and permitStorage use the same key internally — sharing one database
+// overwrites the encrypted keypair and forces the user to re-sign on every decryption.
+const permitDBStorage = new IndexedDBStorage("PermitStore");
 
-// IMPORTANT: use a separate IndexedDBStorage instance for sessionStorage.
-// Both storage and sessionStorage use the same key internally — if they share the same
-// database, the session entry overwrites the encrypted keypair, which corrupts credentials
-// and forces the user to re-sign on every balance decryption.
-const sessionDBStorage = new IndexedDBStorage("SessionStore");
+// `hoodi` is the shipped Hoodi cleartext chain preset (chain 560048). cleartext() is the
+// relayer transport — Hoodi runs the cleartext FHEVM host stack, so there is no real
+// relayer/KMS network to call.
+const config = createConfig({
+  chains: [hoodi],
+  ethereum,
+  provider,
+  storage: indexedDBStorage, // "CredentialStore" DB — encrypted FHE keypair
+  permitStorage: permitDBStorage, // "PermitStore" DB — EIP-712 permit signatures
+  relayers: { [hoodi.id]: cleartext() },
+});
 
-<ZamaProvider
-  relayer={relayer}
-  signer={signer}
-  storage={indexedDBStorage} // "CredentialStore" DB — encrypted FHE keypair
-  sessionStorage={sessionDBStorage} // "SessionStore" DB — EIP-712 session signatures
->
-  ...
-</ZamaProvider>;
+<ZamaProvider config={config}>...</ZamaProvider>;
 ```
 
 ### Hook usage
 
 ```tsx
-import { parseUnits, isError } from "ethers";
+import { parseUnits } from "ethers";
 import {
-  useZamaSDK,
+  useShield,
   useListPairs,
   useHasPermit,
   useGrantPermit,
   useConfidentialTransfer,
   useUnshield,
   useConfidentialBalance,
-  allowanceContract,
-  approveContract,
-  balanceOfContract,
 } from "@zama-fhe/react-sdk";
 
 // Fetch all valid token pairs from the on-chain WrappersRegistry.
@@ -16245,10 +16239,10 @@ const erc20Decimals = pair?.underlying.decimals ?? 0;
 
 // Explicit decrypt pattern: check credentials before enabling the balance display.
 // useHasPermit returns true only when cached credentials cover the selected token.
-const { data: hasPermit } = useHasPermit({
-  contractAddresses: cTokenAddress ? [cTokenAddress] : [],
-  query: { enabled: Boolean(cTokenAddress) },
-});
+const { data: hasPermit } = useHasPermit(
+  { contractAddresses: cTokenAddress ? [cTokenAddress] : [] },
+  { enabled: Boolean(cTokenAddress) },
+);
 
 // useGrantPermit triggers the EIP-712 wallet signature that authorizes decryption.
 // Pass all confidential token addresses at once — a single signature covers all tokens.
@@ -16258,74 +16252,30 @@ function handleDecrypt() {
   if (addresses.length > 0) grantPermits.mutate(addresses);
 }
 
-const transfer = useConfidentialTransfer({ tokenAddress: cTokenAddress });
-const unshield = useUnshield({ tokenAddress: cTokenAddress, wrapperAddress: cTokenAddress });
+const transfer = useConfidentialTransfer({ address: cTokenAddress });
+const unshield = useUnshield(cTokenAddress);
 
 // Pass enabled: false until the user has authorized decrypt (hasPermit).
 // This prevents the hook from firing an EIP-712 prompt on mount.
 const balance = useConfidentialBalance(
-  { tokenAddress: cTokenAddress ?? "0x0000000000000000000000000000000000000000" },
+  // `account` (the balance holder) is optional — it defaults to the connected signer.
+  // page.tsx passes it explicitly; omit it for the connected wallet's own balance.
+  { address: cTokenAddress ?? "0x0000000000000000000000000000000000000000" },
   { enabled: !!hasPermit && !!cTokenAddress },
 );
 
-// Shield: manual approval + wrap.
-// Spend cap strategy: approve for the user's full ERC-20 balance (not the exact shield amount).
-// This avoids re-approval on every shield — subsequent shields within the remaining cap
-// need only the wrap transaction. Re-approval is only triggered when the cap is exceeded.
-//
-// USDT-style detection (non-zero insufficient allowance): writeContract uses the signer,
-// so eth_estimateGas runs with from=userAddress. For USDT-style tokens, gas estimation
-// reverts before the wallet is prompted. We catch this and fall back to reset(0) + approve.
-// User rejections (ACTION_REJECTED) are re-thrown immediately.
-//
-// The shield logic runs inside an async function (e.g., a TanStack Query mutationFn):
-const sdk = useZamaSDK();
-const shieldAmount = parseUnits("10", erc20Decimals);
-const token = sdk.createToken(cTokenAddress);
-const userAddress = await sdk.signer.getAddress();
-
-const currentAllowance = (await sdk.signer.readContract(
-  allowanceContract(erc20Address, userAddress, cTokenAddress),
-)) as bigint;
-
-if (currentAllowance < shieldAmount) {
-  const erc20Balance = (await sdk.signer.readContract(
-    balanceOfContract(erc20Address, userAddress),
-  )) as bigint;
-
-  if (currentAllowance > 0n) {
-    // Try direct overwrite — works for standard ERC-20s (2 txs total: approve + wrap).
-    // USDT-style: gas estimation fails pre-wallet → fall back to reset + approve (3 txs).
-    let needsReset = false;
-    try {
-      const approveHash = await sdk.signer.writeContract(
-        approveContract(erc20Address, cTokenAddress, erc20Balance),
-      );
-      await sdk.signer.waitForTransactionReceipt(approveHash);
-    } catch (err) {
-      if (isError(err, "ACTION_REJECTED")) throw err; // user rejected — stop here
-      needsReset = true; // gas estimation reverted → USDT-style token
-    }
-    if (needsReset) {
-      const resetHash = await sdk.signer.writeContract(
-        approveContract(erc20Address, cTokenAddress, 0n),
-      );
-      await sdk.signer.waitForTransactionReceipt(resetHash);
-      const approveHash = await sdk.signer.writeContract(
-        approveContract(erc20Address, cTokenAddress, erc20Balance),
-      );
-      await sdk.signer.waitForTransactionReceipt(approveHash);
-    }
-  } else {
-    // Zero allowance: direct approve — no reset needed for any token.
-    const approveHash = await sdk.signer.writeContract(
-      approveContract(erc20Address, cTokenAddress, erc20Balance),
-    );
-    await sdk.signer.waitForTransactionReceipt(approveHash);
-  }
-}
-// approvalStrategy: 'skip' — allowance is confirmed above (or was already sufficient).
-await token.shield(shieldAmount, { approvalStrategy: "skip" });
+// Shield: useShield owns the entire approve + wrap flow — the app does not read ERC-20
+// allowances, submit approvals, or call wrapper contracts. approvalStrategy "exact" approves
+// exactly the shielded amount; the SDK performs the USDT-style allowance reset when an
+// existing non-zero allowance would otherwise block the approval, and routes through ERC-1363
+// transferAndCall when the underlying ERC-20 supports it.
+const shield = useShield({ address: cTokenAddress });
+shield.mutate({
+  amount: parseUnits("10", erc20Decimals),
+  approvalStrategy: "exact",
+  onApprovalSubmitted: () => setPhase("approve"),
+  onShieldSubmitted: () => setPhase("wrap"),
+});
 
 // Transfer: FHE encryption (local) + 1 transaction.
 // Amount is in confidential token units — use cTokenDecimals.
@@ -16333,7 +16283,7 @@ await token.shield(shieldAmount, { approvalStrategy: "skip" });
 transfer.mutate({
   to: "0xRecipient",
   amount: parseUnits("5", cTokenDecimals),
-  callbacks: { onEncryptComplete: () => setStep(2) },
+  onEncryptComplete: () => setStep(2),
 });
 
 // Unshield: 2 transactions (unwrap + finalizeUnwrap).
@@ -16341,7 +16291,7 @@ transfer.mutate({
 // onFinalizing fires between the two transactions — use it to update the progress UI.
 unshield.mutate({
   amount: parseUnits("2", cTokenDecimals),
-  callbacks: { onFinalizing: () => setStep(2) },
+  onFinalizing: () => setStep(2),
 });
 ```
 
@@ -16358,21 +16308,21 @@ import { DelegationNotFoundError, DelegationExpiredError } from "@zama-fhe/sdk";
 
 // Grant decryption access — 1 transaction.
 // expirationDate: undefined → SDK sends MAX_UINT64 on-chain (permanent delegation).
-const delegate = useDelegateDecryption({ tokenAddress: cTokenAddress });
+const delegate = useDelegateDecryption(cTokenAddress);
 // Permanent delegation (no expiry):
 delegate.mutate({ delegateAddress: "0xDelegate" });
 // With expiry (must be at least 1 hour in the future):
 delegate.mutate({ delegateAddress: "0xDelegate", expirationDate: new Date("2027-01-01") });
 
 // Revoke decryption access — 1 transaction.
-const revoke = useRevokeDelegation({ tokenAddress: cTokenAddress });
+const revoke = useRevokeDelegation(cTokenAddress);
 revoke.mutate({ delegateAddress: "0xDelegate" });
 
 // Query delegation status — fires automatically when both addresses are valid.
 // Pass undefined for either address to disable the query (useful before the user
 // has entered an address).
 const { data: status } = useDelegationStatus({
-  tokenAddress: cTokenAddress,
+  contractAddress: cTokenAddress,
   delegatorAddress: "0xOwner", // the wallet that granted the delegation
   delegateAddress: "0xDelegate", // the wallet that received it (usually the connected wallet)
 });
@@ -16381,8 +16331,8 @@ const { data: status } = useDelegationStatus({
 
 // Decrypt owner's balance as a delegate — 0 transactions (read + local cache).
 // Throws DelegationNotFoundError / DelegationExpiredError if the ACL check fails.
-// Note: useDecryptBalanceAs takes a positional tokenAddress argument (unlike
-// useDelegateDecryption / useRevokeDelegation which use a config object { tokenAddress }).
+// Note: useDecryptBalanceAs, useDelegateDecryption, and useRevokeDelegation all take a
+// positional tokenAddress as their first argument.
 const decryptAs = useDecryptBalanceAs(cTokenAddress);
 decryptAs.mutate({ delegatorAddress: "0xOwner" });
 // decryptAs.data → bigint (raw balance)
@@ -16421,10 +16371,10 @@ Copy `.env.example` to `.env.local` and fill in `NEXT_PUBLIC_HOODI_RPC_URL` if y
 | ERC-20 balance shows `0`                                  | Tokens not yet minted                                                                                                                                    | Click the **Mint** button or use one of the methods in [Minting test tokens](#minting-test-tokens)                                                                                                                                                                                                                                                               |
 | Confidential balance shows `—` immediately after connect  | No shielded balance yet — no encrypted handle to read                                                                                                    | Shield some tokens first; the balance will display once there is something to decrypt                                                                                                                                                                                                                                                                            |
 | "Decrypting…" stays indefinitely                          | Wallet EIP-712 signature request was missed (small notification badge)                                                                                   | Open your wallet and approve the pending signature request; balance will update immediately                                                                                                                                                                                                                                                                      |
-| Asked to sign an EIP-712 message after each action        | Session not yet cached (first use — expected)                                                                                                            | Approve once — subsequent decryptions reuse the IndexedDB-persisted session credential (30-day TTL). If the prompt recurs every time, make sure `storage` and `sessionStorage` in `ZamaProvider` point to **different** `IndexedDBStorage` instances — sharing the same instance corrupts the stored credentials (see Providers setup)                           |
-| Shield fails immediately after approving spend cap        | Approval transaction not yet confirmed on Hoodi when wrap was attempted                                                                                  | Wait for the approval confirmation and retry — the app detects this and shows a hint                                                                                                                                                                                                                                                                             |
+| Asked to sign an EIP-712 message after each action        | Session not yet cached (first use — expected)                                                                                                            | Approve once — subsequent decryptions reuse the IndexedDB-persisted session credential (30-day TTL). If the prompt recurs every time, make sure `storage` and `permitStorage` in `ZamaProvider` point to **different** `IndexedDBStorage` instances — sharing the same instance corrupts the stored credentials (see Providers setup)                            |
+| Shield fails right after the approval transaction         | The approval reverted or was rejected before the wrap step                                                                                               | Retry — useShield re-reads the allowance and re-approves only if needed                                                                                                                                                                                                                                                                                          |
 | Shield fails after a recent transfer or other operation   | Pending transaction in the mempool caused a nonce conflict                                                                                               | Wait for all pending transactions to confirm, then retry                                                                                                                                                                                                                                                                                                         |
-| Shield stuck on "Shielding… (1/2)"                        | Ran out of Hoodi ETH after the approval transaction                                                                                                      | Top up your wallet with Hoodi ETH and try again                                                                                                                                                                                                                                                                                                                  |
+| Shield stuck on "Shielding… (approving)"                  | Ran out of Hoodi ETH after the approval transaction                                                                                                      | Top up your wallet with Hoodi ETH and try again                                                                                                                                                                                                                                                                                                                  |
 | Shield completes but balances unchanged                   | Decimal mismatch — wrong number of decimals used to parse the amount                                                                                     | Ensure the amount input uses the ERC-20 contract's decimals (not the ERC-7984 token's); decimals are available as `pair.underlying.decimals` and `pair.confidential.decimals` from `useListPairs`                                                                                                                                                                |
 | "nonce too low: next nonce X, tx nonce Y"                 | The Hoodi public RPC returned a stale nonce; ethers built the tx with an outdated value                                                                  | This is fixed by routing `eth_getTransactionCount` through the wallet in the hybrid provider. If you see this in your own integration, ensure `eth_getTransactionCount` is NOT routed to a load-balanced RPC — it must go through the same node that will receive your `eth_sendTransaction`                                                                     |
 | "Transaction reverted" on any operation                   | Insufficient token balance, or wrong network                                                                                                             | Verify you are on Hoodi (chainId 560048) and have sufficient tokens                                                                                                                                                                                                                                                                                              |
@@ -16465,7 +16415,7 @@ Tests run automatically on CI for every pull request that touches `examples/exam
 ## Going further
 
 - **Additional tokens** — register new ERC-7984 pairs in the on-chain WrappersRegistry at `0x1807aE2f693F8530DFB126D0eF98F2F2518F292f`. The app picks them up automatically via `useListPairs` on the next load — no code change required.
-- **Production use** — replace `RelayerCleartext` with `RelayerWeb` (browser) or `RelayerNode` (server) when targeting a chain with the full FHE co-processor (Sepolia, Mainnet).
+- **Production use** — replace `cleartext()` with `web()` (browser) or `node()` (server) when targeting a chain with the full FHE co-processor (Sepolia, Mainnet).
 - **Batch balance decryption** — for multiple tokens, use `useConfidentialBalances` (batch hook) to decrypt all balances in a single relayer call.
 - **Optimistic balance updates** — for `useConfidentialTransfer`, pass `optimistic: true` to immediately update the cached confidential balance while the transaction confirms, then roll back automatically on error. Improves perceived responsiveness in production UIs.
 
@@ -16475,9 +16425,9 @@ Tests run automatically on CI for every pull request that touches `examples/exam
 
 | Package                 | Version            | Role                                                                                                                                                                                                                             |
 | ----------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@zama-fhe/sdk`         | see `package.json` | FHE core — `RelayerCleartext`, `EthersSigner`, contract builders                                                                                                                                                                 |
+| `@zama-fhe/sdk`         | see `package.json` | FHE core — `cleartext()`, `createConfig`, contract builders                                                                                                                                                                      |
 | `@zama-fhe/react-sdk`   | see `package.json` | React hooks — `useListPairs`, `useHasPermit`, `useGrantPermit`, `useConfidentialTransfer`, `useUnshield`, `useConfidentialBalance`, `useDelegateDecryption`, `useRevokeDelegation`, `useDelegationStatus`, `useDecryptBalanceAs` |
-| `ethers`                | ^6.13.0            | Ethereum client (via `EthersSigner`)                                                                                                                                                                                             |
+| `ethers`                | ^6.13.0            | Ethereum client (via `ethers adapter`)                                                                                                                                                                                           |
 | `@tanstack/react-query` | ^5.90.0            | Async state management                                                                                                                                                                                                           |
 | `next`                  | ^16.0.0            | React framework (App Router)                                                                                                                                                                                                     |
 | **Chain**               | Hoodi testnet      | chainId 560048                                                                                                                                                                                                                   |


### PR DESCRIPTION
## What

Upgrades **example-hoodi** from `@zama-fhe/sdk` **2.2.0 → 3.1.0**, completing the example-app coverage. hoodi is an ethers + cleartext Next.js app.

## Changes

- **Config rewrite** (`providers.tsx`): `createConfig({ chains: [hoodi], ethereum, provider, storage, permitStorage, relayers: { [hoodi.id]: cleartext() } })` + `<ZamaProvider config>`, replacing the old `RelayerCleartext` / `EthersSigner` / `sessionStorage` wiring. Uses the **shipped `hoodi` chain preset** (chain 560048). The Hoodi load-balancer **hybrid EIP-1193 provider is preserved** as the `ethereum`.
- **Shield (SDK-150 drift removed)**: `ShieldCard` drops the hand-rolled approve+wrap and uses a single `useShield` call with `approvalStrategy: "exact"`.
- **Hook surface**: permit renames (`useIsAllowed`/`useAllow` → `useHasPermit`/`useGrantPermit`), positional `tokenAddress` for unshield/resume/delegate/revoke, `{ address }` for transfer/balance, flattened mutate callbacks, `useDelegationStatus({ contractAddress })`.
- **Imports**: `Address`/`Hex`, contract builders, and the pending-unshield/storage helpers moved from `@zama-fhe/react-sdk` to `@zama-fhe/sdk`.
- **`page.tsx`**: reads via `sdk.provider`, mint via `signer.writeContract` + `sdk.provider.waitForTransactionReceipt`, `confidentialHandle` → `confidentialBalance` query key.
- **WALKTHROUGH.md** updated to the 3.1.0 API.

## SDK-150 audit

No reimplemented-primitive drift remains beyond shield (now fixed). The residual manual `readContract`/`writeContract` are the **public ERC-20 balance display** and the **test mint** — justified.
## Validation

`tsc --noEmit` **green** against 3.1.0; oxfmt clean; no unused imports; E2E selectors unchanged (button names / card titles are stable). One commit.

> ⚠️ **Runtime caveat to confirm:** in 3.1 `createConfig` already splits `ethereum` (wallet) and `provider` (RPC). The Hoodi load-balancer hybrid provider is kept as `ethereum`; its nonce/receipt routing now partly overlaps `provider`. The hybrid workaround should be confirmed at runtime — the **`example-hoodi-e2e` CI job** is the gate.
>
> Standalone install needs `--config.minimumReleaseAge=0` until ~2026-06-25; the merge itself is unaffected (examples aren't workspace members).
