### PR TITLE
fix(sdk): resolve node worker without import.meta.resolve for SSR bundlers [SDK-235]

### DIFF
--- a/packages/sdk/src/worker/__tests__/worker.bundler.test.ts
+++ b/packages/sdk/src/worker/__tests__/worker.bundler.test.ts
@@ -8,11 +8,13 @@
  * Run `pnpm build` before running these tests.
  */
 import { describe, test, expect } from "vitest";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 
 const DIST = resolve(__dirname, "../../../dist");
 const hasBuild = existsSync(resolve(DIST, "relayer-sdk.worker.js"));
+const ESM_DIR = resolve(DIST, "esm");
+const hasEsmBuild = existsSync(ESM_DIR);
 
 describe.skipIf(!hasBuild)("worker build smoke tests", () => {
   const workerPath = resolve(DIST, "relayer-sdk.worker.js");
@@ -41,5 +43,22 @@ describe.skipIf(!hasBuild)("worker build smoke tests", () => {
   test("standalone worker file exports filename alongside code", () => {
     const content = readFileSync(indexPath, "utf-8");
     expect(content).toContain("relayer-sdk.worker.js");
+  });
+});
+
+describe.skipIf(!hasEsmBuild)("node worker resolution is SSR-bundler safe (SDK-235)", () => {
+  // `import.meta.resolve` is rewritten to `__vite_ssr_import_meta__.resolve` by
+  // Vite's SSR transform (used by Ponder and other server-side bundlers), where
+  // it is undefined at runtime — so the Node worker factory throws and can never
+  // spawn its worker. No shipped ESM chunk may reference it, regardless of which
+  // rolldown chunk the node worker client lands in.
+  test("no shipped ESM chunk uses import.meta.resolve", () => {
+    const files = readdirSync(ESM_DIR, { recursive: true }) as string[];
+    const offenders = files
+      .filter((file) => file.endsWith(".js"))
+      .filter((file) =>
+        readFileSync(resolve(ESM_DIR, file), "utf-8").includes("import.meta.resolve"),
+      );
+    expect(offenders).toEqual([]);
   });
 });

--- a/packages/sdk/src/worker/worker.node-client.ts
+++ b/packages/sdk/src/worker/worker.node-client.ts
@@ -1,5 +1,7 @@
 import { Worker } from "node:worker_threads";
 import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
 import type { FheChain } from "../chains/types";
 import type {
   GenericLogger,
@@ -30,7 +32,14 @@ export class NodeWorkerClient extends BaseWorkerClient<Worker, NodeWorkerClientC
   protected createWorker(): Worker {
     // Resolve relative to the @zama-fhe/sdk/node entry point so the path is
     // correct regardless of which rolldown chunk this code lands in.
-    const nodeEntry = new URL(import.meta.resolve("@zama-fhe/sdk/node"));
+    //
+    // Use createRequire(...).resolve rather than import.meta.resolve: Vite's
+    // SSR transform (Ponder and other server-side bundlers) rewrites
+    // `import.meta.resolve` to `__vite_ssr_import_meta__.resolve`, which is
+    // undefined at runtime and makes this throw. createRequire only relies on
+    // `import.meta.url`, which those transforms preserve. See SDK-235.
+    const require = createRequire(import.meta.url);
+    const nodeEntry = pathToFileURL(require.resolve("@zama-fhe/sdk/node"));
     return new Worker(new URL("relayer-sdk.node-worker.js", nodeEntry));
   }
 


### PR DESCRIPTION
## Problem

`@zama-fhe/sdk/node`'s worker factory resolved its entry with `import.meta.resolve("@zama-fhe/sdk/node")`. Vite's SSR transform — used by **Ponder** and other server-side bundlers — rewrites `import.meta.resolve` to `__vite_ssr_import_meta__.resolve`, which is **undefined at runtime**. `createWorker()` then throws and the Node relayer can never spawn its worker, breaking any server-side integration running inside a Vite-SSR runtime.

Surfaced via the Product Integrations take-home (a server-side ERC-7984 indexer on Ponder). Fixes [SDK-235](https://linear.app/zama/issue/SDK-235).

## Fix

`packages/sdk/src/worker/worker.node-client.ts` now uses `createRequire(import.meta.url).resolve(...)`:

```ts
const require = createRequire(import.meta.url);
const nodeEntry = pathToFileURL(require.resolve("@zama-fhe/sdk/node"));
return new Worker(new URL("relayer-sdk.node-worker.js", nodeEntry));
```

- **SSR-safe** — relies only on `import.meta.url` (preserved by the SSR transform) plus `node:module`/`node:url`. No `import.meta.resolve`.
- **Preserves the #285 chunk-location fix** — `require.resolve` resolves the package entry regardless of which rolldown chunk this code is tree-shaken into, so the worker path stays correct.

Requires the SDK to be externalized server-side, which is inherent to spawning a worker from a file (and the default for Ponder / Vite SSR).

## Tests

- New build-gated regression test in `worker.bundler.test.ts`: asserts **no shipped ESM chunk references `import.meta.resolve`** — the exact construct that breaks SSR consumers. Fails on the old code, passes after the fix.

## Verification

- RED → GREEN: test failed on `dist/esm/node/index.js`, passes after rebuild.
- Runtime check (real Node ESM, package self-reference): resolves to the existing `dist/esm/node/relayer-sdk.node-worker.js`.
- Worker suite: 90 passed / 5 skipped. `typecheck` ✅, `lint` ✅.

## Not a duplicate of SDK-46

SDK-46 (Done) fixed an earlier `new URL('relayer-sdk.node-worker.js', import.meta.url)` path-layout mismatch. The current code used `import.meta.resolve(...)`, so this Vite-SSR incompatibility is a distinct issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)