### PR TITLE
docs(gitbook): strengthen Build with an LLM page for agents

### DIFF
--- a/docs/gitbook/src/tutorials/build-with-an-llm.md
+++ b/docs/gitbook/src/tutorials/build-with-an-llm.md
@@ -5,15 +5,15 @@ description: Give coding agents grounded Zama SDK context — install the Zama s
 
 # Build with an LLM
 
-Give your coding agent a grounded view of the Zama SDK so it writes correct FHEVM code instead of guessing. The fastest way is to install the Zama skills; if your agent doesn't support skills, point it at the SDK's `llms.txt` files instead.
+Give your coding agent a grounded view of the Zama SDK so it writes correct FHEVM code instead of guessing. The fastest way is to install the Zama skills; if your agent doesn't support skills, point it at the SDK's [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) files instead.
 
 ## Install the Zama skills
 
 The Zama skills give your agent expert, always-current guidance on the protocol and SDK. They live in [`zama-ai/skills`](https://github.com/zama-ai/skills) (separate from this repo) and install as one bundle of three skills that route automatically by what you're working on:
 
-- **`zama-typescript`** — the TypeScript SDK, React, browser, and Node.js integration. This is the skill that drives SDK work.
-- `zama-solidity` — encrypted Solidity, FHE types, ACL, and ERC-7984.
-- `zama-protocol` — FHEVM concepts, protocol architecture, and planning.
+1. **`zama-typescript`** — the TypeScript SDK, React, browser, and Node.js integration. This is the skill that drives SDK work.
+2. `zama-solidity` — encrypted Solidity, FHE types, ACL, and ERC-7984.
+3. `zama-protocol` — FHEVM concepts, protocol architecture, and planning.
 
 Install once and your agent has all three; ask an SDK question and `zama-typescript` loads automatically.
 
@@ -40,7 +40,7 @@ Works with most skill-aware agents. Add `--list` to choose which skills to insta
 For Codex, Cursor, or manual setup, see the [skills README](https://github.com/zama-ai/skills).
 
 {% hint style="info" %}
-No skill support? Point your agent at the `llms.txt` files below instead.
+No skill support? Point your agent at the [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) files below instead.
 {% endhint %}
 
 ## Use llms.txt
@@ -52,7 +52,7 @@ Point your agent at the SDK's LLM-ready files when it can't use skills — or to
 | [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt)           | the agent needs to **discover** the right guide, example, or reference, then fetch only that | a compact map of guides, concepts, SDK and React reference pages, and approved examples   |
 | [`llms-full.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms-full.txt) | the agent has a **large context window** and you want the whole public corpus in one paste   | the complete docs bundle plus approved examples and README context (API reports excluded) |
 
-Start with `llms.txt` for normal coding tasks; reach for `llms-full.txt` only when you want everything loaded at once. The `source_path` values such as `docs/gitbook/src/...` are provenance metadata, not local paths — if you haven't cloned the repo, use the raw GitHub URLs.
+Start with [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) for normal coding tasks; reach for [`llms-full.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms-full.txt) only when you want everything loaded at once. The `source_path` values such as `docs/gitbook/src/...` are provenance metadata, not local paths — if you haven't cloned the repo, use the raw GitHub URLs.
 
 To ground an agent, paste:
 
@@ -85,7 +85,7 @@ Then give it a task. (With the skills installed your agent is already grounded �
 Whichever path you use, agent guidance follows one source order:
 
 1. **Official documentation** — published through GitBook from `docs/gitbook/src`.
-2. **Approved official examples** — listed in the `Official Examples` section of `llms.txt`.
+2. **Approved official examples** — listed in the `Official Examples` section of [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt).
 3. **API reports** — fallback only, for exported-API details.
 
 Prefer docs over examples when the docs already answer the question, and prefer the approved examples in this repo over ad hoc implementations.
@@ -93,5 +93,5 @@ Prefer docs over examples when the docs already answer the question, and prefer 
 ### Recommended workflows
 
 - **New integration** — install the skills, read the closest approved example, then open the matching guide for detail.
-- **Deeper grounding** — load `llms-full.txt` (or follow the `llms.txt` links), and fall back to API reports only for exported-surface questions.
+- **Deeper grounding** — load [`llms-full.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms-full.txt) (or follow the [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) links), and fall back to API reports only for exported-surface questions.
 - **Debugging** — start with the [error guide](../guides/handle-errors.md), compare against the closest approved example, and inspect API reports last.

--- a/docs/gitbook/src/tutorials/build-with-an-llm.md
+++ b/docs/gitbook/src/tutorials/build-with-an-llm.md
@@ -5,7 +5,7 @@ description: Give coding agents grounded Zama SDK context — install the Zama s
 
 # Build with an LLM
 
-Give your coding agent a grounded view of the Zama SDK so it writes correct FHEVM code instead of guessing. The fastest way is to install the Zama skills; if your agent doesn't support skills, point it at the SDK's [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) files instead.
+Give your coding agent a grounded view of the Zama SDK so it writes correct FHEVM code instead of guessing. The fastest way is to install the Zama skills; otherwise point your agent at the SDK's [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) files or connect the docs over MCP.
 
 ## Install the Zama skills
 
@@ -45,7 +45,7 @@ No skill support? Point your agent at the [`llms.txt`](https://raw.githubusercon
 
 ## Give guidance to AI agents / LLMs
 
-Point your agent at the SDK's LLM-ready files when it can't use skills — or to pull a specific doc on demand. They give a grounded map of the public docs, approved examples, and SDK reference without cloning the repo.
+The Zama SDK ships as `@zama-fhe/sdk` (and `@zama-fhe/react-sdk` for React) — **not** the legacy `@zama-fhe/relayer-sdk` that most LLM training data still defaults to. Point your agent at the SDK's LLM-ready files to ground it on the current API when it can't use skills — or to pull a specific doc on demand. They give a grounded map of the public docs, approved examples, and SDK reference without cloning the repo.
 
 | File                                                                                | Use it when                                                                                  | Your agent gets                                                                           |
 | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
@@ -58,7 +58,7 @@ Start with [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.
 
 To ground an agent, paste:
 
-> Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
+> You're building with the Zama SDK — `@zama-fhe/sdk` (and `@zama-fhe/react-sdk` for React), not the legacy `@zama-fhe/relayer-sdk`. Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant guides and approved examples before writing any code. Treat the official docs as the source of truth, prefer the official examples listed in llms.txt over ad hoc implementations, and use the API reference only to confirm exact signatures.
 
 Then give it a task. (With the skills installed your agent is already grounded — skip straight here.)
 
@@ -81,25 +81,15 @@ Then give it a task. (With the skills installed your agent is already grounded �
 
 > Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
 >
-> Debug this Zama SDK integration: check the official error guide first, then compare against the closest approved example.
+> Debug this Zama SDK integration: read the error handling guide (https://docs.zama.org/protocol/sdk/guides/handle-errors.md) — it covers catching, matching, and recovering from SDK errors — diagnose against it, then compare with the closest official example.
 
 {% endtab %}
 {% endtabs %}
 
-## Agent guidance
+## Connect the docs over MCP
 
-### Source of truth
+Every page in these docs has a **Copy ▾** menu (top-right) with built-in agent connectors — reach for these when you want live access to the current docs rather than a static paste:
 
-Whichever path you use, agent guidance follows one source order:
-
-1. **Official documentation** — published through GitBook from `docs/gitbook/src`.
-2. **Approved official examples** — listed in the **Official Examples** section of [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt).
-3. **API reports** — fallback only, for exported-API details.
-
-Prefer docs over examples when the docs already answer the question, and prefer the approved examples in this repo over ad hoc implementations.
-
-### Recommended workflows
-
-- **New integration** — install the skills, read the closest approved example, then open the matching guide for detail.
-- **Deeper grounding** — load [`llms-full.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms-full.txt) (or follow the [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) links), and fall back to API reports only for exported-surface questions.
-- **Debugging** — start with the [error guide](../guides/handle-errors.md), compare against the closest approved example, and inspect API reports last.
+- **Connect with MCP** — add the docs as an MCP server in Claude Code, Cursor, VS Code, or Codex for live, searchable access to the current API. Stronger than `llms.txt` for MCP-capable agents, since it always reflects the published docs.
+- **Open in ChatGPT** / **Open in Claude** — start a chat already grounded on the page you're viewing.
+- **Copy page as Markdown** / **View as Markdown** — grab a single page as plain markdown for your agent, or append `.md` to any docs URL (e.g. `https://docs.zama.org/protocol/sdk/overview.md`).

--- a/docs/gitbook/src/tutorials/build-with-an-llm.md
+++ b/docs/gitbook/src/tutorials/build-with-an-llm.md
@@ -43,7 +43,7 @@ For Codex, Cursor, or manual setup, see the [skills README](https://github.com/z
 No skill support? Point your agent at the [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) files below instead.
 {% endhint %}
 
-## Use llms.txt
+## Give guidance to AI agents / LLMs
 
 Point your agent at the SDK's LLM-ready files when it can't use skills — or to pull a specific doc on demand. They give a grounded map of the public docs, approved examples, and SDK reference without cloning the repo.
 
@@ -54,6 +54,8 @@ Point your agent at the SDK's LLM-ready files when it can't use skills — or to
 
 Start with [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) for normal coding tasks; reach for [`llms-full.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms-full.txt) only when you want everything loaded at once. The `source_path` values such as `docs/gitbook/src/...` are provenance metadata, not local paths — if you haven't cloned the repo, use the raw GitHub URLs.
 
+### Example prompts
+
 To ground an agent, paste:
 
 > Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
@@ -63,16 +65,22 @@ Then give it a task. (With the skills installed your agent is already grounded �
 {% tabs %}
 {% tab title="React (wagmi)" %}
 
+> Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
+>
 > Add confidential balances and transfers to this Next.js app, following the approved `react-wagmi` example.
 
 {% endtab %}
 {% tab title="Node.js" %}
 
+> Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
+>
 > Build a Node.js backend with the `node()` transport and per-request isolation, following the approved `node-viem` example.
 
 {% endtab %}
 {% tab title="Debugging" %}
 
+> Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
+>
 > Debug this Zama SDK integration: check the official error guide first, then compare against the closest approved example.
 
 {% endtab %}
@@ -85,7 +93,7 @@ Then give it a task. (With the skills installed your agent is already grounded �
 Whichever path you use, agent guidance follows one source order:
 
 1. **Official documentation** — published through GitBook from `docs/gitbook/src`.
-2. **Approved official examples** — listed in the `Official Examples` section of [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt).
+2. **Approved official examples** — listed in the **Official Examples** section of [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt).
 3. **API reports** — fallback only, for exported-API details.
 
 Prefer docs over examples when the docs already answer the question, and prefer the approved examples in this repo over ad hoc implementations.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1343,7 +1343,7 @@ For Codex, Cursor, or manual setup, see the [skills README](https://github.com/z
 > No skill support? Point your agent at the [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) files below instead.
 
 
-## Use llms.txt
+## Give guidance to AI agents / LLMs
 
 Point your agent at the SDK's LLM-ready files when it can't use skills — or to pull a specific doc on demand. They give a grounded map of the public docs, approved examples, and SDK reference without cloning the repo.
 
@@ -1354,6 +1354,8 @@ Point your agent at the SDK's LLM-ready files when it can't use skills — or to
 
 Start with [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) for normal coding tasks; reach for [`llms-full.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms-full.txt) only when you want everything loaded at once. The `source_path` values such as `docs/gitbook/src/...` are provenance metadata, not local paths — if you haven't cloned the repo, use the raw GitHub URLs.
 
+### Example prompts
+
 To ground an agent, paste:
 
 > Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
@@ -1363,14 +1365,20 @@ Then give it a task. (With the skills installed your agent is already grounded �
 
 ### Tab: React (wagmi)
 
+> Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
+>
 > Add confidential balances and transfers to this Next.js app, following the approved `react-wagmi` example.
 
 ### Tab: Node.js
 
+> Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
+>
 > Build a Node.js backend with the `node()` transport and per-request isolation, following the approved `node-viem` example.
 
 ### Tab: Debugging
 
+> Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
+>
 > Debug this Zama SDK integration: check the official error guide first, then compare against the closest approved example.
 
 
@@ -1381,7 +1389,7 @@ Then give it a task. (With the skills installed your agent is already grounded �
 Whichever path you use, agent guidance follows one source order:
 
 1. **Official documentation** — published through GitBook from `docs/gitbook/src`.
-2. **Approved official examples** — listed in the `Official Examples` section of [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt).
+2. **Approved official examples** — listed in the **Official Examples** section of [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt).
 3. **API reports** — fallback only, for exported-API details.
 
 Prefer docs over examples when the docs already answer the question, and prefer the approved examples in this repo over ad hoc implementations.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1307,7 +1307,7 @@ For a runnable React dApp using these APIs end-to-end, follow [Build your first 
 
 # Build with an LLM
 
-Give your coding agent a grounded view of the Zama SDK so it writes correct FHEVM code instead of guessing. The fastest way is to install the Zama skills; if your agent doesn't support skills, point it at the SDK's [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) files instead.
+Give your coding agent a grounded view of the Zama SDK so it writes correct FHEVM code instead of guessing. The fastest way is to install the Zama skills; otherwise point your agent at the SDK's [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) files or connect the docs over MCP.
 
 ## Install the Zama skills
 
@@ -1345,7 +1345,7 @@ For Codex, Cursor, or manual setup, see the [skills README](https://github.com/z
 
 ## Give guidance to AI agents / LLMs
 
-Point your agent at the SDK's LLM-ready files when it can't use skills — or to pull a specific doc on demand. They give a grounded map of the public docs, approved examples, and SDK reference without cloning the repo.
+The Zama SDK ships as `@zama-fhe/sdk` (and `@zama-fhe/react-sdk` for React) — **not** the legacy `@zama-fhe/relayer-sdk` that most LLM training data still defaults to. Point your agent at the SDK's LLM-ready files to ground it on the current API when it can't use skills — or to pull a specific doc on demand. They give a grounded map of the public docs, approved examples, and SDK reference without cloning the repo.
 
 | File                                                                                | Use it when                                                                                  | Your agent gets                                                                           |
 | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
@@ -1358,7 +1358,7 @@ Start with [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.
 
 To ground an agent, paste:
 
-> Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
+> You're building with the Zama SDK — `@zama-fhe/sdk` (and `@zama-fhe/react-sdk` for React), not the legacy `@zama-fhe/relayer-sdk`. Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant guides and approved examples before writing any code. Treat the official docs as the source of truth, prefer the official examples listed in llms.txt over ad hoc implementations, and use the API reference only to confirm exact signatures.
 
 Then give it a task. (With the skills installed your agent is already grounded — skip straight here.)
 
@@ -1379,26 +1379,16 @@ Then give it a task. (With the skills installed your agent is already grounded �
 
 > Read https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt and follow its links to the relevant Zama SDK guides and approved examples before writing any code.
 >
-> Debug this Zama SDK integration: check the official error guide first, then compare against the closest approved example.
+> Debug this Zama SDK integration: read the error handling guide (https://docs.zama.org/protocol/sdk/guides/handle-errors.md) — it covers catching, matching, and recovering from SDK errors — diagnose against it, then compare with the closest official example.
 
 
-## Agent guidance
+## Connect the docs over MCP
 
-### Source of truth
+Every page in these docs has a **Copy ▾** menu (top-right) with built-in agent connectors — reach for these when you want live access to the current docs rather than a static paste:
 
-Whichever path you use, agent guidance follows one source order:
-
-1. **Official documentation** — published through GitBook from `docs/gitbook/src`.
-2. **Approved official examples** — listed in the **Official Examples** section of [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt).
-3. **API reports** — fallback only, for exported-API details.
-
-Prefer docs over examples when the docs already answer the question, and prefer the approved examples in this repo over ad hoc implementations.
-
-### Recommended workflows
-
-- **New integration** — install the skills, read the closest approved example, then open the matching guide for detail.
-- **Deeper grounding** — load [`llms-full.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms-full.txt) (or follow the [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) links), and fall back to API reports only for exported-surface questions.
-- **Debugging** — start with the [error guide](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/guides/handle-errors.md), compare against the closest approved example, and inspect API reports last.
+- **Connect with MCP** — add the docs as an MCP server in Claude Code, Cursor, VS Code, or Codex for live, searchable access to the current API. Stronger than `llms.txt` for MCP-capable agents, since it always reflects the published docs.
+- **Open in ChatGPT** / **Open in Claude** — start a chat already grounded on the page you're viewing.
+- **Copy page as Markdown** / **View as Markdown** — grab a single page as plain markdown for your agent, or append `.md` to any docs URL (e.g. `https://docs.zama.org/protocol/sdk/overview.md`).
 
 ## Migrate from v2 to v3
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1307,15 +1307,15 @@ For a runnable React dApp using these APIs end-to-end, follow [Build your first 
 
 # Build with an LLM
 
-Give your coding agent a grounded view of the Zama SDK so it writes correct FHEVM code instead of guessing. The fastest way is to install the Zama skills; if your agent doesn't support skills, point it at the SDK's `llms.txt` files instead.
+Give your coding agent a grounded view of the Zama SDK so it writes correct FHEVM code instead of guessing. The fastest way is to install the Zama skills; if your agent doesn't support skills, point it at the SDK's [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) files instead.
 
 ## Install the Zama skills
 
 The Zama skills give your agent expert, always-current guidance on the protocol and SDK. They live in [`zama-ai/skills`](https://github.com/zama-ai/skills) (separate from this repo) and install as one bundle of three skills that route automatically by what you're working on:
 
-- **`zama-typescript`** — the TypeScript SDK, React, browser, and Node.js integration. This is the skill that drives SDK work.
-- `zama-solidity` — encrypted Solidity, FHE types, ACL, and ERC-7984.
-- `zama-protocol` — FHEVM concepts, protocol architecture, and planning.
+1. **`zama-typescript`** — the TypeScript SDK, React, browser, and Node.js integration. This is the skill that drives SDK work.
+2. `zama-solidity` — encrypted Solidity, FHE types, ACL, and ERC-7984.
+3. `zama-protocol` — FHEVM concepts, protocol architecture, and planning.
 
 Install once and your agent has all three; ask an SDK question and `zama-typescript` loads automatically.
 
@@ -1340,7 +1340,7 @@ For Codex, Cursor, or manual setup, see the [skills README](https://github.com/z
 
 
 > [!INFO]
-> No skill support? Point your agent at the `llms.txt` files below instead.
+> No skill support? Point your agent at the [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) files below instead.
 
 
 ## Use llms.txt
@@ -1352,7 +1352,7 @@ Point your agent at the SDK's LLM-ready files when it can't use skills — or to
 | [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt)           | the agent needs to **discover** the right guide, example, or reference, then fetch only that | a compact map of guides, concepts, SDK and React reference pages, and approved examples   |
 | [`llms-full.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms-full.txt) | the agent has a **large context window** and you want the whole public corpus in one paste   | the complete docs bundle plus approved examples and README context (API reports excluded) |
 
-Start with `llms.txt` for normal coding tasks; reach for `llms-full.txt` only when you want everything loaded at once. The `source_path` values such as `docs/gitbook/src/...` are provenance metadata, not local paths — if you haven't cloned the repo, use the raw GitHub URLs.
+Start with [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) for normal coding tasks; reach for [`llms-full.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms-full.txt) only when you want everything loaded at once. The `source_path` values such as `docs/gitbook/src/...` are provenance metadata, not local paths — if you haven't cloned the repo, use the raw GitHub URLs.
 
 To ground an agent, paste:
 
@@ -1381,7 +1381,7 @@ Then give it a task. (With the skills installed your agent is already grounded �
 Whichever path you use, agent guidance follows one source order:
 
 1. **Official documentation** — published through GitBook from `docs/gitbook/src`.
-2. **Approved official examples** — listed in the `Official Examples` section of `llms.txt`.
+2. **Approved official examples** — listed in the `Official Examples` section of [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt).
 3. **API reports** — fallback only, for exported-API details.
 
 Prefer docs over examples when the docs already answer the question, and prefer the approved examples in this repo over ad hoc implementations.
@@ -1389,7 +1389,7 @@ Prefer docs over examples when the docs already answer the question, and prefer 
 ### Recommended workflows
 
 - **New integration** — install the skills, read the closest approved example, then open the matching guide for detail.
-- **Deeper grounding** — load `llms-full.txt` (or follow the `llms.txt` links), and fall back to API reports only for exported-surface questions.
+- **Deeper grounding** — load [`llms-full.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms-full.txt) (or follow the [`llms.txt`](https://raw.githubusercontent.com/zama-ai/sdk/main/llms.txt) links), and fall back to API reports only for exported-surface questions.
 - **Debugging** — start with the [error guide](https://raw.githubusercontent.com/zama-ai/sdk/main/docs/gitbook/src/guides/handle-errors.md), compare against the closest approved example, and inspect API reports last.
 
 ## Migrate from v2 to v3


### PR DESCRIPTION
Reworks `docs/gitbook/src/tutorials/build-with-an-llm.md` so the page works as agent grounding, not human prose. (Originated from GitBook edits that need a PR to sync back to GitHub.)

## Changes

- **Package disambiguation** — names `@zama-fhe/sdk` / `@zama-fhe/react-sdk` and flags the legacy `@zama-fhe/relayer-sdk`, countering stale LLM priors that predate this repo.
- **Source-of-truth ordering folded into the grounding prompt** — docs → official examples → API reference is now an operative instruction the agent ingests, not a separate section it might skip.
- **Official examples via llms.txt** — references the examples listed in `llms.txt` instead of "examples in this repo" (agents grounding via `llms.txt` have no clone).
- **Error handling guide as a fetchable URL** — the Debugging prompt links the guide (`https://docs.zama.org/protocol/sdk/guides/handle-errors.md`) with context on what it covers; the redundant Recommended workflows section is dropped.
- **New "Connect the docs over MCP" section** — surfaces the per-page connectors (MCP, Open in ChatGPT/Claude, Copy/View as Markdown).
- Numbered the skills list; linked bare `llms.txt`/`llms-full.txt` mentions.

`pnpm docs:check-links` passes; `llms.txt`/`llms-full.txt` regenerated by the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)