### PR TITLE
feat(sdk): surface relayer back-pressure (retryAfterMs/retryable) on RelayerRequestFailedError [SDK-236]

### DIFF
--- a/docs/gitbook/src/guides/handle-errors.md
+++ b/docs/gitbook/src/guides/handle-errors.md
@@ -108,31 +108,31 @@ Each handler receives the error typed as the base `ZamaError`, so `.code` and `.
 
 Here is a quick reference for the most common errors and how to respond:
 
-| Error                                  | Recommended action                                                                                                                      |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `SigningRejectedError`                 | Show a retry prompt. The user needs to approve the wallet signature.                                                                    |
-| `SigningFailedError`                   | Check wallet connectivity. Hardware wallets may need a firmware update.                                                                 |
-| `EncryptionFailedError`                | Check your CSP headers -- the Web Worker needs `wasm-unsafe-eval`.                                                                      |
-| `DecryptionFailedError`                | May indicate an interrupted unshield. Check for pending state with `loadPendingUnshield()`.                                             |
-| `TransactionRevertedError`             | Inspect the revert reason. Common causes: insufficient balance, expired approval.                                                       |
-| `InvalidTransportKeyPairError`         | The transport key pair is stale. Clear credentials and prompt for a fresh signature.                                                    |
-| `TransportKeyPairExpiredError`         | Same as above -- the transport key pair TTL has elapsed.                                                                                |
-| `NoCiphertextError`                    | Not an error per se. The account has never shielded. Show an empty state in your UI.                                                    |
-| `RelayerRequestFailedError`            | Verify `relayerUrl` in your config. If using API key auth, check the `auth` option. Inspect `.statusCode`.                              |
-| `ConfigurationError`                   | Invalid SDK configuration or FHE worker failed to initialize. Check your transport config and CSP headers.                              |
-| `InsufficientConfidentialBalanceError` | Show the user their balance and the shortfall. The operation needs more confidential tokens.                                            |
-| `InsufficientERC20BalanceError`        | Show the user their public token balance. They need more tokens before shielding.                                                       |
-| `BalanceCheckUnavailableError`         | Call `sdk.permits.grantPermit([token.address])` to sign permits, or pass `skipBalanceCheck: true` to bypass (useful for smart wallets). |
-| `ERC20ReadFailedError`                 | Check network connectivity and RPC endpoint. Retry the shield operation.                                                                |
-| `SignerRequiredError`                  | Connect a wallet. The operation requires a signer but the SDK was configured without one.                                               |
-| `DelegationSelfNotAllowedError`        | Cannot delegate to yourself. Use a different delegate address.                                                                          |
-| `DelegationCooldownError`              | Wait for the next block before retrying delegate/revoke on the same tuple.                                                              |
-| `DelegationNotFoundError`              | No active delegation exists. Verify the delegator, delegate, and contract addresses.                                                    |
-| `DelegationExpiredError`               | The delegation has expired. Create a new delegation.                                                                                    |
-| `SignerNotConfiguredError`             | The SDK was built without a signer. Pass one to `createConfig`, or connect a wallet.                                                    |
-| `WalletNotConnectedError`              | A signer exists but no wallet account is connected. Prompt the user to connect.                                                         |
-| `WalletAccountNotReadyError`           | The wallet adapter is still resolving its account. Wait for the connection to settle, then retry.                                       |
-| `ChainMismatchError`                   | The wallet is on a different chain than the operation targets. Prompt the user to switch networks.                                      |
+| Error                                  | Recommended action                                                                                                                                |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SigningRejectedError`                 | Show a retry prompt. The user needs to approve the wallet signature.                                                                              |
+| `SigningFailedError`                   | Check wallet connectivity. Hardware wallets may need a firmware update.                                                                           |
+| `EncryptionFailedError`                | Check your CSP headers -- the Web Worker needs `wasm-unsafe-eval`.                                                                                |
+| `DecryptionFailedError`                | May indicate an interrupted unshield. Check for pending state with `loadPendingUnshield()`.                                                       |
+| `TransactionRevertedError`             | Inspect the revert reason. Common causes: insufficient balance, expired approval.                                                                 |
+| `InvalidTransportKeyPairError`         | The transport key pair is stale. Clear credentials and prompt for a fresh signature.                                                              |
+| `TransportKeyPairExpiredError`         | Same as above -- the transport key pair TTL has elapsed.                                                                                          |
+| `NoCiphertextError`                    | Not an error per se. The account has never shielded. Show an empty state in your UI.                                                              |
+| `RelayerRequestFailedError`            | Verify `relayerUrl` in your config. If using API key auth, check the `auth` option. Inspect `.statusCode`; on a 429, retry after `.retryAfterMs`. |
+| `ConfigurationError`                   | Invalid SDK configuration or FHE worker failed to initialize. Check your transport config and CSP headers.                                        |
+| `InsufficientConfidentialBalanceError` | Show the user their balance and the shortfall. The operation needs more confidential tokens.                                                      |
+| `InsufficientERC20BalanceError`        | Show the user their public token balance. They need more tokens before shielding.                                                                 |
+| `BalanceCheckUnavailableError`         | Call `sdk.permits.grantPermit([token.address])` to sign permits, or pass `skipBalanceCheck: true` to bypass (useful for smart wallets).           |
+| `ERC20ReadFailedError`                 | Check network connectivity and RPC endpoint. Retry the shield operation.                                                                          |
+| `SignerRequiredError`                  | Connect a wallet. The operation requires a signer but the SDK was configured without one.                                                         |
+| `DelegationSelfNotAllowedError`        | Cannot delegate to yourself. Use a different delegate address.                                                                                    |
+| `DelegationCooldownError`              | Wait for the next block before retrying delegate/revoke on the same tuple.                                                                        |
+| `DelegationNotFoundError`              | No active delegation exists. Verify the delegator, delegate, and contract addresses.                                                              |
+| `DelegationExpiredError`               | The delegation has expired. Create a new delegation.                                                                                              |
+| `SignerNotConfiguredError`             | The SDK was built without a signer. Pass one to `createConfig`, or connect a wallet.                                                              |
+| `WalletNotConnectedError`              | A signer exists but no wallet account is connected. Prompt the user to connect.                                                                   |
+| `WalletAccountNotReadyError`           | The wallet adapter is still resolving its account. Wait for the connection to settle, then retry.                                                 |
+| `ChainMismatchError`                   | The wallet is on a different chain than the operation targets. Prompt the user to switch networks.                                                |
 
 ### 5. Distinguish "no balance" from "zero balance"
 

