### PR TITLE
ci(docs): run doc link checks on direct pushes to main/prerelease

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   pull_request:
     branches: [main, prerelease]
-    paths:
+    paths: &doc-paths
       - "docs/**"
       - "examples/**/README.md"
       - "examples/**/WALKTHROUGH.md"
@@ -16,10 +16,19 @@ on:
       - "llms-full.txt"
       - "package.json"
       - "pnpm-lock.yaml"
+      - ".github/workflows/docs.yml"
+  # semantic-release forces branch-to-branch merges (prerelease→main) with the
+  # docs:retarget fix committed directly on top, so doc changes routinely reach
+  # main/prerelease via direct push, never a PR. Run the checks there too.
+  push:
+    branches: [main, prerelease]
+    paths: *doc-paths
   workflow_call:
 
+# Namespaced by workflow so the standalone Docs run (push/PR) and the docs job
+# reused by release.yml don't share a group on the same ref and cancel each other.
 concurrency:
-  group: docs-${{ github.ref }}
+  group: docs-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -65,16 +74,18 @@ jobs:
       # docs.zama.org .../stable|alpha). `github.base_ref` is the branch this PR lands
       # on — reliable here even though the PR is checked out detached. If the committed
       # URLs target the wrong branch (e.g. a promotion that forgot `pnpm docs:retarget`),
-      # this fails. `ref_name` covers the workflow_call (release) path.
+      # this fails. `ref_name` covers the direct-push and workflow_call (release) paths.
       - name: Verify doc URLs target the right branch
         run: pnpm docs:check-target "${{ github.base_ref || github.ref_name }}"
 
   # External link liveness for the published docs + READMEs. Internal links and
   # anchors are checked above by `pnpm docs:check-links`; this job covers `https://`
-  # targets. PR-only — skipped on the release `workflow_call` so external flakiness
-  # can't block a release. If it flakes on PRs, move to a scheduled (cron) workflow.
+  # targets. Runs for PRs and direct pushes to main/prerelease, but NOT when this
+  # workflow is reused by release.yml: there `github.workflow` is the caller's name
+  # ("Release"), so external flakiness still can't block a release. If it flakes on
+  # PRs, move to a scheduled (cron) workflow.
   link-check:
-    if: github.event_name == 'pull_request'
+    if: github.workflow == 'Docs'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Why

semantic-release forces branch-to-branch merges (prerelease→main) with the `docs:retarget` fix committed directly on top, so **doc changes routinely reach `main`/`prerelease` via direct push, not a PR**.

Today on a direct push:
- The *internal* doc checks (`docs:check-links`, `llm:check`, `docs:check-target`) run only as a **`release.yml` gate** (it calls `docs.yml` via `workflow_call`).
- The **external lychee `link-check` is skipped entirely** on that path (`if: github.event_name == 'pull_request'`) — by design, so flaky external hosts can't block a release.

Net: dead **external** links arriving via a direct merge are never caught, and there's no first-class "Docs" status on pushes.

## Change (`docs.yml` only)

- **Add a `push` trigger** for `main`/`prerelease` (same paths as the PR trigger, shared via a YAML anchor so the two lists can't drift). The internal `docs` job now also runs standalone on direct pushes.
- **Run lychee on PRs *and* direct pushes**, gated on `github.workflow == 'Docs'`. When `docs.yml` is reused by `release.yml`, `github.workflow` is the caller's name (`Release`), so lychee still never runs on the release path — **external flakiness still can't block a release**.
- **Namespace the concurrency group** by `github.workflow` so the standalone Docs run and the release-reused docs job don't cancel each other on the same ref.
- **Self-reference `docs.yml`** in its own `paths` so edits to the workflow trigger it (lands here because this PR already edits `docs.yml`; the other path-filtered laggards are in #485).

## Validation

- `actionlint` clean (anchor parses).
- `check-target` already falls back to `github.ref_name` when `base_ref` is empty, so it resolves the pushed branch correctly on direct pushes.

## Related

- #485 — applies the same self-reference fix to `abi.yml` and `example-hoodi-e2e.yml` (the remaining `paths`-filtered workflows that don't self-reference; `codemod`/`integration` already do).

🤖 Generated with [Claude Code](https://claude.com/claude-code)