### PR TITLE
ci: self-reference workflow files in paths (abi, example-hoodi-e2e)

### DIFF
--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/abi/**"
       - "package.json"
       - "pnpm-lock.yaml"
+      - ".github/workflows/abi.yml"
   workflow_call:
 
 concurrency:

--- a/.github/workflows/example-hoodi-e2e.yml
+++ b/.github/workflows/example-hoodi-e2e.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, prerelease]
     paths:
       - "examples/example-hoodi/**"
+      - ".github/workflows/example-hoodi-e2e.yml"
 
 concurrency:
   group: example-hoodi-e2e-${{ github.ref }}


### PR DESCRIPTION
## Why

A `paths`-filtered workflow that doesn't list its **own** file never re-runs when you edit the workflow — so a change to the workflow ships without ever executing. Today the repo is split:

| `paths`-filtered workflow | self-references its own file? |
|---|---|
| `codemod.yml` | ✅ |
| `integration.yml` | ✅ |
| `abi.yml` | ❌ → fixed here |
| `example-hoodi-e2e.yml` | ❌ → fixed here |
| `docs.yml` | ❌ → fixed in #484 (the PR already editing it) |

(The 9 workflows without a `paths` filter — lint, vitest, playwright, api-report, etc. — already run on every PR, so self-reference is n/a.)

## Change

Add the workflow's own path to `abi.yml` and `example-hoodi-e2e.yml`. `docs.yml` gets the same one-liner in #484, which already edits it — splitting it here would just collide on `docs.yml`'s `paths` block.

## Why it's safe

Neither `main` nor `prerelease` has a `required_status_checks` rule (protection is `pull_request` + 1 review + linear-history + non-fast-forward). So no check is merge-blocking, and path-filtering can't trigger the classic "required check skipped on an unrelated PR → never reported → PR stuck" deadlock. Keeping `paths` is pure CI-minute savings; this change just makes workflow edits self-testing.

`actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)