--- a/docs/gitbook/src/reference/sdk/errors.md
+++ b/docs/gitbook/src/reference/sdk/errors.md
@@ -277,18 +277,25 @@ try {
 
 **Code:** `RELAYER_REQUEST_FAILED`
 
-The HTTP request to the relayer failed. The error exposes `.statusCode` for further diagnosis.
+The HTTP request to the relayer failed. The error exposes `.statusCode` for further diagnosis. On rate-limited responses (HTTP 429) it also surfaces the relayer's back-pressure: `.retryable` is `true`, and `.retryAfterMs` carries the server's suggested delay when the response included a `Retry-After` header (otherwise `undefined`).
 
 ```ts
 matchZamaError(error, {
-  RELAYER_REQUEST_FAILED: (e) => {
-    if (e.statusCode === 401) showError("Authentication failed");
-    else showError("Relayer unavailable — try again later");
+  RELAYER_REQUEST_FAILED: async (e) => {
+    if (e.statusCode === 401) {
+      showError("Authentication failed");
+    } else if (e.retryable) {
+      // Honour the server's delay when provided; fall back to your own backoff.
+      await sleep(e.retryAfterMs ?? 1000);
+      retry();
+    } else {
+      showError("Relayer unavailable — try again later");
+    }
   },
 });
 ```
 
-**How to handle:** Check `relayerUrl` in your transport config. If using API key authentication, verify the `auth` option. Check relayer service health.
+**How to handle:** For a 429, wait `.retryAfterMs` (when present) before retrying instead of inventing a backoff. Otherwise, check `relayerUrl` in your transport config, verify the `auth` option if using API key authentication, and check relayer service health.
 
 ## "No balance" vs "zero balance"
 

--- a/docs/gitbook/src/reference/sdk/errors.md
+++ b/docs/gitbook/src/reference/sdk/errors.md
@@ -297,6 +297,8 @@ matchZamaError(error, {
 
 **How to handle:** For a 429, wait `.retryAfterMs` (when present) before retrying instead of inventing a backoff. Otherwise, check `relayerUrl` in your transport config, verify the `auth` option if using API key authentication, and check relayer service health.
 
+> **Browser note:** back-pressure is reliable server-side. In the browser, the relayer's 429 is served cross-origin without CORS headers, so `.retryAfterMs` (and sometimes `.statusCode`) may be unavailable — fall back to your own backoff.
+
 ## "No balance" vs "zero balance"
 
 These are distinct states:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3724,31 +3724,31 @@ Each handler receives the error typed as the base `ZamaError`, so `.code` and `.
 
 Here is a quick reference for the most common errors and how to respond:
 
-| Error                                  | Recommended action                                                                                                                      |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `SigningRejectedError`                 | Show a retry prompt. The user needs to approve the wallet signature.                                                                    |
-| `SigningFailedError`                   | Check wallet connectivity. Hardware wallets may need a firmware update.                                                                 |
-| `EncryptionFailedError`                | Check your CSP headers -- the Web Worker needs `wasm-unsafe-eval`.                                                                      |
-| `DecryptionFailedError`                | May indicate an interrupted unshield. Check for pending state with `loadPendingUnshield()`.                                             |
-| `TransactionRevertedError`             | Inspect the revert reason. Common causes: insufficient balance, expired approval.                                                       |
-| `InvalidTransportKeyPairError`         | The transport key pair is stale. Clear credentials and prompt for a fresh signature.                                                    |
-| `TransportKeyPairExpiredError`         | Same as above -- the transport key pair TTL has elapsed.                                                                                |
-| `NoCiphertextError`                    | Not an error per se. The account has never shielded. Show an empty state in your UI.                                                    |
-| `RelayerRequestFailedError`            | Verify `relayerUrl` in your config. If using API key auth, check the `auth` option. Inspect `.statusCode`.                              |
-| `ConfigurationError`                   | Invalid SDK configuration or FHE worker failed to initialize. Check your transport config and CSP headers.                              |
-| `InsufficientConfidentialBalanceError` | Show the user their balance and the shortfall. The operation needs more confidential tokens.                                            |
-| `InsufficientERC20BalanceError`        | Show the user their public token balance. They need more tokens before shielding.                                                       |
-| `BalanceCheckUnavailableError`         | Call `sdk.permits.grantPermit([token.address])` to sign permits, or pass `skipBalanceCheck: true` to bypass (useful for smart wallets). |
-| `ERC20ReadFailedError`                 | Check network connectivity and RPC endpoint. Retry the shield operation.                                                                |
-| `SignerRequiredError`                  | Connect a wallet. The operation requires a signer but the SDK was configured without one.                                               |
-| `DelegationSelfNotAllowedError`        | Cannot delegate to yourself. Use a different delegate address.                                                                          |
-| `DelegationCooldownError`              | Wait for the next block before retrying delegate/revoke on the same tuple.                                                              |
-| `DelegationNotFoundError`              | No active delegation exists. Verify the delegator, delegate, and contract addresses.                                                    |
-| `DelegationExpiredError`               | The delegation has expired. Create a new delegation.                                                                                    |
-| `SignerNotConfiguredError`             | The SDK was built without a signer. Pass one to `createConfig`, or connect a wallet.                                                    |
-| `WalletNotConnectedError`              | A signer exists but no wallet account is connected. Prompt the user to connect.                                                         |
-| `WalletAccountNotReadyError`           | The wallet adapter is still resolving its account. Wait for the connection to settle, then retry.                                       |
-| `ChainMismatchError`                   | The wallet is on a different chain than the operation targets. Prompt the user to switch networks.                                      |
+| Error                                  | Recommended action                                                                                                                                |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SigningRejectedError`                 | Show a retry prompt. The user needs to approve the wallet signature.                                                                              |
+| `SigningFailedError`                   | Check wallet connectivity. Hardware wallets may need a firmware update.                                                                           |
+| `EncryptionFailedError`                | Check your CSP headers -- the Web Worker needs `wasm-unsafe-eval`.                                                                                |
+| `DecryptionFailedError`                | May indicate an interrupted unshield. Check for pending state with `loadPendingUnshield()`.                                                       |
+| `TransactionRevertedError`             | Inspect the revert reason. Common causes: insufficient balance, expired approval.                                                                 |
+| `InvalidTransportKeyPairError`         | The transport key pair is stale. Clear credentials and prompt for a fresh signature.                                                              |
+| `TransportKeyPairExpiredError`         | Same as above -- the transport key pair TTL has elapsed.                                                                                          |
+| `NoCiphertextError`                    | Not an error per se. The account has never shielded. Show an empty state in your UI.                                                              |
+| `RelayerRequestFailedError`            | Verify `relayerUrl` in your config. If using API key auth, check the `auth` option. Inspect `.statusCode`; on a 429, retry after `.retryAfterMs`. |
+| `ConfigurationError`                   | Invalid SDK configuration or FHE worker failed to initialize. Check your transport config and CSP headers.                                        |
+| `InsufficientConfidentialBalanceError` | Show the user their balance and the shortfall. The operation needs more confidential tokens.                                                      |
+| `InsufficientERC20BalanceError`        | Show the user their public token balance. They need more tokens before shielding.                                                                 |
+| `BalanceCheckUnavailableError`         | Call `sdk.permits.grantPermit([token.address])` to sign permits, or pass `skipBalanceCheck: true` to bypass (useful for smart wallets).           |
+| `ERC20ReadFailedError`                 | Check network connectivity and RPC endpoint. Retry the shield operation.                                                                          |
+| `SignerRequiredError`                  | Connect a wallet. The operation requires a signer but the SDK was configured without one.                                                         |
+| `DelegationSelfNotAllowedError`        | Cannot delegate to yourself. Use a different delegate address.                                                                                    |
+| `DelegationCooldownError`              | Wait for the next block before retrying delegate/revoke on the same tuple.                                                                        |
+| `DelegationNotFoundError`              | No active delegation exists. Verify the delegator, delegate, and contract addresses.                                                              |
+| `DelegationExpiredError`               | The delegation has expired. Create a new delegation.                                                                                              |
+| `SignerNotConfiguredError`             | The SDK was built without a signer. Pass one to `createConfig`, or connect a wallet.                                                              |
+| `WalletNotConnectedError`              | A signer exists but no wallet account is connected. Prompt the user to connect.                                                                   |
+| `WalletAccountNotReadyError`           | The wallet adapter is still resolving its account. Wait for the connection to settle, then retry.                                                 |
+| `ChainMismatchError`                   | The wallet is on a different chain than the operation targets. Prompt the user to switch networks.                                                |
 
 ### 5. Distinguish "no balance" from "zero balance"
 
@@ -7644,18 +7644,25 @@ try {
 
 **Code:** `RELAYER_REQUEST_FAILED`
 
-The HTTP request to the relayer failed. The error exposes `.statusCode` for further diagnosis.
+The HTTP request to the relayer failed. The error exposes `.statusCode` for further diagnosis. On rate-limited responses (HTTP 429) it also surfaces the relayer's back-pressure: `.retryable` is `true`, and `.retryAfterMs` carries the server's suggested delay when the response included a `Retry-After` header (otherwise `undefined`).
 
 ```ts
 matchZamaError(error, {
-  RELAYER_REQUEST_FAILED: (e) => {
-    if (e.statusCode === 401) showError("Authentication failed");
-    else showError("Relayer unavailable — try again later");
+  RELAYER_REQUEST_FAILED: async (e) => {
+    if (e.statusCode === 401) {
+      showError("Authentication failed");
+    } else if (e.retryable) {
+      // Honour the server's delay when provided; fall back to your own backoff.
+      await sleep(e.retryAfterMs ?? 1000);
+      retry();
+    } else {
+      showError("Relayer unavailable — try again later");
+    }
   },
 });
 ```
 
-**How to handle:** Check `relayerUrl` in your transport config. If using API key authentication, verify the `auth` option. Check relayer service health.
+**How to handle:** For a 429, wait `.retryAfterMs` (when present) before retrying instead of inventing a backoff. Otherwise, check `relayerUrl` in your transport config, verify the `auth` option if using API key authentication, and check relayer service health.
 
 ## "No balance" vs "zero balance"
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7664,6 +7664,8 @@ matchZamaError(error, {
 
 **How to handle:** For a 429, wait `.retryAfterMs` (when present) before retrying instead of inventing a backoff. Otherwise, check `relayerUrl` in your transport config, verify the `auth` option if using API key authentication, and check relayer service health.
 
+> **Browser note:** back-pressure is reliable server-side. In the browser, the relayer's 429 is served cross-origin without CORS headers, so `.retryAfterMs` (and sometimes `.statusCode`) may be unavailable — fall back to your own backoff.
+
 ## "No balance" vs "zero balance"
 
 These are distinct states:

--- a/packages/sdk/etc/sdk-node.api.md
+++ b/packages/sdk/etc/sdk-node.api.md
@@ -296,6 +296,7 @@ export type EncryptResult = {
 export interface ErrorResponse extends BaseResponse {
     // (undocumented)
     error: string;
+    retryAfterMs?: number;
     statusCode?: number;
     // (undocumented)
     success: false;

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -12675,7 +12675,11 @@ export class RelayerDispatcher implements RelayerSDK, Disposable {
 
 // @public
 export class RelayerRequestFailedError extends ZamaError {
-    constructor(message: string, statusCode?: number, options?: ErrorOptions);
+    constructor(message: string, statusCode?: number, options?: ErrorOptions & {
+        retryAfterMs?: number;
+    });
+    readonly retryable: boolean;
+    readonly retryAfterMs: number | undefined;
     readonly statusCode: number | undefined;
 }
 

--- a/packages/sdk/src/errors/__tests__/decrypt.test.ts
+++ b/packages/sdk/src/errors/__tests__/decrypt.test.ts
@@ -83,6 +83,36 @@ describe("wrapDecryptError", () => {
     });
   });
 
+  describe("relayer back-pressure (429)", () => {
+    test("surfaces retryAfterMs and marks a 429 retryable", () => {
+      const error = Object.assign(new Error("rate limited"), {
+        statusCode: 429,
+        retryAfterMs: 2500,
+      });
+      const wrapped = wrapDecryptError(error, "fallback") as RelayerRequestFailedError;
+      expect(wrapped.statusCode).toBe(429);
+      expect(wrapped.retryAfterMs).toBe(2500);
+      expect(wrapped.retryable).toBe(true);
+    });
+
+    test("parses Retry-After from a raw relayer error's response headers", () => {
+      const error = Object.assign(new Error("rate limited"), {
+        statusCode: 429,
+        cause: { response: new Response(null, { headers: { "Retry-After": "5" } }) },
+      });
+      const wrapped = wrapDecryptError(error, "fallback") as RelayerRequestFailedError;
+      expect(wrapped.retryAfterMs).toBe(5000);
+      expect(wrapped.retryable).toBe(true);
+    });
+
+    test("a non-429 status is not retryable and has no retry delay", () => {
+      const error = Object.assign(new Error("server error"), { statusCode: 503 });
+      const wrapped = wrapDecryptError(error, "fallback") as RelayerRequestFailedError;
+      expect(wrapped.retryable).toBe(false);
+      expect(wrapped.retryAfterMs).toBeUndefined();
+    });
+  });
+
   describe("fallback to DecryptionFailedError", () => {
     test("wraps an Error without statusCode as DecryptionFailedError", () => {
       const error = new Error("network down");

--- a/packages/sdk/src/errors/__tests__/decrypt.test.ts
+++ b/packages/sdk/src/errors/__tests__/decrypt.test.ts
@@ -105,8 +105,13 @@ describe("wrapDecryptError", () => {
       expect(wrapped.retryable).toBe(true);
     });
 
-    test("a non-429 status is not retryable and has no retry delay", () => {
-      const error = Object.assign(new Error("server error"), { statusCode: 503 });
+    test("a non-429 status is not retryable and drops any Retry-After delay", () => {
+      // Even though the 503 carries a Retry-After header, it is not surfaced:
+      // retryAfterMs stays consistent with retryable (429-only).
+      const error = Object.assign(new Error("server error"), {
+        statusCode: 503,
+        cause: { response: new Response(null, { headers: { "Retry-After": "10" } }) },
+      });
       const wrapped = wrapDecryptError(error, "fallback") as RelayerRequestFailedError;
       expect(wrapped.retryable).toBe(false);
       expect(wrapped.retryAfterMs).toBeUndefined();

--- a/packages/sdk/src/errors/__tests__/errors.test-d.ts
+++ b/packages/sdk/src/errors/__tests__/errors.test-d.ts
@@ -67,6 +67,11 @@ describe("RelayerRequestFailedError", () => {
   test("has optional statusCode", () => {
     expectTypeOf<RelayerRequestFailedError["statusCode"]>().toEqualTypeOf<number | undefined>();
   });
+
+  test("exposes back-pressure: retryAfterMs and retryable", () => {
+    expectTypeOf<RelayerRequestFailedError["retryAfterMs"]>().toEqualTypeOf<number | undefined>();
+    expectTypeOf<RelayerRequestFailedError["retryable"]>().toEqualTypeOf<boolean>();
+  });
 });
 
 describe("matchZamaError", () => {

--- a/packages/sdk/src/errors/__tests__/errors.test.ts
+++ b/packages/sdk/src/errors/__tests__/errors.test.ts
@@ -81,6 +81,18 @@ describe("RelayerRequestFailedError", () => {
     const err = new RelayerRequestFailedError("request failed", 500, { cause });
     expect(err.cause).toBe(cause);
   });
+
+  test("surfaces relayer back-pressure: retryAfterMs and retryable for a 429", () => {
+    const err = new RelayerRequestFailedError("rate limited", 429, { retryAfterMs: 2500 });
+    expect(err.retryAfterMs).toBe(2500);
+    expect(err.retryable).toBe(true);
+  });
+
+  test("retryable is false and retryAfterMs undefined for non-429 statuses", () => {
+    expect(new RelayerRequestFailedError("server error", 503).retryable).toBe(false);
+    expect(new RelayerRequestFailedError("server error", 503).retryAfterMs).toBeUndefined();
+    expect(new RelayerRequestFailedError("no status").retryable).toBe(false);
+  });
 });
 
 describe("matchZamaError", () => {

--- a/packages/sdk/src/errors/__tests__/errors.test.ts
+++ b/packages/sdk/src/errors/__tests__/errors.test.ts
@@ -88,10 +88,13 @@ describe("RelayerRequestFailedError", () => {
     expect(err.retryable).toBe(true);
   });
 
-  test("retryable is false and retryAfterMs undefined for non-429 statuses", () => {
+  test("retryable is false for non-429 statuses, and a delay is dropped to stay consistent", () => {
     expect(new RelayerRequestFailedError("server error", 503).retryable).toBe(false);
-    expect(new RelayerRequestFailedError("server error", 503).retryAfterMs).toBeUndefined();
     expect(new RelayerRequestFailedError("no status").retryable).toBe(false);
+    // retryAfterMs only makes sense when retryable: a 503 with a delay drops it.
+    expect(
+      new RelayerRequestFailedError("server error", 503, { retryAfterMs: 5000 }).retryAfterMs,
+    ).toBeUndefined();
   });
 });
 

--- a/packages/sdk/src/errors/decrypt.ts
+++ b/packages/sdk/src/errors/decrypt.ts
@@ -4,7 +4,7 @@ import { NoCiphertextError } from "./credential";
 import { RelayerRequestFailedError } from "./relayer";
 import { DelegationNotPropagatedError } from "./delegation";
 import { SigningRejectedError, SigningFailedError } from "./signing";
-import { extractHttpStatus } from "../utils/error";
+import { extractHttpStatus, extractRetryAfterMs } from "../utils/error";
 
 /**
  * Inspect a caught error for an HTTP status code and return the appropriate
@@ -58,7 +58,7 @@ export function wrapDecryptError(
     return new RelayerRequestFailedError(
       error instanceof Error ? error.message : fallbackMessage,
       statusCode,
-      { cause: error },
+      { cause: error, retryAfterMs: extractRetryAfterMs(error) },
     );
   }
 

--- a/packages/sdk/src/errors/encrypt.ts
+++ b/packages/sdk/src/errors/encrypt.ts
@@ -1,4 +1,4 @@
-import { extractHttpStatus } from "../utils/error";
+import { extractHttpStatus, extractRetryAfterMs } from "../utils/error";
 import { ZamaError } from "./base";
 import { EncryptionFailedError } from "./encryption";
 import { RelayerRequestFailedError } from "./relayer";
@@ -31,6 +31,7 @@ export function wrapEncryptError(error: unknown, fallbackMessage: string): ZamaE
       statusCode,
       {
         cause: error,
+        retryAfterMs: extractRetryAfterMs(error),
       },
     );
   }

--- a/packages/sdk/src/errors/relayer.ts
+++ b/packages/sdk/src/errors/relayer.ts
@@ -7,8 +7,8 @@ export class RelayerRequestFailedError extends ZamaError {
 
   /**
    * Server-driven retry delay in milliseconds, from the relayer's `Retry-After`
-   * header. Present on rate-limited (429) responses that carry the header;
-   * `undefined` otherwise.
+   * header. Set only on back-pressure (HTTP 429) responses that carry the
+   * header; `undefined` otherwise. Implies {@link retryable}.
    */
   readonly retryAfterMs: number | undefined;
 
@@ -26,8 +26,9 @@ export class RelayerRequestFailedError extends ZamaError {
     super(ZamaErrorCode.RelayerRequestFailed, message, options);
     this.name = "RelayerRequestFailedError";
     this.statusCode = statusCode;
-    this.retryAfterMs = options?.retryAfterMs;
     this.retryable = statusCode === 429;
+    // Keep the two fields consistent: a delay only makes sense when retryable.
+    this.retryAfterMs = this.retryable ? options?.retryAfterMs : undefined;
   }
 }
 

--- a/packages/sdk/src/errors/relayer.ts
+++ b/packages/sdk/src/errors/relayer.ts
@@ -5,10 +5,29 @@ export class RelayerRequestFailedError extends ZamaError {
   /** HTTP status code from the relayer, if available. */
   readonly statusCode: number | undefined;
 
-  constructor(message: string, statusCode?: number, options?: ErrorOptions) {
+  /**
+   * Server-driven retry delay in milliseconds, from the relayer's `Retry-After`
+   * header. Present on rate-limited (429) responses that carry the header;
+   * `undefined` otherwise.
+   */
+  readonly retryAfterMs: number | undefined;
+
+  /**
+   * Whether the request may be safely retried. `true` for relayer back-pressure
+   * (HTTP 429); pair with {@link retryAfterMs} for the server's suggested delay.
+   */
+  readonly retryable: boolean;
+
+  constructor(
+    message: string,
+    statusCode?: number,
+    options?: ErrorOptions & { retryAfterMs?: number },
+  ) {
     super(ZamaErrorCode.RelayerRequestFailed, message, options);
     this.name = "RelayerRequestFailedError";
     this.statusCode = statusCode;
+    this.retryAfterMs = options?.retryAfterMs;
+    this.retryable = statusCode === 429;
   }
 }
 

--- a/packages/sdk/src/utils/__tests__/error.test.ts
+++ b/packages/sdk/src/utils/__tests__/error.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from "../../test-fixtures";
-import { toError, isContractCallError, extractHttpStatus } from "../error";
+import {
+  toError,
+  isContractCallError,
+  extractHttpStatus,
+  extractRetryAfterMs,
+  parseRetryAfterHeader,
+} from "../error";
 
 describe("toError", () => {
   test("returns the same Error instance", () => {
@@ -138,5 +144,83 @@ describe("extractHttpStatus", () => {
     expect(extractHttpStatus(null)).toBeUndefined();
     expect(extractHttpStatus(undefined)).toBeUndefined();
     expect(extractHttpStatus(403)).toBeUndefined();
+  });
+});
+
+describe("parseRetryAfterHeader", () => {
+  test("parses delta-seconds into milliseconds", () => {
+    expect(parseRetryAfterHeader("120")).toBe(120_000);
+  });
+
+  test("treats 0 seconds as 0 ms (retry immediately)", () => {
+    expect(parseRetryAfterHeader("0")).toBe(0);
+  });
+
+  test("parses a future HTTP-date as a positive delay", () => {
+    const future = new Date(Date.now() + 10_000).toUTCString();
+    const ms = parseRetryAfterHeader(future);
+    expect(ms).toBeGreaterThan(0);
+    expect(ms).toBeLessThanOrEqual(10_000);
+  });
+
+  test("floors a past HTTP-date to 0", () => {
+    expect(parseRetryAfterHeader(new Date(Date.now() - 60_000).toUTCString())).toBe(0);
+  });
+
+  test("returns undefined for absent or unparseable values", () => {
+    expect(parseRetryAfterHeader(null)).toBeUndefined();
+    expect(parseRetryAfterHeader(undefined)).toBeUndefined();
+    expect(parseRetryAfterHeader("")).toBeUndefined();
+    expect(parseRetryAfterHeader("   ")).toBeUndefined();
+    expect(parseRetryAfterHeader("soon")).toBeUndefined();
+    expect(parseRetryAfterHeader("12.5")).toBeUndefined();
+  });
+});
+
+describe("extractRetryAfterMs", () => {
+  test("reads a numeric retryAfterMs normalized onto the error", () => {
+    expect(extractRetryAfterMs(Object.assign(new Error("429"), { retryAfterMs: 2500 }))).toBe(2500);
+  });
+
+  test("reads retryAfterMs from the cause", () => {
+    expect(extractRetryAfterMs(new Error("boom", { cause: { retryAfterMs: 1000 } }))).toBe(1000);
+  });
+
+  test("parses the Retry-After header on a raw relayer error (cause.response)", () => {
+    // relayer-sdk throws `new Error(msg, { cause: { ..., response } })`
+    const relayerError = new Error("Relayer rate limit exceeded", {
+      cause: {
+        code: "RELAYER_FETCH_ERROR",
+        status: 429,
+        response: new Response(null, {
+          status: 429,
+          headers: { "Retry-After": "30" },
+        }),
+      },
+    });
+    expect(extractRetryAfterMs(relayerError)).toBe(30_000);
+  });
+
+  test("prefers a normalized retryAfterMs over the cause's response header", () => {
+    const error = Object.assign(
+      new Error("boom", {
+        cause: { response: new Response(null, { headers: { "Retry-After": "99" } }) },
+      }),
+      { retryAfterMs: 1500 },
+    );
+    expect(extractRetryAfterMs(error)).toBe(1500);
+  });
+
+  test("returns undefined when no retry signal is present", () => {
+    expect(extractRetryAfterMs(new Error("plain"))).toBeUndefined();
+    expect(
+      extractRetryAfterMs(new Error("429 no header", { cause: { status: 429 } })),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for non-object values", () => {
+    expect(extractRetryAfterMs("string")).toBeUndefined();
+    expect(extractRetryAfterMs(null)).toBeUndefined();
+    expect(extractRetryAfterMs(undefined)).toBeUndefined();
   });
 });

--- a/packages/sdk/src/utils/error.ts
+++ b/packages/sdk/src/utils/error.ts
@@ -61,3 +61,59 @@ export function extractHttpStatus(error: unknown): number | undefined {
   }
   return undefined;
 }
+
+/**
+ * Parse an HTTP `Retry-After` header value into milliseconds, or `undefined`
+ * when it is absent/unparseable. Per RFC 9110 the value is either a
+ * non-negative number of seconds (`120`) or an HTTP-date; a past date floors
+ * to `0`.
+ */
+export function parseRetryAfterHeader(value: string | null | undefined): number | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return undefined;
+  }
+  // delta-seconds: a non-negative integer
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+  // HTTP-date — an IMF-fixdate always carries alphabetic day/month names, so
+  // require a letter before deferring to the lenient Date.parse.
+  if (/[a-zA-Z]/.test(trimmed)) {
+    const dateMs = Date.parse(trimmed);
+    if (!Number.isNaN(dateMs)) {
+      return Math.max(0, dateMs - Date.now());
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract the relayer's server-driven retry delay (in milliseconds) from a
+ * caught error. Reads, in order, a numeric `retryAfterMs` already normalized
+ * onto the error (or its `cause`) — e.g. across the worker boundary — or the
+ * `Retry-After` header on a raw relayer error's `cause.response`.
+ */
+export function extractRetryAfterMs(error: unknown): number | undefined {
+  if (error === null || error === undefined || typeof error !== "object") {
+    return undefined;
+  }
+  const e = error as Record<string, unknown>;
+  if (typeof e.retryAfterMs === "number") {
+    return e.retryAfterMs;
+  }
+  if (e.cause !== null && e.cause !== undefined && typeof e.cause === "object") {
+    const cause = e.cause as Record<string, unknown>;
+    if (typeof cause.retryAfterMs === "number") {
+      return cause.retryAfterMs;
+    }
+    const response = cause.response as { headers?: { get?: (name: string) => string | null } };
+    if (response?.headers && typeof response.headers.get === "function") {
+      return parseRetryAfterHeader(response.headers.get("Retry-After"));
+    }
+  }
+  return undefined;
+}

--- a/packages/sdk/src/worker/relayer-sdk.node-worker.ts
+++ b/packages/sdk/src/worker/relayer-sdk.node-worker.ts
@@ -30,6 +30,7 @@ import type {
   WorkerRequest,
 } from "./worker.types";
 import { prefixHex, unprefixHex } from "../utils";
+import { extractHttpStatus, extractRetryAfterMs } from "../utils/error";
 
 if (!parentPort) {
   throw new Error("This script must be run as a worker thread");
@@ -96,8 +97,20 @@ function sendSuccess<T>(
   port.postMessage(response, transfer);
 }
 
-function sendError(id: string, type: WorkerRequest["type"], error: string): void {
+function sendError(
+  id: string,
+  type: WorkerRequest["type"],
+  error: string,
+  statusCode?: number,
+  retryAfterMs?: number,
+): void {
   const response: ErrorResponse = { id, type, success: false, error };
+  if (statusCode !== undefined) {
+    response.statusCode = statusCode;
+  }
+  if (retryAfterMs !== undefined) {
+    response.retryAfterMs = retryAfterMs;
+  }
   port.postMessage(response);
 }
 
@@ -182,7 +195,7 @@ async function handleEncrypt(request: EncryptRequest): Promise<void> {
     sendSuccess(id, type, response, transferList);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    sendError(id, type, message);
+    sendError(id, type, message, extractHttpStatus(error), extractRetryAfterMs(error));
   }
 }
 
@@ -213,7 +226,7 @@ async function handleUserDecrypt(request: UserDecryptRequest): Promise<void> {
     sendSuccess(id, type, response);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    sendError(id, type, message);
+    sendError(id, type, message, extractHttpStatus(error), extractRetryAfterMs(error));
   }
 }
 
@@ -230,7 +243,7 @@ async function handlePublicDecrypt(request: PublicDecryptRequest): Promise<void>
     sendSuccess(id, type, response);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    sendError(id, type, message);
+    sendError(id, type, message, extractHttpStatus(error), extractRetryAfterMs(error));
   }
 }
 
@@ -323,7 +336,7 @@ async function handleDelegatedUserDecrypt(request: DelegatedUserDecryptRequest):
     sendSuccess(id, type, response);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    sendError(id, type, message);
+    sendError(id, type, message, extractHttpStatus(error), extractRetryAfterMs(error));
   }
 }
 
@@ -345,7 +358,7 @@ async function handleRequestZKProofVerification(
     sendSuccess(id, type, result, transferList);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    sendError(id, type, message);
+    sendError(id, type, message, extractHttpStatus(error), extractRetryAfterMs(error));
   }
 }
 
@@ -362,7 +375,7 @@ async function handleGetPublicKey(request: GetPublicKeyRequest): Promise<void> {
     sendSuccess(id, type, response);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    sendError(id, type, message);
+    sendError(id, type, message, extractHttpStatus(error), extractRetryAfterMs(error));
   }
 }
 
@@ -382,7 +395,7 @@ async function handleGetPublicParams(request: GetPublicParamsRequest): Promise<v
     sendSuccess(id, type, response);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    sendError(id, type, message);
+    sendError(id, type, message, extractHttpStatus(error), extractRetryAfterMs(error));
   }
 }
 

--- a/packages/sdk/src/worker/relayer-sdk.worker.ts
+++ b/packages/sdk/src/worker/relayer-sdk.worker.ts
@@ -7,6 +7,7 @@ import type { EncryptInput, RelayerSDKGlobal } from "../relayer/relayer-sdk.type
 import type { FhevmInstance, FhevmInstanceConfig } from "@zama-fhe/relayer-sdk/bundle";
 import type { FheChain } from "../chains/types";
 import { prefixHex, unprefixHex } from "../utils";
+import { extractHttpStatus, extractRetryAfterMs } from "../utils/error";
 import { getBrowserExtensionRuntime } from "./browser-extension";
 import type {
   CreateDelegatedEIP712Request,
@@ -444,74 +445,6 @@ async function handleUserDecrypt(request: UserDecryptRequest): Promise<void> {
     const statusCode = extractHttpStatus(error);
     sendError(id, type, message, statusCode, extractRetryAfterMs(error));
   }
-}
-
-/**
- * Extract an HTTP status code from an error, if present.
- * Relayer SDK errors may carry a `status` or `statusCode` property.
- */
-function extractHttpStatus(error: unknown): number | undefined {
-  if (error === null || error === undefined || typeof error !== "object") {
-    return undefined;
-  }
-  const e = error as Record<string, unknown>;
-  if (typeof e.statusCode === "number") {
-    return e.statusCode;
-  }
-  if (typeof e.status === "number") {
-    return e.status;
-  }
-  // Check nested cause
-  if (e.cause !== null && e.cause !== undefined && typeof e.cause === "object") {
-    const cause = e.cause as Record<string, unknown>;
-    if (typeof cause.statusCode === "number") {
-      return cause.statusCode;
-    }
-    if (typeof cause.status === "number") {
-      return cause.status;
-    }
-  }
-  return undefined;
-}
-
-/**
- * Extract the relayer's server-driven retry delay (ms) from the `Retry-After`
- * header on a thrown relayer error's `cause.response`. The raw `Response` is not
- * serializable across the worker boundary, so the delay is read here and
- * forwarded as a number. Parses delta-seconds or an HTTP-date (past dates → 0).
- */
-function extractRetryAfterMs(error: unknown): number | undefined {
-  if (error === null || error === undefined || typeof error !== "object") {
-    return undefined;
-  }
-  const cause = (error as { cause?: unknown }).cause;
-  if (cause === null || cause === undefined || typeof cause !== "object") {
-    return undefined;
-  }
-  const response = (cause as { response?: { headers?: { get?: (name: string) => string | null } } })
-    .response;
-  if (!response?.headers || typeof response.headers.get !== "function") {
-    return undefined;
-  }
-  const value = response.headers.get("Retry-After");
-  if (value === null) {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  if (trimmed === "") {
-    return undefined;
-  }
-  if (/^\d+$/.test(trimmed)) {
-    return Number(trimmed) * 1000;
-  }
-  // HTTP-date — require alphabetic day/month names before the lenient Date.parse.
-  if (/[a-zA-Z]/.test(trimmed)) {
-    const dateMs = Date.parse(trimmed);
-    if (!Number.isNaN(dateMs)) {
-      return Math.max(0, dateMs - Date.now());
-    }
-  }
-  return undefined;
 }
 
 /**

--- a/packages/sdk/src/worker/relayer-sdk.worker.ts
+++ b/packages/sdk/src/worker/relayer-sdk.worker.ts
@@ -148,6 +148,7 @@ function sendError(
   type: WorkerRequest["type"],
   error: string,
   statusCode?: number,
+  retryAfterMs?: number,
 ): void {
   const response: ErrorResponse = {
     id,
@@ -157,6 +158,9 @@ function sendError(
   };
   if (statusCode !== undefined) {
     response.statusCode = statusCode;
+  }
+  if (retryAfterMs !== undefined) {
+    response.retryAfterMs = retryAfterMs;
   }
   self.postMessage(response);
 }
@@ -403,7 +407,7 @@ async function handleEncrypt(request: EncryptRequest): Promise<void> {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const statusCode = extractHttpStatus(error);
-    sendError(id, type, message, statusCode);
+    sendError(id, type, message, statusCode, extractRetryAfterMs(error));
   }
 }
 
@@ -438,7 +442,7 @@ async function handleUserDecrypt(request: UserDecryptRequest): Promise<void> {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const statusCode = extractHttpStatus(error);
-    sendError(id, type, message, statusCode);
+    sendError(id, type, message, statusCode, extractRetryAfterMs(error));
   }
 }
 
@@ -471,6 +475,46 @@ function extractHttpStatus(error: unknown): number | undefined {
 }
 
 /**
+ * Extract the relayer's server-driven retry delay (ms) from the `Retry-After`
+ * header on a thrown relayer error's `cause.response`. The raw `Response` is not
+ * serializable across the worker boundary, so the delay is read here and
+ * forwarded as a number. Parses delta-seconds or an HTTP-date (past dates → 0).
+ */
+function extractRetryAfterMs(error: unknown): number | undefined {
+  if (error === null || error === undefined || typeof error !== "object") {
+    return undefined;
+  }
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause === null || cause === undefined || typeof cause !== "object") {
+    return undefined;
+  }
+  const response = (cause as { response?: { headers?: { get?: (name: string) => string | null } } })
+    .response;
+  if (!response?.headers || typeof response.headers.get !== "function") {
+    return undefined;
+  }
+  const value = response.headers.get("Retry-After");
+  if (value === null) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return undefined;
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+  // HTTP-date — require alphabetic day/month names before the lenient Date.parse.
+  if (/[a-zA-Z]/.test(trimmed)) {
+    const dateMs = Date.parse(trimmed);
+    if (!Number.isNaN(dateMs)) {
+      return Math.max(0, dateMs - Date.now());
+    }
+  }
+  return undefined;
+}
+
+/**
  * Handle PUBLIC_DECRYPT request.
  */
 async function handlePublicDecrypt(request: PublicDecryptRequest): Promise<void> {
@@ -487,7 +531,7 @@ async function handlePublicDecrypt(request: PublicDecryptRequest): Promise<void>
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const statusCode = extractHttpStatus(error);
-    sendError(id, type, message, statusCode);
+    sendError(id, type, message, statusCode, extractRetryAfterMs(error));
   }
 }
 
@@ -593,7 +637,7 @@ async function handleDelegatedUserDecrypt(request: DelegatedUserDecryptRequest):
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const statusCode = extractHttpStatus(error);
-    sendError(id, type, message, statusCode);
+    sendError(id, type, message, statusCode, extractRetryAfterMs(error));
   }
 }
 
@@ -620,7 +664,7 @@ async function handleRequestZKProofVerification(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const statusCode = extractHttpStatus(error);
-    sendError(id, type, message, statusCode);
+    sendError(id, type, message, statusCode, extractRetryAfterMs(error));
   }
 }
 
@@ -641,7 +685,7 @@ async function handleGetPublicKey(request: GetPublicKeyRequest): Promise<void> {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const statusCode = extractHttpStatus(error);
-    sendError(id, type, message, statusCode);
+    sendError(id, type, message, statusCode, extractRetryAfterMs(error));
   }
 }
 
@@ -665,7 +709,7 @@ async function handleGetPublicParams(request: GetPublicParamsRequest): Promise<v
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const statusCode = extractHttpStatus(error);
-    sendError(id, type, message, statusCode);
+    sendError(id, type, message, statusCode, extractRetryAfterMs(error));
   }
 }
 

--- a/packages/sdk/src/worker/worker.base-client.ts
+++ b/packages/sdk/src/worker/worker.base-client.ts
@@ -178,6 +178,9 @@ export abstract class BaseWorkerClient<TWorker, TConfig> {
       if ("statusCode" in response && typeof response.statusCode === "number") {
         (err as Error & { statusCode?: number }).statusCode = response.statusCode;
       }
+      if ("retryAfterMs" in response && typeof response.retryAfterMs === "number") {
+        (err as Error & { retryAfterMs?: number }).retryAfterMs = response.retryAfterMs;
+      }
       pending.reject(err);
     }
   }

--- a/packages/sdk/src/worker/worker.types.ts
+++ b/packages/sdk/src/worker/worker.types.ts
@@ -228,6 +228,8 @@ export interface ErrorResponse extends BaseResponse {
   error: string;
   /** HTTP status code from the relayer, when available. */
   statusCode?: number;
+  /** Server-driven retry delay (ms) from the relayer's `Retry-After` header, when available. */
+  retryAfterMs?: number;
 }
 
 export type WorkerResponse<T> = SuccessResponse<T> | ErrorResponse;


### PR DESCRIPTION
Closes [SDK-236](https://linear.app/zama/issue/SDK-236/surface-relayer-back-pressure-retryafter-retryable-on).

## Problem

When the relayer returns HTTP 429, `RelayerRequestFailedError` exposed only `.statusCode` — nothing about *when* it is safe to retry. A server-side consumer batching decryptions had to invent its own backoff with no server-driven signal, making it easy to either keep hammering the relayer or back off too conservatively.

The 429 originates at Cloudflare (the relayer sits behind it) and its block response carries a `Retry-After` header. That signal was present on the HTTP response but never surfaced on the SDK error a consumer catches.

## What this does

Adds two fields to `RelayerRequestFailedError`:

| Field | Meaning |
| --- | --- |
| `retryAfterMs?: number` | The relayer's `Retry-After` delay (ms). Present on 429s that carry the header; `undefined` otherwise. |
| `retryable: boolean` | `true` for HTTP 429 (the one status whose semantics are unambiguously "retry later"). |

```ts
matchZamaError(error, {
  RELAYER_REQUEST_FAILED: async (e) => {
    if (e.retryable) {
      await sleep(e.retryAfterMs ?? 1000); // honour the server's delay
      retry();
    }
  },
});
```

The constructor stays backward-compatible: `(message, statusCode?, options?: ErrorOptions & { retryAfterMs?: number })`.

## How

The SDK exercises the relayer-sdk **V1** path (`fetchRelayerV1Post` → `throwRelayerResponseError`), which throws `new Error(msg, { cause })` where `cause.response` is the full Fetch `Response`. The `Retry-After` header is read from there. Because a `Response` is **not serializable across the worker boundary**, the delay is extracted *inside* each worker and forwarded as a number alongside `statusCode`:

- `utils/error.ts` — `parseRetryAfterHeader` (delta-seconds or HTTP-date → ms) + `extractRetryAfterMs`.
- Worker protocol — `ErrorResponse.retryAfterMs`, reattached onto the rebuilt error in `worker.base-client.ts`.
- Browser + Node workers — extract and forward the delay on every relayer-touching handler.
- `errors/decrypt.ts` / `errors/encrypt.ts` — thread the delay into the error.

### Drive-by fix

The Node worker previously **did not forward `statusCode` at all** (`sendError(id, type, message)`), so even the existing 429 *detection* didn't work server-side — the exact environment SDK-236 targets. This PR forwards both `statusCode` and `retryAfterMs` from the Node worker.

## "To confirm" from the ticket — verified against the live relayer

The ticket asked to confirm the 429 carries `Retry-After` (rather than a custom page that strips it). Confirmed empirically against the testnet relayer: a real 429 is a Cloudflare response (`server: cloudflare`) carrying **`Retry-After: 300`**, with a JSON body `{"error":{"label":"rate_limited",...}}`. So even though the body is custom, `Retry-After` is preserved — `retryAfterMs` is populated correctly server-side.

Two consequences this PR accounts for:

- **No `RateLimit-*` fallback.** The real 429 carries `Retry-After` only (the `RateLimit-*` headers seen on 2xx/4xx come from a separate per-second app limiter, not the 429), so reading `Retry-After` is sufficient and correct.
- **Browser caveat (documented).** The 429 is served cross-origin without CORS headers, so in the browser `retryAfterMs` (and sometimes `statusCode`) may be unavailable. Back-pressure is reliable server-side — the SDK-236 target.

## Tests

- `parseRetryAfterHeader` / `extractRetryAfterMs` (delta-seconds, HTTP-date, past date → 0, absent/malformed → undefined, numeric-normalized precedence).
- `wrapDecryptError` 429 propagation (header → `retryAfterMs`, `retryable`).
- `RelayerRequestFailedError` field + type assertions.

All 1149 SDK tests pass; typecheck, lint, format, and `llm:check` are clean. API reports regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
