### PR TITLE
refactor(sdk): type matchZamaError handlers by matched error subclass [SDK-231]

### DIFF
--- a/docs/gitbook/src/guides/handle-errors.md
+++ b/docs/gitbook/src/guides/handle-errors.md
@@ -89,8 +89,8 @@ matchZamaError(error, {
   SIGNING_REJECTED: () => toast("Please approve the transaction"),
   ENCRYPTION_FAILED: () => toast("Encryption failed -- please retry"),
   TRANSACTION_REVERTED: (e) => toast(`Transaction failed: ${e.message}`),
-  INSUFFICIENT_CONFIDENTIAL_BALANCE: () => toast("Insufficient confidential balance"),
-  INSUFFICIENT_ERC20_BALANCE: () => toast("Not enough tokens to shield"),
+  INSUFFICIENT_CONFIDENTIAL_BALANCE: (e) => toast(`Need ${e.requested}, have ${e.available}`),
+  INSUFFICIENT_ERC20_BALANCE: (e) => toast(`Need ${e.requested}, have ${e.available}`),
   BALANCE_CHECK_UNAVAILABLE: () => toast("Sign to verify your balance first"),
   ERC20_READ_FAILED: () => toast("Could not read token balance -- check your connection"),
   _: () => toast("Something went wrong"),
@@ -102,7 +102,7 @@ matchZamaError(error, {
 
 The `_` wildcard catches any `ZamaError` not explicitly handled. If the error is not a `ZamaError` at all (and no `_` is provided), `matchZamaError` returns `undefined`.
 
-Each handler receives the error typed as the base `ZamaError`, so `.code` and `.message` are available but subclass-specific fields are not. To read fields like `InsufficientConfidentialBalanceError.available` or `RelayerRequestFailedError.statusCode`, narrow with `instanceof` (step 2) inside the handler.
+Each handler receives the error class for its code, so subclass fields are available without a cast — `INSUFFICIENT_CONFIDENTIAL_BALANCE` hands you an `InsufficientConfidentialBalanceError` with `.available` / `.requested`, `RELAYER_REQUEST_FAILED` an error with `.statusCode`, and so on.
 
 ### 4. Handle specific errors
 

--- a/docs/gitbook/src/reference/sdk/errors.md
+++ b/docs/gitbook/src/reference/sdk/errors.md
@@ -65,9 +65,9 @@ const message = matchZamaError(error, {
 });
 ```
 
-| Parameter  | Type                                                                              | Description                             |
-| ---------- | --------------------------------------------------------------------------------- | --------------------------------------- |
-| `error`    | `unknown`                                                                         | The caught error                        |
+| Parameter  | Type                                                                           | Description                             |
+| ---------- | ------------------------------------------------------------------------------ | --------------------------------------- |
+| `error`    | `unknown`                                                                      | The caught error                        |
 | `handlers` | `{ [K in ErrorCode]?: (e: ErrorForCode[K]) => T } & { _?: (e: unknown) => T }` | Map of error codes to handler functions |
 
 The `_` wildcard catches any `ZamaError` not explicitly handled. Each handler receives the error class for its code, so subclass fields like `InsufficientConfidentialBalanceError.available` or `RelayerRequestFailedError.statusCode` are available without a cast.

--- a/docs/gitbook/src/reference/sdk/errors.md
+++ b/docs/gitbook/src/reference/sdk/errors.md
@@ -57,20 +57,20 @@ const message = matchZamaError(error, {
   ENCRYPTION_FAILED: () => "Encryption failed — try again",
   TRANSACTION_REVERTED: (e) => `Transaction failed: ${e.message}`,
   NO_CIPHERTEXT: () => "No confidential balance — shield tokens first",
-  INSUFFICIENT_CONFIDENTIAL_BALANCE: () => "Insufficient confidential balance",
-  INSUFFICIENT_ERC20_BALANCE: () => "Not enough tokens to shield",
+  INSUFFICIENT_CONFIDENTIAL_BALANCE: (e) => `Need ${e.requested}, have ${e.available}`,
+  INSUFFICIENT_ERC20_BALANCE: (e) => `Need ${e.requested}, have ${e.available}`,
   BALANCE_CHECK_UNAVAILABLE: () => "Sign to verify your balance first",
   ERC20_READ_FAILED: () => "Could not read token balance -- check your connection",
   _: (e) => `Unexpected error: ${e}`,
 });
 ```
 
-| Parameter  | Type                                                                 | Description                             |
-| ---------- | -------------------------------------------------------------------- | --------------------------------------- |
-| `error`    | `unknown`                                                            | The caught error                        |
-| `handlers` | `Record<ErrorCode, (e: ZamaError) => T> & { _?: (e: unknown) => T }` | Map of error codes to handler functions |
+| Parameter  | Type                                                                              | Description                             |
+| ---------- | --------------------------------------------------------------------------------- | --------------------------------------- |
+| `error`    | `unknown`                                                                         | The caught error                        |
+| `handlers` | `{ [K in ErrorCode]?: (e: ErrorForCode[K]) => T } & { _?: (e: unknown) => T }` | Map of error codes to handler functions |
 
-The `_` wildcard catches any `ZamaError` not explicitly handled. Handlers receive the error typed as the base `ZamaError` (`.code`, `.message`); to read subclass fields like `InsufficientConfidentialBalanceError.available` or `RelayerRequestFailedError.statusCode`, narrow with `instanceof` (see the detail sections below).
+The `_` wildcard catches any `ZamaError` not explicitly handled. Each handler receives the error class for its code, so subclass fields like `InsufficientConfidentialBalanceError.available` or `RelayerRequestFailedError.statusCode` are available without a cast.
 
 ## Error summary
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3709,8 +3709,8 @@ matchZamaError(error, {
   SIGNING_REJECTED: () => toast("Please approve the transaction"),
   ENCRYPTION_FAILED: () => toast("Encryption failed -- please retry"),
   TRANSACTION_REVERTED: (e) => toast(`Transaction failed: ${e.message}`),
-  INSUFFICIENT_CONFIDENTIAL_BALANCE: () => toast("Insufficient confidential balance"),
-  INSUFFICIENT_ERC20_BALANCE: () => toast("Not enough tokens to shield"),
+  INSUFFICIENT_CONFIDENTIAL_BALANCE: (e) => toast(`Need ${e.requested}, have ${e.available}`),
+  INSUFFICIENT_ERC20_BALANCE: (e) => toast(`Need ${e.requested}, have ${e.available}`),
   BALANCE_CHECK_UNAVAILABLE: () => toast("Sign to verify your balance first"),
   ERC20_READ_FAILED: () => toast("Could not read token balance -- check your connection"),
   _: () => toast("Something went wrong"),
@@ -3720,7 +3720,7 @@ matchZamaError(error, {
 
 The `_` wildcard catches any `ZamaError` not explicitly handled. If the error is not a `ZamaError` at all (and no `_` is provided), `matchZamaError` returns `undefined`.
 
-Each handler receives the error typed as the base `ZamaError`, so `.code` and `.message` are available but subclass-specific fields are not. To read fields like `InsufficientConfidentialBalanceError.available` or `RelayerRequestFailedError.statusCode`, narrow with `instanceof` (step 2) inside the handler.
+Each handler receives the error class for its code, so subclass fields are available without a cast — `INSUFFICIENT_CONFIDENTIAL_BALANCE` hands you an `InsufficientConfidentialBalanceError` with `.available` / `.requested`, `RELAYER_REQUEST_FAILED` an error with `.statusCode`, and so on.
 
 ### 4. Handle specific errors
 
@@ -7419,20 +7419,20 @@ const message = matchZamaError(error, {
   ENCRYPTION_FAILED: () => "Encryption failed — try again",
   TRANSACTION_REVERTED: (e) => `Transaction failed: ${e.message}`,
   NO_CIPHERTEXT: () => "No confidential balance — shield tokens first",
-  INSUFFICIENT_CONFIDENTIAL_BALANCE: () => "Insufficient confidential balance",
-  INSUFFICIENT_ERC20_BALANCE: () => "Not enough tokens to shield",
+  INSUFFICIENT_CONFIDENTIAL_BALANCE: (e) => `Need ${e.requested}, have ${e.available}`,
+  INSUFFICIENT_ERC20_BALANCE: (e) => `Need ${e.requested}, have ${e.available}`,
   BALANCE_CHECK_UNAVAILABLE: () => "Sign to verify your balance first",
   ERC20_READ_FAILED: () => "Could not read token balance -- check your connection",
   _: (e) => `Unexpected error: ${e}`,
 });
 ```
 
-| Parameter  | Type                                                                 | Description                             |
-| ---------- | -------------------------------------------------------------------- | --------------------------------------- |
-| `error`    | `unknown`                                                            | The caught error                        |
-| `handlers` | `Record<ErrorCode, (e: ZamaError) => T> & { _?: (e: unknown) => T }` | Map of error codes to handler functions |
+| Parameter  | Type                                                                              | Description                             |
+| ---------- | --------------------------------------------------------------------------------- | --------------------------------------- |
+| `error`    | `unknown`                                                                         | The caught error                        |
+| `handlers` | `{ [K in ErrorCode]?: (e: ErrorForCode[K]) => T } & { _?: (e: unknown) => T }` | Map of error codes to handler functions |
 
-The `_` wildcard catches any `ZamaError` not explicitly handled. Handlers receive the error typed as the base `ZamaError` (`.code`, `.message`); to read subclass fields like `InsufficientConfidentialBalanceError.available` or `RelayerRequestFailedError.statusCode`, narrow with `instanceof` (see the detail sections below).
+The `_` wildcard catches any `ZamaError` not explicitly handled. Each handler receives the error class for its code, so subclass fields like `InsufficientConfidentialBalanceError.available` or `RelayerRequestFailedError.statusCode` are available without a cast.
 
 ## Error summary
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7427,9 +7427,9 @@ const message = matchZamaError(error, {
 });
 ```
 
-| Parameter  | Type                                                                              | Description                             |
-| ---------- | --------------------------------------------------------------------------------- | --------------------------------------- |
-| `error`    | `unknown`                                                                         | The caught error                        |
+| Parameter  | Type                                                                           | Description                             |
+| ---------- | ------------------------------------------------------------------------------ | --------------------------------------- |
+| `error`    | `unknown`                                                                      | The caught error                        |
 | `handlers` | `{ [K in ErrorCode]?: (e: ErrorForCode[K]) => T } & { _?: (e: unknown) => T }` | Map of error codes to handler functions |
 
 The `_` wildcard catches any `ZamaError` not explicitly handled. Each handler receives the error class for its code, so subclass fields like `InsufficientConfidentialBalanceError.available` or `RelayerRequestFailedError.statusCode` are available without a cast.

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -11245,7 +11245,7 @@ export const mainnet: {
 };
 
 // @public
-export function matchZamaError<R>(error: unknown, handlers: Partial<Record<ZamaErrorCode, (error: ZamaError) => R>> & {
+export function matchZamaError<R>(error: unknown, handlers: { [K in ZamaErrorCode]?: (error: ErrorForCode[K]) => R } & {
     _?: (error: unknown) => R;
 }): R | undefined;
 

--- a/packages/sdk/src/errors/__tests__/errors.test-d.ts
+++ b/packages/sdk/src/errors/__tests__/errors.test-d.ts
@@ -15,6 +15,9 @@ import type {
   DelegationNotFoundError,
   DelegationExpiredError,
   DelegationNotPropagatedError,
+  InsufficientConfidentialBalanceError,
+  InsufficientERC20BalanceError,
+  ChainMismatchError,
 } from "..";
 import { ZamaError, ZamaErrorCode, matchZamaError } from "..";
 
@@ -85,5 +88,43 @@ describe("matchZamaError", () => {
       },
     });
     expectTypeOf(result).toEqualTypeOf<"fallback" | undefined>();
+  });
+
+  test("a code-keyed handler receives that code's error subclass", () => {
+    matchZamaError(new Error("any"), {
+      INSUFFICIENT_CONFIDENTIAL_BALANCE: (e) => {
+        expectTypeOf(e).toEqualTypeOf<InsufficientConfidentialBalanceError>();
+        // subclass fields are reachable without a cast
+        expectTypeOf(e.available).toEqualTypeOf<bigint>();
+        expectTypeOf(e.requested).toEqualTypeOf<bigint>();
+      },
+      INSUFFICIENT_ERC20_BALANCE: (e) => {
+        expectTypeOf(e).toEqualTypeOf<InsufficientERC20BalanceError>();
+      },
+      RELAYER_REQUEST_FAILED: (e) => {
+        expectTypeOf(e).toEqualTypeOf<RelayerRequestFailedError>();
+        expectTypeOf(e.statusCode).toEqualTypeOf<number | undefined>();
+      },
+      CHAIN_MISMATCH: (e) => {
+        expectTypeOf(e).toEqualTypeOf<ChainMismatchError>();
+        expectTypeOf(e.signerChainId).toEqualTypeOf<number>();
+        expectTypeOf(e.providerChainId).toEqualTypeOf<number>();
+      },
+    });
+  });
+
+  test("narrowing is additive: base-typed and base-field handlers still compile", () => {
+    // a handler reading only base fields still compiles and infers the return type
+    const fromBaseField = matchZamaError(new Error("any"), {
+      SIGNING_REJECTED: (e) => e.message,
+    });
+    expectTypeOf(fromBaseField).toEqualTypeOf<string | undefined>();
+
+    // a handler annotated with the base type stays assignable (params are contravariant)
+    const baseHandler = (e: ZamaError) => e.code;
+    const fromBaseHandler = matchZamaError(new Error("any"), {
+      SIGNING_REJECTED: baseHandler,
+    });
+    expectTypeOf(fromBaseHandler).toEqualTypeOf<ZamaErrorCode | undefined>();
   });
 });

--- a/packages/sdk/src/errors/base.ts
+++ b/packages/sdk/src/errors/base.ts
@@ -91,32 +91,3 @@ export class ZamaError extends Error {
     this.code = code;
   }
 }
-
-/**
- * Pattern-match on a {@link ZamaError} by its error code.
- * Falls through to the `_` wildcard handler if no specific handler matches.
- * Returns `undefined` if the error is not a `ZamaError` and no `_` handler is provided.
- *
- * @example
- * ```ts
- * matchZamaError(error, {
- *   SIGNING_REJECTED: () => toast("Please approve in wallet"),
- *   TRANSACTION_REVERTED: (e) => toast(`Tx failed: ${e.message}`),
- *   _: () => toast("Unknown error"),
- * });
- * ```
- */
-export function matchZamaError<R>(
-  error: unknown,
-  handlers: Partial<Record<ZamaErrorCode, (error: ZamaError) => R>> & {
-    _?: (error: unknown) => R;
-  },
-): R | undefined {
-  if (error instanceof ZamaError) {
-    const handler = handlers[error.code];
-    if (handler) {
-      return handler(error);
-    }
-  }
-  return handlers._?.(error);
-}

--- a/packages/sdk/src/errors/index.ts
+++ b/packages/sdk/src/errors/index.ts
@@ -1,4 +1,5 @@
-export { ZamaError, ZamaErrorCode, matchZamaError } from "./base";
+export { ZamaError, ZamaErrorCode } from "./base";
+export { matchZamaError } from "./match";
 export { SigningRejectedError, SigningFailedError } from "./signing";
 export { EncryptionFailedError, DecryptionFailedError } from "./encryption";
 export { TransactionRevertedError } from "./transaction";

--- a/packages/sdk/src/errors/match.ts
+++ b/packages/sdk/src/errors/match.ts
@@ -1,0 +1,107 @@
+import { ZamaError } from "./base";
+import type { ZamaErrorCode } from "./base";
+import type { ChainMismatchError } from "./chain";
+import type {
+  NoCiphertextError,
+  TransportKeyPairExpiredError,
+  InvalidTransportKeyPairError,
+} from "./credential";
+import type {
+  AclPausedError,
+  DelegationContractIsSelfError,
+  DelegationCooldownError,
+  DelegationDelegateEqualsContractError,
+  DelegationExpirationTooSoonError,
+  DelegationExpiredError,
+  DelegationExpiryUnchangedError,
+  DelegationNotFoundError,
+  DelegationNotPropagatedError,
+  DelegationSelfNotAllowedError,
+} from "./delegation";
+import type { DecryptionFailedError, EncryptionFailedError } from "./encryption";
+import type {
+  BalanceCheckUnavailableError,
+  ERC20ReadFailedError,
+  InsufficientConfidentialBalanceError,
+  InsufficientERC20BalanceError,
+} from "./balance";
+import type { ConfigurationError, RelayerRequestFailedError } from "./relayer";
+import type {
+  SignerNotConfiguredError,
+  WalletAccountNotReadyError,
+  WalletNotConnectedError,
+} from "./signer";
+import type { SigningFailedError, SigningRejectedError } from "./signing";
+import type { TransactionRevertedError } from "./transaction";
+
+/** Identity type that fails to instantiate unless `T` maps every code to a `ZamaError`. */
+type Complete<T extends Record<ZamaErrorCode, ZamaError>> = T;
+
+/**
+ * Maps each {@link ZamaErrorCode} to the error class thrown with that code, so
+ * {@link matchZamaError} handlers receive the matched subtype instead of the base
+ * `ZamaError`. Hand-maintained; the `Complete` wrapper fails the build if a code is
+ * added without an entry here (or mapped to a non-`ZamaError`).
+ */
+type ErrorForCode = Complete<{
+  [ZamaErrorCode.SigningRejected]: SigningRejectedError;
+  [ZamaErrorCode.SigningFailed]: SigningFailedError;
+  [ZamaErrorCode.EncryptionFailed]: EncryptionFailedError;
+  [ZamaErrorCode.DecryptionFailed]: DecryptionFailedError;
+  [ZamaErrorCode.TransactionReverted]: TransactionRevertedError;
+  [ZamaErrorCode.TransportKeyPairExpired]: TransportKeyPairExpiredError;
+  [ZamaErrorCode.InvalidTransportKeyPair]: InvalidTransportKeyPairError;
+  [ZamaErrorCode.NoCiphertext]: NoCiphertextError;
+  [ZamaErrorCode.RelayerRequestFailed]: RelayerRequestFailedError;
+  [ZamaErrorCode.Configuration]: ConfigurationError;
+  [ZamaErrorCode.DelegationSelfNotAllowed]: DelegationSelfNotAllowedError;
+  [ZamaErrorCode.DelegationCooldown]: DelegationCooldownError;
+  [ZamaErrorCode.DelegationNotFound]: DelegationNotFoundError;
+  [ZamaErrorCode.DelegationExpired]: DelegationExpiredError;
+  [ZamaErrorCode.InsufficientConfidentialBalance]: InsufficientConfidentialBalanceError;
+  [ZamaErrorCode.InsufficientERC20Balance]: InsufficientERC20BalanceError;
+  [ZamaErrorCode.BalanceCheckUnavailable]: BalanceCheckUnavailableError;
+  [ZamaErrorCode.ERC20ReadFailed]: ERC20ReadFailedError;
+  [ZamaErrorCode.DelegationExpiryUnchanged]: DelegationExpiryUnchangedError;
+  [ZamaErrorCode.DelegationDelegateEqualsContract]: DelegationDelegateEqualsContractError;
+  [ZamaErrorCode.DelegationContractIsSelf]: DelegationContractIsSelfError;
+  [ZamaErrorCode.AclPaused]: AclPausedError;
+  [ZamaErrorCode.DelegationExpirationTooSoon]: DelegationExpirationTooSoonError;
+  [ZamaErrorCode.DelegationNotPropagated]: DelegationNotPropagatedError;
+  [ZamaErrorCode.ChainMismatch]: ChainMismatchError;
+  [ZamaErrorCode.SignerNotConfigured]: SignerNotConfiguredError;
+  [ZamaErrorCode.WalletNotConnected]: WalletNotConnectedError;
+  [ZamaErrorCode.WalletAccountNotReady]: WalletAccountNotReadyError;
+}>;
+
+/**
+ * Pattern-match on a {@link ZamaError} by its error code. Each handler receives the
+ * error class for its code, so subclass fields are available without a cast.
+ * Falls through to the `_` wildcard handler if no specific handler matches.
+ * Returns `undefined` if the error is not a `ZamaError` and no `_` handler is provided.
+ *
+ * @example
+ * ```ts
+ * matchZamaError(error, {
+ *   SIGNING_REJECTED: () => toast("Please approve in wallet"),
+ *   INSUFFICIENT_CONFIDENTIAL_BALANCE: (e) => toast(`Need ${e.requested}, have ${e.available}`),
+ *   RELAYER_REQUEST_FAILED: (e) => toast(`Relayer failed (${e.statusCode})`),
+ *   _: () => toast("Unknown error"),
+ * });
+ * ```
+ */
+export function matchZamaError<R>(
+  error: unknown,
+  handlers: { [K in ZamaErrorCode]?: (error: ErrorForCode[K]) => R } & {
+    _?: (error: unknown) => R;
+  },
+): R | undefined {
+  if (error instanceof ZamaError) {
+    // `error.code` narrows the handler at runtime; the cast bridges the per-code param types.
+    const handler = handlers[error.code] as ((error: ZamaError) => R) | undefined;
+    if (handler) {
+      return handler(error);
+    }
+  }
+  return handlers._?.(error);
+}

--- a/packages/sdk/src/errors/match.ts
+++ b/packages/sdk/src/errors/match.ts
@@ -34,7 +34,11 @@ import type {
 import type { SigningFailedError, SigningRejectedError } from "./signing";
 import type { TransactionRevertedError } from "./transaction";
 
-/** Identity type that fails to instantiate unless `T` maps every code to a `ZamaError`. */
+/**
+ * Identity type that fails to instantiate unless `T` maps every code to a `ZamaError`.
+ * Guards presence + value type only: a wrong-but-valid mapping (a code pointing at a
+ * structurally identical sibling class) still compiles — `errors.test-d.ts` backstops that.
+ */
 type Complete<T extends Record<ZamaErrorCode, ZamaError>> = T;
 
 /**


### PR DESCRIPTION
## What

`matchZamaError(error, handlers)` routed by code but typed every handler to receive the **base** `ZamaError`, so a handler keyed on a code couldn't read that subclass's own fields without a cast (`TS2339`). This types the handler for each code to receive **that code's error class**, so subclass fields are reachable without a cast:

```ts
matchZamaError(error, {
  INSUFFICIENT_CONFIDENTIAL_BALANCE: (e) => `need ${e.requested}, have ${e.available}`, // ✅
  RELAYER_REQUEST_FAILED: (e) => e.statusCode,                                          // ✅
});
```

Closes [SDK-231](https://linear.app/zama/issue/SDK-231).

## How

- New `errors/match.ts` holds a hand-maintained `ErrorForCode` map (code → error class) and `matchZamaError`. The function moves out of `base.ts` so the low-level module stays free of subclass imports (no `base ⇄ subclass` cycle).
- A `Complete<T extends Record<ZamaErrorCode, ZamaError>>` wrapper around the map **fails the build** if a code is added without an entry (or mapped to a non-`ZamaError`) — drift protection that lives in `src/`, so `pnpm typecheck` enforces it.
- **Types-only:** the runtime body is unchanged (a single internal cast bridges the per-code param types at the `instanceof` dispatch).
- **Purely additive:** the `_` wildcard, base-field handlers, and handlers explicitly annotated `(e: ZamaError) => …` all still compile (params are contravariant).

## Tests / docs / artifacts

- `errors.test-d.ts`: asserts each rich code narrows to its subtype (`available`/`requested`, `statusCode`, `signerChainId`/`providerChainId`) + additivity assertions.
- Restores the subclass-field examples in `handle-errors.md` / `errors.md` that previously had to fall back to `instanceof` (the doc workaround SDK-231 was filed to remove).
- Regenerated `sdk.api.md` and the LLM corpus.

## Notes for reviewers

- The one thing the compiler can't guard is a *wrong-but-valid* class mapping (e.g. `CHAIN_MISMATCH → SigningRejectedError`) — many error classes are structurally identical, so this is only caught by the `test-d` assertions.
- Heads-up (out of scope here): the repo's `vitest --project typecheck` runner collects `*.test-d.ts` but doesn't actually type-check them (the project tsconfig excludes `__tests__`), so type-test assertions don't currently gate CI. Enabling real enforcement surfaces ~3 pre-existing failures in `credentials.test-d.ts` — worth a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)