### PR TITLE
style: collapse object literals via oxfmt objectWrap

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -5,6 +5,7 @@
   "trailingComma": "all",
   "printWidth": 100,
   "tabWidth": 2,
+  "objectWrap": "collapse",
   "sortPackageJson": false,
   "ignorePatterns": [
     "dist",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -21,17 +21,10 @@
     "restriction": "off",
     "nursery": "off"
   },
-  "options": {
-    "denyWarnings": true,
-    "typeAware": true
-  },
-  "env": {
-    "builtin": true
-  },
+  "options": { "denyWarnings": true, "typeAware": true },
+  "env": { "builtin": true },
   "settings": {
-    "react": {
-      "version": "19.2.4"
-    },
+    "react": { "version": "19.2.4" },
     "next": {
       "rootDir": [
         "packages/test-nextjs",
@@ -164,9 +157,7 @@
         "packages/sdk/src/worker/**",
         "packages/sdk/src/token/token.ts"
       ],
-      "rules": {
-        "no-console": "off"
-      }
+      "rules": { "no-console": "off" }
     },
     {
       "files": [
@@ -180,9 +171,7 @@
         "packages/sdk/src/viem/viem-signer.ts",
         "packages/sdk/src/worker/worker.node-pool.ts"
       ],
-      "rules": {
-        "@typescript-eslint/no-non-null-assertion": "off"
-      }
+      "rules": { "@typescript-eslint/no-non-null-assertion": "off" }
     }
   ]
 }

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -28,9 +28,7 @@ module.exports = {
         // title notes for every `* ` bullet in a squash body, which the
         // analyzer treats as breaking. Header `!` still escalates via
         // breakingHeaderPattern, which ignores noteKeywords.
-        parserOpts: {
-          noteKeywords: ["__NO_BREAKING_NOTES__"],
-        },
+        parserOpts: { noteKeywords: ["__NO_BREAKING_NOTES__"] },
         releaseRules: [
           { breaking: true, release: "major" },
           { scope: "security", release: "patch" },
@@ -73,24 +71,16 @@ module.exports = {
             { type: "test", hidden: true },
           ],
         },
-        writerOpts: {
-          mainTemplate,
-          commitPartial,
-        },
+        writerOpts: { mainTemplate, commitPartial },
       },
     ],
     [
       "@semantic-release/changelog",
-      {
-        changelogFile: "CHANGELOG.md",
-        changelogTitle: "# Changelog",
-      },
+      { changelogFile: "CHANGELOG.md", changelogTitle: "# Changelog" },
     ],
     [
       "@semantic-release/exec",
-      {
-        prepareCmd: "node scripts/release/prepare-lockstep.mjs ${nextRelease.version}",
-      },
+      { prepareCmd: "node scripts/release/prepare-lockstep.mjs ${nextRelease.version}" },
     ],
     [
       "@semantic-release/git",

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,14 +1,6 @@
 [
-  {
-    "name": "@zama-fhe/sdk (ESM)",
-    "path": "packages/sdk/dist/esm/**/*.js",
-    "limit": "66 KB"
-  },
-  {
-    "name": "@zama-fhe/sdk (CJS)",
-    "path": "packages/sdk/dist/cjs/**/*.cjs",
-    "limit": "57 KB"
-  },
+  { "name": "@zama-fhe/sdk (ESM)", "path": "packages/sdk/dist/esm/**/*.js", "limit": "66 KB" },
+  { "name": "@zama-fhe/sdk (CJS)", "path": "packages/sdk/dist/cjs/**/*.cjs", "limit": "57 KB" },
   {
     "name": "@zama-fhe/react-sdk (all JS)",
     "path": "packages/react-sdk/dist/**/*.js",

--- a/api-extractor.base.json
+++ b/api-extractor.base.json
@@ -17,20 +17,11 @@
       }
     }
   },
-  "apiReport": {
-    "enabled": true,
-    "reportFolder": "<projectFolder>/etc/"
-  },
-  "docModel": {
-    "enabled": true
-  },
-  "dtsRollup": {
-    "enabled": true
-  },
+  "apiReport": { "enabled": true, "reportFolder": "<projectFolder>/etc/" },
+  "docModel": { "enabled": true },
+  "dtsRollup": { "enabled": true },
   "messages": {
-    "compilerMessageReporting": {
-      "default": { "logLevel": "warning" }
-    },
+    "compilerMessageReporting": { "default": { "logLevel": "warning" } },
     "extractorMessageReporting": {
       "default": { "logLevel": "warning" },
       "ae-forgotten-export": { "logLevel": "none", "addToApiReportFile": false },

--- a/claude-setup/settings.json
+++ b/claude-setup/settings.json
@@ -1,14 +1,7 @@
 {
-  "env": {
-    "ENABLE_LSP_TOOL": "1"
-  },
+  "env": { "ENABLE_LSP_TOOL": "1" },
   "extraKnownMarketplaces": {
-    "zama-marketplace": {
-      "source": {
-        "source": "github",
-        "repo": "zama-ai/zama-marketplace"
-      }
-    }
+    "zama-marketplace": { "source": { "source": "github", "repo": "zama-ai/zama-marketplace" } }
   },
   "enabledPlugins": {
     "zama-developer@zama-marketplace": true,
@@ -38,15 +31,7 @@
   },
   "hooks": {
     "PostToolUse": [
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "pnpm format"
-          }
-        ]
-      }
+      { "matcher": "Write|Edit", "hooks": [{ "type": "command", "command": "pnpm format" }] }
     ]
   }
 }

--- a/claude-setup/skills/jsdoc/SKILL.md
+++ b/claude-setup/skills/jsdoc/SKILL.md
@@ -243,14 +243,8 @@ export type EncryptInput =
       value: boolean | bigint;
       type: "ebool";
     }
-  | {
-      value: bigint;
-      type: Exclude<SDK.FheTypeName, "ebool" | "eaddress">;
-    }
-  | {
-      value: Address;
-      type: "eaddress";
-    };
+  | { value: bigint; type: Exclude<SDK.FheTypeName, "ebool" | "eaddress"> }
+  | { value: Address; type: "eaddress" };
 
 // BAD — property JSDoc restates the name
 export interface ConfidentialTransferEvent {

--- a/codemods/sdk-migration-v3/scripts/react-config-token-field-renamed-to-address.ts
+++ b/codemods/sdk-migration-v3/scripts/react-config-token-field-renamed-to-address.ts
@@ -20,10 +20,7 @@ const HOOKS = new Set([
   "useConfidentialIsOperator",
 ]);
 
-const RENAME: Record<string, string> = {
-  tokenAddress: "address",
-  tokenAddresses: "addresses",
-};
+const RENAME: Record<string, string> = { tokenAddress: "address", tokenAddresses: "addresses" };
 
 // Pre-filter: only visit files that call one of the affected hooks.
 export const getSelector: GetSelector<Tsx> = () => ({

--- a/codemods/sdk-migration-v3/tests/core-rename-createzamaconfig-to-createconfig/idempotent/expected.tsx
+++ b/codemods/sdk-migration-v3/tests/core-rename-createzamaconfig-to-createconfig/idempotent/expected.tsx
@@ -1,5 +1,3 @@
 import { createConfig } from "@zama-fhe/sdk/viem";
 
-export const config = createConfig({
-  chain: { id: 11155111 },
-});
+export const config = createConfig({ chain: { id: 11155111 } });

--- a/codemods/sdk-migration-v3/tests/core-rename-createzamaconfig-to-createconfig/idempotent/input.tsx
+++ b/codemods/sdk-migration-v3/tests/core-rename-createzamaconfig-to-createconfig/idempotent/input.tsx
@@ -1,5 +1,3 @@
 import { createConfig } from "@zama-fhe/sdk/viem";
 
-export const config = createConfig({
-  chain: { id: 11155111 },
-});
+export const config = createConfig({ chain: { id: 11155111 } });

--- a/codemods/sdk-migration-v3/tests/core-rename-createzamaconfig-to-createconfig/rename/expected.tsx
+++ b/codemods/sdk-migration-v3/tests/core-rename-createzamaconfig-to-createconfig/rename/expected.tsx
@@ -1,5 +1,3 @@
 import { createConfig } from "@zama-fhe/sdk/viem";
 
-export const config = createConfig({
-  chain: { id: 11155111 },
-});
+export const config = createConfig({ chain: { id: 11155111 } });

--- a/codemods/sdk-migration-v3/tests/core-rename-createzamaconfig-to-createconfig/rename/input.tsx
+++ b/codemods/sdk-migration-v3/tests/core-rename-createzamaconfig-to-createconfig/rename/input.tsx
@@ -1,5 +1,3 @@
 import { createZamaConfig } from "@zama-fhe/sdk/viem";
 
-export const config = createZamaConfig({
-  chain: { id: 11155111 },
-});
+export const config = createZamaConfig({ chain: { id: 11155111 } });

--- a/docs/gitbook/.gitbook/includes/signer-setup.md
+++ b/docs/gitbook/.gitbook/includes/signer-setup.md
@@ -9,10 +9,7 @@ const publicClient = createPublicClient({
   chain: sepolia,
   transport: http("https://sepolia.infura.io/v3/YOUR_KEY"),
 });
-const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
+const walletClient = createWalletClient({ chain: sepolia, transport: custom(window.ethereum!) });
 ```
 
 ### ethers

--- a/docs/gitbook/src/concepts/security-model.md
+++ b/docs/gitbook/src/concepts/security-model.md
@@ -95,9 +95,7 @@ const config = createConfig({
   chains: [sepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: web({ security: { integrityCheck: false } }),
-  },
+  relayers: { [sepolia.id]: web({ security: { integrityCheck: false } }) },
 });
 ```
 
@@ -177,9 +175,7 @@ const config = createConfig({
   walletClient,
   relayers: {
     [sepolia.id]: web({
-      security: {
-        getCsrfToken: () => document.cookie.match(/csrf=(\w+)/)?.[1] ?? "",
-      },
+      security: { getCsrfToken: () => document.cookie.match(/csrf=(\w+)/)?.[1] ?? "" },
     }),
   },
 });

--- a/docs/gitbook/src/guides/authentication.md
+++ b/docs/gitbook/src/guides/authentication.md
@@ -42,10 +42,7 @@ const app = express();
 app.use(express.json());
 
 // Map chain IDs to their network config
-const Configs: Record<number, typeof mainnet> = {
-  [mainnet.id]: mainnet,
-  [sepolia.id]: sepolia,
-};
+const Configs: Record<number, typeof mainnet> = { [mainnet.id]: mainnet, [sepolia.id]: sepolia };
 
 app.use("/api/relayer/:chainId", async (req, res) => {
   const config = Configs[Number(req.params.chainId)];
@@ -59,10 +56,7 @@ app.use("/api/relayer/:chainId", async (req, res) => {
 
   const response = await fetch(url, {
     method: req.method,
-    headers: {
-      "content-type": "application/json",
-      "x-api-key": process.env.RELAYER_API_KEY!,
-    },
+    headers: { "content-type": "application/json", "x-api-key": process.env.RELAYER_API_KEY! },
     body,
     // @ts-expect-error: required by the relayer
     duplex: "half",
@@ -109,10 +103,7 @@ const config = createConfig({
   publicClient,
   walletClient,
   storage,
-  relayers: {
-    [myMainnet.id]: web(),
-    [mySepolia.id]: web(),
-  },
+  relayers: { [myMainnet.id]: web(), [mySepolia.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);

--- a/docs/gitbook/src/guides/check-balances.md
+++ b/docs/gitbook/src/guides/check-balances.md
@@ -194,13 +194,7 @@ const {
   data: balance,
   isLoading,
   error,
-} = useConfidentialBalance(
-  {
-    address: "0xToken",
-    account: address,
-  },
-  { refetchInterval: 5_000 },
-);
+} = useConfidentialBalance({ address: "0xToken", account: address }, { refetchInterval: 5_000 });
 ```
 
 {% endtab %}
@@ -238,14 +232,10 @@ import { zamaQueryKeys } from "@zama-fhe/sdk/query";
 const queryClient = useQueryClient();
 
 // Invalidate all balance queries
-queryClient.invalidateQueries({
-  queryKey: zamaQueryKeys.confidentialBalance.all,
-});
+queryClient.invalidateQueries({ queryKey: zamaQueryKeys.confidentialBalance.all });
 
 // Invalidate one token
-queryClient.invalidateQueries({
-  queryKey: zamaQueryKeys.confidentialBalance.token("0xToken"),
-});
+queryClient.invalidateQueries({ queryKey: zamaQueryKeys.confidentialBalance.token("0xToken") });
 ```
 
 {% endtab %}

--- a/docs/gitbook/src/guides/configuration.md
+++ b/docs/gitbook/src/guides/configuration.md
@@ -94,10 +94,7 @@ const publicClient = createPublicClient({
   chain: sepolia,
   transport: http("https://sepolia.infura.io/v3/YOUR_KEY"),
 });
-const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
+const walletClient = createWalletClient({ chain: sepolia, transport: custom(window.ethereum!) });
 ```
 
 {% endtab %}
@@ -142,10 +139,7 @@ const myMainnet = {
 const zamaConfig = createZamaConfig({
   chains: [mySepolia, myMainnet],
   wagmiConfig,
-  relayers: {
-    [mySepolia.id]: web(),
-    [myMainnet.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web(), [myMainnet.id]: web() },
 });
 ```
 
@@ -171,10 +165,7 @@ const config = createConfig({
   chains: [mySepolia, myMainnet],
   publicClient,
   walletClient,
-  relayers: {
-    [mySepolia.id]: web(),
-    [myMainnet.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web(), [myMainnet.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -197,9 +188,7 @@ const mySepolia = {
 const config = createConfig({
   chains: [mySepolia],
   ethereum: window.ethereum!,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -224,9 +213,7 @@ const config = createConfig({
   publicClient,
   walletClient,
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -252,9 +239,7 @@ const config = createConfig({
   signer: myCustomSigner, // implements GenericSigner
   provider: myCustomProvider, // implements GenericProvider
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -284,9 +269,7 @@ const config = createConfig({
   walletClient,
   storage: indexedDBStorage,
   permitStorage: chromeSessionStorage,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -376,10 +359,7 @@ const config = createConfig({
   chains: [mySepolia, myMainnet],
   publicClient,
   walletClient,
-  relayers: {
-    [mySepolia.id]: sharedWeb,
-    [myMainnet.id]: sharedWeb,
-  },
+  relayers: { [mySepolia.id]: sharedWeb, [myMainnet.id]: sharedWeb },
 });
 ```
 

--- a/docs/gitbook/src/guides/delegated-decryption.md
+++ b/docs/gitbook/src/guides/delegated-decryption.md
@@ -37,9 +37,7 @@ const { txHash } = await sdk.delegations.delegateDecryption({
 // 2. Wait 1–2 minutes for gateway propagation
 
 // 3. Delegate reads the delegator's balance
-const balance = await token.decryptBalanceAs({
-  delegatorAddress: "0xDelegator",
-});
+const balance = await token.decryptBalanceAs({ delegatorAddress: "0xDelegator" });
 ```
 
 {% endtab %}
@@ -94,9 +92,7 @@ The delegate calls `token.decryptBalanceAs` to read the delegator's balance. The
 {% tab title="SDK" %}
 
 ```ts
-const balance = await token.decryptBalanceAs({
-  delegatorAddress: "0xDelegator",
-});
+const balance = await token.decryptBalanceAs({ delegatorAddress: "0xDelegator" });
 ```
 
 {% endtab %}
@@ -125,9 +121,7 @@ import { Token } from "@zama-fhe/sdk";
 
 const tokens = addresses.map((a) => sdk.createToken(a));
 
-const balances = await Token.batchDecryptBalancesAs(tokens, {
-  delegatorAddress: "0xDelegator",
-});
+const balances = await Token.batchDecryptBalancesAs(tokens, { delegatorAddress: "0xDelegator" });
 
 // balances is a Map<Address, bigint>
 for (const [address, balance] of balances) {
@@ -190,9 +184,7 @@ try {
 }
 
 try {
-  const balance = await token.decryptBalanceAs({
-    delegatorAddress: "0xDelegator",
-  });
+  const balance = await token.decryptBalanceAs({ delegatorAddress: "0xDelegator" });
 } catch (error) {
   if (error instanceof SigningRejectedError) {
     // user cancelled the wallet prompt — do not retry automatically

--- a/docs/gitbook/src/guides/local-development.md
+++ b/docs/gitbook/src/guides/local-development.md
@@ -39,9 +39,7 @@ const config = createConfig({
   publicClient,
   walletClient,
   storage: memoryStorage,
-  relayers: {
-    [hardhat.id]: cleartext(),
-  },
+  relayers: { [hardhat.id]: cleartext() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -87,9 +85,7 @@ const config = createConfig({
   chains: [myHardhat],
   publicClient,
   walletClient,
-  relayers: {
-    [myHardhat.id]: cleartext(),
-  },
+  relayers: { [myHardhat.id]: cleartext() },
 });
 
 const sdk = new ZamaSDK(config);

--- a/docs/gitbook/src/guides/migrate-v2-to-v3.md
+++ b/docs/gitbook/src/guides/migrate-v2-to-v3.md
@@ -172,9 +172,7 @@ const auth = RELAYER_API_KEY
 
 const relayer = new RelayerNode({
   getChainId: async () => sepolia.id,
-  transports: {
-    [sepolia.id]: { network: SEPOLIA_RPC_URL, ...(auth && { auth }) },
-  },
+  transports: { [sepolia.id]: { network: SEPOLIA_RPC_URL, ...(auth && { auth }) } },
 });
 
 using sdk = new ZamaSDK({ relayer, signer, storage: new MemoryStorage() });
@@ -192,9 +190,7 @@ import { node } from "@zama-fhe/sdk/node";
 const zamaSepolia = {
   ...sepolia,
   network: SEPOLIA_RPC_URL,
-  ...(RELAYER_API_KEY && {
-    auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY },
-  }),
+  ...(RELAYER_API_KEY && { auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY } }),
 } as const satisfies FheChain;
 
 using sdk = new ZamaSDK(
@@ -587,12 +583,7 @@ import { useUserDecrypt } from "@zama-fhe/react-sdk";
 const [handles, setHandles] = useState<{ handle: string; contractAddress: `0x${string}` }[]>([]);
 const { data: decrypted } = useUserDecrypt({ handles });
 
-const handle = (await sdk.signer.readContract({
-  address,
-  abi,
-  functionName,
-  args,
-})) as string;
+const handle = (await sdk.signer.readContract({ address, abi, functionName, args })) as string;
 setHandles([{ handle, contractAddress }]);
 // read result:
 decrypted?.[handles[0].handle];

--- a/docs/gitbook/src/guides/nextjs-ssr.md
+++ b/docs/gitbook/src/guides/nextjs-ssr.md
@@ -56,10 +56,7 @@ import { web } from "@zama-fhe/sdk/web";
 import { createConfig as createZamaConfig } from "@zama-fhe/react-sdk/wagmi";
 import { sepolia as sepoliaFhe, type FheChain } from "@zama-fhe/sdk/chains";
 
-const wagmiConfig = createConfig({
-  chains: [sepolia],
-  transports: { [sepolia.id]: http() },
-});
+const wagmiConfig = createConfig({ chains: [sepolia], transports: { [sepolia.id]: http() } });
 
 const mySepolia = {
   ...sepoliaFhe,

--- a/docs/gitbook/src/guides/node-js-backend.md
+++ b/docs/gitbook/src/guides/node-js-backend.md
@@ -34,11 +34,7 @@ import { sepolia as sepoliaViem } from "viem/chains";
 
 const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
 const publicClient = createPublicClient({ chain: sepoliaViem, transport: http() });
-const walletClient = createWalletClient({
-  account,
-  chain: sepoliaViem,
-  transport: http(),
-});
+const walletClient = createWalletClient({ account, chain: sepoliaViem, transport: http() });
 
 const mySepolia = {
   ...sepolia,
@@ -51,9 +47,7 @@ const config = createConfig({
   publicClient,
   walletClient,
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -83,9 +77,7 @@ app.post("/api/transfer", (req, res) => {
       publicClient,
       walletClient,
       storage: asyncLocalStorage,
-      relayers: {
-        [mySepolia.id]: node(),
-      },
+      relayers: { [mySepolia.id]: node() },
     });
     const sdk = new ZamaSDK(config);
     const token = sdk.createToken("0xTokenAddress");
@@ -168,9 +160,7 @@ const config = createConfig({
   signer: myRelayerSigner, // GenericSigner backed by your relayer
   provider: myRpcProvider, // GenericProvider backed by an RPC client
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);

--- a/docs/gitbook/src/guides/shield-tokens.md
+++ b/docs/gitbook/src/guides/shield-tokens.md
@@ -92,9 +92,7 @@ console.log("Shield tx:", txHash);
 ```tsx
 import { useShield } from "@zama-fhe/react-sdk";
 
-const { mutateAsync: shield, isPending } = useShield({
-  address: "0xWrapperAddress",
-});
+const { mutateAsync: shield, isPending } = useShield({ address: "0xWrapperAddress" });
 
 const { txHash } = await shield({ amount: 1000n });
 ```
@@ -171,13 +169,7 @@ console.log("Confirmed in block:", receipt.blockNumber);
 {% tab title="React" %}
 
 ```tsx
-const {
-  mutateAsync: shield,
-  isPending,
-  isSuccess,
-} = useShield({
-  address: "0xWrapperAddress",
-});
+const { mutateAsync: shield, isPending, isSuccess } = useShield({ address: "0xWrapperAddress" });
 
 // isPending is true while the transaction is in flight
 // isSuccess flips to true when the mutation completes

--- a/docs/gitbook/src/guides/transfer-privately.md
+++ b/docs/gitbook/src/guides/transfer-privately.md
@@ -56,10 +56,7 @@ const { mutateAsync: transfer, isPending } = useConfidentialTransfer({
   address: "0xEncryptedERC20Address",
 });
 
-const { txHash } = await transfer({
-  to: "0xRecipientAddress",
-  amount: 500n,
-});
+const { txHash } = await transfer({ to: "0xRecipientAddress", amount: 500n });
 ```
 
 {% endtab %}
@@ -90,11 +87,7 @@ import { useConfidentialTransferFrom } from "@zama-fhe/react-sdk";
 
 const { mutateAsync: transferFrom } = useConfidentialTransferFrom("0xEncryptedERC20Address");
 
-await transferFrom({
-  from: "0xOwnerAddress",
-  to: "0xRecipientAddress",
-  amount: 500n,
-});
+await transferFrom({ from: "0xOwnerAddress", to: "0xRecipientAddress", amount: 500n });
 ```
 
 {% endtab %}
@@ -131,9 +124,7 @@ const {
   isPending, // true while the transaction is in flight
   isSuccess, // true after the mutation completes
   error, // populated if the transfer fails
-} = useConfidentialTransfer({
-  address: "0xEncryptedERC20Address",
-});
+} = useConfidentialTransfer({ address: "0xEncryptedERC20Address" });
 
 // Balance caches are invalidated automatically on success.
 // The useConfidentialBalance hook picks up the updated balance
@@ -157,13 +148,7 @@ const TOKEN = "0xEncryptedERC20Address";
 function TransferForm() {
   const { address } = useAccount();
   const { data: balance } = useConfidentialBalance({ address: TOKEN, account: address });
-  const {
-    mutateAsync: transfer,
-    isPending,
-    error,
-  } = useConfidentialTransfer({
-    address: TOKEN,
-  });
+  const { mutateAsync: transfer, isPending, error } = useConfidentialTransfer({ address: TOKEN });
 
   const handleTransfer = async () => {
     await transfer({ to: "0xRecipient", amount: 100n });

--- a/docs/gitbook/src/guides/web-extensions.md
+++ b/docs/gitbook/src/guides/web-extensions.md
@@ -55,9 +55,7 @@ const sdk = new ZamaSDK(config);
 {
   "manifest_version": 3,
   "permissions": ["storage"],
-  "background": {
-    "service_worker": "background.js"
-  }
+  "background": { "service_worker": "background.js" }
 }
 ```
 

--- a/docs/gitbook/src/reference/react/ZamaProvider.md
+++ b/docs/gitbook/src/reference/react/ZamaProvider.md
@@ -41,9 +41,7 @@ const mySepolia = {
 const zamaConfig = createZamaConfig({
   chains: [mySepolia],
   wagmiConfig,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 const queryClient = new QueryClient();
 
@@ -76,10 +74,7 @@ const publicClient = createPublicClient({
   chain: sepolia,
   transport: http("https://sepolia.infura.io/v3/YOUR_KEY"),
 });
-const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
+const walletClient = createWalletClient({ chain: sepolia, transport: custom(window.ethereum!) });
 
 const mySepolia = {
   ...sepoliaFhe,
@@ -90,9 +85,7 @@ const zamaConfig = createConfig({
   chains: [mySepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 const queryClient = new QueryClient();
 
@@ -121,9 +114,7 @@ const zamaConfig = createConfig({
   chains: [hardhat],
   publicClient,
   walletClient,
-  relayers: {
-    [hardhat.id]: cleartext(),
-  },
+  relayers: { [hardhat.id]: cleartext() },
 });
 const queryClient = new QueryClient();
 

--- a/docs/gitbook/src/reference/react/query-keys.md
+++ b/docs/gitbook/src/reference/react/query-keys.md
@@ -27,9 +27,7 @@ const queryClient = useQueryClient();
 queryClient.invalidateQueries({ queryKey: zamaQueryKeys.confidentialBalance.all });
 
 // Invalidate one token's balances
-queryClient.invalidateQueries({
-  queryKey: zamaQueryKeys.confidentialBalance.token("0xToken"),
-});
+queryClient.invalidateQueries({ queryKey: zamaQueryKeys.confidentialBalance.token("0xToken") });
 
 // Invalidate a specific owner's balance
 queryClient.invalidateQueries({
@@ -112,9 +110,7 @@ import { zamaQueryKeys } from "@zama-fhe/sdk/query";
 
 ```tsx
 // After a transfer made outside the SDK
-queryClient.invalidateQueries({
-  queryKey: zamaQueryKeys.confidentialBalance.token("0xToken"),
-});
+queryClient.invalidateQueries({ queryKey: zamaQueryKeys.confidentialBalance.token("0xToken") });
 ```
 
 ### Prefetch balances on hover

--- a/docs/gitbook/src/reference/react/useConfidentialBalance.md
+++ b/docs/gitbook/src/reference/react/useConfidentialBalance.md
@@ -28,10 +28,7 @@ function TokenBalance({ tokenAddress }: { tokenAddress: `0x${string}` }) {
     data: balance,
     isLoading,
     error,
-  } = useConfidentialBalance({
-    address: tokenAddress,
-    account: address,
-  });
+  } = useConfidentialBalance({ address: tokenAddress, account: address });
 
   if (isLoading) return <span>Decrypting...</span>;
   if (error) return <span>Error: {error.message}</span>;
@@ -60,10 +57,7 @@ const myMainnet = {
 
 export const zamaConfig = createConfig({
   chains: [mySepolia, myMainnet],
-  relayers: {
-    [mySepolia.id]: web(),
-    [myMainnet.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web(), [myMainnet.id]: web() },
   wagmiConfig,
 });
 ```
@@ -87,10 +81,7 @@ Contract address of the confidential token.
 {% tab title="component.tsx" %}
 
 ```tsx
-const { data } = useConfidentialBalance({
-  address: "0xToken",
-  account: address,
-});
+const { data } = useConfidentialBalance({ address: "0xToken", account: address });
 ```
 
 {% endtab %}
@@ -111,10 +102,7 @@ Address whose balance to read. The query is disabled while `undefined`. Pass the
 import { useAccount } from "wagmi";
 
 const { address } = useAccount();
-const { data } = useConfidentialBalance({
-  address: "0xToken",
-  account: address,
-});
+const { data } = useConfidentialBalance({ address: "0xToken", account: address });
 ```
 
 {% endtab %}

--- a/docs/gitbook/src/reference/react/useConfidentialIsOperator.md
+++ b/docs/gitbook/src/reference/react/useConfidentialIsOperator.md
@@ -95,11 +95,7 @@ function OperatorCheck({
   holder: `0x${string}`;
   spender: `0x${string}`;
 }) {
-  const { data: isOperator } = useConfidentialIsOperatorSuspense({
-    tokenAddress,
-    holder,
-    spender,
-  });
+  const { data: isOperator } = useConfidentialIsOperatorSuspense({ tokenAddress, holder, spender });
 
   // data is always defined — no loading state needed
   return <span>{isOperator ? "Approved" : "Not approved"}</span>;

--- a/docs/gitbook/src/reference/react/useConfidentialSetOperator.md
+++ b/docs/gitbook/src/reference/react/useConfidentialSetOperator.md
@@ -61,9 +61,7 @@ const { mutateAsync: setOperator } = useConfidentialSetOperator("0xToken");
 Address of the operator to approve.
 
 ```ts
-await setOperator({
-  operator: "0xDEX",
-});
+await setOperator({ operator: "0xDEX" });
 ```
 
 ---
@@ -77,10 +75,7 @@ Unix timestamp (seconds) when the approval expires. Defaults to 1 hour from now.
 ```ts
 const oneDay = Math.floor(Date.now() / 1000) + 86_400;
 
-await setOperator({
-  operator: "0xDEX",
-  until: oneDay,
-});
+await setOperator({ operator: "0xDEX", until: oneDay });
 ```
 
 ## Return Type

--- a/docs/gitbook/src/reference/react/useConfidentialTokenAddress.md
+++ b/docs/gitbook/src/reference/react/useConfidentialTokenAddress.md
@@ -22,9 +22,7 @@ import { useConfidentialTokenAddress } from "@zama-fhe/react-sdk";
 import { useConfidentialTokenAddress } from "@zama-fhe/react-sdk";
 
 function LookupWrapper({ tokenAddress }: { tokenAddress: `0x${string}` }) {
-  const { data, isLoading, error } = useConfidentialTokenAddress({
-    tokenAddress,
-  });
+  const { data, isLoading, error } = useConfidentialTokenAddress({ tokenAddress });
 
   if (isLoading) return <p>Looking up...</p>;
   if (error) return <p>Error: {error.message}</p>;

--- a/docs/gitbook/src/reference/react/useConfidentialTransfer.md
+++ b/docs/gitbook/src/reference/react/useConfidentialTransfer.md
@@ -22,15 +22,10 @@ import { useConfidentialTransfer } from "@zama-fhe/react-sdk";
 import { useConfidentialTransfer } from "@zama-fhe/react-sdk";
 
 function SendButton({ tokenAddress }: { tokenAddress: `0x${string}` }) {
-  const { mutateAsync: transfer, isPending } = useConfidentialTransfer({
-    address: tokenAddress,
-  });
+  const { mutateAsync: transfer, isPending } = useConfidentialTransfer({ address: tokenAddress });
 
   async function handleSend() {
-    const { txHash, receipt } = await transfer({
-      to: "0xRecipient",
-      amount: 1000n,
-    });
+    const { txHash, receipt } = await transfer({ to: "0xRecipient", amount: 1000n });
     console.log("Confirmed in block", receipt.blockNumber);
   }
 
@@ -89,9 +84,7 @@ Contract address of the confidential token.
 {% tab title="component.tsx" %}
 
 ```tsx
-const { mutateAsync: transfer } = useConfidentialTransfer({
-  address: "0xToken",
-});
+const { mutateAsync: transfer } = useConfidentialTransfer({ address: "0xToken" });
 ```
 
 {% endtab %}
@@ -104,10 +97,7 @@ const { mutateAsync: transfer } = useConfidentialTransfer({
 Default: `false`. When `true`, optimistically subtracts the transfer amount from the cached confidential balance before the transaction confirms; rolls back on error.
 
 ```tsx
-const { mutateAsync: transfer } = useConfidentialTransfer({
-  address: "0xToken",
-  optimistic: true,
-});
+const { mutateAsync: transfer } = useConfidentialTransfer({ address: "0xToken", optimistic: true });
 ```
 
 ---

--- a/docs/gitbook/src/reference/react/useConfidentialTransferFrom.md
+++ b/docs/gitbook/src/reference/react/useConfidentialTransferFrom.md
@@ -120,11 +120,7 @@ Number of tokens to transfer (in the token's smallest unit). Encrypted before su
 {% tab title="component.tsx" %}
 
 ```tsx
-await transferFrom({
-  from: "0xOwner",
-  to: "0xRecipient",
-  amount: 500n,
-});
+await transferFrom({ from: "0xOwner", to: "0xRecipient", amount: 500n });
 ```
 
 {% endtab %}

--- a/docs/gitbook/src/reference/react/useDecryptBalanceAs.md
+++ b/docs/gitbook/src/reference/react/useDecryptBalanceAs.md
@@ -85,10 +85,7 @@ The address that delegated decryption rights.
 The address whose on-chain balance to read. Defaults to `delegatorAddress`. Use this when the balance holder differs from the delegator.
 
 ```ts
-await decryptAs({
-  delegatorAddress: "0xDelegator",
-  accountAddress: "0xBalanceHolder",
-});
+await decryptAs({ delegatorAddress: "0xDelegator", accountAddress: "0xBalanceHolder" });
 ```
 
 ## Return Type

--- a/docs/gitbook/src/reference/react/useDelegateDecryption.md
+++ b/docs/gitbook/src/reference/react/useDelegateDecryption.md
@@ -76,10 +76,7 @@ The address to grant decryption rights to.
 When the delegation expires. If omitted, the delegation is permanent.
 
 ```ts
-await delegate({
-  delegateAddress: "0xDelegate",
-  expirationDate: new Date("2025-12-31"),
-});
+await delegate({ delegateAddress: "0xDelegate", expirationDate: new Date("2025-12-31") });
 ```
 
 ## Return Type

--- a/docs/gitbook/src/reference/react/useHasPermit.md
+++ b/docs/gitbook/src/reference/react/useHasPermit.md
@@ -80,9 +80,7 @@ function GatedDecrypt({
 Contract addresses to check credentials against. Returns `true` only when stored permits cover **all** specified addresses.
 
 ```tsx
-const { data: hasPermit } = useHasPermit({
-  contractAddresses: ["0xContractA", "0xContractB"],
-});
+const { data: hasPermit } = useHasPermit({ contractAddresses: ["0xContractA", "0xContractB"] });
 ```
 
 An empty list is a no-op: the query is disabled and `data` stays `undefined`, so you can call the hook unconditionally even when there is nothing to check yet.

--- a/docs/gitbook/src/reference/react/useIsConfidentialTokenValid.md
+++ b/docs/gitbook/src/reference/react/useIsConfidentialTokenValid.md
@@ -26,9 +26,7 @@ function ValidityCheck({ confidentialTokenAddress }: { confidentialTokenAddress:
     data: isValid,
     isLoading,
     error,
-  } = useIsConfidentialTokenValid({
-    confidentialTokenAddress,
-  });
+  } = useIsConfidentialTokenValid({ confidentialTokenAddress });
 
   if (isLoading) return <p>Checking...</p>;
   if (error) return <p>Error: {error.message}</p>;

--- a/docs/gitbook/src/reference/react/useListPairs.md
+++ b/docs/gitbook/src/reference/react/useListPairs.md
@@ -24,11 +24,7 @@ import { useListPairs } from "@zama-fhe/react-sdk";
 import { useListPairs } from "@zama-fhe/react-sdk";
 
 function TokenPairList() {
-  const { data, isLoading, error } = useListPairs({
-    page: 1,
-    pageSize: 20,
-    metadata: true,
-  });
+  const { data, isLoading, error } = useListPairs({ page: 1, pageSize: 20, metadata: true });
 
   if (isLoading) return <p>Loading pairs...</p>;
   if (error) return <p>Error: {error.message}</p>;

--- a/docs/gitbook/src/reference/react/useShield.md
+++ b/docs/gitbook/src/reference/react/useShield.md
@@ -81,9 +81,7 @@ import { type UseShieldConfig } from "@zama-fhe/react-sdk";
 Address of the confidential wrapper contract.
 
 ```ts
-const { mutateAsync: shield } = useShield({
-  address: "0xWrapper",
-});
+const { mutateAsync: shield } = useShield({ address: "0xWrapper" });
 ```
 
 ### optimistic
@@ -93,10 +91,7 @@ const { mutateAsync: shield } = useShield({
 Default: `false`. When `true`, optimistically adds the wrapped amount to the cached confidential balance before the transaction confirms; rolls back on error.
 
 ```ts
-const { mutateAsync: shield } = useShield({
-  address: "0xWrapper",
-  optimistic: true,
-});
+const { mutateAsync: shield } = useShield({ address: "0xWrapper", optimistic: true });
 ```
 
 ---

--- a/docs/gitbook/src/reference/react/useTokenAddress.md
+++ b/docs/gitbook/src/reference/react/useTokenAddress.md
@@ -22,9 +22,7 @@ import { useTokenAddress } from "@zama-fhe/react-sdk";
 import { useTokenAddress } from "@zama-fhe/react-sdk";
 
 function ReverseLookup({ confidentialTokenAddress }: { confidentialTokenAddress: `0x${string}` }) {
-  const { data, isLoading, error } = useTokenAddress({
-    confidentialTokenAddress,
-  });
+  const { data, isLoading, error } = useTokenAddress({ confidentialTokenAddress });
 
   if (isLoading) return <p>Looking up...</p>;
   if (error) return <p>Error: {error.message}</p>;

--- a/docs/gitbook/src/reference/react/useTokenPairsSlice.md
+++ b/docs/gitbook/src/reference/react/useTokenPairsSlice.md
@@ -22,14 +22,7 @@ import { useTokenPairsSlice } from "@zama-fhe/react-sdk";
 import { useTokenPairsSlice } from "@zama-fhe/react-sdk";
 
 function PairSlice() {
-  const {
-    data: pairs,
-    isLoading,
-    error,
-  } = useTokenPairsSlice({
-    fromIndex: 0n,
-    toIndex: 10n,
-  });
+  const { data: pairs, isLoading, error } = useTokenPairsSlice({ fromIndex: 0n, toIndex: 10n });
 
   if (isLoading) return <p>Loading...</p>;
   if (error) return <p>Error: {error.message}</p>;

--- a/docs/gitbook/src/reference/react/useUnderlyingAllowance.md
+++ b/docs/gitbook/src/reference/react/useUnderlyingAllowance.md
@@ -28,10 +28,7 @@ function AllowanceDisplay({
   wrapperAddress: `0x${string}`;
   owner: `0x${string}` | undefined;
 }) {
-  const { data: allowance, isLoading } = useUnderlyingAllowance({
-    address: wrapperAddress,
-    owner,
-  });
+  const { data: allowance, isLoading } = useUnderlyingAllowance({ address: wrapperAddress, owner });
 
   if (isLoading) return <span>Loading allowance...</span>;
   return <span>Allowance: {allowance?.toString() ?? "0"}</span>;
@@ -50,10 +47,7 @@ function AllowanceDisplay({
 Address of the confidential wrapper contract. The hook reads the underlying ERC-20 allowance granted by `owner` to this wrapper.
 
 ```ts
-const { data: allowance } = useUnderlyingAllowance({
-  address: "0xWrapper",
-  owner: "0xOwner",
-});
+const { data: allowance } = useUnderlyingAllowance({ address: "0xWrapper", owner: "0xOwner" });
 ```
 
 ---
@@ -65,10 +59,7 @@ const { data: allowance } = useUnderlyingAllowance({
 Address whose allowance to read. The query is disabled while `undefined`.
 
 ```ts
-const { data: allowance } = useUnderlyingAllowance({
-  address: "0xWrapper",
-  owner: "0xOwner",
-});
+const { data: allowance } = useUnderlyingAllowance({ address: "0xWrapper", owner: "0xOwner" });
 ```
 
 ## Return Type
@@ -92,10 +83,7 @@ function Allowance({
   wrapperAddress: `0x${string}`;
   owner: `0x${string}`;
 }) {
-  const { data: allowance } = useUnderlyingAllowanceSuspense({
-    address: wrapperAddress,
-    owner,
-  });
+  const { data: allowance } = useUnderlyingAllowanceSuspense({ address: wrapperAddress, owner });
 
   // data is always defined — no loading state needed
   return <span>Allowance: {allowance.toString()}</span>;

--- a/docs/gitbook/src/reference/react/useWrapperDiscovery.md
+++ b/docs/gitbook/src/reference/react/useWrapperDiscovery.md
@@ -26,10 +26,7 @@ function WrapperInfo({ tokenAddress }: { tokenAddress: `0x${string}` }) {
     data: wrapperAddress,
     isLoading,
     error,
-  } = useWrapperDiscovery({
-    tokenAddress,
-    erc20Address: "0xUSDC",
-  });
+  } = useWrapperDiscovery({ tokenAddress, erc20Address: "0xUSDC" });
 
   if (isLoading) return <p>Discovering wrapper...</p>;
   if (error) return <p>Error: {error.message}</p>;
@@ -56,10 +53,7 @@ Address of any confidential token you control. Used to scope the query cache key
 Address of the ERC-20 token to discover the wrapper for. Pass `undefined` to disable the query.
 
 ```ts
-useWrapperDiscovery({
-  tokenAddress: "0xConfidentialToken",
-  erc20Address: "0xUSDC",
-});
+useWrapperDiscovery({ tokenAddress: "0xConfidentialToken", erc20Address: "0xUSDC" });
 ```
 
 ## Return Type

--- a/docs/gitbook/src/reference/sdk/EthersProvider.md
+++ b/docs/gitbook/src/reference/sdk/EthersProvider.md
@@ -53,9 +53,7 @@ Pass exactly one of the two parameters below.
 Pre-built ethers provider (e.g. `JsonRpcProvider`, `WebSocketProvider`).
 
 ```ts
-const provider = new EthersProvider({
-  provider: new JsonRpcProvider(rpcUrl),
-});
+const provider = new EthersProvider({ provider: new JsonRpcProvider(rpcUrl) });
 ```
 
 ---
@@ -67,9 +65,7 @@ const provider = new EthersProvider({
 Raw EIP-1193 provider from the browser wallet. The adapter wraps it in a `BrowserProvider` internally.
 
 ```ts
-const provider = new EthersProvider({
-  ethereum: window.ethereum!,
-});
+const provider = new EthersProvider({ ethereum: window.ethereum! });
 ```
 
 ## Methods

--- a/docs/gitbook/src/reference/sdk/EthersSigner.md
+++ b/docs/gitbook/src/reference/sdk/EthersSigner.md
@@ -55,9 +55,7 @@ Pass exactly one of the two parameters below.
 Raw EIP-1193 provider from the browser wallet (e.g. `window.ethereum`). Enables automatic credential cleanup on disconnect and account change.
 
 ```ts
-const signer = new EthersSigner({
-  ethereum: window.ethereum!,
-});
+const signer = new EthersSigner({ ethereum: window.ethereum! });
 ```
 
 ---
@@ -72,9 +70,7 @@ Ethers signer for server-side or scripted use. `subscribe()` is not available in
 const provider = new JsonRpcProvider(rpcUrl);
 const wallet = new Wallet(privateKey, provider);
 
-const signer = new EthersSigner({
-  signer: wallet,
-});
+const signer = new EthersSigner({ signer: wallet });
 ```
 
 ## Methods

--- a/docs/gitbook/src/reference/sdk/FheArtifactCache.md
+++ b/docs/gitbook/src/reference/sdk/FheArtifactCache.md
@@ -35,9 +35,7 @@ const config = createConfig({
   chains: [sepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: web(),
-  },
+  relayers: { [sepolia.id]: web() },
 });
 ```
 
@@ -78,9 +76,7 @@ const config = createConfig({
   chains: [sepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [sepolia.id]: node({ poolSize: 4 }) },
 });
 ```
 

--- a/docs/gitbook/src/reference/sdk/RelayerCleartext.md
+++ b/docs/gitbook/src/reference/sdk/RelayerCleartext.md
@@ -31,9 +31,7 @@ const config = createConfig({
   chains: [hardhat],
   publicClient,
   walletClient,
-  relayers: {
-    [hardhat.id]: cleartext(),
-  },
+  relayers: { [hardhat.id]: cleartext() },
 });
 ```
 

--- a/docs/gitbook/src/reference/sdk/RelayerNode.md
+++ b/docs/gitbook/src/reference/sdk/RelayerNode.md
@@ -25,9 +25,7 @@ const config = createConfig({
   chains: [sepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [sepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);

--- a/docs/gitbook/src/reference/sdk/RelayerWeb.md
+++ b/docs/gitbook/src/reference/sdk/RelayerWeb.md
@@ -31,9 +31,7 @@ const config = createConfig({
   chains: [sepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: web(),
-  },
+  relayers: { [sepolia.id]: web() },
 });
 ```
 
@@ -44,10 +42,7 @@ const config = createConfig({
 import { RelayerWeb } from "@zama-fhe/sdk/web";
 import { sepolia } from "@zama-fhe/sdk/chains";
 
-const relayer = new RelayerWeb({
-  chain: sepolia,
-  worker: relayerWorkerClient,
-});
+const relayer = new RelayerWeb({ chain: sepolia, worker: relayerWorkerClient });
 ```
 
 {% endtab %}

--- a/docs/gitbook/src/reference/sdk/ViemProvider.md
+++ b/docs/gitbook/src/reference/sdk/ViemProvider.md
@@ -41,9 +41,7 @@ You rarely need to instantiate `ViemProvider` directly. The viem `createConfig` 
 Viem public client for reading chain data.
 
 ```ts
-const provider = new ViemProvider({
-  publicClient,
-});
+const provider = new ViemProvider({ publicClient });
 ```
 
 ## Methods

--- a/docs/gitbook/src/reference/sdk/ViemSigner.md
+++ b/docs/gitbook/src/reference/sdk/ViemSigner.md
@@ -20,10 +20,7 @@ import { createWalletClient, custom } from "viem";
 import { sepolia } from "viem/chains";
 import { ViemSigner } from "@zama-fhe/sdk/viem";
 
-const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
+const walletClient = createWalletClient({ chain: sepolia, transport: custom(window.ethereum!) });
 
 const signer = new ViemSigner({ walletClient, ethereum: window.ethereum });
 ```
@@ -41,9 +38,7 @@ You rarely need to instantiate `ViemSigner` directly. The viem `createConfig` bu
 Viem wallet client for signing transactions and typed data.
 
 ```ts
-const signer = new ViemSigner({
-  walletClient,
-});
+const signer = new ViemSigner({ walletClient });
 ```
 
 ---
@@ -55,10 +50,7 @@ const signer = new ViemSigner({
 Raw EIP-1193 provider for wallet lifecycle event subscriptions. When provided, the signer emits wallet account transitions on disconnect, account change, and chain change. Omit if you handle lifecycle events manually.
 
 ```ts
-const signer = new ViemSigner({
-  walletClient,
-  ethereum: window.ethereum,
-});
+const signer = new ViemSigner({ walletClient, ethereum: window.ethereum });
 ```
 
 ## Methods

--- a/docs/gitbook/src/reference/sdk/ZamaSDK.md
+++ b/docs/gitbook/src/reference/sdk/ZamaSDK.md
@@ -28,10 +28,7 @@ const config = createConfig({
   chains: [sepolia, mainnet],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: web(),
-    [mainnet.id]: web(),
-  },
+  relayers: { [sepolia.id]: web(), [mainnet.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);

--- a/docs/gitbook/src/reference/sdk/contract-builders.md
+++ b/docs/gitbook/src/reference/sdk/contract-builders.md
@@ -15,10 +15,7 @@ type ReadContractConfig = {
   args: readonly unknown[];
 };
 
-type WriteContractConfig = ReadContractConfig & {
-  value?: bigint;
-  gas?: bigint;
-};
+type WriteContractConfig = ReadContractConfig & { value?: bigint; gas?: bigint };
 ```
 
 {% hint style="warning" %}

--- a/docs/gitbook/src/reference/sdk/errors.md
+++ b/docs/gitbook/src/reference/sdk/errors.md
@@ -174,9 +174,7 @@ try {
 The wallet attempted to sign but failed for a reason other than user rejection — network issues, hardware wallet firmware problems, or RPC timeouts.
 
 ```ts
-matchZamaError(error, {
-  SIGNING_FAILED: (e) => console.error("Wallet signing error:", e.message),
-});
+matchZamaError(error, { SIGNING_FAILED: (e) => console.error("Wallet signing error:", e.message) });
 ```
 
 **How to handle:** Check wallet connectivity and firmware version. Retry after the underlying issue is resolved.
@@ -202,9 +200,7 @@ matchZamaError(error, {
 FHE decryption failed. Can occur after an interrupted unshield or when the transport key pair state is corrupted.
 
 ```ts
-matchZamaError(error, {
-  DECRYPTION_FAILED: () => showError("Decryption failed — try refreshing"),
-});
+matchZamaError(error, { DECRYPTION_FAILED: () => showError("Decryption failed — try refreshing") });
 ```
 
 **How to handle:** If this happens after a page reload during unshield, use `loadPendingUnshield()` and `resumeUnshield()` to recover. Otherwise, calling `sdk.permits.clear()` and retrying forces a fresh transport key pair.
@@ -315,9 +311,7 @@ try {
 Thrown when the SDK configuration is invalid (e.g. forbidden chain ID, unsupported signer type) or when the FHE worker fails to initialize (e.g. missing WASM support, terminated relayer).
 
 ```ts
-matchZamaError(error, {
-  CONFIGURATION: (e) => console.error("Configuration error:", e.message),
-});
+matchZamaError(error, { CONFIGURATION: (e) => console.error("Configuration error:", e.message) });
 ```
 
 **How to handle:** Check your transport config, CSP headers, and that the relayer has not been terminated. If the error mentions worker initialization, verify WASM support and `wasm-unsafe-eval` in your CSP.
@@ -438,9 +432,7 @@ matchZamaError(error, {
 No active delegation exists for the given `(delegator, delegate, contract)` tuple. Thrown when attempting to revoke a non-existent delegation, and by `decryptBalanceAs` / `batchDecryptBalancesAs` (including on cache hits) when the delegation is missing or has been revoked.
 
 ```ts
-matchZamaError(error, {
-  DELEGATION_NOT_FOUND: () => showError("No active delegation found"),
-});
+matchZamaError(error, { DELEGATION_NOT_FOUND: () => showError("No active delegation found") });
 ```
 
 **How to handle:** Verify the delegator, delegate, and contract addresses are correct.
@@ -537,9 +529,7 @@ matchZamaError(error, {
 Caught from the on-chain `EnforcedPause` revert. The ACL contract is paused, temporarily disabling all delegation operations.
 
 ```ts
-matchZamaError(error, {
-  ACL_PAUSED: () => showError("Delegation is temporarily disabled"),
-});
+matchZamaError(error, { ACL_PAUSED: () => showError("Delegation is temporarily disabled") });
 ```
 
 **How to handle:** Wait for the ACL contract to be unpaused. This is an operator-level action — contact the protocol team if this persists.

--- a/docs/gitbook/src/reference/sdk/event-decoders.md
+++ b/docs/gitbook/src/reference/sdk/event-decoders.md
@@ -37,10 +37,7 @@ import {
 Decodes an array of raw log entries into typed event objects. Each returned event has an `.eventName` discriminator.
 
 ```ts
-const logs = await publicClient.getLogs({
-  address: tokenAddress,
-  topics: [TOKEN_TOPICS],
-});
+const logs = await publicClient.getLogs({ address: tokenAddress, topics: [TOKEN_TOPICS] });
 
 const events = decodeOnChainEvents(logs);
 

--- a/docs/gitbook/src/reference/sdk/network-presets.md
+++ b/docs/gitbook/src/reference/sdk/network-presets.md
@@ -56,10 +56,7 @@ const config = createConfig({
   chains: [sepolia, mainnet],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: web(),
-    [mainnet.id]: web(),
-  },
+  relayers: { [sepolia.id]: web(), [mainnet.id]: web() },
 });
 ```
 
@@ -106,9 +103,7 @@ const config = createConfig({
   chains: [hardhat],
   publicClient,
   walletClient,
-  relayers: {
-    [hardhat.id]: cleartext(),
-  },
+  relayers: { [hardhat.id]: cleartext() },
 });
 ```
 
@@ -127,10 +122,7 @@ const myMainnet = { ...mainnet, relayerUrl: "/api/relayer/1" } as const satisfie
 const config = createConfig({
   chains: [mySepolia, myMainnet],
   wagmiConfig,
-  relayers: {
-    [mySepolia.id]: web(),
-    [myMainnet.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web(), [myMainnet.id]: web() },
 });
 ```
 

--- a/docs/gitbook/src/tutorials/first-confidential-dapp.md
+++ b/docs/gitbook/src/tutorials/first-confidential-dapp.md
@@ -52,9 +52,7 @@ import { sepolia as sepoliaFhe, type FheChain } from "@zama-fhe/sdk/chains";
 
 export const wagmiConfig = createConfig({
   chains: [sepolia],
-  transports: {
-    [sepolia.id]: http("https://sepolia.infura.io/v3/YOUR_KEY"),
-  },
+  transports: { [sepolia.id]: http("https://sepolia.infura.io/v3/YOUR_KEY") },
 });
 
 export const mySepolia = {
@@ -131,10 +129,7 @@ export function BalanceDisplay() {
     data: balance,
     isLoading,
     error,
-  } = useConfidentialBalance({
-    address: TOKEN_ADDRESS,
-    account: address,
-  });
+  } = useConfidentialBalance({ address: TOKEN_ADDRESS, account: address });
 
   if (error) return <p>Failed to load balance.</p>;
 
@@ -165,9 +160,7 @@ import { useShield } from "@zama-fhe/react-sdk";
 import { WRAPPER_ADDRESS } from "./config";
 
 export function ShieldForm() {
-  const { mutateAsync: shield, isPending } = useShield({
-    address: WRAPPER_ADDRESS,
-  });
+  const { mutateAsync: shield, isPending } = useShield({ address: WRAPPER_ADDRESS });
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -210,9 +203,7 @@ import { useConfidentialTransfer } from "@zama-fhe/react-sdk";
 import { TOKEN_ADDRESS } from "./config";
 
 export function TransferForm() {
-  const { mutateAsync: transfer, isPending } = useConfidentialTransfer({
-    address: TOKEN_ADDRESS,
-  });
+  const { mutateAsync: transfer, isPending } = useConfidentialTransfer({ address: TOKEN_ADDRESS });
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();

--- a/docs/gitbook/src/tutorials/quick-start.md
+++ b/docs/gitbook/src/tutorials/quick-start.md
@@ -79,9 +79,7 @@ import { sepolia as sepoliaFhe, type FheChain } from "@zama-fhe/sdk/chains";
 const wagmiConfig = createConfig({
   chains: [sepolia],
   connectors: [injected()],
-  transports: {
-    [sepolia.id]: http("https://sepolia.infura.io/v3/YOUR_KEY"),
-  },
+  transports: { [sepolia.id]: http("https://sepolia.infura.io/v3/YOUR_KEY") },
 });
 
 const mySepolia = {
@@ -125,10 +123,7 @@ const publicClient = createPublicClient({
   chain: sepolia,
   transport: http("https://sepolia.infura.io/v3/YOUR_KEY"),
 });
-const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
+const walletClient = createWalletClient({ chain: sepolia, transport: custom(window.ethereum!) });
 
 const mySepolia = {
   ...sepoliaFhe,
@@ -139,9 +134,7 @@ const config = createConfig({
   chains: [mySepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -164,9 +157,7 @@ const mySepolia = {
 const config = createConfig({
   chains: [mySepolia],
   ethereum: window.ethereum!,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -202,9 +193,7 @@ const config = createConfig({
   publicClient,
   walletClient,
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -229,9 +218,7 @@ const config = createConfig({
   chains: [mySepolia],
   signer: wallet,
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -271,9 +258,7 @@ function MyTokenPage() {
     address: WRAPPER,
     account: address,
   });
-  const { mutateAsync: shield, isPending: isShielding } = useShield({
-    address: WRAPPER,
-  });
+  const { mutateAsync: shield, isPending: isShielding } = useShield({ address: WRAPPER });
   const { mutateAsync: transfer, isPending: isSending } = useConfidentialTransfer({
     address: WRAPPER,
   });

--- a/docs/llm/corpus.config.json
+++ b/docs/llm/corpus.config.json
@@ -1,10 +1,7 @@
 {
   "schemaVersion": 1,
   "rawGithubBaseUrl": "https://raw.githubusercontent.com/zama-ai/sdk/prerelease",
-  "docs": {
-    "root": "docs/gitbook/src",
-    "summary": "docs/gitbook/src/SUMMARY.md"
-  },
+  "docs": { "root": "docs/gitbook/src", "summary": "docs/gitbook/src/SUMMARY.md" },
   "examples": {
     "approved": [
       "example-hoodi",

--- a/examples/example-bnb/e2e/fixtures.ts
+++ b/examples/example-bnb/e2e/fixtures.ts
@@ -257,11 +257,7 @@ async function interceptRpc(page: Page, options: RpcOptions = {}) {
         const [tx = {}] = (req.params ?? []) as Array<{ to?: string; data?: string }>;
         return { jsonrpc: "2.0", id: req.id ?? 1, result: resolveEthCall(tx) };
       }
-      return {
-        jsonrpc: "2.0",
-        id: req.id ?? 1,
-        result: staticResults[req.method ?? ""] ?? null,
-      };
+      return { jsonrpc: "2.0", id: req.id ?? 1, result: staticResults[req.method ?? ""] ?? null };
     }
 
     await route.fulfill({

--- a/examples/example-bnb/playwright.config.ts
+++ b/examples/example-bnb/playwright.config.ts
@@ -3,10 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30_000,
-  use: {
-    baseURL: "http://localhost:3000",
-    trace: "on-first-retry",
-  },
+  use: { baseURL: "http://localhost:3000", trace: "on-first-retry" },
   webServer: {
     command: "npm run dev",
     url: "http://localhost:3000",
@@ -16,10 +13,5 @@ export default defineConfig({
     // interceptRpc route mock — tests must always go through the Playwright interceptor.
     env: { NEXT_PUBLIC_BSC_TESTNET_RPC_URL: "" },
   },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-  ],
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 });

--- a/examples/example-bnb/src/app/page.tsx
+++ b/examples/example-bnb/src/app/page.tsx
@@ -99,9 +99,7 @@ function SelectedTokenPanel({
   const queryClient = useQueryClient();
   const sdk = useZamaSDK();
 
-  const { data: isAllowed } = useHasPermit({
-    contractAddresses: [token.confidentialTokenAddress],
-  });
+  const { data: isAllowed } = useHasPermit({ contractAddresses: [token.confidentialTokenAddress] });
 
   const decimals = token.confidential.decimals;
   const erc20Decimals = token.underlying.decimals;
@@ -361,9 +359,7 @@ export default function Home() {
     setConnectError(null);
     setIsConnecting(true);
     try {
-      const accounts = (await ethereum.request({
-        method: "eth_requestAccounts",
-      })) as string[];
+      const accounts = (await ethereum.request({ method: "eth_requestAccounts" })) as string[];
 
       await handleSwitchToBnb();
       setAddress(accounts[0] ?? null);

--- a/examples/example-bnb/src/components/RevokeDelegationCard.tsx
+++ b/examples/example-bnb/src/components/RevokeDelegationCard.tsx
@@ -17,9 +17,7 @@ export function RevokeDelegationCard({
 }: RevokeDelegationCardProps) {
   const [delegateAddress, setDelegateAddress] = useState("");
 
-  const revoke = useRevokeDelegation(tokenAddress, {
-    onSuccess: () => setDelegateAddress(""),
-  });
+  const revoke = useRevokeDelegation(tokenAddress, { onSuccess: () => setDelegateAddress("") });
 
   function handleRevoke() {
     revoke.mutate({ delegateAddress: delegateAddress as Address });

--- a/examples/example-bnb/tsconfig.json
+++ b/examples/example-bnb/tsconfig.json
@@ -13,14 +13,8 @@
     "jsx": "react-jsx",
     "incremental": true,
     "target": "ES2020",
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": [
     "next-env.d.ts",

--- a/examples/example-hoodi/WALKTHROUGH.md
+++ b/examples/example-hoodi/WALKTHROUGH.md
@@ -421,10 +421,7 @@ transfer.mutate({
 // Unshield: 2 transactions (unwrap + finalizeUnwrap).
 // Amount is in confidential token units — use cTokenDecimals.
 // onFinalizing fires between the two transactions — use it to update the progress UI.
-unshield.mutate({
-  amount: parseUnits("2", cTokenDecimals),
-  onFinalizing: () => setStep(2),
-});
+unshield.mutate({ amount: parseUnits("2", cTokenDecimals), onFinalizing: () => setStep(2) });
 ```
 
 ### Delegation hooks

--- a/examples/example-hoodi/e2e/fixtures.ts
+++ b/examples/example-hoodi/e2e/fixtures.ts
@@ -256,11 +256,7 @@ async function interceptRpc(page: Page, options: RpcOptions = {}) {
         const [tx = {}] = (req.params ?? []) as Array<{ to?: string; data?: string }>;
         return { jsonrpc: "2.0", id: req.id ?? 1, result: resolveEthCall(tx) };
       }
-      return {
-        jsonrpc: "2.0",
-        id: req.id ?? 1,
-        result: staticResults[req.method ?? ""] ?? null,
-      };
+      return { jsonrpc: "2.0", id: req.id ?? 1, result: staticResults[req.method ?? ""] ?? null };
     }
 
     await route.fulfill({

--- a/examples/example-hoodi/playwright.config.ts
+++ b/examples/example-hoodi/playwright.config.ts
@@ -3,10 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30_000,
-  use: {
-    baseURL: "http://localhost:3000",
-    trace: "on-first-retry",
-  },
+  use: { baseURL: "http://localhost:3000", trace: "on-first-retry" },
   webServer: {
     command: "npm run dev",
     url: "http://localhost:3000",
@@ -16,10 +13,5 @@ export default defineConfig({
     // interceptRpc route mock — tests must always go through the Playwright interceptor.
     env: { NEXT_PUBLIC_HOODI_RPC_URL: "" },
   },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-  ],
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 });

--- a/examples/example-hoodi/src/app/page.tsx
+++ b/examples/example-hoodi/src/app/page.tsx
@@ -252,9 +252,7 @@ export default function Home() {
     setConnectError(null);
     setIsConnecting(true);
     try {
-      const accounts = (await ethereum.request({
-        method: "eth_requestAccounts",
-      })) as string[];
+      const accounts = (await ethereum.request({ method: "eth_requestAccounts" })) as string[];
 
       // Switch before setting address: both chainId and address are then known
       // when the first non-connect-screen render fires, avoiding a brief flash

--- a/examples/example-hoodi/src/components/RevokeDelegationCard.tsx
+++ b/examples/example-hoodi/src/components/RevokeDelegationCard.tsx
@@ -14,9 +14,7 @@ interface RevokeDelegationCardProps {
 export function RevokeDelegationCard({ tokenAddress, disabled }: RevokeDelegationCardProps) {
   const [delegateAddress, setDelegateAddress] = useState("");
 
-  const revoke = useRevokeDelegation(tokenAddress, {
-    onSuccess: () => setDelegateAddress(""),
-  });
+  const revoke = useRevokeDelegation(tokenAddress, { onSuccess: () => setDelegateAddress("") });
 
   function handleRevoke() {
     revoke.mutate({ delegateAddress: delegateAddress as Address });

--- a/examples/example-hoodi/tsconfig.json
+++ b/examples/example-hoodi/tsconfig.json
@@ -13,14 +13,8 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": [
     "next-env.d.ts",

--- a/examples/example-ingen/src/app/page.tsx
+++ b/examples/example-ingen/src/app/page.tsx
@@ -99,9 +99,7 @@ function SelectedTokenPanel({
   const queryClient = useQueryClient();
   const sdk = useZamaSDK();
 
-  const { data: isAllowed } = useHasPermit({
-    contractAddresses: [token.confidentialTokenAddress],
-  });
+  const { data: isAllowed } = useHasPermit({ contractAddresses: [token.confidentialTokenAddress] });
 
   const decimals = token.confidential.decimals;
   const erc20Decimals = token.underlying.decimals;
@@ -361,9 +359,7 @@ export default function Home() {
     setConnectError(null);
     setIsConnecting(true);
     try {
-      const accounts = (await ethereum.request({
-        method: "eth_requestAccounts",
-      })) as string[];
+      const accounts = (await ethereum.request({ method: "eth_requestAccounts" })) as string[];
 
       await handleSwitchToIngen();
       setAddress(accounts[0] ?? null);

--- a/examples/example-ingen/src/components/RevokeDelegationCard.tsx
+++ b/examples/example-ingen/src/components/RevokeDelegationCard.tsx
@@ -17,9 +17,7 @@ export function RevokeDelegationCard({
 }: RevokeDelegationCardProps) {
   const [delegateAddress, setDelegateAddress] = useState("");
 
-  const revoke = useRevokeDelegation(tokenAddress, {
-    onSuccess: () => setDelegateAddress(""),
-  });
+  const revoke = useRevokeDelegation(tokenAddress, { onSuccess: () => setDelegateAddress("") });
 
   function handleRevoke() {
     revoke.mutate({ delegateAddress: delegateAddress as Address });

--- a/examples/example-ingen/tsconfig.json
+++ b/examples/example-ingen/tsconfig.json
@@ -13,14 +13,8 @@
     "jsx": "react-jsx",
     "incremental": true,
     "target": "ES2020",
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": [
     "next-env.d.ts",

--- a/examples/node-ethers/WALKTHROUGH.md
+++ b/examples/node-ethers/WALKTHROUGH.md
@@ -66,9 +66,7 @@ It then derives a Zama Sepolia chain config from the SDK preset:
 const zamaSepolia = {
   ...sepolia,
   network: SEPOLIA_RPC_URL,
-  ...(RELAYER_API_KEY && {
-    auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY },
-  }),
+  ...(RELAYER_API_KEY && { auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY } }),
 } as const satisfies FheChain;
 ```
 
@@ -83,9 +81,7 @@ using sdkA = new ZamaSDK(
     chains: [zamaSepolia],
     signer: walletA,
     storage: new MemoryStorage(),
-    relayers: {
-      [zamaSepolia.id]: node(),
-    },
+    relayers: { [zamaSepolia.id]: node() },
   }),
 );
 ```

--- a/examples/node-ethers/src/index.ts
+++ b/examples/node-ethers/src/index.ts
@@ -55,9 +55,7 @@ async function main() {
   const zamaSepolia = {
     ...sepolia,
     network: SEPOLIA_RPC_URL,
-    ...(RELAYER_API_KEY && {
-      auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY },
-    }),
+    ...(RELAYER_API_KEY && { auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY } }),
   } as const satisfies FheChain;
 
   // Each SDK instance has its own signer and credential context.
@@ -70,9 +68,7 @@ async function main() {
       chains: [zamaSepolia],
       signer: walletA,
       storage: new MemoryStorage(),
-      relayers: {
-        [zamaSepolia.id]: node(),
-      },
+      relayers: { [zamaSepolia.id]: node() },
     }),
   );
   using sdkB = new ZamaSDK(
@@ -80,9 +76,7 @@ async function main() {
       chains: [zamaSepolia],
       signer: walletB,
       storage: new MemoryStorage(),
-      relayers: {
-        [zamaSepolia.id]: node(),
-      },
+      relayers: { [zamaSepolia.id]: node() },
     }),
   );
 

--- a/examples/node-viem/WALKTHROUGH.md
+++ b/examples/node-viem/WALKTHROUGH.md
@@ -72,9 +72,7 @@ It then derives an FHE Sepolia chain object from the SDK preset:
 const zamaSepolia = {
   ...sepolia,
   network: SEPOLIA_RPC_URL,
-  ...(RELAYER_API_KEY && {
-    auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY },
-  }),
+  ...(RELAYER_API_KEY && { auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY } }),
 } as const satisfies FheChain;
 ```
 
@@ -90,9 +88,7 @@ using sdkA = new ZamaSDK(
     publicClient,
     walletClient: walletClientA,
     storage: new MemoryStorage(),
-    relayers: {
-      [zamaSepolia.id]: node(),
-    },
+    relayers: { [zamaSepolia.id]: node() },
   }),
 );
 ```

--- a/examples/node-viem/src/index.ts
+++ b/examples/node-viem/src/index.ts
@@ -57,9 +57,7 @@ async function main() {
   const zamaSepolia = {
     ...sepolia,
     network: SEPOLIA_RPC_URL,
-    ...(RELAYER_API_KEY && {
-      auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY },
-    }),
+    ...(RELAYER_API_KEY && { auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY } }),
   } as const satisfies FheChain;
 
   // A single public client is shared for read operations.
@@ -80,9 +78,7 @@ async function main() {
       publicClient,
       walletClient: walletClientA,
       storage: new MemoryStorage(),
-      relayers: {
-        [zamaSepolia.id]: node(),
-      },
+      relayers: { [zamaSepolia.id]: node() },
     }),
   );
   using sdkB = new ZamaSDK(
@@ -91,9 +87,7 @@ async function main() {
       publicClient,
       walletClient: walletClientB,
       storage: new MemoryStorage(),
-      relayers: {
-        [zamaSepolia.id]: node(),
-      },
+      relayers: { [zamaSepolia.id]: node() },
     }),
   );
 

--- a/examples/react-ethers/WALKTHROUGH.md
+++ b/examples/react-ethers/WALKTHROUGH.md
@@ -143,11 +143,7 @@ shield.mutate({
 
 ```ts
 const transfer = useConfidentialTransfer({ address: tokenAddress }, { onSuccess });
-transfer.mutate({
-  to: recipient,
-  amount: parsedAmount,
-  onEncryptComplete: () => setStep(2),
-});
+transfer.mutate({ to: recipient, amount: parsedAmount, onEncryptComplete: () => setStep(2) });
 ```
 
 Two phases: encrypting the amount locally (step 1), then submitting the transaction (step 2). `onEncryptComplete` fires between them so the UI can update the button label.

--- a/examples/react-ethers/playwright.config.ts
+++ b/examples/react-ethers/playwright.config.ts
@@ -3,10 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30_000,
-  use: {
-    baseURL: "http://localhost:3000",
-    trace: "on-first-retry",
-  },
+  use: { baseURL: "http://localhost:3000", trace: "on-first-retry" },
   webServer: {
     command: "npm run dev",
     url: "http://localhost:3000",
@@ -16,10 +13,5 @@ export default defineConfig({
     // Without this, a dev's .env.local override would bypass the route mock.
     env: { NEXT_PUBLIC_SEPOLIA_RPC_URL: "" },
   },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-  ],
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 });

--- a/examples/react-ethers/src/app/page.tsx
+++ b/examples/react-ethers/src/app/page.tsx
@@ -102,9 +102,7 @@ function SelectedTokenPanel({
   const sdk = useZamaSDK();
 
   // Check whether cached credentials cover the selected confidential token.
-  const { data: isAllowed } = useHasPermit({
-    contractAddresses: [token.confidentialTokenAddress],
-  });
+  const { data: isAllowed } = useHasPermit({ contractAddresses: [token.confidentialTokenAddress] });
 
   const decimals = token.confidential.decimals;
   const erc20Decimals = token.underlying.decimals;
@@ -401,9 +399,7 @@ export default function Home() {
     setConnectError(null);
     setIsConnecting(true);
     try {
-      const accounts = (await ethereum.request({
-        method: "eth_requestAccounts",
-      })) as string[];
+      const accounts = (await ethereum.request({ method: "eth_requestAccounts" })) as string[];
 
       // Switch before setting address: both chainId and address are then known
       // when the first non-connect-screen render fires, avoiding a brief flash

--- a/examples/react-ethers/src/components/RevokeDelegationCard.tsx
+++ b/examples/react-ethers/src/components/RevokeDelegationCard.tsx
@@ -17,9 +17,7 @@ export function RevokeDelegationCard({
 }: RevokeDelegationCardProps) {
   const [delegateAddress, setDelegateAddress] = useState("");
 
-  const revoke = useRevokeDelegation(tokenAddress, {
-    onSuccess: () => setDelegateAddress(""),
-  });
+  const revoke = useRevokeDelegation(tokenAddress, { onSuccess: () => setDelegateAddress("") });
 
   function handleRevoke() {
     revoke.mutate({ delegateAddress: delegateAddress as Address });

--- a/examples/react-ethers/tsconfig.json
+++ b/examples/react-ethers/tsconfig.json
@@ -13,14 +13,8 @@
     "jsx": "react-jsx",
     "incremental": true,
     "target": "ES2020",
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": [
     "next-env.d.ts",

--- a/examples/react-turnkey-wallet/postcss.config.mjs
+++ b/examples/react-turnkey-wallet/postcss.config.mjs
@@ -1,7 +1,3 @@
-const config = {
-  plugins: {
-    "@tailwindcss/postcss": {},
-  },
-};
+const config = { plugins: { "@tailwindcss/postcss": {} } };
 
 export default config;

--- a/examples/react-turnkey-wallet/src/app/api/relayer/[...path]/route.ts
+++ b/examples/react-turnkey-wallet/src/app/api/relayer/[...path]/route.ts
@@ -42,9 +42,7 @@ async function proxy(request: NextRequest, path: string[]): Promise<Response> {
 
   return new Response(await upstream.text(), {
     status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("Content-Type") ?? "application/json",
-    },
+    headers: { "Content-Type": upstream.headers.get("Content-Type") ?? "application/json" },
   });
 }
 

--- a/examples/react-turnkey-wallet/src/app/layout.tsx
+++ b/examples/react-turnkey-wallet/src/app/layout.tsx
@@ -8,11 +8,7 @@ export const metadata: Metadata = {
   description: "Demo app for using Turnkey wallets with Zama FHE confidential tokens on Sepolia",
 };
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" className="h-full antialiased">
       <body className="min-h-full flex flex-col bg-zinc-50 dark:bg-zinc-950">

--- a/examples/react-turnkey-wallet/src/components/providers.tsx
+++ b/examples/react-turnkey-wallet/src/components/providers.tsx
@@ -65,10 +65,7 @@ function signatureToHex(signature: { r: string; s: string; v: string }): `0x${st
   return serializeSignature(signature, "hex") as `0x${string}`;
 }
 
-type EmbeddedEthereumAccount = WalletAccount & {
-  address: Address;
-  organizationId?: string;
-};
+type EmbeddedEthereumAccount = WalletAccount & { address: Address; organizationId?: string };
 
 function buildTurnkeyAccount(input: {
   walletAccount: EmbeddedEthereumAccount;
@@ -165,9 +162,7 @@ export function Providers({ children }: { children: ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <TurnkeyProvider
         config={turnkeyConfig}
-        callbacks={{
-          onError: (error) => console.error("Turnkey error:", error),
-        }}
+        callbacks={{ onError: (error) => console.error("Turnkey error:", error) }}
       >
         <TurnkeyZamaBridge>{children}</TurnkeyZamaBridge>
       </TurnkeyProvider>
@@ -257,10 +252,7 @@ function TurnkeyZamaBridge({ children }: { children: ReactNode }) {
           transport: http(RPC_URL),
         }) as WalletClient;
 
-        const nextPublicClient = createPublicClient({
-          chain: viemChain,
-          transport: http(RPC_URL),
-        });
+        const nextPublicClient = createPublicClient({ chain: viemChain, transport: http(RPC_URL) });
 
         if (!cancelled) {
           setWalletAddress(ethAccount.address as Address);

--- a/examples/react-turnkey-wallet/src/hooks/react-turnkey-wallet/use-pending-unshield.ts
+++ b/examples/react-turnkey-wallet/src/hooks/react-turnkey-wallet/use-pending-unshield.ts
@@ -42,9 +42,5 @@ export function usePendingUnshield(selectedPair: TokenWrapperPairWithMetadata | 
     setPendingUnshieldHash(null);
   }, [selectedPair]);
 
-  return {
-    pendingUnshieldHash,
-    setPendingUnshieldHash,
-    clearStoredPendingUnshield,
-  };
+  return { pendingUnshieldHash, setPendingUnshieldHash, clearStoredPendingUnshield };
 }

--- a/examples/react-turnkey-wallet/src/hooks/react-turnkey-wallet/use-token-pairs.ts
+++ b/examples/react-turnkey-wallet/src/hooks/react-turnkey-wallet/use-token-pairs.ts
@@ -22,10 +22,5 @@ export function useTokenPairs(selectedTokenAddressState: Address | null) {
     [selectedTokenAddress, validPairs],
   );
 
-  return {
-    isRegistryPending,
-    validPairs,
-    selectedTokenAddress,
-    selectedPair,
-  };
+  return { isRegistryPending, validPairs, selectedTokenAddress, selectedPair };
 }

--- a/examples/react-turnkey-wallet/tsconfig.json
+++ b/examples/react-turnkey-wallet/tsconfig.json
@@ -13,14 +13,8 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": [
     "next-env.d.ts",

--- a/examples/react-viem/WALKTHROUGH.md
+++ b/examples/react-viem/WALKTHROUGH.md
@@ -37,11 +37,7 @@ const zamaSepolia = {
   network: SEPOLIA_RPC_URL,
 } as const;
 
-const walletClient = createWalletClient({
-  account,
-  chain: sepolia,
-  transport: custom(ethereum),
-});
+const walletClient = createWalletClient({ account, chain: sepolia, transport: custom(ethereum) });
 const signer = ethereum ? new ViemSigner({ walletClient, ethereum }) : undefined;
 
 const zamaConfig = createConfig({
@@ -208,11 +204,7 @@ required.
 
 ```ts
 const transfer = useConfidentialTransfer({ address: tokenAddress }, { onSuccess });
-transfer.mutate({
-  to: recipient,
-  amount: parsedAmount,
-  onEncryptComplete: () => setStep(2),
-});
+transfer.mutate({ to: recipient, amount: parsedAmount, onEncryptComplete: () => setStep(2) });
 ```
 
 Two phases: encrypting the amount locally (step 1), then submitting the transaction (step 2). `onEncryptComplete` fires between them so the UI can update the button label.
@@ -320,9 +312,7 @@ shows a "Decrypt Balance" button rather than a balance value. This avoids blind-
 prompts on mount.
 
 ```ts
-const { data: hasPermit } = useHasPermit({
-  contractAddresses: [token.confidentialTokenAddress],
-});
+const { data: hasPermit } = useHasPermit({ contractAddresses: [token.confidentialTokenAddress] });
 // All registry pairs are passed at once — one signature covers all tokens,
 // so switching tokens does not prompt the wallet again.
 const grantPermits = useGrantPermit();

--- a/examples/react-viem/playwright.config.ts
+++ b/examples/react-viem/playwright.config.ts
@@ -3,10 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30_000,
-  use: {
-    baseURL: "http://localhost:3000",
-    trace: "on-first-retry",
-  },
+  use: { baseURL: "http://localhost:3000", trace: "on-first-retry" },
   webServer: {
     command: "npm run dev",
     url: "http://localhost:3000",
@@ -16,10 +13,5 @@ export default defineConfig({
     // Without this, a dev's .env.local override would bypass the route mock.
     env: { NEXT_PUBLIC_SEPOLIA_RPC_URL: "" },
   },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-  ],
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 });

--- a/examples/react-viem/src/app/page.tsx
+++ b/examples/react-viem/src/app/page.tsx
@@ -36,10 +36,7 @@ const MINT_ABI = parseAbi(["function mint(address to, uint256 amount)"]);
 
 // Routes ETH balance reads through the direct Sepolia RPC so polling is fast
 // and independent of the injected wallet's own RPC endpoint.
-const rpcClient = createPublicClient({
-  chain: sepolia,
-  transport: http(SEPOLIA_RPC_URL),
-});
+const rpcClient = createPublicClient({ chain: sepolia, transport: http(SEPOLIA_RPC_URL) });
 
 // Attempt to switch to Sepolia. If the network is unknown to the wallet (error 4902),
 // prompt to add it. Errors from wallet_switchEthereumChain (including 4001 user rejection)
@@ -90,9 +87,7 @@ function SelectedTokenPanel({
   const sdk = useZamaSDK();
 
   // Check whether cached credentials cover the selected confidential token.
-  const { data: isAllowed } = useHasPermit({
-    contractAddresses: [token.confidentialTokenAddress],
-  });
+  const { data: isAllowed } = useHasPermit({ contractAddresses: [token.confidentialTokenAddress] });
 
   const decimals = token.confidential.decimals;
   const erc20Decimals = token.underlying.decimals;
@@ -388,9 +383,7 @@ export default function Home() {
     setConnectError(null);
     setIsConnecting(true);
     try {
-      const accounts = (await ethereum.request({
-        method: "eth_requestAccounts",
-      })) as string[];
+      const accounts = (await ethereum.request({ method: "eth_requestAccounts" })) as string[];
 
       const currentChainId = (await ethereum.request({ method: "eth_chainId" })) as string;
       setAddress(accounts[0] ?? null);

--- a/examples/react-viem/src/components/RevokeDelegationCard.tsx
+++ b/examples/react-viem/src/components/RevokeDelegationCard.tsx
@@ -17,9 +17,7 @@ export function RevokeDelegationCard({
 }: RevokeDelegationCardProps) {
   const [delegateAddress, setDelegateAddress] = useState("");
 
-  const revoke = useRevokeDelegation(tokenAddress, {
-    onSuccess: () => setDelegateAddress(""),
-  });
+  const revoke = useRevokeDelegation(tokenAddress, { onSuccess: () => setDelegateAddress("") });
 
   function handleRevoke() {
     revoke.mutate({ delegateAddress: delegateAddress as Address });

--- a/examples/react-viem/src/providers.tsx
+++ b/examples/react-viem/src/providers.tsx
@@ -134,10 +134,7 @@ export function Providers({ children }: { children: ReactNode }) {
   // SEPOLIA_RPC_URL overrides the default RPC if NEXT_PUBLIC_SEPOLIA_RPC_URL is set.
   const zamaConfig = useMemo(() => {
     const ethereum = getEthereumProvider();
-    const publicClient = createPublicClient({
-      chain: sepolia,
-      transport: http(SEPOLIA_RPC_URL),
-    });
+    const publicClient = createPublicClient({ chain: sepolia, transport: http(SEPOLIA_RPC_URL) });
     const provider = new ViemProvider({ publicClient });
     const zamaSepolia = {
       ...fheSepolia,

--- a/examples/react-viem/tsconfig.json
+++ b/examples/react-viem/tsconfig.json
@@ -13,14 +13,8 @@
     "jsx": "react-jsx",
     "incremental": true,
     "target": "ES2020",
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": [
     "next-env.d.ts",

--- a/examples/react-wagmi/WALKTHROUGH.md
+++ b/examples/react-wagmi/WALKTHROUGH.md
@@ -210,9 +210,7 @@ shows a "Decrypt Balance" button rather than a balance value. This avoids blind-
 prompts on mount.
 
 ```ts
-const { data: hasPermit } = useHasPermit({
-  contractAddresses: [token.confidentialTokenAddress],
-});
+const { data: hasPermit } = useHasPermit({ contractAddresses: [token.confidentialTokenAddress] });
 // All registry pairs are passed at once to useGrantPermit — one signature covers all tokens,
 // so switching tokens does not prompt the wallet again.
 const grantPermits = useGrantPermit();

--- a/examples/react-wagmi/e2e/fixtures.ts
+++ b/examples/react-wagmi/e2e/fixtures.ts
@@ -148,10 +148,7 @@ function resolveEthCall(params: unknown[] | undefined, options: RpcOptions): str
 
   if (to === MULTICALL3 && sel === "0x82ad56cb") {
     try {
-      const { args } = decodeFunctionData({
-        abi: MULTICALL3_ABI,
-        data: data as Hex,
-      });
+      const { args } = decodeFunctionData({ abi: MULTICALL3_ABI, data: data as Hex });
       const [calls] = args;
       const results = calls.map((call) => ({
         success: true,

--- a/examples/react-wagmi/e2e/network.spec.ts
+++ b/examples/react-wagmi/e2e/network.spec.ts
@@ -8,11 +8,7 @@ test.describe("wrong network screen", () => {
     // accounts: [] → shows connect screen on load.
     // chainId: WRONG_CHAIN_ID → after connecting, wagmi reads eth_chainId = WRONG_CHAIN_ID
     //   → chainId !== SEPOLIA_CHAIN_ID → Screen 2 ("Sepolia Network Required") renders.
-    await mockWallet({
-      accounts: [],
-      chainId: WRONG_CHAIN_ID,
-      requestAccounts: [TEST_ADDRESS],
-    });
+    await mockWallet({ accounts: [], chainId: WRONG_CHAIN_ID, requestAccounts: [TEST_ADDRESS] });
     await page.goto("/");
     await page.getByRole("button", { name: "Connect Wallet" }).click({ force: true });
   });

--- a/examples/react-wagmi/playwright.config.ts
+++ b/examples/react-wagmi/playwright.config.ts
@@ -3,10 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30_000,
-  use: {
-    baseURL: "http://localhost:3000",
-    trace: "on-first-retry",
-  },
+  use: { baseURL: "http://localhost:3000", trace: "on-first-retry" },
   webServer: {
     command: "npm run dev",
     url: "http://localhost:3000",
@@ -16,10 +13,5 @@ export default defineConfig({
     // Without this, a dev's .env.local override would bypass the route mock.
     env: { NEXT_PUBLIC_SEPOLIA_RPC_URL: "" },
   },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-  ],
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 });

--- a/examples/react-wagmi/src/app/page.tsx
+++ b/examples/react-wagmi/src/app/page.tsx
@@ -265,9 +265,7 @@ function TokenWorkspace({ address, token, validPairs, refetchEth }: TokenWorkspa
 
   // Check whether cached credentials cover the selected confidential token.
   // This component only mounts once a token is selected, so no placeholder address is needed.
-  const { data: isAllowed } = useHasPermit({
-    contractAddresses: [token.confidentialTokenAddress],
-  });
+  const { data: isAllowed } = useHasPermit({ contractAddresses: [token.confidentialTokenAddress] });
 
   // Metadata for the selected token pair is sourced directly from the registry response
   // (useListPairs with metadata: true), removing separate metadata queries.

--- a/examples/react-wagmi/src/components/RevokeDelegationCard.tsx
+++ b/examples/react-wagmi/src/components/RevokeDelegationCard.tsx
@@ -17,9 +17,7 @@ export function RevokeDelegationCard({
 }: RevokeDelegationCardProps) {
   const [delegateAddress, setDelegateAddress] = useState("");
 
-  const revoke = useRevokeDelegation(tokenAddress, {
-    onSuccess: () => setDelegateAddress(""),
-  });
+  const revoke = useRevokeDelegation(tokenAddress, { onSuccess: () => setDelegateAddress("") });
 
   function handleRevoke() {
     revoke.mutate({ delegateAddress: delegateAddress as Address });

--- a/examples/react-wagmi/tsconfig.json
+++ b/examples/react-wagmi/tsconfig.json
@@ -13,14 +13,8 @@
     "jsx": "react-jsx",
     "incremental": true,
     "target": "ES2020",
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": [
     "next-env.d.ts",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -232,9 +232,7 @@ import { sepolia as sepoliaFhe, type FheChain } from "@zama-fhe/sdk/chains";
 const wagmiConfig = createConfig({
   chains: [sepolia],
   connectors: [injected()],
-  transports: {
-    [sepolia.id]: http("https://sepolia.infura.io/v3/YOUR_KEY"),
-  },
+  transports: { [sepolia.id]: http("https://sepolia.infura.io/v3/YOUR_KEY") },
 });
 
 const mySepolia = {
@@ -277,10 +275,7 @@ const publicClient = createPublicClient({
   chain: sepolia,
   transport: http("https://sepolia.infura.io/v3/YOUR_KEY"),
 });
-const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
+const walletClient = createWalletClient({ chain: sepolia, transport: custom(window.ethereum!) });
 
 const mySepolia = {
   ...sepoliaFhe,
@@ -291,9 +286,7 @@ const config = createConfig({
   chains: [mySepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -315,9 +308,7 @@ const mySepolia = {
 const config = createConfig({
   chains: [mySepolia],
   ethereum: window.ethereum!,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -352,9 +343,7 @@ const config = createConfig({
   publicClient,
   walletClient,
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -378,9 +367,7 @@ const config = createConfig({
   chains: [mySepolia],
   signer: wallet,
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -419,9 +406,7 @@ function MyTokenPage() {
     address: WRAPPER,
     account: address,
   });
-  const { mutateAsync: shield, isPending: isShielding } = useShield({
-    address: WRAPPER,
-  });
+  const { mutateAsync: shield, isPending: isShielding } = useShield({ address: WRAPPER });
   const { mutateAsync: transfer, isPending: isSending } = useConfidentialTransfer({
     address: WRAPPER,
   });
@@ -632,9 +617,7 @@ import { sepolia as sepoliaFhe, type FheChain } from "@zama-fhe/sdk/chains";
 
 export const wagmiConfig = createConfig({
   chains: [sepolia],
-  transports: {
-    [sepolia.id]: http("https://sepolia.infura.io/v3/YOUR_KEY"),
-  },
+  transports: { [sepolia.id]: http("https://sepolia.infura.io/v3/YOUR_KEY") },
 });
 
 export const mySepolia = {
@@ -707,10 +690,7 @@ export function BalanceDisplay() {
     data: balance,
     isLoading,
     error,
-  } = useConfidentialBalance({
-    address: TOKEN_ADDRESS,
-    account: address,
-  });
+  } = useConfidentialBalance({ address: TOKEN_ADDRESS, account: address });
 
   if (error) return <p>Failed to load balance.</p>;
 
@@ -739,9 +719,7 @@ import { useShield } from "@zama-fhe/react-sdk";
 import { WRAPPER_ADDRESS } from "./config";
 
 export function ShieldForm() {
-  const { mutateAsync: shield, isPending } = useShield({
-    address: WRAPPER_ADDRESS,
-  });
+  const { mutateAsync: shield, isPending } = useShield({ address: WRAPPER_ADDRESS });
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -782,9 +760,7 @@ import { useConfidentialTransfer } from "@zama-fhe/react-sdk";
 import { TOKEN_ADDRESS } from "./config";
 
 export function TransferForm() {
-  const { mutateAsync: transfer, isPending } = useConfidentialTransfer({
-    address: TOKEN_ADDRESS,
-  });
+  const { mutateAsync: transfer, isPending } = useConfidentialTransfer({ address: TOKEN_ADDRESS });
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -1556,9 +1532,7 @@ const auth = RELAYER_API_KEY
 
 const relayer = new RelayerNode({
   getChainId: async () => sepolia.id,
-  transports: {
-    [sepolia.id]: { network: SEPOLIA_RPC_URL, ...(auth && { auth }) },
-  },
+  transports: { [sepolia.id]: { network: SEPOLIA_RPC_URL, ...(auth && { auth }) } },
 });
 
 using sdk = new ZamaSDK({ relayer, signer, storage: new MemoryStorage() });
@@ -1575,9 +1549,7 @@ import { node } from "@zama-fhe/sdk/node";
 const zamaSepolia = {
   ...sepolia,
   network: SEPOLIA_RPC_URL,
-  ...(RELAYER_API_KEY && {
-    auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY },
-  }),
+  ...(RELAYER_API_KEY && { auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY } }),
 } as const satisfies FheChain;
 
 using sdk = new ZamaSDK(
@@ -1964,12 +1936,7 @@ import { useUserDecrypt } from "@zama-fhe/react-sdk";
 const [handles, setHandles] = useState<{ handle: string; contractAddress: `0x${string}` }[]>([]);
 const { data: decrypted } = useUserDecrypt({ handles });
 
-const handle = (await sdk.signer.readContract({
-  address,
-  abi,
-  functionName,
-  args,
-})) as string;
+const handle = (await sdk.signer.readContract({ address, abi, functionName, args })) as string;
 setHandles([{ handle, contractAddress }]);
 // read result:
 decrypted?.[handles[0].handle];
@@ -2226,10 +2193,7 @@ const publicClient = createPublicClient({
   chain: sepolia,
   transport: http("https://sepolia.infura.io/v3/YOUR_KEY"),
 });
-const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
+const walletClient = createWalletClient({ chain: sepolia, transport: custom(window.ethereum!) });
 ```
 
 ### Tab: ethers
@@ -2271,10 +2235,7 @@ const myMainnet = {
 const zamaConfig = createZamaConfig({
   chains: [mySepolia, myMainnet],
   wagmiConfig,
-  relayers: {
-    [mySepolia.id]: web(),
-    [myMainnet.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web(), [myMainnet.id]: web() },
 });
 ```
 
@@ -2299,10 +2260,7 @@ const config = createConfig({
   chains: [mySepolia, myMainnet],
   publicClient,
   walletClient,
-  relayers: {
-    [mySepolia.id]: web(),
-    [myMainnet.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web(), [myMainnet.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -2324,9 +2282,7 @@ const mySepolia = {
 const config = createConfig({
   chains: [mySepolia],
   ethereum: window.ethereum!,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -2350,9 +2306,7 @@ const config = createConfig({
   publicClient,
   walletClient,
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -2377,9 +2331,7 @@ const config = createConfig({
   signer: myCustomSigner, // implements GenericSigner
   provider: myCustomProvider, // implements GenericProvider
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -2408,9 +2360,7 @@ const config = createConfig({
   walletClient,
   storage: indexedDBStorage,
   permitStorage: chromeSessionStorage,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -2498,10 +2448,7 @@ const config = createConfig({
   chains: [mySepolia, myMainnet],
   publicClient,
   walletClient,
-  relayers: {
-    [mySepolia.id]: sharedWeb,
-    [myMainnet.id]: sharedWeb,
-  },
+  relayers: { [mySepolia.id]: sharedWeb, [myMainnet.id]: sharedWeb },
 });
 ```
 
@@ -2561,10 +2508,7 @@ const app = express();
 app.use(express.json());
 
 // Map chain IDs to their network config
-const Configs: Record<number, typeof mainnet> = {
-  [mainnet.id]: mainnet,
-  [sepolia.id]: sepolia,
-};
+const Configs: Record<number, typeof mainnet> = { [mainnet.id]: mainnet, [sepolia.id]: sepolia };
 
 app.use("/api/relayer/:chainId", async (req, res) => {
   const config = Configs[Number(req.params.chainId)];
@@ -2578,10 +2522,7 @@ app.use("/api/relayer/:chainId", async (req, res) => {
 
   const response = await fetch(url, {
     method: req.method,
-    headers: {
-      "content-type": "application/json",
-      "x-api-key": process.env.RELAYER_API_KEY!,
-    },
+    headers: { "content-type": "application/json", "x-api-key": process.env.RELAYER_API_KEY! },
     body,
     // @ts-expect-error: required by the relayer
     duplex: "half",
@@ -2628,10 +2569,7 @@ const config = createConfig({
   publicClient,
   walletClient,
   storage,
-  relayers: {
-    [myMainnet.id]: web(),
-    [mySepolia.id]: web(),
-  },
+  relayers: { [myMainnet.id]: web(), [mySepolia.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -2863,9 +2801,7 @@ console.log("Shield tx:", txHash);
 ```tsx
 import { useShield } from "@zama-fhe/react-sdk";
 
-const { mutateAsync: shield, isPending } = useShield({
-  address: "0xWrapperAddress",
-});
+const { mutateAsync: shield, isPending } = useShield({ address: "0xWrapperAddress" });
 
 const { txHash } = await shield({ amount: 1000n });
 ```
@@ -2933,13 +2869,7 @@ console.log("Confirmed in block:", receipt.blockNumber);
 ### Tab: React
 
 ```tsx
-const {
-  mutateAsync: shield,
-  isPending,
-  isSuccess,
-} = useShield({
-  address: "0xWrapperAddress",
-});
+const { mutateAsync: shield, isPending, isSuccess } = useShield({ address: "0xWrapperAddress" });
 
 // isPending is true while the transaction is in flight
 // isSuccess flips to true when the mutation completes
@@ -3012,10 +2942,7 @@ const { mutateAsync: transfer, isPending } = useConfidentialTransfer({
   address: "0xEncryptedERC20Address",
 });
 
-const { txHash } = await transfer({
-  to: "0xRecipientAddress",
-  amount: 500n,
-});
+const { txHash } = await transfer({ to: "0xRecipientAddress", amount: 500n });
 ```
 
 
@@ -3043,11 +2970,7 @@ import { useConfidentialTransferFrom } from "@zama-fhe/react-sdk";
 
 const { mutateAsync: transferFrom } = useConfidentialTransferFrom("0xEncryptedERC20Address");
 
-await transferFrom({
-  from: "0xOwnerAddress",
-  to: "0xRecipientAddress",
-  amount: 500n,
-});
+await transferFrom({ from: "0xOwnerAddress", to: "0xRecipientAddress", amount: 500n });
 ```
 
 
@@ -3081,9 +3004,7 @@ const {
   isPending, // true while the transaction is in flight
   isSuccess, // true after the mutation completes
   error, // populated if the transfer fails
-} = useConfidentialTransfer({
-  address: "0xEncryptedERC20Address",
-});
+} = useConfidentialTransfer({ address: "0xEncryptedERC20Address" });
 
 // Balance caches are invalidated automatically on success.
 // The useConfidentialBalance hook picks up the updated balance
@@ -3105,13 +3026,7 @@ const TOKEN = "0xEncryptedERC20Address";
 function TransferForm() {
   const { address } = useAccount();
   const { data: balance } = useConfidentialBalance({ address: TOKEN, account: address });
-  const {
-    mutateAsync: transfer,
-    isPending,
-    error,
-  } = useConfidentialTransfer({
-    address: TOKEN,
-  });
+  const { mutateAsync: transfer, isPending, error } = useConfidentialTransfer({ address: TOKEN });
 
   const handleTransfer = async () => {
     await transfer({ to: "0xRecipient", amount: 100n });
@@ -3557,13 +3472,7 @@ const {
   data: balance,
   isLoading,
   error,
-} = useConfidentialBalance(
-  {
-    address: "0xToken",
-    account: address,
-  },
-  { refetchInterval: 5_000 },
-);
+} = useConfidentialBalance({ address: "0xToken", account: address }, { refetchInterval: 5_000 });
 ```
 
 ### Tab: Multiple tokens
@@ -3598,14 +3507,10 @@ import { zamaQueryKeys } from "@zama-fhe/sdk/query";
 const queryClient = useQueryClient();
 
 // Invalidate all balance queries
-queryClient.invalidateQueries({
-  queryKey: zamaQueryKeys.confidentialBalance.all,
-});
+queryClient.invalidateQueries({ queryKey: zamaQueryKeys.confidentialBalance.all });
 
 // Invalidate one token
-queryClient.invalidateQueries({
-  queryKey: zamaQueryKeys.confidentialBalance.token("0xToken"),
-});
+queryClient.invalidateQueries({ queryKey: zamaQueryKeys.confidentialBalance.token("0xToken") });
 ```
 
 
@@ -3859,11 +3764,7 @@ import { sepolia as sepoliaViem } from "viem/chains";
 
 const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
 const publicClient = createPublicClient({ chain: sepoliaViem, transport: http() });
-const walletClient = createWalletClient({
-  account,
-  chain: sepoliaViem,
-  transport: http(),
-});
+const walletClient = createWalletClient({ account, chain: sepoliaViem, transport: http() });
 
 const mySepolia = {
   ...sepolia,
@@ -3876,9 +3777,7 @@ const config = createConfig({
   publicClient,
   walletClient,
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -3908,9 +3807,7 @@ app.post("/api/transfer", (req, res) => {
       publicClient,
       walletClient,
       storage: asyncLocalStorage,
-      relayers: {
-        [mySepolia.id]: node(),
-      },
+      relayers: { [mySepolia.id]: node() },
     });
     const sdk = new ZamaSDK(config);
     const token = sdk.createToken("0xTokenAddress");
@@ -3993,9 +3890,7 @@ const config = createConfig({
   signer: myRelayerSigner, // GenericSigner backed by your relayer
   provider: myRpcProvider, // GenericProvider backed by an RPC client
   storage: memoryStorage,
-  relayers: {
-    [mySepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [mySepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -4069,9 +3964,7 @@ const sdk = new ZamaSDK(config);
 {
   "manifest_version": 3,
   "permissions": ["storage"],
-  "background": {
-    "service_worker": "background.js"
-  }
+  "background": { "service_worker": "background.js" }
 }
 ```
 
@@ -4147,9 +4040,7 @@ const config = createConfig({
   publicClient,
   walletClient,
   storage: memoryStorage,
-  relayers: {
-    [hardhat.id]: cleartext(),
-  },
+  relayers: { [hardhat.id]: cleartext() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -4195,9 +4086,7 @@ const config = createConfig({
   chains: [myHardhat],
   publicClient,
   walletClient,
-  relayers: {
-    [myHardhat.id]: cleartext(),
-  },
+  relayers: { [myHardhat.id]: cleartext() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -4284,10 +4173,7 @@ import { web } from "@zama-fhe/sdk/web";
 import { createConfig as createZamaConfig } from "@zama-fhe/react-sdk/wagmi";
 import { sepolia as sepoliaFhe, type FheChain } from "@zama-fhe/sdk/chains";
 
-const wagmiConfig = createConfig({
-  chains: [sepolia],
-  transports: { [sepolia.id]: http() },
-});
+const wagmiConfig = createConfig({ chains: [sepolia], transports: { [sepolia.id]: http() } });
 
 const mySepolia = {
   ...sepoliaFhe,
@@ -4561,9 +4447,7 @@ const { txHash } = await sdk.delegations.delegateDecryption({
 // 2. Wait 1–2 minutes for gateway propagation
 
 // 3. Delegate reads the delegator's balance
-const balance = await token.decryptBalanceAs({
-  delegatorAddress: "0xDelegator",
-});
+const balance = await token.decryptBalanceAs({ delegatorAddress: "0xDelegator" });
 ```
 
 
@@ -4616,9 +4500,7 @@ The delegate calls `token.decryptBalanceAs` to read the delegator's balance. The
 ### Tab: SDK
 
 ```ts
-const balance = await token.decryptBalanceAs({
-  delegatorAddress: "0xDelegator",
-});
+const balance = await token.decryptBalanceAs({ delegatorAddress: "0xDelegator" });
 ```
 
 
@@ -4645,9 +4527,7 @@ import { Token } from "@zama-fhe/sdk";
 
 const tokens = addresses.map((a) => sdk.createToken(a));
 
-const balances = await Token.batchDecryptBalancesAs(tokens, {
-  delegatorAddress: "0xDelegator",
-});
+const balances = await Token.batchDecryptBalancesAs(tokens, { delegatorAddress: "0xDelegator" });
 
 // balances is a Map<Address, bigint>
 for (const [address, balance] of balances) {
@@ -4708,9 +4588,7 @@ try {
 }
 
 try {
-  const balance = await token.decryptBalanceAs({
-    delegatorAddress: "0xDelegator",
-  });
+  const balance = await token.decryptBalanceAs({ delegatorAddress: "0xDelegator" });
 } catch (error) {
   if (error instanceof SigningRejectedError) {
     // user cancelled the wallet prompt — do not retry automatically
@@ -5242,10 +5120,7 @@ const config = createConfig({
   chains: [sepolia, mainnet],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: web(),
-    [mainnet.id]: web(),
-  },
+  relayers: { [sepolia.id]: web(), [mainnet.id]: web() },
 });
 
 const sdk = new ZamaSDK(config);
@@ -6330,9 +6205,7 @@ const config = createConfig({
   chains: [sepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: web(),
-  },
+  relayers: { [sepolia.id]: web() },
 });
 ```
 
@@ -6342,10 +6215,7 @@ const config = createConfig({
 import { RelayerWeb } from "@zama-fhe/sdk/web";
 import { sepolia } from "@zama-fhe/sdk/chains";
 
-const relayer = new RelayerWeb({
-  chain: sepolia,
-  worker: relayerWorkerClient,
-});
+const relayer = new RelayerWeb({ chain: sepolia, worker: relayerWorkerClient });
 ```
 
 
@@ -6440,9 +6310,7 @@ const config = createConfig({
   chains: [sepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [sepolia.id]: node({ poolSize: 4 }) },
 });
 
 const sdk = new ZamaSDK(config);
@@ -6510,9 +6378,7 @@ const config = createConfig({
   chains: [hardhat],
   publicClient,
   walletClient,
-  relayers: {
-    [hardhat.id]: cleartext(),
-  },
+  relayers: { [hardhat.id]: cleartext() },
 });
 ```
 
@@ -6912,9 +6778,7 @@ const provider = new ViemProvider({ publicClient });
 Viem public client for reading chain data.
 
 ```ts
-const provider = new ViemProvider({
-  publicClient,
-});
+const provider = new ViemProvider({ publicClient });
 ```
 
 ## Methods
@@ -6952,10 +6816,7 @@ import { createWalletClient, custom } from "viem";
 import { sepolia } from "viem/chains";
 import { ViemSigner } from "@zama-fhe/sdk/viem";
 
-const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
+const walletClient = createWalletClient({ chain: sepolia, transport: custom(window.ethereum!) });
 
 const signer = new ViemSigner({ walletClient, ethereum: window.ethereum });
 ```
@@ -6974,9 +6835,7 @@ const signer = new ViemSigner({ walletClient, ethereum: window.ethereum });
 Viem wallet client for signing transactions and typed data.
 
 ```ts
-const signer = new ViemSigner({
-  walletClient,
-});
+const signer = new ViemSigner({ walletClient });
 ```
 
 ---
@@ -6988,10 +6847,7 @@ const signer = new ViemSigner({
 Raw EIP-1193 provider for wallet lifecycle event subscriptions. When provided, the signer emits wallet account transitions on disconnect, account change, and chain change. Omit if you handle lifecycle events manually.
 
 ```ts
-const signer = new ViemSigner({
-  walletClient,
-  ethereum: window.ethereum,
-});
+const signer = new ViemSigner({ walletClient, ethereum: window.ethereum });
 ```
 
 ## Methods
@@ -7072,9 +6928,7 @@ Pass exactly one of the two parameters below.
 Pre-built ethers provider (e.g. `JsonRpcProvider`, `WebSocketProvider`).
 
 ```ts
-const provider = new EthersProvider({
-  provider: new JsonRpcProvider(rpcUrl),
-});
+const provider = new EthersProvider({ provider: new JsonRpcProvider(rpcUrl) });
 ```
 
 ---
@@ -7086,9 +6940,7 @@ const provider = new EthersProvider({
 Raw EIP-1193 provider from the browser wallet. The adapter wraps it in a `BrowserProvider` internally.
 
 ```ts
-const provider = new EthersProvider({
-  ethereum: window.ethereum!,
-});
+const provider = new EthersProvider({ ethereum: window.ethereum! });
 ```
 
 ## Methods
@@ -7159,9 +7011,7 @@ Pass exactly one of the two parameters below.
 Raw EIP-1193 provider from the browser wallet (e.g. `window.ethereum`). Enables automatic credential cleanup on disconnect and account change.
 
 ```ts
-const signer = new EthersSigner({
-  ethereum: window.ethereum!,
-});
+const signer = new EthersSigner({ ethereum: window.ethereum! });
 ```
 
 ---
@@ -7176,9 +7026,7 @@ Ethers signer for server-side or scripted use. `subscribe()` is not available in
 const provider = new JsonRpcProvider(rpcUrl);
 const wallet = new Wallet(privateKey, provider);
 
-const signer = new EthersSigner({
-  signer: wallet,
-});
+const signer = new EthersSigner({ signer: wallet });
 ```
 
 ## Methods
@@ -7541,9 +7389,7 @@ try {
 The wallet attempted to sign but failed for a reason other than user rejection — network issues, hardware wallet firmware problems, or RPC timeouts.
 
 ```ts
-matchZamaError(error, {
-  SIGNING_FAILED: (e) => console.error("Wallet signing error:", e.message),
-});
+matchZamaError(error, { SIGNING_FAILED: (e) => console.error("Wallet signing error:", e.message) });
 ```
 
 **How to handle:** Check wallet connectivity and firmware version. Retry after the underlying issue is resolved.
@@ -7569,9 +7415,7 @@ matchZamaError(error, {
 FHE decryption failed. Can occur after an interrupted unshield or when the transport key pair state is corrupted.
 
 ```ts
-matchZamaError(error, {
-  DECRYPTION_FAILED: () => showError("Decryption failed — try refreshing"),
-});
+matchZamaError(error, { DECRYPTION_FAILED: () => showError("Decryption failed — try refreshing") });
 ```
 
 **How to handle:** If this happens after a page reload during unshield, use `loadPendingUnshield()` and `resumeUnshield()` to recover. Otherwise, calling `sdk.permits.clear()` and retrying forces a fresh transport key pair.
@@ -7682,9 +7526,7 @@ try {
 Thrown when the SDK configuration is invalid (e.g. forbidden chain ID, unsupported signer type) or when the FHE worker fails to initialize (e.g. missing WASM support, terminated relayer).
 
 ```ts
-matchZamaError(error, {
-  CONFIGURATION: (e) => console.error("Configuration error:", e.message),
-});
+matchZamaError(error, { CONFIGURATION: (e) => console.error("Configuration error:", e.message) });
 ```
 
 **How to handle:** Check your transport config, CSP headers, and that the relayer has not been terminated. If the error mentions worker initialization, verify WASM support and `wasm-unsafe-eval` in your CSP.
@@ -7805,9 +7647,7 @@ matchZamaError(error, {
 No active delegation exists for the given `(delegator, delegate, contract)` tuple. Thrown when attempting to revoke a non-existent delegation, and by `decryptBalanceAs` / `batchDecryptBalancesAs` (including on cache hits) when the delegation is missing or has been revoked.
 
 ```ts
-matchZamaError(error, {
-  DELEGATION_NOT_FOUND: () => showError("No active delegation found"),
-});
+matchZamaError(error, { DELEGATION_NOT_FOUND: () => showError("No active delegation found") });
 ```
 
 **How to handle:** Verify the delegator, delegate, and contract addresses are correct.
@@ -7904,9 +7744,7 @@ matchZamaError(error, {
 Caught from the on-chain `EnforcedPause` revert. The ACL contract is paused, temporarily disabling all delegation operations.
 
 ```ts
-matchZamaError(error, {
-  ACL_PAUSED: () => showError("Delegation is temporarily disabled"),
-});
+matchZamaError(error, { ACL_PAUSED: () => showError("Delegation is temporarily disabled") });
 ```
 
 **How to handle:** Wait for the ACL contract to be unpaused. This is an operator-level action — contact the protocol team if this persists.
@@ -7956,10 +7794,7 @@ type ReadContractConfig = {
   args: readonly unknown[];
 };
 
-type WriteContractConfig = ReadContractConfig & {
-  value?: bigint;
-  gas?: bigint;
-};
+type WriteContractConfig = ReadContractConfig & { value?: bigint; gas?: bigint };
 ```
 
 
@@ -8174,9 +8009,7 @@ const config = createConfig({
   chains: [sepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: web(),
-  },
+  relayers: { [sepolia.id]: web() },
 });
 ```
 
@@ -8215,9 +8048,7 @@ const config = createConfig({
   chains: [sepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: node({ poolSize: 4 }),
-  },
+  relayers: { [sepolia.id]: node({ poolSize: 4 }) },
 });
 ```
 
@@ -8383,10 +8214,7 @@ import {
 Decodes an array of raw log entries into typed event objects. Each returned event has an `.eventName` discriminator.
 
 ```ts
-const logs = await publicClient.getLogs({
-  address: tokenAddress,
-  topics: [TOKEN_TOPICS],
-});
+const logs = await publicClient.getLogs({ address: tokenAddress, topics: [TOKEN_TOPICS] });
 
 const events = decodeOnChainEvents(logs);
 
@@ -8878,10 +8706,7 @@ const config = createConfig({
   chains: [sepolia, mainnet],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: web(),
-    [mainnet.id]: web(),
-  },
+  relayers: { [sepolia.id]: web(), [mainnet.id]: web() },
 });
 ```
 
@@ -8928,9 +8753,7 @@ const config = createConfig({
   chains: [hardhat],
   publicClient,
   walletClient,
-  relayers: {
-    [hardhat.id]: cleartext(),
-  },
+  relayers: { [hardhat.id]: cleartext() },
 });
 ```
 
@@ -8949,10 +8772,7 @@ const myMainnet = { ...mainnet, relayerUrl: "/api/relayer/1" } as const satisfie
 const config = createConfig({
   chains: [mySepolia, myMainnet],
   wagmiConfig,
-  relayers: {
-    [mySepolia.id]: web(),
-    [myMainnet.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web(), [myMainnet.id]: web() },
 });
 ```
 
@@ -9070,9 +8890,7 @@ const mySepolia = {
 const zamaConfig = createZamaConfig({
   chains: [mySepolia],
   wagmiConfig,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 const queryClient = new QueryClient();
 
@@ -9104,10 +8922,7 @@ const publicClient = createPublicClient({
   chain: sepolia,
   transport: http("https://sepolia.infura.io/v3/YOUR_KEY"),
 });
-const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
+const walletClient = createWalletClient({ chain: sepolia, transport: custom(window.ethereum!) });
 
 const mySepolia = {
   ...sepoliaFhe,
@@ -9118,9 +8933,7 @@ const zamaConfig = createConfig({
   chains: [mySepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [mySepolia.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web() },
 });
 const queryClient = new QueryClient();
 
@@ -9148,9 +8961,7 @@ const zamaConfig = createConfig({
   chains: [hardhat],
   publicClient,
   walletClient,
-  relayers: {
-    [hardhat.id]: cleartext(),
-  },
+  relayers: { [hardhat.id]: cleartext() },
 });
 const queryClient = new QueryClient();
 
@@ -9215,10 +9026,7 @@ function TokenBalance({ tokenAddress }: { tokenAddress: `0x${string}` }) {
     data: balance,
     isLoading,
     error,
-  } = useConfidentialBalance({
-    address: tokenAddress,
-    account: address,
-  });
+  } = useConfidentialBalance({ address: tokenAddress, account: address });
 
   if (isLoading) return <span>Decrypting...</span>;
   if (error) return <span>Error: {error.message}</span>;
@@ -9246,10 +9054,7 @@ const myMainnet = {
 
 export const zamaConfig = createConfig({
   chains: [mySepolia, myMainnet],
-  relayers: {
-    [mySepolia.id]: web(),
-    [myMainnet.id]: web(),
-  },
+  relayers: { [mySepolia.id]: web(), [myMainnet.id]: web() },
   wagmiConfig,
 });
 ```
@@ -9271,10 +9076,7 @@ Contract address of the confidential token.
 ### Tab: component.tsx
 
 ```tsx
-const { data } = useConfidentialBalance({
-  address: "0xToken",
-  account: address,
-});
+const { data } = useConfidentialBalance({ address: "0xToken", account: address });
 ```
 
 
@@ -9293,10 +9095,7 @@ Address whose balance to read. The query is disabled while `undefined`. Pass the
 import { useAccount } from "wagmi";
 
 const { address } = useAccount();
-const { data } = useConfidentialBalance({
-  address: "0xToken",
-  account: address,
-});
+const { data } = useConfidentialBalance({ address: "0xToken", account: address });
 ```
 
 
@@ -9633,15 +9432,10 @@ import { useConfidentialTransfer } from "@zama-fhe/react-sdk";
 import { useConfidentialTransfer } from "@zama-fhe/react-sdk";
 
 function SendButton({ tokenAddress }: { tokenAddress: `0x${string}` }) {
-  const { mutateAsync: transfer, isPending } = useConfidentialTransfer({
-    address: tokenAddress,
-  });
+  const { mutateAsync: transfer, isPending } = useConfidentialTransfer({ address: tokenAddress });
 
   async function handleSend() {
-    const { txHash, receipt } = await transfer({
-      to: "0xRecipient",
-      amount: 1000n,
-    });
+    const { txHash, receipt } = await transfer({ to: "0xRecipient", amount: 1000n });
     console.log("Confirmed in block", receipt.blockNumber);
   }
 
@@ -9697,9 +9491,7 @@ Contract address of the confidential token.
 ### Tab: component.tsx
 
 ```tsx
-const { mutateAsync: transfer } = useConfidentialTransfer({
-  address: "0xToken",
-});
+const { mutateAsync: transfer } = useConfidentialTransfer({ address: "0xToken" });
 ```
 
 
@@ -9710,10 +9502,7 @@ const { mutateAsync: transfer } = useConfidentialTransfer({
 Default: `false`. When `true`, optimistically subtracts the transfer amount from the cached confidential balance before the transaction confirms; rolls back on error.
 
 ```tsx
-const { mutateAsync: transfer } = useConfidentialTransfer({
-  address: "0xToken",
-  optimistic: true,
-});
+const { mutateAsync: transfer } = useConfidentialTransfer({ address: "0xToken", optimistic: true });
 ```
 
 ---
@@ -9995,11 +9784,7 @@ Number of tokens to transfer (in the token's smallest unit). Encrypted before su
 ### Tab: component.tsx
 
 ```tsx
-await transferFrom({
-  from: "0xOwner",
-  to: "0xRecipient",
-  amount: 500n,
-});
+await transferFrom({ from: "0xOwner", to: "0xRecipient", amount: 500n });
 ```
 
 
@@ -10148,9 +9933,7 @@ import { type UseShieldConfig } from "@zama-fhe/react-sdk";
 Address of the confidential wrapper contract.
 
 ```ts
-const { mutateAsync: shield } = useShield({
-  address: "0xWrapper",
-});
+const { mutateAsync: shield } = useShield({ address: "0xWrapper" });
 ```
 
 ### optimistic
@@ -10160,10 +9943,7 @@ const { mutateAsync: shield } = useShield({
 Default: `false`. When `true`, optimistically adds the wrapped amount to the cached confidential balance before the transaction confirms; rolls back on error.
 
 ```ts
-const { mutateAsync: shield } = useShield({
-  address: "0xWrapper",
-  optimistic: true,
-});
+const { mutateAsync: shield } = useShield({ address: "0xWrapper", optimistic: true });
 ```
 
 ---
@@ -11570,9 +11350,7 @@ function GatedDecrypt({
 Contract addresses to check credentials against. Returns `true` only when stored permits cover **all** specified addresses.
 
 ```tsx
-const { data: hasPermit } = useHasPermit({
-  contractAddresses: ["0xContractA", "0xContractB"],
-});
+const { data: hasPermit } = useHasPermit({ contractAddresses: ["0xContractA", "0xContractB"] });
 ```
 
 An empty list is a no-op: the query is disabled and `data` stays `undefined`, so you can call the hook unconditionally even when there is nothing to check yet.
@@ -11979,9 +11757,7 @@ const { mutateAsync: setOperator } = useConfidentialSetOperator("0xToken");
 Address of the operator to approve.
 
 ```ts
-await setOperator({
-  operator: "0xDEX",
-});
+await setOperator({ operator: "0xDEX" });
 ```
 
 ---
@@ -11995,10 +11771,7 @@ Unix timestamp (seconds) when the approval expires. Defaults to 1 hour from now.
 ```ts
 const oneDay = Math.floor(Date.now() / 1000) + 86_400;
 
-await setOperator({
-  operator: "0xDEX",
-  until: oneDay,
-});
+await setOperator({ operator: "0xDEX", until: oneDay });
 ```
 
 ## Return Type
@@ -12210,11 +11983,7 @@ function OperatorCheck({
   holder: `0x${string}`;
   spender: `0x${string}`;
 }) {
-  const { data: isOperator } = useConfidentialIsOperatorSuspense({
-    tokenAddress,
-    holder,
-    spender,
-  });
+  const { data: isOperator } = useConfidentialIsOperatorSuspense({ tokenAddress, holder, spender });
 
   // data is always defined — no loading state needed
   return <span>{isOperator ? "Approved" : "Not approved"}</span>;
@@ -12266,10 +12035,7 @@ function AllowanceDisplay({
   wrapperAddress: `0x${string}`;
   owner: `0x${string}` | undefined;
 }) {
-  const { data: allowance, isLoading } = useUnderlyingAllowance({
-    address: wrapperAddress,
-    owner,
-  });
+  const { data: allowance, isLoading } = useUnderlyingAllowance({ address: wrapperAddress, owner });
 
   if (isLoading) return <span>Loading allowance...</span>;
   return <span>Allowance: {allowance?.toString() ?? "0"}</span>;
@@ -12286,10 +12052,7 @@ function AllowanceDisplay({
 Address of the confidential wrapper contract. The hook reads the underlying ERC-20 allowance granted by `owner` to this wrapper.
 
 ```ts
-const { data: allowance } = useUnderlyingAllowance({
-  address: "0xWrapper",
-  owner: "0xOwner",
-});
+const { data: allowance } = useUnderlyingAllowance({ address: "0xWrapper", owner: "0xOwner" });
 ```
 
 ---
@@ -12301,10 +12064,7 @@ const { data: allowance } = useUnderlyingAllowance({
 Address whose allowance to read. The query is disabled while `undefined`.
 
 ```ts
-const { data: allowance } = useUnderlyingAllowance({
-  address: "0xWrapper",
-  owner: "0xOwner",
-});
+const { data: allowance } = useUnderlyingAllowance({ address: "0xWrapper", owner: "0xOwner" });
 ```
 
 ## Return Type
@@ -12381,10 +12141,7 @@ function Allowance({
   wrapperAddress: `0x${string}`;
   owner: `0x${string}`;
 }) {
-  const { data: allowance } = useUnderlyingAllowanceSuspense({
-    address: wrapperAddress,
-    owner,
-  });
+  const { data: allowance } = useUnderlyingAllowanceSuspense({ address: wrapperAddress, owner });
 
   // data is always defined — no loading state needed
   return <span>Allowance: {allowance.toString()}</span>;
@@ -12434,10 +12191,7 @@ function WrapperInfo({ tokenAddress }: { tokenAddress: `0x${string}` }) {
     data: wrapperAddress,
     isLoading,
     error,
-  } = useWrapperDiscovery({
-    tokenAddress,
-    erc20Address: "0xUSDC",
-  });
+  } = useWrapperDiscovery({ tokenAddress, erc20Address: "0xUSDC" });
 
   if (isLoading) return <p>Discovering wrapper...</p>;
   if (error) return <p>Error: {error.message}</p>;
@@ -12462,10 +12216,7 @@ Address of any confidential token you control. Used to scope the query cache key
 Address of the ERC-20 token to discover the wrapper for. Pass `undefined` to disable the query.
 
 ```ts
-useWrapperDiscovery({
-  tokenAddress: "0xConfidentialToken",
-  erc20Address: "0xUSDC",
-});
+useWrapperDiscovery({ tokenAddress: "0xConfidentialToken", erc20Address: "0xUSDC" });
 ```
 
 ## Return Type
@@ -12638,11 +12389,7 @@ import { useListPairs } from "@zama-fhe/react-sdk";
 import { useListPairs } from "@zama-fhe/react-sdk";
 
 function TokenPairList() {
-  const { data, isLoading, error } = useListPairs({
-    page: 1,
-    pageSize: 20,
-    metadata: true,
-  });
+  const { data, isLoading, error } = useListPairs({ page: 1, pageSize: 20, metadata: true });
 
   if (isLoading) return <p>Loading pairs...</p>;
   if (error) return <p>Error: {error.message}</p>;
@@ -13063,14 +12810,7 @@ import { useTokenPairsSlice } from "@zama-fhe/react-sdk";
 import { useTokenPairsSlice } from "@zama-fhe/react-sdk";
 
 function PairSlice() {
-  const {
-    data: pairs,
-    isLoading,
-    error,
-  } = useTokenPairsSlice({
-    fromIndex: 0n,
-    toIndex: 10n,
-  });
+  const { data: pairs, isLoading, error } = useTokenPairsSlice({ fromIndex: 0n, toIndex: 10n });
 
   if (isLoading) return <p>Loading...</p>;
   if (error) return <p>Error: {error.message}</p>;
@@ -13338,9 +13078,7 @@ import { useConfidentialTokenAddress } from "@zama-fhe/react-sdk";
 import { useConfidentialTokenAddress } from "@zama-fhe/react-sdk";
 
 function LookupWrapper({ tokenAddress }: { tokenAddress: `0x${string}` }) {
-  const { data, isLoading, error } = useConfidentialTokenAddress({
-    tokenAddress,
-  });
+  const { data, isLoading, error } = useConfidentialTokenAddress({ tokenAddress });
 
   if (isLoading) return <p>Looking up...</p>;
   if (error) return <p>Error: {error.message}</p>;
@@ -13463,9 +13201,7 @@ import { useTokenAddress } from "@zama-fhe/react-sdk";
 import { useTokenAddress } from "@zama-fhe/react-sdk";
 
 function ReverseLookup({ confidentialTokenAddress }: { confidentialTokenAddress: `0x${string}` }) {
-  const { data, isLoading, error } = useTokenAddress({
-    confidentialTokenAddress,
-  });
+  const { data, isLoading, error } = useTokenAddress({ confidentialTokenAddress });
 
   if (isLoading) return <p>Looking up...</p>;
   if (error) return <p>Error: {error.message}</p>;
@@ -13591,9 +13327,7 @@ function ValidityCheck({ confidentialTokenAddress }: { confidentialTokenAddress:
     data: isValid,
     isLoading,
     error,
-  } = useIsConfidentialTokenValid({
-    confidentialTokenAddress,
-  });
+  } = useIsConfidentialTokenValid({ confidentialTokenAddress });
 
   if (isLoading) return <p>Checking...</p>;
   if (error) return <p>Error: {error.message}</p>;
@@ -14468,10 +14202,7 @@ The address to grant decryption rights to.
 When the delegation expires. If omitted, the delegation is permanent.
 
 ```ts
-await delegate({
-  delegateAddress: "0xDelegate",
-  expirationDate: new Date("2025-12-31"),
-});
+await delegate({ delegateAddress: "0xDelegate", expirationDate: new Date("2025-12-31") });
 ```
 
 ## Return Type
@@ -14989,10 +14720,7 @@ The address that delegated decryption rights.
 The address whose on-chain balance to read. Defaults to `delegatorAddress`. Use this when the balance holder differs from the delegator.
 
 ```ts
-await decryptAs({
-  delegatorAddress: "0xDelegator",
-  accountAddress: "0xBalanceHolder",
-});
+await decryptAs({ delegatorAddress: "0xDelegator", accountAddress: "0xBalanceHolder" });
 ```
 
 ## Return Type
@@ -15300,9 +15028,7 @@ const queryClient = useQueryClient();
 queryClient.invalidateQueries({ queryKey: zamaQueryKeys.confidentialBalance.all });
 
 // Invalidate one token's balances
-queryClient.invalidateQueries({
-  queryKey: zamaQueryKeys.confidentialBalance.token("0xToken"),
-});
+queryClient.invalidateQueries({ queryKey: zamaQueryKeys.confidentialBalance.token("0xToken") });
 
 // Invalidate a specific owner's balance
 queryClient.invalidateQueries({
@@ -15385,9 +15111,7 @@ import { zamaQueryKeys } from "@zama-fhe/sdk/query";
 
 ```tsx
 // After a transfer made outside the SDK
-queryClient.invalidateQueries({
-  queryKey: zamaQueryKeys.confidentialBalance.token("0xToken"),
-});
+queryClient.invalidateQueries({ queryKey: zamaQueryKeys.confidentialBalance.token("0xToken") });
 ```
 
 ### Prefetch balances on hover
@@ -15683,9 +15407,7 @@ const config = createConfig({
   chains: [sepolia],
   publicClient,
   walletClient,
-  relayers: {
-    [sepolia.id]: web({ security: { integrityCheck: false } }),
-  },
+  relayers: { [sepolia.id]: web({ security: { integrityCheck: false } }) },
 });
 ```
 
@@ -15767,9 +15489,7 @@ const config = createConfig({
   walletClient,
   relayers: {
     [sepolia.id]: web({
-      security: {
-        getCsrfToken: () => document.cookie.match(/csrf=(\w+)/)?.[1] ?? "",
-      },
+      security: { getCsrfToken: () => document.cookie.match(/csrf=(\w+)/)?.[1] ?? "" },
     }),
   },
 });
@@ -16359,10 +16079,7 @@ transfer.mutate({
 // Unshield: 2 transactions (unwrap + finalizeUnwrap).
 // Amount is in confidential token units — use cTokenDecimals.
 // onFinalizing fires between the two transactions — use it to update the progress UI.
-unshield.mutate({
-  amount: parseUnits("2", cTokenDecimals),
-  onFinalizing: () => setStep(2),
-});
+unshield.mutate({ amount: parseUnits("2", cTokenDecimals), onFinalizing: () => setStep(2) });
 ```
 
 ### Delegation hooks
@@ -16743,9 +16460,7 @@ It then derives a Zama Sepolia chain config from the SDK preset:
 const zamaSepolia = {
   ...sepolia,
   network: SEPOLIA_RPC_URL,
-  ...(RELAYER_API_KEY && {
-    auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY },
-  }),
+  ...(RELAYER_API_KEY && { auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY } }),
 } as const satisfies FheChain;
 ```
 
@@ -16760,9 +16475,7 @@ using sdkA = new ZamaSDK(
     chains: [zamaSepolia],
     signer: walletA,
     storage: new MemoryStorage(),
-    relayers: {
-      [zamaSepolia.id]: node(),
-    },
+    relayers: { [zamaSepolia.id]: node() },
   }),
 );
 ```
@@ -17202,9 +16915,7 @@ It then derives an FHE Sepolia chain object from the SDK preset:
 const zamaSepolia = {
   ...sepolia,
   network: SEPOLIA_RPC_URL,
-  ...(RELAYER_API_KEY && {
-    auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY },
-  }),
+  ...(RELAYER_API_KEY && { auth: { __type: "ApiKeyHeader" as const, value: RELAYER_API_KEY } }),
 } as const satisfies FheChain;
 ```
 
@@ -17220,9 +16931,7 @@ using sdkA = new ZamaSDK(
     publicClient,
     walletClient: walletClientA,
     storage: new MemoryStorage(),
-    relayers: {
-      [zamaSepolia.id]: node(),
-    },
+    relayers: { [zamaSepolia.id]: node() },
   }),
 );
 ```
@@ -17623,11 +17332,7 @@ shield.mutate({
 
 ```ts
 const transfer = useConfidentialTransfer({ address: tokenAddress }, { onSuccess });
-transfer.mutate({
-  to: recipient,
-  amount: parsedAmount,
-  onEncryptComplete: () => setStep(2),
-});
+transfer.mutate({ to: recipient, amount: parsedAmount, onEncryptComplete: () => setStep(2) });
 ```
 
 Two phases: encrypting the amount locally (step 1), then submitting the transaction (step 2). `onEncryptComplete` fires between them so the UI can update the button label.
@@ -17900,11 +17605,7 @@ const zamaSepolia = {
   network: SEPOLIA_RPC_URL,
 } as const;
 
-const walletClient = createWalletClient({
-  account,
-  chain: sepolia,
-  transport: custom(ethereum),
-});
+const walletClient = createWalletClient({ account, chain: sepolia, transport: custom(ethereum) });
 const signer = ethereum ? new ViemSigner({ walletClient, ethereum }) : undefined;
 
 const zamaConfig = createConfig({
@@ -18071,11 +17772,7 @@ required.
 
 ```ts
 const transfer = useConfidentialTransfer({ address: tokenAddress }, { onSuccess });
-transfer.mutate({
-  to: recipient,
-  amount: parsedAmount,
-  onEncryptComplete: () => setStep(2),
-});
+transfer.mutate({ to: recipient, amount: parsedAmount, onEncryptComplete: () => setStep(2) });
 ```
 
 Two phases: encrypting the amount locally (step 1), then submitting the transaction (step 2). `onEncryptComplete` fires between them so the UI can update the button label.
@@ -18183,9 +17880,7 @@ shows a "Decrypt Balance" button rather than a balance value. This avoids blind-
 prompts on mount.
 
 ```ts
-const { data: hasPermit } = useHasPermit({
-  contractAddresses: [token.confidentialTokenAddress],
-});
+const { data: hasPermit } = useHasPermit({ contractAddresses: [token.confidentialTokenAddress] });
 // All registry pairs are passed at once — one signature covers all tokens,
 // so switching tokens does not prompt the wallet again.
 const grantPermits = useGrantPermit();
@@ -18559,9 +18254,7 @@ shows a "Decrypt Balance" button rather than a balance value. This avoids blind-
 prompts on mount.
 
 ```ts
-const { data: hasPermit } = useHasPermit({
-  contractAddresses: [token.confidentialTokenAddress],
-});
+const { data: hasPermit } = useHasPermit({ contractAddresses: [token.confidentialTokenAddress] });
 // All registry pairs are passed at once to useGrantPermit — one signature covers all tokens,
 // so switching tokens does not prompt the wallet again.
 const grantPermits = useGrantPermit();
@@ -18955,15 +18648,9 @@ import { sepolia } from "viem/chains";
 
 const tokenAddress = "0xYourConfidentialToken" as Address;
 const rpcUrl = "https://sepolia.infura.io/v3/YOUR_KEY";
-const publicClient = createPublicClient({
-  chain: sepolia,
-  transport: http(rpcUrl),
-});
+const publicClient = createPublicClient({ chain: sepolia, transport: http(rpcUrl) });
 
-const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
+const walletClient = createWalletClient({ chain: sepolia, transport: custom(window.ethereum!) });
 
 const chain = {
   ...sepoliaFhe,
@@ -19000,10 +18687,7 @@ function AuthGate({
 }
 
 function Balance() {
-  const { data: balance, isLoading } = useConfidentialBalance({
-    address: tokenAddress,
-    account,
-  });
+  const { data: balance, isLoading } = useConfidentialBalance({ address: tokenAddress, account });
 
   if (isLoading) return <p>Decrypting...</p>;
   return <p>Balance: {balance?.toString()}</p>;

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -45,15 +45,9 @@ import { sepolia } from "viem/chains";
 
 const tokenAddress = "0xYourConfidentialToken" as Address;
 const rpcUrl = "https://sepolia.infura.io/v3/YOUR_KEY";
-const publicClient = createPublicClient({
-  chain: sepolia,
-  transport: http(rpcUrl),
-});
+const publicClient = createPublicClient({ chain: sepolia, transport: http(rpcUrl) });
 
-const walletClient = createWalletClient({
-  chain: sepolia,
-  transport: custom(window.ethereum!),
-});
+const walletClient = createWalletClient({ chain: sepolia, transport: custom(window.ethereum!) });
 
 const chain = {
   ...sepoliaFhe,
@@ -90,10 +84,7 @@ function AuthGate({
 }
 
 function Balance() {
-  const { data: balance, isLoading } = useConfidentialBalance({
-    address: tokenAddress,
-    account,
-  });
+  const { data: balance, isLoading } = useConfidentialBalance({ address: tokenAddress, account });
 
   if (isLoading) return <p>Decrypting...</p>;
   return <p>Balance: {balance?.toString()}</p>;

--- a/packages/react-sdk/rolldown.config.ts
+++ b/packages/react-sdk/rolldown.config.ts
@@ -2,17 +2,8 @@ import { defineConfig } from "rolldown";
 import { dts } from "rolldown-plugin-dts";
 
 export default defineConfig({
-  input: {
-    index: "src/index.ts",
-    "wagmi/index": "src/wagmi/index.ts",
-  },
-  output: {
-    dir: "dist",
-    format: "esm",
-    sourcemap: true,
-    minify: true,
-    banner: '"use client";',
-  },
+  input: { index: "src/index.ts", "wagmi/index": "src/wagmi/index.ts" },
+  output: { dir: "dist", format: "esm", sourcemap: true, minify: true, banner: '"use client";' },
   external: [
     /^react/,
     /^@tanstack/,
@@ -23,9 +14,7 @@ export default defineConfig({
     /^@noble/,
     /^@scure/,
   ],
-  resolve: {
-    tsconfigFilename: "tsconfig.build.json",
-  },
+  resolve: { tsconfigFilename: "tsconfig.build.json" },
   treeshake: true,
   plugins: [dts({ tsconfig: "tsconfig.build.json" })],
 });

--- a/packages/react-sdk/src/__tests__/config.test.ts
+++ b/packages/react-sdk/src/__tests__/config.test.ts
@@ -9,26 +9,17 @@ import { WagmiSigner } from "../wagmi/wagmi-signer";
 
 vi.mock(import("../wagmi/wagmi-signer"), async (importOriginal) => {
   const actual = await importOriginal();
-  return {
-    ...actual,
-    WagmiSigner: vi.fn(),
-  };
+  return { ...actual, WagmiSigner: vi.fn() };
 });
 
 vi.mock(import("../../../sdk/src/viem/viem-signer"), async (importOriginal) => {
   const actual = await importOriginal();
-  return {
-    ...actual,
-    ViemSigner: vi.fn(),
-  };
+  return { ...actual, ViemSigner: vi.fn() };
 });
 
 vi.mock(import("../../../sdk/src/ethers/ethers-signer"), async (importOriginal) => {
   const actual = await importOriginal();
-  return {
-    ...actual,
-    EthersSigner: vi.fn(),
-  };
+  return { ...actual, EthersSigner: vi.fn() };
 });
 
 const MockWagmiSigner = vi.mocked(WagmiSigner);
@@ -36,9 +27,7 @@ const MockViemSigner = vi.mocked(ViemSigner);
 const MockEthersSigner = vi.mocked(EthersSigner);
 
 function mockWagmiConfig(chainIds: number[] = [11155111]) {
-  return {
-    chains: chainIds.map((id) => ({ id, name: `Chain ${id}` })),
-  } as any;
+  return { chains: chainIds.map((id) => ({ id, name: `Chain ${id}` })) } as any;
 }
 
 beforeEach(() => {
@@ -86,9 +75,7 @@ describe("createConfig", () => {
       const config = createWagmiConfig({
         chains: [sepolia],
         wagmiConfig: mockWagmiConfig([11155111]),
-        relayers: {
-          [11155111]: web(),
-        },
+        relayers: { [11155111]: web() },
       });
       expect(config.relayer).toBeDefined();
     });

--- a/packages/react-sdk/src/__tests__/optional-signer.test.tsx
+++ b/packages/react-sdk/src/__tests__/optional-signer.test.tsx
@@ -9,9 +9,7 @@ import { useMetadata } from "../token/use-metadata";
 
 describe("ZamaProvider with signer={undefined}", () => {
   test("mounts cleanly and exposes signer-free SDK", ({ renderWithProviders }) => {
-    const { result } = renderWithProviders(() => useZamaSDK(), {
-      signer: undefined,
-    });
+    const { result } = renderWithProviders(() => useZamaSDK(), { signer: undefined });
 
     expect(result.current).toBeDefined();
     expect(result.current.signer).toBeUndefined();
@@ -34,9 +32,7 @@ describe("ZamaProvider with signer={undefined}", () => {
       .mockResolvedValueOnce("TT")
       .mockResolvedValueOnce(18);
 
-    const { result } = renderWithProviders(() => useMetadata(tokenAddress), {
-      signer: undefined,
-    });
+    const { result } = renderWithProviders(() => useMetadata(tokenAddress), { signer: undefined });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual({ name: "TestToken", symbol: "TT", decimals: 18 });

--- a/packages/react-sdk/src/__tests__/provider-hooks-extended.test.tsx
+++ b/packages/react-sdk/src/__tests__/provider-hooks-extended.test.tsx
@@ -62,9 +62,7 @@ describe("useMetadataSuspense", () => {
       .mockResolvedValueOnce("TT")
       .mockResolvedValueOnce(18);
 
-    const { result } = renderWithProviders(() => useMetadataSuspense(tokenAddress), {
-      signer,
-    });
+    const { result } = renderWithProviders(() => useMetadataSuspense(tokenAddress), { signer });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual({ name: "TestToken", symbol: "TT", decimals: 18 });
@@ -85,9 +83,7 @@ describe("useTotalSupplySuspense", () => {
       return 100000n;
     });
 
-    const { result } = renderWithProviders(() => useTotalSupplySuspense(tokenAddress), {
-      signer,
-    });
+    const { result } = renderWithProviders(() => useTotalSupplySuspense(tokenAddress), { signer });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBe(100000n);

--- a/packages/react-sdk/src/__tests__/provider.test.tsx
+++ b/packages/react-sdk/src/__tests__/provider.test.tsx
@@ -70,14 +70,8 @@ describe("ZamaProvider & useZamaSDK", () => {
     queryClient.setQueryData(wagmiBalanceKey, 2n);
 
     listener({
-      previous: {
-        address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
-        chainId: 31337,
-      },
-      next: {
-        address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
-        chainId: 1,
-      },
+      previous: { address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa", chainId: 31337 },
+      next: { address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa", chainId: 1 },
     });
 
     return waitFor(() => {
@@ -110,14 +104,8 @@ describe("ZamaProvider & useZamaSDK", () => {
     expect(signer.walletAccount.subscribe).toHaveBeenCalledTimes(1);
     const listener = vi.mocked(signer.walletAccount.subscribe).mock.calls[0]![0];
     listener({
-      previous: {
-        address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
-        chainId: 31337,
-      },
-      next: {
-        address: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
-        chainId: 1,
-      },
+      previous: { address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa", chainId: 31337 },
+      next: { address: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB", chainId: 1 },
     });
 
     await waitFor(() => {
@@ -171,11 +159,7 @@ describe("ZamaProvider & useZamaSDK", () => {
 
     // onEvent is stabilized via ref — verify it delegates correctly
     const wrappedOnEvent = tokenSDKConstructorArgs[0].onEvent!;
-    wrappedOnEvent({
-      type: "credentials:loading",
-      timestamp: 1,
-      contractAddresses: [],
-    } as never);
+    wrappedOnEvent({ type: "credentials:loading", timestamp: 1, contractAddresses: [] } as never);
     expect(onEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-sdk/src/__tests__/use-user-decrypt.test.tsx
+++ b/packages/react-sdk/src/__tests__/use-user-decrypt.test.tsx
@@ -22,9 +22,7 @@ describe("useDecryptValues", () => {
       ),
     );
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true), {
-      timeout: 5_000,
-    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
 
     expect(result.current.data).toEqual({ "0xhandle1": 100n, "0xhandle2": true });
   });
@@ -47,9 +45,7 @@ describe("useDecryptValues", () => {
       ),
     );
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true), {
-      timeout: 5_000,
-    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
 
     expect(relayer.userDecrypt).toHaveBeenCalledTimes(2);
     expect(result.current.data).toEqual({ "0xh1": 10n, "0xh2": 20n });
@@ -68,9 +64,7 @@ describe("useDecryptValues", () => {
       }),
     );
 
-    await waitFor(() => expect(result.current.isError).toBe(true), {
-      timeout: 5_000,
-    });
+    await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 5_000 });
     expect(result.current.error?.message).toContain("keygen failed");
   });
 
@@ -123,11 +117,9 @@ describe("useDecryptValues", () => {
       // Prime credentials once on mount so isAllowed flips to true,
       // then invalidate so the cached `false` result is re-fetched.
       useEffect(() => {
-        void sdk.permits.grantPermit([tokenAddress]).then(() =>
-          queryClient.invalidateQueries({
-            queryKey: zamaQueryKeys.hasPermit.all,
-          }),
-        );
+        void sdk.permits
+          .grantPermit([tokenAddress])
+          .then(() => queryClient.invalidateQueries({ queryKey: zamaQueryKeys.hasPermit.all }));
       }, [sdk, queryClient]);
 
       const isAllowed = useHasPermit({ contractAddresses: [tokenAddress] });
@@ -138,9 +130,7 @@ describe("useDecryptValues", () => {
     });
 
     await waitFor(() => expect(result.current.isAllowed.data).toBe(true));
-    await waitFor(() => expect(result.current.decrypt.isSuccess).toBe(true), {
-      timeout: 5_000,
-    });
+    await waitFor(() => expect(result.current.decrypt.isSuccess).toBe(true), { timeout: 5_000 });
 
     expect(result.current.decrypt.data).toEqual({ "0xh": 42n });
     // Exactly one signature: the credential priming. The decrypt itself must

--- a/packages/react-sdk/src/__tests__/wagmi-signer-subscribe.test.ts
+++ b/packages/react-sdk/src/__tests__/wagmi-signer-subscribe.test.ts
@@ -250,11 +250,7 @@ describe("WagmiSigner.subscribe", () => {
     onWalletAccountChange.mockClear();
 
     capturedOnChange!(
-      {
-        status: "connected",
-        address: ADDR_A.toLowerCase() as Address,
-        chainId: 1,
-      },
+      { status: "connected", address: ADDR_A.toLowerCase() as Address, chainId: 1 },
       { status: "connected", address: ADDR_A, chainId: 1 },
     );
     expect(onWalletAccountChange).not.toHaveBeenCalled();

--- a/packages/react-sdk/src/balance/__tests__/optimistic-balance-update.test.ts
+++ b/packages/react-sdk/src/balance/__tests__/optimistic-balance-update.test.ts
@@ -21,10 +21,7 @@ const WALLET_ACCOUNT = { address: userAddress, chainId: 31337 };
 
 describe("unwrapOptimisticCallerContext", () => {
   test("returns wrappedContext and callerContext when optimistic is true", () => {
-    const inner: OptimisticMutateContext = {
-      snapshot: [],
-      callerContext: { requestId: "abc" },
-    };
+    const inner: OptimisticMutateContext = { snapshot: [], callerContext: { requestId: "abc" } };
     const { wrappedContext, callerContext } = unwrapOptimisticCallerContext(true, inner);
     expect(wrappedContext).toBe(inner);
     expect(callerContext).toEqual({ requestId: "abc" });

--- a/packages/react-sdk/src/balance/__tests__/use-confidential-balance.test.tsx
+++ b/packages/react-sdk/src/balance/__tests__/use-confidential-balance.test.tsx
@@ -13,9 +13,7 @@ describe("useConfidentialBalance", () => {
       useConfidentialBalance({ address: tokenAddress, account: userAddress }),
     );
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true), {
-      timeout: 5_000,
-    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
 
     expect(result.current.data).toBe(123n);
     expect(provider.readContract).toHaveBeenCalledWith(
@@ -67,9 +65,7 @@ describe("useConfidentialBalance", () => {
       useConfidentialBalance({ address: tokenAddress, account: OTHER }),
     );
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true), {
-      timeout: 5_000,
-    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
     expect(result.current.data).toBe(456n);
     expect(provider.readContract).toHaveBeenCalledWith(
       expect.objectContaining({ functionName: "confidentialBalanceOf", args: [OTHER] }),
@@ -92,9 +88,7 @@ describe("useConfidentialBalance", () => {
         useConfidentialBalance({ address: tokenAddress, account: userAddress }),
       );
 
-      await waitFor(() => expect(result.current.isSuccess).toBe(true), {
-        timeout: 5_000,
-      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
 
       const { data, dataUpdatedAt, ...state } = result.current;
       const { promise: statePromise, ...stableState } = state;
@@ -152,9 +146,7 @@ describe("useConfidentialBalance", () => {
         useConfidentialBalance({ address: tokenAddress, account: userAddress }),
       );
 
-      await waitFor(() => expect(result.current.isSuccess).toBe(true), {
-        timeout: 5_000,
-      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
       expect(result.current.data).toBe(111n);
 
       currentHandle = handleB;
@@ -162,9 +154,7 @@ describe("useConfidentialBalance", () => {
         await result.current.refetch();
       });
 
-      await waitFor(() => expect(result.current.data).toBe(222n), {
-        timeout: 5_000,
-      });
+      await waitFor(() => expect(result.current.data).toBe(222n), { timeout: 5_000 });
       expect(relayer.userDecrypt).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({ encryptedValues: [handleA] }),
@@ -189,9 +179,7 @@ describe("useConfidentialBalance", () => {
         useConfidentialBalance({ address: tokenAddress, account: userAddress }),
       );
 
-      await waitFor(() => expect(result.current.isSuccess).toBe(true), {
-        timeout: 5_000,
-      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
       const firstData = result.current.data;
 
       rerender();

--- a/packages/react-sdk/src/balance/__tests__/use-confidential-balances-enabled.test.tsx
+++ b/packages/react-sdk/src/balance/__tests__/use-confidential-balances-enabled.test.tsx
@@ -14,18 +14,14 @@ vi.mock("../../utils/query", async () => {
 
 const mockSdk = {
   signer: {
-    walletAccount: {
-      getSnapshot: vi.fn().mockReturnValue({ address: OWNER, chainId: 31337 }),
-    },
+    walletAccount: { getSnapshot: vi.fn().mockReturnValue({ address: OWNER, chainId: 31337 }) },
   },
   onWalletAccountChange: vi.fn().mockReturnValue(() => {}),
   provider: { readContract: vi.fn() },
   createToken: vi.fn((address: Address) => ({ address })),
 };
 
-vi.mock("../../provider", () => ({
-  useZamaSDK: vi.fn(() => mockSdk),
-}));
+vi.mock("../../provider", () => ({ useZamaSDK: vi.fn(() => mockSdk) }));
 
 vi.mock("@zama-fhe/sdk/query", () => ({
   confidentialBalancesQueryOptions: vi.fn(() => ({

--- a/packages/react-sdk/src/balance/__tests__/use-confidential-balances.test.tsx
+++ b/packages/react-sdk/src/balance/__tests__/use-confidential-balances.test.tsx
@@ -34,9 +34,7 @@ describe("useConfidentialBalances", () => {
       }),
     );
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true), {
-      timeout: 5_000,
-    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
 
     expect(result.current.data?.results.get(tokenAddress)).toBe(10n);
     expect(result.current.data?.results.get(otherTokenAddress)).toBe(20n);
@@ -67,9 +65,7 @@ describe("useConfidentialBalances", () => {
       useConfidentialBalances({ addresses: [mixedCaseToken], account: userAddress }),
     );
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true), {
-      timeout: 5_000,
-    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
 
     expect(result.current.data?.results.get(mixedCaseToken)).toBe(33n);
   });
@@ -108,9 +104,7 @@ describe("useConfidentialBalances", () => {
       useConfidentialBalances({ addresses: [tokenAddress], account: OTHER }),
     );
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true), {
-      timeout: 5_000,
-    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
     expect(result.current.data?.results.get(tokenAddress)).toBe(77n);
     expect(provider.readContract).toHaveBeenCalledWith(
       expect.objectContaining({ functionName: "confidentialBalanceOf", args: [OTHER] }),
@@ -146,9 +140,7 @@ describe("useConfidentialBalances", () => {
         useConfidentialBalances({ addresses: tokens, account: userAddress }),
       );
 
-      await waitFor(() => expect(result.current.isSuccess).toBe(true), {
-        timeout: 5_000,
-      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5_000 });
 
       const { data, dataUpdatedAt, ...state } = result.current;
       const { promise: statePromise, ...stableState } = state;

--- a/packages/react-sdk/src/balance/use-confidential-balance.ts
+++ b/packages/react-sdk/src/balance/use-confidential-balance.ts
@@ -46,10 +46,7 @@ export function useConfidentialBalance(
 
   const baseOptions = confidentialBalanceQueryOptions(
     token,
-    {
-      tokenAddress: address,
-      account,
-    },
+    { tokenAddress: address, account },
     { walletAccount },
   );
 

--- a/packages/react-sdk/src/balance/use-confidential-balances.ts
+++ b/packages/react-sdk/src/balance/use-confidential-balances.ts
@@ -55,13 +55,7 @@ export function useConfidentialBalances(
 
   const tokens = useMemo(() => addresses.map((addr) => sdk.createToken(addr)), [sdk, addresses]);
 
-  const baseOptions = confidentialBalancesQueryOptions(
-    tokens,
-    {
-      account,
-    },
-    { walletAccount },
-  );
+  const baseOptions = confidentialBalancesQueryOptions(tokens, { account }, { walletAccount });
 
   return useQuery<BatchBalancesResult>({
     ...baseOptions,

--- a/packages/react-sdk/src/decrypt/use-user-decrypt.ts
+++ b/packages/react-sdk/src/decrypt/use-user-decrypt.ts
@@ -18,9 +18,7 @@ export function useDecryptValues(
 ) {
   const sdk = useZamaSDK();
   const walletAccount = useWalletAccount(sdk);
-  const queryOpts = decryptValuesQueryOptions(sdk, encryptedInputs, {
-    walletAccount,
-  });
+  const queryOpts = decryptValuesQueryOptions(sdk, encryptedInputs, { walletAccount });
   return useQuery<DecryptResult>({
     ...queryOpts,
     ...options,

--- a/packages/react-sdk/src/delegations/__tests__/use-delegation-status.test.tsx
+++ b/packages/react-sdk/src/delegations/__tests__/use-delegation-status.test.tsx
@@ -34,9 +34,7 @@ describe("useDelegationStatus", () => {
     tokenAddress,
     userAddress,
   }) => {
-    vi.mocked(useQuery).mockReturnValue({
-      data: { isActive: true, expiryTimestamp: 0n },
-    } as never);
+    vi.mocked(useQuery).mockReturnValue({ data: { isActive: true, expiryTimestamp: 0n } } as never);
 
     renderWithProviders(() =>
       useDelegationStatus({

--- a/packages/react-sdk/src/operator/__tests__/use-confidential-is-operator.test.tsx
+++ b/packages/react-sdk/src/operator/__tests__/use-confidential-is-operator.test.tsx
@@ -63,10 +63,7 @@ describe("useConfidentialIsOperator", () => {
     const { result, rerender } = renderHook(
       ({ spender }) =>
         useConfidentialIsOperator({ address: tokenAddress, spender, holder: HOLDER }),
-      {
-        wrapper: ctx.Wrapper,
-        initialProps: { spender: undefined as Address | undefined },
-      },
+      { wrapper: ctx.Wrapper, initialProps: { spender: undefined as Address | undefined } },
     );
 
     expect(result.current.isPending).toBe(true);
@@ -95,10 +92,7 @@ describe("useConfidentialIsOperator", () => {
           spender: spenderAddress,
           holder: HOLDER,
         }),
-      {
-        wrapper: ctx.Wrapper,
-        initialProps: { address: undefined as Address | undefined },
-      },
+      { wrapper: ctx.Wrapper, initialProps: { address: undefined as Address | undefined } },
     );
 
     expect(result.current.isPending).toBe(true);
@@ -120,11 +114,7 @@ describe("useConfidentialIsOperator", () => {
 
     const { result } = renderWithProviders(() =>
       useConfidentialIsOperator(
-        {
-          address: tokenAddress,
-          spender: spenderAddress,
-          holder: HOLDER,
-        },
+        { address: tokenAddress, spender: spenderAddress, holder: HOLDER },
         { enabled: false },
       ),
     );

--- a/packages/react-sdk/src/operator/use-confidential-is-operator.ts
+++ b/packages/react-sdk/src/operator/use-confidential-is-operator.ts
@@ -46,10 +46,7 @@ export function useConfidentialIsOperator(
 ) {
   const { address, spender, holder } = config;
   const sdk = useZamaSDK();
-  const baseOpts = confidentialIsOperatorQueryOptions(sdk, address, {
-    holder,
-    spender,
-  });
+  const baseOpts = confidentialIsOperatorQueryOptions(sdk, address, { holder, spender });
 
   return useQuery({
     ...baseOpts,
@@ -76,9 +73,6 @@ export function useConfidentialIsOperatorSuspense(config: UseConfidentialIsOpera
   const sdk = useZamaSDK();
 
   return useSuspenseQuery<boolean>(
-    confidentialIsOperatorQueryOptions(sdk, address, {
-      holder,
-      spender,
-    }),
+    confidentialIsOperatorQueryOptions(sdk, address, { holder, spender }),
   );
 }

--- a/packages/react-sdk/src/permits/__tests__/use-grant-permit.test.tsx
+++ b/packages/react-sdk/src/permits/__tests__/use-grant-permit.test.tsx
@@ -35,11 +35,7 @@ describe("useGrantPermit", () => {
         queryClient.getQueryCache().find({ queryKey: zamaQueryKeys.hasPermit.all }) === undefined;
       expect(variables).toEqual([tokenAddress, otherTokenAddress]);
     });
-    const { result, queryClient } = renderWithProviders(() =>
-      useGrantPermit({
-        onSuccess,
-      }),
-    );
+    const { result, queryClient } = renderWithProviders(() => useGrantPermit({ onSuccess }));
     queryClient.setQueryData(zamaQueryKeys.hasPermit.all, true);
 
     await act(() => result.current.mutateAsync([tokenAddress, otherTokenAddress]));

--- a/packages/react-sdk/src/permits/__tests__/use-has-permit.test.tsx
+++ b/packages/react-sdk/src/permits/__tests__/use-has-permit.test.tsx
@@ -101,11 +101,7 @@ describe("useHasPermit", () => {
     renderWithProviders(() => useHasPermit({ contractAddresses: [] }), { signer });
 
     await waitFor(() => {
-      expect(vi.mocked(useQuery)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          enabled: false,
-        }),
-      );
+      expect(vi.mocked(useQuery)).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
     });
   });
 });

--- a/packages/react-sdk/src/relayer/__tests__/use-encrypt.test.tsx
+++ b/packages/react-sdk/src/relayer/__tests__/use-encrypt.test.tsx
@@ -31,9 +31,6 @@ describe("useEncrypt", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(relayer.encrypt).toHaveBeenCalledTimes(1);
-    expect(result.current.data).toEqual({
-      encryptedValues: [handle],
-      inputProof,
-    });
+    expect(result.current.data).toEqual({ encryptedValues: [handle], inputProof });
   });
 });

--- a/packages/react-sdk/src/shield/__tests__/use-approve-underlying.test.tsx
+++ b/packages/react-sdk/src/shield/__tests__/use-approve-underlying.test.tsx
@@ -52,9 +52,7 @@ describe("useApproveUnderlying", () => {
     const onSuccess = vi.fn();
 
     const { result, queryClient } = renderWithProviders(() =>
-      useApproveUnderlying(wrapperAddress, {
-        onSuccess,
-      }),
+      useApproveUnderlying(wrapperAddress, { onSuccess }),
     );
 
     queryClient.setQueryData(allowanceKey, 500n);

--- a/packages/react-sdk/src/test-fixtures/index.tsx
+++ b/packages/react-sdk/src/test-fixtures/index.tsx
@@ -16,9 +16,7 @@ export const test = baseTest.extend<ReactSDKTestFixtures>({
   ...mutationFixtures,
 });
 
-expect.extend({
-  ...mutationAssertions,
-});
+expect.extend({ ...mutationAssertions });
 
 export { expect };
 export type { ReactAddressFixtures } from "./addresses";

--- a/packages/react-sdk/src/test-fixtures/query-client.ts
+++ b/packages/react-sdk/src/test-fixtures/query-client.ts
@@ -11,10 +11,7 @@ export const queryClientFixtures: FixturesOf<QueryClientFixtures> = {
   queryClient: async ({}, use) => {
     await use(
       new QueryClient({
-        defaultOptions: {
-          queries: { retry: false },
-          mutations: { retry: false },
-        },
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
       }),
     );
   },

--- a/packages/react-sdk/src/test-fixtures/wrapper.tsx
+++ b/packages/react-sdk/src/test-fixtures/wrapper.tsx
@@ -32,9 +32,7 @@ export interface WrapperFixtures {
     hook: () => TResult,
     overrides?: Partial<ZamaConfig>,
     options?: Omit<RenderHookOptions<unknown>, "wrapper">,
-  ) => ReturnType<typeof renderHook<TResult, unknown>> & {
-    queryClient: QueryClient;
-  };
+  ) => ReturnType<typeof renderHook<TResult, unknown>> & { queryClient: QueryClient };
 }
 
 type WrapperDeps = QueryClientFixtures & {
@@ -89,10 +87,7 @@ export const wrapperFixtures: FixturesOf<WrapperFixtures, WrapperDeps> = {
       options?: Omit<RenderHookOptions<unknown>, "wrapper">,
     ) {
       const { Wrapper, queryClient } = createWrapper(overrides);
-      return {
-        ...renderHook(hook, { wrapper: Wrapper, ...options }),
-        queryClient,
-      };
+      return { ...renderHook(hook, { wrapper: Wrapper, ...options }), queryClient };
     }
     await use(renderWithProviders);
   },

--- a/packages/react-sdk/src/token/__tests__/use-wrapper-discovery.test.tsx
+++ b/packages/react-sdk/src/token/__tests__/use-wrapper-discovery.test.tsx
@@ -49,10 +49,7 @@ describe("useWrapperDiscovery", () => {
     const ctx = createWrapper({ signer });
     const { result, rerender } = renderHook(
       ({ erc20Address }) => useWrapperDiscovery({ tokenAddress: tokenAddress, erc20Address }),
-      {
-        wrapper: ctx.Wrapper,
-        initialProps: { erc20Address: undefined as Address | undefined },
-      },
+      { wrapper: ctx.Wrapper, initialProps: { erc20Address: undefined as Address | undefined } },
     );
 
     expect(result.current.isPending).toBe(true);

--- a/packages/react-sdk/src/token/use-is-confidential.ts
+++ b/packages/react-sdk/src/token/use-is-confidential.ts
@@ -27,10 +27,7 @@ export function useIsConfidential(
 ) {
   const sdk = useZamaSDK();
 
-  return useQuery<boolean>({
-    ...isConfidentialQueryOptions(sdk, tokenAddress),
-    ...options,
-  });
+  return useQuery<boolean>({ ...isConfidentialQueryOptions(sdk, tokenAddress), ...options });
 }
 
 /**
@@ -70,10 +67,7 @@ export function useIsWrapper(
 ) {
   const sdk = useZamaSDK();
 
-  return useQuery<boolean>({
-    ...isWrapperQueryOptions(sdk, tokenAddress),
-    ...options,
-  });
+  return useQuery<boolean>({ ...isWrapperQueryOptions(sdk, tokenAddress), ...options });
 }
 
 /**

--- a/packages/react-sdk/src/token/use-metadata.ts
+++ b/packages/react-sdk/src/token/use-metadata.ts
@@ -25,10 +25,7 @@ export function useMetadata(
   options?: Omit<UseQueryOptions<TokenMetadata>, "queryKey" | "queryFn">,
 ) {
   const sdk = useZamaSDK();
-  return useQuery<TokenMetadata>({
-    ...tokenMetadataQueryOptions(sdk, tokenAddress),
-    ...options,
-  });
+  return useQuery<TokenMetadata>({ ...tokenMetadataQueryOptions(sdk, tokenAddress), ...options });
 }
 
 /**

--- a/packages/react-sdk/src/token/use-total-supply.ts
+++ b/packages/react-sdk/src/token/use-total-supply.ts
@@ -27,10 +27,7 @@ export function useTotalSupply(
 ) {
   const sdk = useZamaSDK();
 
-  return useQuery<bigint>({
-    ...totalSupplyQueryOptions(sdk, tokenAddress),
-    ...options,
-  });
+  return useQuery<bigint>({ ...totalSupplyQueryOptions(sdk, tokenAddress), ...options });
 }
 
 /**

--- a/packages/react-sdk/src/token/use-wrapper-discovery.ts
+++ b/packages/react-sdk/src/token/use-wrapper-discovery.ts
@@ -92,10 +92,6 @@ export function useWrapperDiscoverySuspense(config: UseWrapperDiscoverySuspenseC
   const registryAddress = useWrappersRegistryAddress();
 
   return useSuspenseQuery<Address | null>(
-    wrapperDiscoveryQueryOptions(sdk.registry, {
-      tokenAddress,
-      erc20Address,
-      registryAddress,
-    }),
+    wrapperDiscoveryQueryOptions(sdk.registry, { tokenAddress, erc20Address, registryAddress }),
   );
 }

--- a/packages/react-sdk/src/transfer/__tests__/use-confidential-transfer-and-call.test.tsx
+++ b/packages/react-sdk/src/transfer/__tests__/use-confidential-transfer-and-call.test.tsx
@@ -188,19 +188,14 @@ describe("useConfidentialTransferAndCall", () => {
   }) => {
     vi.mocked(signer.writeContract).mockResolvedValue("0xtxhash");
 
-    const expectedContext = {
-      requestId: "transfer-and-call-success-optimistic",
-    } as const;
+    const expectedContext = { requestId: "transfer-and-call-success-optimistic" } as const;
     const onMutate = vi.fn().mockReturnValue(expectedContext);
     const onSuccess = vi.fn();
 
     const { result } = renderWithProviders(() =>
       useConfidentialTransferAndCall(
         { address: tokenAddress, optimistic: true },
-        {
-          onMutate,
-          onSuccess,
-        },
+        { onMutate, onSuccess },
       ),
     );
 
@@ -263,19 +258,14 @@ describe("useConfidentialTransferAndCall", () => {
   }) => {
     vi.mocked(signer.writeContract).mockResolvedValue("0xtxhash");
 
-    const expectedContext = {
-      requestId: "transfer-and-call-settled-optimistic",
-    } as const;
+    const expectedContext = { requestId: "transfer-and-call-settled-optimistic" } as const;
     const onMutate = vi.fn().mockReturnValue(expectedContext);
     const onSettled = vi.fn();
 
     const { result } = renderWithProviders(() =>
       useConfidentialTransferAndCall(
         { address: tokenAddress, optimistic: true },
-        {
-          onMutate,
-          onSettled,
-        },
+        { onMutate, onSettled },
       ),
     );
 
@@ -616,9 +606,7 @@ describe("useConfidentialTransferAndCall error propagation", () => {
     const { Wrapper } = createWrapper();
     const { result } = renderHook(
       () => useMutation(confidentialTransferAndCallMutationOptions(mockWrappedToken)),
-      {
-        wrapper: Wrapper,
-      },
+      { wrapper: Wrapper },
     );
 
     await act(async () => {

--- a/packages/react-sdk/src/transfer/__tests__/use-confidential-transfer.test.tsx
+++ b/packages/react-sdk/src/transfer/__tests__/use-confidential-transfer.test.tsx
@@ -160,20 +160,12 @@ describe("useConfidentialTransfer", () => {
   }) => {
     vi.mocked(signer.writeContract).mockResolvedValue("0xtxhash");
 
-    const expectedContext = {
-      requestId: "transfer-success-optimistic",
-    } as const;
+    const expectedContext = { requestId: "transfer-success-optimistic" } as const;
     const onMutate = vi.fn().mockReturnValue(expectedContext);
     const onSuccess = vi.fn();
 
     const { result } = renderWithProviders(() =>
-      useConfidentialTransfer(
-        { address: tokenAddress, optimistic: true },
-        {
-          onMutate,
-          onSuccess,
-        },
-      ),
+      useConfidentialTransfer({ address: tokenAddress, optimistic: true }, { onMutate, onSuccess }),
     );
 
     await act(() =>
@@ -222,20 +214,12 @@ describe("useConfidentialTransfer", () => {
   }) => {
     vi.mocked(signer.writeContract).mockResolvedValue("0xtxhash");
 
-    const expectedContext = {
-      requestId: "transfer-settled-optimistic",
-    } as const;
+    const expectedContext = { requestId: "transfer-settled-optimistic" } as const;
     const onMutate = vi.fn().mockReturnValue(expectedContext);
     const onSettled = vi.fn();
 
     const { result } = renderWithProviders(() =>
-      useConfidentialTransfer(
-        { address: tokenAddress, optimistic: true },
-        {
-          onMutate,
-          onSettled,
-        },
-      ),
+      useConfidentialTransfer({ address: tokenAddress, optimistic: true }, { onMutate, onSettled }),
     );
 
     await act(() =>
@@ -539,9 +523,7 @@ describe("useConfidentialTransfer error propagation", () => {
     const { Wrapper } = createWrapper();
     const { result } = renderHook(
       () => useMutation(confidentialTransferMutationOptions(mockWrappedToken)),
-      {
-        wrapper: Wrapper,
-      },
+      { wrapper: Wrapper },
     );
 
     await act(async () => {

--- a/packages/react-sdk/src/utils/query.ts
+++ b/packages/react-sdk/src/utils/query.ts
@@ -39,19 +39,13 @@ type AnyKeySuspenseOptions<TData, TError> = UseSuspenseQueryOptions<
 export function useQuery<TData = unknown, TError = DefaultError>(
   options: AnyKeyQueryOptions<TData, TError>,
 ): UseQueryResult<TData, TError> {
-  return tanstack_useQuery({
-    ...options,
-    queryKeyHashFn: hashFn,
-  });
+  return tanstack_useQuery({ ...options, queryKeyHashFn: hashFn });
 }
 
 export function useSuspenseQuery<TData = unknown, TError = DefaultError>(
   options: AnyKeySuspenseOptions<TData, TError>,
 ): UseSuspenseQueryResult<TData, TError> {
-  return tanstack_useSuspenseQuery({
-    ...options,
-    queryKeyHashFn: hashFn,
-  });
+  return tanstack_useSuspenseQuery({ ...options, queryKeyHashFn: hashFn });
 }
 
 /**
@@ -72,9 +66,6 @@ export function useQueries<
 }): TCombinedResult {
   return tanstack_useQueries({
     ...options,
-    queries: queries.map((q) => ({
-      ...q,
-      queryKeyHashFn: hashFn,
-    })) as [...QueriesOptions<T>],
+    queries: queries.map((q) => ({ ...q, queryKeyHashFn: hashFn })) as [...QueriesOptions<T>],
   });
 }

--- a/packages/react-sdk/src/wrappers-registry/use-confidential-token-address.ts
+++ b/packages/react-sdk/src/wrappers-registry/use-confidential-token-address.ts
@@ -18,9 +18,6 @@ export function useConfidentialTokenAddress({
   const registryAddress = useWrappersRegistryAddress();
 
   return useQuery<readonly [boolean, Address]>(
-    confidentialTokenAddressQueryOptions(sdk, {
-      registryAddress,
-      tokenAddress,
-    }),
+    confidentialTokenAddressQueryOptions(sdk, { registryAddress, tokenAddress }),
   );
 }

--- a/packages/react-sdk/src/wrappers-registry/use-is-confidential-token-valid.ts
+++ b/packages/react-sdk/src/wrappers-registry/use-is-confidential-token-valid.ts
@@ -21,9 +21,6 @@ export function useIsConfidentialTokenValid({
   const registryAddress = useWrappersRegistryAddress();
 
   return useQuery<boolean>(
-    isConfidentialTokenValidQueryOptions(sdk, {
-      registryAddress,
-      confidentialTokenAddress,
-    }),
+    isConfidentialTokenValidQueryOptions(sdk, { registryAddress, confidentialTokenAddress }),
   );
 }

--- a/packages/react-sdk/src/wrappers-registry/use-list-pairs.ts
+++ b/packages/react-sdk/src/wrappers-registry/use-list-pairs.ts
@@ -27,22 +27,13 @@ export function useListPairs({
   page = 1,
   pageSize = 100,
   metadata = false,
-}: {
-  page?: number;
-  pageSize?: number;
-  metadata?: boolean;
-} = {}) {
+}: { page?: number; pageSize?: number; metadata?: boolean } = {}) {
   const sdk = useZamaSDK();
   const registryAddress = useWrappersRegistryAddress();
 
   // Pass sdk.registry (a lazy singleton) so the class-level TTL cache is shared
   // across all queryFn executions — rather than constructing a new instance each time.
   return useQuery<PaginatedResult<TokenWrapperPair | TokenWrapperPairWithMetadata>>(
-    listPairsQueryOptions(sdk.registry, {
-      registryAddress,
-      page,
-      pageSize,
-      metadata,
-    }),
+    listPairsQueryOptions(sdk.registry, { registryAddress, page, pageSize, metadata }),
   );
 }

--- a/packages/react-sdk/src/wrappers-registry/use-token-address.ts
+++ b/packages/react-sdk/src/wrappers-registry/use-token-address.ts
@@ -18,9 +18,6 @@ export function useTokenAddress({
   const registryAddress = useWrappersRegistryAddress();
 
   return useQuery<readonly [boolean, Address]>(
-    tokenAddressQueryOptions(sdk, {
-      registryAddress,
-      confidentialTokenAddress,
-    }),
+    tokenAddressQueryOptions(sdk, { registryAddress, confidentialTokenAddress }),
   );
 }

--- a/packages/react-sdk/src/wrappers-registry/use-token-pair.ts
+++ b/packages/react-sdk/src/wrappers-registry/use-token-pair.ts
@@ -15,10 +15,5 @@ export function useTokenPair({ index }: { index: bigint | undefined }) {
   const sdk = useZamaSDK();
   const registryAddress = useWrappersRegistryAddress();
 
-  return useQuery<TokenWrapperPair>(
-    tokenPairQueryOptions(sdk, {
-      registryAddress,
-      index,
-    }),
-  );
+  return useQuery<TokenWrapperPair>(tokenPairQueryOptions(sdk, { registryAddress, index }));
 }

--- a/packages/react-sdk/src/wrappers-registry/use-token-pairs-length.ts
+++ b/packages/react-sdk/src/wrappers-registry/use-token-pairs-length.ts
@@ -12,9 +12,5 @@ export function useTokenPairsLength() {
   const sdk = useZamaSDK();
   const registryAddress = useWrappersRegistryAddress();
 
-  return useQuery<bigint>(
-    tokenPairsLengthQueryOptions(sdk, {
-      registryAddress,
-    }),
-  );
+  return useQuery<bigint>(tokenPairsLengthQueryOptions(sdk, { registryAddress }));
 }

--- a/packages/react-sdk/src/wrappers-registry/use-token-pairs-registry.ts
+++ b/packages/react-sdk/src/wrappers-registry/use-token-pairs-registry.ts
@@ -14,9 +14,5 @@ export function useTokenPairsRegistry() {
   const sdk = useZamaSDK();
   const registryAddress = useWrappersRegistryAddress();
 
-  return useQuery<readonly TokenWrapperPair[]>(
-    tokenPairsQueryOptions(sdk, {
-      registryAddress,
-    }),
-  );
+  return useQuery<readonly TokenWrapperPair[]>(tokenPairsQueryOptions(sdk, { registryAddress }));
 }

--- a/packages/react-sdk/src/wrappers-registry/use-token-pairs-slice.ts
+++ b/packages/react-sdk/src/wrappers-registry/use-token-pairs-slice.ts
@@ -23,10 +23,6 @@ export function useTokenPairsSlice({
   const registryAddress = useWrappersRegistryAddress();
 
   return useQuery<readonly TokenWrapperPair[]>(
-    tokenPairsSliceQueryOptions(sdk, {
-      registryAddress,
-      fromIndex,
-      toIndex,
-    }),
+    tokenPairsSliceQueryOptions(sdk, { registryAddress, fromIndex, toIndex }),
   );
 }

--- a/packages/react-sdk/tsconfig.json
+++ b/packages/react-sdk/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "tsBuildInfoFile": ".tsbuildinfo"
-  },
+  "compilerOptions": { "tsBuildInfoFile": ".tsbuildinfo" },
   "include": ["src/**/*.ts", "src/**/*.tsx", "../../iife.d.ts"],
   "exclude": [
     "src/**/*.test.ts",

--- a/packages/sdk/rolldown.config.ts
+++ b/packages/sdk/rolldown.config.ts
@@ -11,9 +11,7 @@ const shared = {
     /^node:/,
     /^zod($|\/)/,
   ],
-  resolve: {
-    tsconfigFilename: "tsconfig.build.json",
-  },
+  resolve: { tsconfigFilename: "tsconfig.build.json" },
   treeshake: true,
 };
 
@@ -35,12 +33,7 @@ export default defineConfig([
       "node/index": "src/node/index.ts",
       "node/relayer-sdk.node-worker": "src/worker/relayer-sdk.node-worker.ts",
     },
-    output: {
-      dir: "dist/esm",
-      format: "esm",
-      sourcemap: true,
-      minify: true,
-    },
+    output: { dir: "dist/esm", format: "esm", sourcemap: true, minify: true },
     ...shared,
     plugins: [iife({ tsconfig: "tsconfig.build.json" }), dts({ tsconfig: "tsconfig.build.json" })],
   },

--- a/packages/sdk/src/__tests__/chain-alignment.test.ts
+++ b/packages/sdk/src/__tests__/chain-alignment.test.ts
@@ -51,10 +51,7 @@ describe("chain alignment guards", () => {
   test.for(MISMATCHED_OPS)(
     "%s throws ChainMismatchError before any side-effect",
     async ([operation, run], { sdk, signer, provider, relayer, tokenAddress }) => {
-      const walletAccount = {
-        address: signer.walletAccount.getSnapshot()!.address,
-        chainId: 1,
-      };
+      const walletAccount = { address: signer.walletAccount.getSnapshot()!.address, chainId: 1 };
       vi.mocked(signer.walletAccount.getSnapshot).mockReturnValue(walletAccount);
       vi.mocked(signer.requireWalletAccount).mockReturnValue(walletAccount);
       vi.mocked(provider.getChainId).mockResolvedValue(11155111);

--- a/packages/sdk/src/__tests__/events.test.ts
+++ b/packages/sdk/src/__tests__/events.test.ts
@@ -89,29 +89,18 @@ describe("decodeConfidentialTransfer", () => {
 
   test("decodes valid log", () => {
     const event = decodeConfidentialTransfer(log);
-    expect(event).toEqual({
-      eventName: "ConfidentialTransfer",
-      from,
-      to,
-      encryptedAmount,
-    });
+    expect(event).toEqual({ eventName: "ConfidentialTransfer", from, to, encryptedAmount });
   });
 
   test("returns null for wrong topic", () => {
     expect(
-      decodeConfidentialTransfer({
-        ...log,
-        topics: [Topics.Wrap, ...log.topics.slice(1)],
-      }),
+      decodeConfidentialTransfer({ ...log, topics: [Topics.Wrap, ...log.topics.slice(1)] }),
     ).toBeNull();
   });
 
   test("returns null for insufficient topics", () => {
     expect(
-      decodeConfidentialTransfer({
-        ...log,
-        topics: [Topics.ConfidentialTransfer],
-      }),
+      decodeConfidentialTransfer({ ...log, topics: [Topics.ConfidentialTransfer] }),
     ).toBeNull();
   });
 });
@@ -128,20 +117,12 @@ describe("decodeWrap", () => {
 
   test("decodes valid log", () => {
     const event = decodeWrap(log);
-    expect(event).toEqual({
-      eventName: "Wrap",
-      to,
-      roundedAmount,
-      encryptedWrappedAmount,
-    });
+    expect(event).toEqual({ eventName: "Wrap", to, roundedAmount, encryptedWrappedAmount });
   });
 
   test("returns null for wrong topic", () => {
     expect(
-      decodeWrap({
-        ...log,
-        topics: [Topics.UnwrapRequested, ...log.topics.slice(1)],
-      }),
+      decodeWrap({ ...log, topics: [Topics.UnwrapRequested, ...log.topics.slice(1)] }),
     ).toBeNull();
   });
 });
@@ -168,10 +149,7 @@ describe("decodeUnwrapRequested", () => {
 
   test("returns null for wrong topic", () => {
     expect(
-      decodeUnwrapRequested({
-        ...log,
-        topics: [Topics.Wrap, ...log.topics.slice(1)],
-      }),
+      decodeUnwrapRequested({ ...log, topics: [Topics.Wrap, ...log.topics.slice(1)] }),
     ).toBeNull();
   });
 });
@@ -200,10 +178,7 @@ describe("decodeUnwrapFinalized", () => {
 
   test("returns null for wrong topic", () => {
     expect(
-      decodeUnwrapFinalized({
-        ...log,
-        topics: [Topics.Wrap, ...log.topics.slice(1)],
-      }),
+      decodeUnwrapFinalized({ ...log, topics: [Topics.Wrap, ...log.topics.slice(1)] }),
     ).toBeNull();
   });
 });
@@ -229,10 +204,7 @@ describe("decodeOnChainEvent", () => {
   });
 
   test("returns null for unknown event", () => {
-    const log: RawLog = {
-      topics: [topic("00".repeat(32))],
-      data: "0x",
-    };
+    const log: RawLog = { topics: [topic("00".repeat(32))], data: "0x" };
     expect(decodeOnChainEvent(log)).toBeNull();
   });
 });
@@ -361,19 +333,13 @@ describe("decodeDelegatedForUserDecryption", () => {
 
   test("returns null for wrong topic", () => {
     expect(
-      decodeDelegatedForUserDecryption({
-        ...log,
-        topics: [Topics.Wrap, ...log.topics.slice(1)],
-      }),
+      decodeDelegatedForUserDecryption({ ...log, topics: [Topics.Wrap, ...log.topics.slice(1)] }),
     ).toBeNull();
   });
 
   test("returns null for insufficient topics", () => {
     expect(
-      decodeDelegatedForUserDecryption({
-        ...log,
-        topics: [AclTopics.DelegatedForUserDecryption],
-      }),
+      decodeDelegatedForUserDecryption({ ...log, topics: [AclTopics.DelegatedForUserDecryption] }),
     ).toBeNull();
   });
 });
@@ -439,10 +405,7 @@ describe("decodeAclEvent", () => {
   });
 
   test("returns null for unknown event", () => {
-    const log: RawLog = {
-      topics: [topic("00".repeat(32))],
-      data: "0x",
-    };
+    const log: RawLog = { topics: [topic("00".repeat(32))], data: "0x" };
     expect(decodeAclEvent(log)).toBeNull();
   });
 });

--- a/packages/sdk/src/__tests__/viem-signer.test.ts
+++ b/packages/sdk/src/__tests__/viem-signer.test.ts
@@ -20,9 +20,7 @@ describe("ViemSigner", () => {
     "%s throws WalletNotConnectedError when no account is configured",
     async (_, call) => {
       const signer = new ViemSigner({
-        walletClient: {
-          getChainId: vi.fn().mockResolvedValue(31337),
-        } as unknown as WalletClient,
+        walletClient: { getChainId: vi.fn().mockResolvedValue(31337) } as unknown as WalletClient,
       });
 
       await expect(

--- a/packages/sdk/src/__tests__/wrappers-registry.test.ts
+++ b/packages/sdk/src/__tests__/wrappers-registry.test.ts
@@ -96,9 +96,7 @@ describe("WrappersRegistry", () => {
 
       expect(result).toBe(5n);
       expect(provider.readContract).toHaveBeenCalledWith(
-        expect.objectContaining({
-          functionName: "getTokenConfidentialTokenPairsLength",
-        }),
+        expect.objectContaining({ functionName: "getTokenConfidentialTokenPairsLength" }),
       );
     });
 
@@ -134,10 +132,7 @@ describe("WrappersRegistry", () => {
         isValid: true,
       });
       expect(provider.readContract).toHaveBeenCalledWith(
-        expect.objectContaining({
-          functionName: "getTokenConfidentialTokenPair",
-          args: [3n],
-        }),
+        expect.objectContaining({ functionName: "getTokenConfidentialTokenPair", args: [3n] }),
       );
     });
 
@@ -172,9 +167,7 @@ describe("WrappersRegistry", () => {
 
       expect(valid).toBe(true);
       expect(provider.readContract).toHaveBeenCalledWith(
-        expect.objectContaining({
-          functionName: "isConfidentialTokenValid",
-        }),
+        expect.objectContaining({ functionName: "isConfidentialTokenValid" }),
       );
     });
   });
@@ -212,11 +205,7 @@ describe("WrappersRegistry", () => {
       vi.mocked(provider.readContract)
         .mockResolvedValueOnce(3n) // getTokenConfidentialTokenPairsLength
         .mockResolvedValueOnce([
-          {
-            tokenAddress: TOKEN,
-            confidentialTokenAddress: C_TOKEN,
-            isValid: true,
-          },
+          { tokenAddress: TOKEN, confidentialTokenAddress: C_TOKEN, isValid: true },
         ]); // getTokenConfidentialTokenPairsSlice
       const registry = new WrappersRegistry({ provider });
 
@@ -252,11 +241,7 @@ describe("WrappersRegistry", () => {
       vi.mocked(provider.readContract)
         .mockResolvedValueOnce(1n) // length
         .mockResolvedValueOnce([
-          {
-            tokenAddress: TOKEN,
-            confidentialTokenAddress: C_TOKEN,
-            isValid: true,
-          },
+          { tokenAddress: TOKEN, confidentialTokenAddress: C_TOKEN, isValid: true },
         ]) // slice
         .mockResolvedValueOnce("USD Coin") // name (underlying)
         .mockResolvedValueOnce("USDC") // symbol (underlying)
@@ -380,10 +365,7 @@ describe("WrappersRegistry", () => {
 
       const result = await registry.getConfidentialToken(TOKEN);
 
-      expect(result).toEqual({
-        confidentialTokenAddress: C_TOKEN,
-        isValid: true,
-      });
+      expect(result).toEqual({ confidentialTokenAddress: C_TOKEN, isValid: true });
     });
 
     test("returns structured result with isValid=false when revoked", async ({ provider }) => {
@@ -393,10 +375,7 @@ describe("WrappersRegistry", () => {
 
       const result = await registry.getConfidentialToken(TOKEN);
 
-      expect(result).toEqual({
-        confidentialTokenAddress: C_TOKEN,
-        isValid: false,
-      });
+      expect(result).toEqual({ confidentialTokenAddress: C_TOKEN, isValid: false });
     });
 
     test("returns null when not registered (zero address)", async ({ provider }) => {

--- a/packages/sdk/src/__tests__/zama-sdk-credentials-lifecycle.test.ts
+++ b/packages/sdk/src/__tests__/zama-sdk-credentials-lifecycle.test.ts
@@ -167,12 +167,7 @@ describe("ZamaSDK credentials lifecycle", () => {
       const signerA = createMockSigner();
       const providerA = createMockProvider();
       const relayerA = createMockRelayer();
-      const sdkA = createSDK({
-        signer: signerA,
-        provider: providerA,
-        relayer: relayerA,
-        storage,
-      });
+      const sdkA = createSDK({ signer: signerA, provider: providerA, relayer: relayerA, storage });
 
       await sdkA.permits.grantPermit([CONTRACT_A, CONTRACT_B]);
       expect(signerA.signTypedData).toHaveBeenCalledOnce();
@@ -190,12 +185,7 @@ describe("ZamaSDK credentials lifecycle", () => {
       const signerB = createMockSigner();
       const providerB = createMockProvider();
       const relayerB = createMockRelayer();
-      const sdkB = createSDK({
-        signer: signerB,
-        provider: providerB,
-        relayer: relayerB,
-        storage,
-      });
+      const sdkB = createSDK({ signer: signerB, provider: providerB, relayer: relayerB, storage });
 
       expect(await sdkB.permits.hasPermit([CONTRACT_A, CONTRACT_B])).toBe(true);
 

--- a/packages/sdk/src/abi/acl.abi.ts
+++ b/packages/sdk/src/abi/acl.abi.ts
@@ -6,16 +6,8 @@ export const aclAbi = [
     type: "function",
     name: "allow",
     inputs: [
-      {
-        name: "handle",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-      {
-        name: "account",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "handle", type: "bytes32", internalType: "bytes32" },
+      { name: "account", type: "address", internalType: "address" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -23,13 +15,7 @@ export const aclAbi = [
   {
     type: "function",
     name: "allowForDecryption",
-    inputs: [
-      {
-        name: "handlesList",
-        type: "bytes32[]",
-        internalType: "bytes32[]",
-      },
-    ],
+    inputs: [{ name: "handlesList", type: "bytes32[]", internalType: "bytes32[]" }],
     outputs: [],
     stateMutability: "nonpayable",
   },
@@ -37,16 +23,8 @@ export const aclAbi = [
     type: "function",
     name: "allowTransient",
     inputs: [
-      {
-        name: "ciphertext",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-      {
-        name: "account",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "ciphertext", type: "bytes32", internalType: "bytes32" },
+      { name: "account", type: "address", internalType: "address" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -62,21 +40,9 @@ export const aclAbi = [
     type: "function",
     name: "delegateForUserDecryption",
     inputs: [
-      {
-        name: "delegate",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "contractAddress",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "expirationDate",
-        type: "uint64",
-        internalType: "uint64",
-      },
+      { name: "delegate", type: "address", internalType: "address" },
+      { name: "contractAddress", type: "address", internalType: "address" },
+      { name: "expirationDate", type: "uint64", internalType: "uint64" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -85,184 +51,72 @@ export const aclAbi = [
     type: "function",
     name: "getUserDecryptionDelegationExpirationDate",
     inputs: [
-      {
-        name: "delegator",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "delegate",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "contractAddress",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "delegator", type: "address", internalType: "address" },
+      { name: "delegate", type: "address", internalType: "address" },
+      { name: "contractAddress", type: "address", internalType: "address" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "uint64",
-        internalType: "uint64",
-      },
-    ],
+    outputs: [{ name: "", type: "uint64", internalType: "uint64" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "isAccountDenied",
-    inputs: [
-      {
-        name: "account",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    inputs: [{ name: "account", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "isAllowed",
     inputs: [
-      {
-        name: "handle",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-      {
-        name: "account",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "handle", type: "bytes32", internalType: "bytes32" },
+      { name: "account", type: "address", internalType: "address" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "isAllowedForDecryption",
-    inputs: [
-      {
-        name: "handle",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    inputs: [{ name: "handle", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "isHandleDelegatedForUserDecryption",
     inputs: [
-      {
-        name: "delegator",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "delegate",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "contractAddress",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "handle",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
+      { name: "delegator", type: "address", internalType: "address" },
+      { name: "delegate", type: "address", internalType: "address" },
+      { name: "contractAddress", type: "address", internalType: "address" },
+      { name: "handle", type: "bytes32", internalType: "bytes32" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "multicall",
-    inputs: [
-      {
-        name: "data",
-        type: "bytes[]",
-        internalType: "bytes[]",
-      },
-    ],
-    outputs: [
-      {
-        name: "results",
-        type: "bytes[]",
-        internalType: "bytes[]",
-      },
-    ],
+    inputs: [{ name: "data", type: "bytes[]", internalType: "bytes[]" }],
+    outputs: [{ name: "results", type: "bytes[]", internalType: "bytes[]" }],
     stateMutability: "payable",
   },
   {
     type: "function",
     name: "persistAllowed",
     inputs: [
-      {
-        name: "handle",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-      {
-        name: "account",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "handle", type: "bytes32", internalType: "bytes32" },
+      { name: "account", type: "address", internalType: "address" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "revokeDelegationForUserDecryption",
     inputs: [
-      {
-        name: "delegate",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "contractAddress",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "delegate", type: "address", internalType: "address" },
+      { name: "contractAddress", type: "address", internalType: "address" },
     ],
     outputs: [],
     stateMutability: "nonpayable",

--- a/packages/sdk/src/abi/confidential-wrapper.abi.ts
+++ b/packages/sdk/src/abi/confidential-wrapper.abi.ts
@@ -6,13 +6,7 @@ export const confidentialWrapperAbi = [
     type: "function",
     name: "UPGRADE_INTERFACE_VERSION",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "string",
-        internalType: "string",
-      },
-    ],
+    outputs: [{ name: "", type: "string", internalType: "string" }],
     stateMutability: "view",
   },
   {
@@ -25,358 +19,144 @@ export const confidentialWrapperAbi = [
   {
     type: "function",
     name: "blockUser",
-    inputs: [
-      {
-        name: "user",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "user", type: "address", internalType: "address" }],
     outputs: [],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "confidentialBalanceOf",
-    inputs: [
-      {
-        name: "account",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    inputs: [{ name: "account", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "bytes32", internalType: "euint64" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "confidentialProtocolId",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "confidentialTotalSupply",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "euint64" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "confidentialTransfer",
     inputs: [
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "encryptedAmount",
-        type: "bytes32",
-        internalType: "externalEuint64",
-      },
-      {
-        name: "inputProof",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "encryptedAmount", type: "bytes32", internalType: "externalEuint64" },
+      { name: "inputProof", type: "bytes", internalType: "bytes" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "euint64" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "confidentialTransfer",
     inputs: [
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "amount",
-        type: "bytes32",
-        internalType: "euint64",
-      },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "amount", type: "bytes32", internalType: "euint64" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "euint64" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "confidentialTransferAndCall",
     inputs: [
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "amount",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-      {
-        name: "data",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "amount", type: "bytes32", internalType: "euint64" },
+      { name: "data", type: "bytes", internalType: "bytes" },
     ],
-    outputs: [
-      {
-        name: "transferred",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    outputs: [{ name: "transferred", type: "bytes32", internalType: "euint64" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "confidentialTransferAndCall",
     inputs: [
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "encryptedAmount",
-        type: "bytes32",
-        internalType: "externalEuint64",
-      },
-      {
-        name: "inputProof",
-        type: "bytes",
-        internalType: "bytes",
-      },
-      {
-        name: "data",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "encryptedAmount", type: "bytes32", internalType: "externalEuint64" },
+      { name: "inputProof", type: "bytes", internalType: "bytes" },
+      { name: "data", type: "bytes", internalType: "bytes" },
     ],
-    outputs: [
-      {
-        name: "transferred",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    outputs: [{ name: "transferred", type: "bytes32", internalType: "euint64" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "confidentialTransferFrom",
     inputs: [
-      {
-        name: "from",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "encryptedAmount",
-        type: "bytes32",
-        internalType: "externalEuint64",
-      },
-      {
-        name: "inputProof",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "from", type: "address", internalType: "address" },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "encryptedAmount", type: "bytes32", internalType: "externalEuint64" },
+      { name: "inputProof", type: "bytes", internalType: "bytes" },
     ],
-    outputs: [
-      {
-        name: "transferred",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    outputs: [{ name: "transferred", type: "bytes32", internalType: "euint64" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "confidentialTransferFrom",
     inputs: [
-      {
-        name: "from",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "amount",
-        type: "bytes32",
-        internalType: "euint64",
-      },
+      { name: "from", type: "address", internalType: "address" },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "amount", type: "bytes32", internalType: "euint64" },
     ],
-    outputs: [
-      {
-        name: "transferred",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    outputs: [{ name: "transferred", type: "bytes32", internalType: "euint64" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "confidentialTransferFromAndCall",
     inputs: [
-      {
-        name: "from",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "encryptedAmount",
-        type: "bytes32",
-        internalType: "externalEuint64",
-      },
-      {
-        name: "inputProof",
-        type: "bytes",
-        internalType: "bytes",
-      },
-      {
-        name: "data",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "from", type: "address", internalType: "address" },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "encryptedAmount", type: "bytes32", internalType: "externalEuint64" },
+      { name: "inputProof", type: "bytes", internalType: "bytes" },
+      { name: "data", type: "bytes", internalType: "bytes" },
     ],
-    outputs: [
-      {
-        name: "transferred",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    outputs: [{ name: "transferred", type: "bytes32", internalType: "euint64" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "confidentialTransferFromAndCall",
     inputs: [
-      {
-        name: "from",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "amount",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-      {
-        name: "data",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "from", type: "address", internalType: "address" },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "amount", type: "bytes32", internalType: "euint64" },
+      { name: "data", type: "bytes", internalType: "bytes" },
     ],
-    outputs: [
-      {
-        name: "transferred",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    outputs: [{ name: "transferred", type: "bytes32", internalType: "euint64" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "contractURI",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "string",
-        internalType: "string",
-      },
-    ],
+    outputs: [{ name: "", type: "string", internalType: "string" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "decimals",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "uint8",
-        internalType: "uint8",
-      },
-    ],
+    outputs: [{ name: "", type: "uint8", internalType: "uint8" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "discloseEncryptedAmount",
     inputs: [
-      {
-        name: "encryptedAmount",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-      {
-        name: "cleartextAmount",
-        type: "uint64",
-        internalType: "uint64",
-      },
-      {
-        name: "decryptionProof",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "encryptedAmount", type: "bytes32", internalType: "euint64" },
+      { name: "cleartextAmount", type: "uint64", internalType: "uint64" },
+      { name: "decryptionProof", type: "bytes", internalType: "bytes" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -385,21 +165,9 @@ export const confidentialWrapperAbi = [
     type: "function",
     name: "finalizeUnwrap",
     inputs: [
-      {
-        name: "unwrapRequestId",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-      {
-        name: "unwrapAmountCleartext",
-        type: "uint64",
-        internalType: "uint64",
-      },
-      {
-        name: "decryptionProof",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "unwrapRequestId", type: "bytes32", internalType: "bytes32" },
+      { name: "unwrapAmountCleartext", type: "uint64", internalType: "uint64" },
+      { name: "decryptionProof", type: "bytes", internalType: "bytes" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -409,16 +177,8 @@ export const confidentialWrapperAbi = [
     name: "getUnderlyingDenyListSelector",
     inputs: [],
     outputs: [
-      {
-        name: "isSet",
-        type: "bool",
-        internalType: "bool",
-      },
-      {
-        name: "selector",
-        type: "bytes4",
-        internalType: "bytes4",
-      },
+      { name: "isSet", type: "bool", internalType: "bool" },
+      { name: "selector", type: "bytes4", internalType: "bytes4" },
     ],
     stateMutability: "view",
   },
@@ -426,44 +186,18 @@ export const confidentialWrapperAbi = [
     type: "function",
     name: "inferredTotalSupply",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "initialize",
     inputs: [
-      {
-        name: "name_",
-        type: "string",
-        internalType: "string",
-      },
-      {
-        name: "symbol_",
-        type: "string",
-        internalType: "string",
-      },
-      {
-        name: "contractURI_",
-        type: "string",
-        internalType: "string",
-      },
-      {
-        name: "underlying_",
-        type: "address",
-        internalType: "contract IERC20",
-      },
-      {
-        name: "owner_",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "name_", type: "string", internalType: "string" },
+      { name: "symbol_", type: "string", internalType: "string" },
+      { name: "contractURI_", type: "string", internalType: "string" },
+      { name: "underlying_", type: "address", internalType: "contract IERC20" },
+      { name: "owner_", type: "address", internalType: "address" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -471,156 +205,72 @@ export const confidentialWrapperAbi = [
   {
     type: "function",
     name: "isBlocked",
-    inputs: [
-      {
-        name: "user",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    inputs: [{ name: "user", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "isOperator",
     inputs: [
-      {
-        name: "holder",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "spender",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "holder", type: "address", internalType: "address" },
+      { name: "spender", type: "address", internalType: "address" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "maxTotalSupply",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "name",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "string",
-        internalType: "string",
-      },
-    ],
+    outputs: [{ name: "", type: "string", internalType: "string" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "onTransferReceived",
     inputs: [
-      {
-        name: "operator",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "from",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "amount",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "data",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "operator", type: "address", internalType: "address" },
+      { name: "from", type: "address", internalType: "address" },
+      { name: "amount", type: "uint256", internalType: "uint256" },
+      { name: "data", type: "bytes", internalType: "bytes" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bytes4",
-        internalType: "bytes4",
-      },
-    ],
+    outputs: [{ name: "", type: "bytes4", internalType: "bytes4" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "owner",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "pendingOwner",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "proxiableUUID",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "rate",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
     stateMutability: "view",
   },
   {
@@ -634,21 +284,9 @@ export const confidentialWrapperAbi = [
     type: "function",
     name: "reinitializeV3",
     inputs: [
-      {
-        name: "blockedUsers",
-        type: "address[]",
-        internalType: "address[]",
-      },
-      {
-        name: "underlyingDenyListSelector",
-        type: "bytes4",
-        internalType: "bytes4",
-      },
-      {
-        name: "hasUnderlyingDenyListSelector_",
-        type: "bool",
-        internalType: "bool",
-      },
+      { name: "blockedUsers", type: "address[]", internalType: "address[]" },
+      { name: "underlyingDenyListSelector", type: "bytes4", internalType: "bytes4" },
+      { name: "hasUnderlyingDenyListSelector_", type: "bool", internalType: "bool" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -663,13 +301,7 @@ export const confidentialWrapperAbi = [
   {
     type: "function",
     name: "requestDiscloseEncryptedAmount",
-    inputs: [
-      {
-        name: "encryptedAmount",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    inputs: [{ name: "encryptedAmount", type: "bytes32", internalType: "euint64" }],
     outputs: [],
     stateMutability: "nonpayable",
   },
@@ -677,16 +309,8 @@ export const confidentialWrapperAbi = [
     type: "function",
     name: "setOperator",
     inputs: [
-      {
-        name: "operator",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "until",
-        type: "uint48",
-        internalType: "uint48",
-      },
+      { name: "operator", type: "address", internalType: "address" },
+      { name: "until", type: "uint48", internalType: "uint48" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -694,58 +318,28 @@ export const confidentialWrapperAbi = [
   {
     type: "function",
     name: "supportsInterface",
-    inputs: [
-      {
-        name: "interfaceId",
-        type: "bytes4",
-        internalType: "bytes4",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    inputs: [{ name: "interfaceId", type: "bytes4", internalType: "bytes4" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "symbol",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "string",
-        internalType: "string",
-      },
-    ],
+    outputs: [{ name: "", type: "string", internalType: "string" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "transferOwnership",
-    inputs: [
-      {
-        name: "newOwner",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "newOwner", type: "address", internalType: "address" }],
     outputs: [],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "unblockUser",
-    inputs: [
-      {
-        name: "user",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "user", type: "address", internalType: "address" }],
     outputs: [],
     stateMutability: "nonpayable",
   },
@@ -753,130 +347,52 @@ export const confidentialWrapperAbi = [
     type: "function",
     name: "underlying",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "unwrap",
     inputs: [
-      {
-        name: "from",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "encryptedAmount",
-        type: "bytes32",
-        internalType: "externalEuint64",
-      },
-      {
-        name: "inputProof",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "from", type: "address", internalType: "address" },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "encryptedAmount", type: "bytes32", internalType: "externalEuint64" },
+      { name: "inputProof", type: "bytes", internalType: "bytes" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "unwrap",
     inputs: [
-      {
-        name: "from",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "amount",
-        type: "bytes32",
-        internalType: "euint64",
-      },
+      { name: "from", type: "address", internalType: "address" },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "amount", type: "bytes32", internalType: "euint64" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "unwrapAmount",
-    inputs: [
-      {
-        name: "unwrapRequestId",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    inputs: [{ name: "unwrapRequestId", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "bytes32", internalType: "euint64" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "unwrapRequester",
-    inputs: [
-      {
-        name: "unwrapRequestId",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "unwrapRequestId", type: "bytes32", internalType: "bytes32" }],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "upgradeToAndCall",
     inputs: [
-      {
-        name: "newImplementation",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "data",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "newImplementation", type: "address", internalType: "address" },
+      { name: "data", type: "bytes", internalType: "bytes" },
     ],
     outputs: [],
     stateMutability: "payable",
@@ -885,42 +401,18 @@ export const confidentialWrapperAbi = [
     type: "function",
     name: "wrap",
     inputs: [
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "amount",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "amount", type: "uint256", internalType: "uint256" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "euint64" }],
     stateMutability: "nonpayable",
   },
   {
     type: "event",
     name: "AmountDiscloseRequested",
     inputs: [
-      {
-        name: "encryptedAmount",
-        type: "bytes32",
-        indexed: true,
-        internalType: "euint64",
-      },
-      {
-        name: "requester",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
+      { name: "encryptedAmount", type: "bytes32", indexed: true, internalType: "euint64" },
+      { name: "requester", type: "address", indexed: true, internalType: "address" },
     ],
     anonymous: false,
   },
@@ -928,18 +420,8 @@ export const confidentialWrapperAbi = [
     type: "event",
     name: "AmountDisclosed",
     inputs: [
-      {
-        name: "encryptedAmount",
-        type: "bytes32",
-        indexed: true,
-        internalType: "euint64",
-      },
-      {
-        name: "amount",
-        type: "uint64",
-        indexed: false,
-        internalType: "uint64",
-      },
+      { name: "encryptedAmount", type: "bytes32", indexed: true, internalType: "euint64" },
+      { name: "amount", type: "uint64", indexed: false, internalType: "uint64" },
     ],
     anonymous: false,
   },
@@ -947,62 +429,25 @@ export const confidentialWrapperAbi = [
     type: "event",
     name: "ConfidentialTransfer",
     inputs: [
-      {
-        name: "from",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "to",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "amount",
-        type: "bytes32",
-        indexed: true,
-        internalType: "euint64",
-      },
+      { name: "from", type: "address", indexed: true, internalType: "address" },
+      { name: "to", type: "address", indexed: true, internalType: "address" },
+      { name: "amount", type: "bytes32", indexed: true, internalType: "euint64" },
     ],
     anonymous: false,
   },
   {
     type: "event",
     name: "Initialized",
-    inputs: [
-      {
-        name: "version",
-        type: "uint64",
-        indexed: false,
-        internalType: "uint64",
-      },
-    ],
+    inputs: [{ name: "version", type: "uint64", indexed: false, internalType: "uint64" }],
     anonymous: false,
   },
   {
     type: "event",
     name: "OperatorSet",
     inputs: [
-      {
-        name: "holder",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "operator",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "until",
-        type: "uint48",
-        indexed: false,
-        internalType: "uint48",
-      },
+      { name: "holder", type: "address", indexed: true, internalType: "address" },
+      { name: "operator", type: "address", indexed: true, internalType: "address" },
+      { name: "until", type: "uint48", indexed: false, internalType: "uint48" },
     ],
     anonymous: false,
   },
@@ -1010,18 +455,8 @@ export const confidentialWrapperAbi = [
     type: "event",
     name: "OwnershipTransferStarted",
     inputs: [
-      {
-        name: "previousOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "newOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
+      { name: "previousOwner", type: "address", indexed: true, internalType: "address" },
+      { name: "newOwner", type: "address", indexed: true, internalType: "address" },
     ],
     anonymous: false,
   },
@@ -1029,18 +464,8 @@ export const confidentialWrapperAbi = [
     type: "event",
     name: "OwnershipTransferred",
     inputs: [
-      {
-        name: "previousOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "newOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
+      { name: "previousOwner", type: "address", indexed: true, internalType: "address" },
+      { name: "newOwner", type: "address", indexed: true, internalType: "address" },
     ],
     anonymous: false,
   },
@@ -1048,18 +473,8 @@ export const confidentialWrapperAbi = [
     type: "event",
     name: "PublicDecryptionVerified",
     inputs: [
-      {
-        name: "handlesList",
-        type: "bytes32[]",
-        indexed: false,
-        internalType: "bytes32[]",
-      },
-      {
-        name: "abiEncodedCleartexts",
-        type: "bytes",
-        indexed: false,
-        internalType: "bytes",
-      },
+      { name: "handlesList", type: "bytes32[]", indexed: false, internalType: "bytes32[]" },
+      { name: "abiEncodedCleartexts", type: "bytes", indexed: false, internalType: "bytes" },
     ],
     anonymous: false,
   },
@@ -1067,30 +482,10 @@ export const confidentialWrapperAbi = [
     type: "event",
     name: "UnwrapFinalized",
     inputs: [
-      {
-        name: "receiver",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "unwrapRequestId",
-        type: "bytes32",
-        indexed: true,
-        internalType: "bytes32",
-      },
-      {
-        name: "encryptedAmount",
-        type: "bytes32",
-        indexed: false,
-        internalType: "euint64",
-      },
-      {
-        name: "cleartextAmount",
-        type: "uint64",
-        indexed: false,
-        internalType: "uint64",
-      },
+      { name: "receiver", type: "address", indexed: true, internalType: "address" },
+      { name: "unwrapRequestId", type: "bytes32", indexed: true, internalType: "bytes32" },
+      { name: "encryptedAmount", type: "bytes32", indexed: false, internalType: "euint64" },
+      { name: "cleartextAmount", type: "uint64", indexed: false, internalType: "uint64" },
     ],
     anonymous: false,
   },
@@ -1098,379 +493,160 @@ export const confidentialWrapperAbi = [
     type: "event",
     name: "UnwrapRequested",
     inputs: [
-      {
-        name: "receiver",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "unwrapRequestId",
-        type: "bytes32",
-        indexed: true,
-        internalType: "bytes32",
-      },
-      {
-        name: "amount",
-        type: "bytes32",
-        indexed: false,
-        internalType: "euint64",
-      },
+      { name: "receiver", type: "address", indexed: true, internalType: "address" },
+      { name: "unwrapRequestId", type: "bytes32", indexed: true, internalType: "bytes32" },
+      { name: "amount", type: "bytes32", indexed: false, internalType: "euint64" },
     ],
     anonymous: false,
   },
   {
     type: "event",
     name: "Upgraded",
-    inputs: [
-      {
-        name: "implementation",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "implementation", type: "address", indexed: true, internalType: "address" }],
     anonymous: false,
   },
   {
     type: "event",
     name: "UserBlocked",
-    inputs: [
-      {
-        name: "user",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "user", type: "address", indexed: true, internalType: "address" }],
     anonymous: false,
   },
   {
     type: "event",
     name: "UserUnblocked",
-    inputs: [
-      {
-        name: "user",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "user", type: "address", indexed: true, internalType: "address" }],
     anonymous: false,
   },
   {
     type: "event",
     name: "Wrap",
     inputs: [
-      {
-        name: "to",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "roundedAmount",
-        type: "uint256",
-        indexed: false,
-        internalType: "uint256",
-      },
-      {
-        name: "encryptedWrappedAmount",
-        type: "bytes32",
-        indexed: false,
-        internalType: "euint64",
-      },
+      { name: "to", type: "address", indexed: true, internalType: "address" },
+      { name: "roundedAmount", type: "uint256", indexed: false, internalType: "uint256" },
+      { name: "encryptedWrappedAmount", type: "bytes32", indexed: false, internalType: "euint64" },
     ],
     anonymous: false,
   },
   {
     type: "error",
     name: "AddressEmptyCode",
-    inputs: [
-      {
-        name: "target",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "target", type: "address", internalType: "address" }],
   },
   {
     type: "error",
     name: "BlockedUser",
-    inputs: [
-      {
-        name: "user",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "user", type: "address", internalType: "address" }],
   },
   {
     type: "error",
     name: "ERC1967InvalidImplementation",
-    inputs: [
-      {
-        name: "implementation",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "implementation", type: "address", internalType: "address" }],
   },
+  { type: "error", name: "ERC1967NonPayable", inputs: [] },
   {
     type: "error",
-    name: "ERC1967NonPayable",
-    inputs: [],
+    name: "ERC7984InvalidReceiver",
+    inputs: [{ name: "receiver", type: "address", internalType: "address" }],
   },
   {
     type: "error",
     name: "ERC7984InvalidReceiver",
-    inputs: [
-      {
-        name: "receiver",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-  },
-  {
-    type: "error",
-    name: "ERC7984InvalidReceiver",
-    inputs: [
-      {
-        name: "receiver",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "receiver", type: "address", internalType: "address" }],
   },
   {
     type: "error",
     name: "ERC7984InvalidSender",
-    inputs: [
-      {
-        name: "sender",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "sender", type: "address", internalType: "address" }],
   },
-  {
-    type: "error",
-    name: "ERC7984TotalSupplyOverflow",
-    inputs: [],
-  },
+  { type: "error", name: "ERC7984TotalSupplyOverflow", inputs: [] },
   {
     type: "error",
     name: "ERC7984UnauthorizedCaller",
-    inputs: [
-      {
-        name: "caller",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "caller", type: "address", internalType: "address" }],
   },
   {
     type: "error",
     name: "ERC7984UnauthorizedSpender",
     inputs: [
-      {
-        name: "holder",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "spender",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "holder", type: "address", internalType: "address" },
+      { name: "spender", type: "address", internalType: "address" },
     ],
   },
   {
     type: "error",
     name: "ERC7984UnauthorizedUseOfEncryptedAmount",
     inputs: [
-      {
-        name: "amount",
-        type: "bytes32",
-        internalType: "euint64",
-      },
-      {
-        name: "user",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "amount", type: "bytes32", internalType: "euint64" },
+      { name: "user", type: "address", internalType: "address" },
     ],
   },
   {
     type: "error",
     name: "ERC7984ZeroBalance",
-    inputs: [
-      {
-        name: "holder",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "holder", type: "address", internalType: "address" }],
   },
-  {
-    type: "error",
-    name: "FailedCall",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "InvalidInitialization",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "InvalidKMSSignatures",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "InvalidUnderlyingDenyListResponse",
-    inputs: [],
-  },
+  { type: "error", name: "FailedCall", inputs: [] },
+  { type: "error", name: "InvalidInitialization", inputs: [] },
+  { type: "error", name: "InvalidKMSSignatures", inputs: [] },
+  { type: "error", name: "InvalidUnderlyingDenyListResponse", inputs: [] },
   {
     type: "error",
     name: "InvalidUnwrapRequest",
-    inputs: [
-      {
-        name: "unwrapRequestId",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
+    inputs: [{ name: "unwrapRequestId", type: "bytes32", internalType: "bytes32" }],
   },
-  {
-    type: "error",
-    name: "NotInitializing",
-    inputs: [],
-  },
+  { type: "error", name: "NotInitializing", inputs: [] },
   {
     type: "error",
     name: "OwnableInvalidOwner",
-    inputs: [
-      {
-        name: "owner",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "owner", type: "address", internalType: "address" }],
   },
   {
     type: "error",
     name: "OwnableUnauthorizedAccount",
-    inputs: [
-      {
-        name: "account",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "account", type: "address", internalType: "address" }],
   },
   {
     type: "error",
     name: "SafeCastOverflowedUintDowncast",
     inputs: [
-      {
-        name: "bits",
-        type: "uint8",
-        internalType: "uint8",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "bits", type: "uint8", internalType: "uint8" },
+      { name: "value", type: "uint256", internalType: "uint256" },
     ],
   },
   {
     type: "error",
     name: "SafeERC20FailedOperation",
-    inputs: [
-      {
-        name: "token",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "token", type: "address", internalType: "address" }],
   },
   {
     type: "error",
     name: "SenderNotAllowedToUseHandle",
     inputs: [
-      {
-        name: "handle",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-      {
-        name: "sender",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "handle", type: "bytes32", internalType: "bytes32" },
+      { name: "sender", type: "address", internalType: "address" },
     ],
   },
-  {
-    type: "error",
-    name: "UUPSUnauthorizedCallContext",
-    inputs: [],
-  },
+  { type: "error", name: "UUPSUnauthorizedCallContext", inputs: [] },
   {
     type: "error",
     name: "UUPSUnsupportedProxiableUUID",
-    inputs: [
-      {
-        name: "slot",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
+    inputs: [{ name: "slot", type: "bytes32", internalType: "bytes32" }],
   },
-  {
-    type: "error",
-    name: "UnderlyingDenyListCallFailed",
-    inputs: [],
-  },
+  { type: "error", name: "UnderlyingDenyListCallFailed", inputs: [] },
   {
     type: "error",
     name: "UnderlyingDenyListedAddress",
-    inputs: [
-      {
-        name: "user",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "user", type: "address", internalType: "address" }],
   },
   {
     type: "error",
     name: "UserAlreadyBlocked",
-    inputs: [
-      {
-        name: "user",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "user", type: "address", internalType: "address" }],
   },
   {
     type: "error",
     name: "UserAlreadyUnblocked",
-    inputs: [
-      {
-        name: "user",
-        type: "address",
-        internalType: "address",
-      },
-    ],
+    inputs: [{ name: "user", type: "address", internalType: "address" }],
   },
-  {
-    type: "error",
-    name: "ZamaProtocolUnsupported",
-    inputs: [],
-  },
+  { type: "error", name: "ZamaProtocolUnsupported", inputs: [] },
 ] as const;

--- a/packages/sdk/src/abi/erc1363.abi.ts
+++ b/packages/sdk/src/abi/erc1363.abi.ts
@@ -6,345 +6,136 @@ export const erc1363Abi = [
     type: "function",
     name: "allowance",
     inputs: [
-      {
-        name: "owner",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "spender",
-        type: "address",
-        internalType: "address",
-      },
+      { name: "owner", type: "address", internalType: "address" },
+      { name: "spender", type: "address", internalType: "address" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "approve",
     inputs: [
-      {
-        name: "spender",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "spender", type: "address", internalType: "address" },
+      { name: "value", type: "uint256", internalType: "uint256" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "approveAndCall",
     inputs: [
-      {
-        name: "spender",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "spender", type: "address", internalType: "address" },
+      { name: "value", type: "uint256", internalType: "uint256" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "approveAndCall",
     inputs: [
-      {
-        name: "spender",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "data",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "spender", type: "address", internalType: "address" },
+      { name: "value", type: "uint256", internalType: "uint256" },
+      { name: "data", type: "bytes", internalType: "bytes" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "balanceOf",
-    inputs: [
-      {
-        name: "account",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
+    inputs: [{ name: "account", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "supportsInterface",
-    inputs: [
-      {
-        name: "interfaceId",
-        type: "bytes4",
-        internalType: "bytes4",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    inputs: [{ name: "interfaceId", type: "bytes4", internalType: "bytes4" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "totalSupply",
     inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
     stateMutability: "view",
   },
   {
     type: "function",
     name: "transfer",
     inputs: [
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "value", type: "uint256", internalType: "uint256" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "transferAndCall",
     inputs: [
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "value", type: "uint256", internalType: "uint256" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "transferAndCall",
     inputs: [
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "data",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "value", type: "uint256", internalType: "uint256" },
+      { name: "data", type: "bytes", internalType: "bytes" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "transferFrom",
     inputs: [
-      {
-        name: "from",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "from", type: "address", internalType: "address" },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "value", type: "uint256", internalType: "uint256" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "transferFromAndCall",
     inputs: [
-      {
-        name: "from",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "data",
-        type: "bytes",
-        internalType: "bytes",
-      },
+      { name: "from", type: "address", internalType: "address" },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "value", type: "uint256", internalType: "uint256" },
+      { name: "data", type: "bytes", internalType: "bytes" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "nonpayable",
   },
   {
     type: "function",
     name: "transferFromAndCall",
     inputs: [
-      {
-        name: "from",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "to",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        internalType: "uint256",
-      },
+      { name: "from", type: "address", internalType: "address" },
+      { name: "to", type: "address", internalType: "address" },
+      { name: "value", type: "uint256", internalType: "uint256" },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "nonpayable",
   },
   {
     type: "event",
     name: "Approval",
     inputs: [
-      {
-        name: "owner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "spender",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        indexed: false,
-        internalType: "uint256",
-      },
+      { name: "owner", type: "address", indexed: true, internalType: "address" },
+      { name: "spender", type: "address", indexed: true, internalType: "address" },
+      { name: "value", type: "uint256", indexed: false, internalType: "uint256" },
     ],
     anonymous: false,
   },
@@ -352,24 +143,9 @@ export const erc1363Abi = [
     type: "event",
     name: "Transfer",
     inputs: [
-      {
-        name: "from",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "to",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "value",
-        type: "uint256",
-        indexed: false,
-        internalType: "uint256",
-      },
+      { name: "from", type: "address", indexed: true, internalType: "address" },
+      { name: "to", type: "address", indexed: true, internalType: "address" },
+      { name: "value", type: "uint256", indexed: false, internalType: "uint256" },
     ],
     anonymous: false,
   },

--- a/packages/sdk/src/abi/erc165.abi.ts
+++ b/packages/sdk/src/abi/erc165.abi.ts
@@ -5,20 +5,8 @@ export const erc165Abi = [
   {
     type: "function",
     name: "supportsInterface",
-    inputs: [
-      {
-        name: "interfaceId",
-        type: "bytes4",
-        internalType: "bytes4",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
+    inputs: [{ name: "interfaceId", type: "bytes4", internalType: "bytes4" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
     stateMutability: "view",
   },
 ] as const;

--- a/packages/sdk/src/config/__tests__/resolve.test.ts
+++ b/packages/sdk/src/config/__tests__/resolve.test.ts
@@ -6,10 +6,7 @@ import type { RelayerSDK } from "../../relayer/relayer-sdk";
 
 /** Stub the public RelayerConfig seam — no internal-module mocking. */
 function mockRelayerConfig(type: RelayerConfig["type"] = "web"): RelayerConfig {
-  return {
-    type,
-    createRelayer: () => ({}) as unknown as RelayerSDK,
-  };
+  return { type, createRelayer: () => ({}) as unknown as RelayerSDK };
 }
 
 describe("resolveChainRelayers", () => {
@@ -71,10 +68,7 @@ describe("resolveChainRelayers", () => {
       [1]: mainnetCfg,
     });
     expect(result.size).toBe(2);
-    expect(result.get(11155111)).toEqual({
-      chain: sepolia,
-      relayer: sepoliaCfg,
-    });
+    expect(result.get(11155111)).toEqual({ chain: sepolia, relayer: sepoliaCfg });
     expect(result.get(1)).toEqual({ chain: mainnet, relayer: mainnetCfg });
   });
 });

--- a/packages/sdk/src/config/__tests__/schema.test.ts
+++ b/packages/sdk/src/config/__tests__/schema.test.ts
@@ -9,10 +9,7 @@ import { LoggerService } from "../../services/logger-service";
 import type { RelayerConfig } from "../types";
 
 function mockRelayerConfig(relayer: RelayerSDK): RelayerConfig {
-  return {
-    type: "test",
-    createRelayer: vi.fn(() => relayer),
-  };
+  return { type: "test", createRelayer: vi.fn(() => relayer) };
 }
 
 describe("createConfig validation", () => {

--- a/packages/sdk/src/config/__tests__/types.test-d.ts
+++ b/packages/sdk/src/config/__tests__/types.test-d.ts
@@ -38,10 +38,7 @@ describe("ZamaConfigBase (mapped relayers)", () => {
     // Valid: relayer for every chain
     assertType<ZamaConfigBase<readonly [typeof sepolia, typeof mainnet]>>({
       chains: [sepolia, mainnet] as const,
-      relayers: {
-        [sepolia.id]: {} as RelayerConfig,
-        [mainnet.id]: {} as RelayerConfig,
-      },
+      relayers: { [sepolia.id]: {} as RelayerConfig, [mainnet.id]: {} as RelayerConfig },
     });
   });
 
@@ -55,9 +52,6 @@ describe("ZamaConfigBase (mapped relayers)", () => {
 
   test("rejects empty chains tuple", () => {
     // @ts-expect-error — empty tuple does not satisfy AtLeastOneChain
-    assertType<ZamaConfigBase<readonly []>>({
-      chains: [] as const,
-      relayers: {},
-    });
+    assertType<ZamaConfigBase<readonly []>>({ chains: [] as const, relayers: {} });
   });
 });

--- a/packages/sdk/src/config/resolve.ts
+++ b/packages/sdk/src/config/resolve.ts
@@ -61,10 +61,7 @@ export function resolveChainRelayers(
       );
     }
 
-    result.set(id, {
-      chain: chainConfig,
-      relayer: relayerConfig,
-    });
+    result.set(id, { chain: chainConfig, relayer: relayerConfig });
   }
 
   const relayerIdSet = new Set(Object.keys(relayers).map(Number));

--- a/packages/sdk/src/contracts/__tests__/contracts.test.ts
+++ b/packages/sdk/src/contracts/__tests__/contracts.test.ts
@@ -250,16 +250,8 @@ describe("Wrapper contract builders", () => {
 // unwrapRequestId, unwrapAmount / unwrapRequester are exposed, and both UnwrapRequested
 // and UnwrapFinalized events include the indexed unwrapRequestId topic.
 describe("confidentialWrapperAbi version smoke test (protocol-apps@71611c624ddc)", () => {
-  type AbiFunction = {
-    type: string;
-    name: string;
-    inputs: { type: string; name: string }[];
-  };
-  type AbiEvent = {
-    type: string;
-    name: string;
-    inputs: { type: string; name: string }[];
-  };
+  type AbiFunction = { type: string; name: string; inputs: { type: string; name: string }[] };
+  type AbiEvent = { type: string; name: string; inputs: { type: string; name: string }[] };
   const fns = (confidentialWrapperAbi as unknown as AbiFunction[]).filter(
     (x) => x.type === "function",
   );

--- a/packages/sdk/src/contracts/erc20.ts
+++ b/packages/sdk/src/contracts/erc20.ts
@@ -9,12 +9,7 @@ import { erc20Abi, type Address } from "viem";
  * ```
  */
 export function nameContract(tokenAddress: Address) {
-  return {
-    address: tokenAddress,
-    abi: erc20Abi,
-    functionName: "name",
-    args: [],
-  } as const;
+  return { address: tokenAddress, abi: erc20Abi, functionName: "name", args: [] } as const;
 }
 
 /**
@@ -26,12 +21,7 @@ export function nameContract(tokenAddress: Address) {
  * ```
  */
 export function symbolContract(tokenAddress: Address) {
-  return {
-    address: tokenAddress,
-    abi: erc20Abi,
-    functionName: "symbol",
-    args: [],
-  } as const;
+  return { address: tokenAddress, abi: erc20Abi, functionName: "symbol", args: [] } as const;
 }
 
 /**
@@ -43,12 +33,7 @@ export function symbolContract(tokenAddress: Address) {
  * ```
  */
 export function decimalsContract(tokenAddress: Address) {
-  return {
-    address: tokenAddress,
-    abi: erc20Abi,
-    functionName: "decimals",
-    args: [],
-  } as const;
+  return { address: tokenAddress, abi: erc20Abi, functionName: "decimals", args: [] } as const;
 }
 
 /**
@@ -60,12 +45,7 @@ export function decimalsContract(tokenAddress: Address) {
  * ```
  */
 export function erc20TotalSupplyContract(tokenAddress: Address) {
-  return {
-    address: tokenAddress,
-    abi: erc20Abi,
-    functionName: "totalSupply",
-    args: [],
-  } as const;
+  return { address: tokenAddress, abi: erc20Abi, functionName: "totalSupply", args: [] } as const;
 }
 
 /**

--- a/packages/sdk/src/contracts/wrappers-registry.ts
+++ b/packages/sdk/src/contracts/wrappers-registry.ts
@@ -8,11 +8,7 @@ export const wrappersRegistryAbi = [
       {
         components: [
           { internalType: "address", name: "tokenAddress", type: "address" },
-          {
-            internalType: "address",
-            name: "confidentialTokenAddress",
-            type: "address",
-          },
+          { internalType: "address", name: "confidentialTokenAddress", type: "address" },
           { internalType: "bool", name: "isValid", type: "bool" },
         ],
         internalType: "struct ConfidentialTokenWrappersRegistry.TokenWrapperPair[]",
@@ -40,11 +36,7 @@ export const wrappersRegistryAbi = [
       {
         components: [
           { internalType: "address", name: "tokenAddress", type: "address" },
-          {
-            internalType: "address",
-            name: "confidentialTokenAddress",
-            type: "address",
-          },
+          { internalType: "address", name: "confidentialTokenAddress", type: "address" },
           { internalType: "bool", name: "isValid", type: "bool" },
         ],
         internalType: "struct ConfidentialTokenWrappersRegistry.TokenWrapperPair[]",
@@ -62,11 +54,7 @@ export const wrappersRegistryAbi = [
       {
         components: [
           { internalType: "address", name: "tokenAddress", type: "address" },
-          {
-            internalType: "address",
-            name: "confidentialTokenAddress",
-            type: "address",
-          },
+          { internalType: "address", name: "confidentialTokenAddress", type: "address" },
           { internalType: "bool", name: "isValid", type: "bool" },
         ],
         internalType: "struct ConfidentialTokenWrappersRegistry.TokenWrapperPair",
@@ -88,13 +76,7 @@ export const wrappersRegistryAbi = [
     type: "function",
   },
   {
-    inputs: [
-      {
-        internalType: "address",
-        name: "confidentialTokenAddress",
-        type: "address",
-      },
-    ],
+    inputs: [{ internalType: "address", name: "confidentialTokenAddress", type: "address" }],
     name: "getTokenAddress",
     outputs: [
       { internalType: "bool", name: "", type: "bool" },
@@ -104,13 +86,7 @@ export const wrappersRegistryAbi = [
     type: "function",
   },
   {
-    inputs: [
-      {
-        internalType: "address",
-        name: "confidentialTokenAddress",
-        type: "address",
-      },
-    ],
+    inputs: [{ internalType: "address", name: "confidentialTokenAddress", type: "address" }],
     name: "isConfidentialTokenValid",
     outputs: [{ internalType: "bool", name: "", type: "bool" }],
     stateMutability: "view",
@@ -134,13 +110,7 @@ export const wrappersRegistryAbi = [
     type: "function",
   },
   {
-    inputs: [
-      {
-        internalType: "address",
-        name: "confidentialTokenAddress",
-        type: "address",
-      },
-    ],
+    inputs: [{ internalType: "address", name: "confidentialTokenAddress", type: "address" }],
     name: "revokeConfidentialToken",
     outputs: [],
     stateMutability: "nonpayable",

--- a/packages/sdk/src/credentials/__tests__/credential-service.test.ts
+++ b/packages/sdk/src/credentials/__tests__/credential-service.test.ts
@@ -176,11 +176,7 @@ describe("CredentialService.allow signing-error wrapping", () => {
       reject: () => new Error("network unreachable"),
       expected: SigningFailedError,
     },
-    {
-      label: "non-Error throw",
-      reject: () => "boom",
-      expected: SigningFailedError,
-    },
+    { label: "non-Error throw", reject: () => "boom", expected: SigningFailedError },
   ])(
     "$label is wrapped via SigningError taxonomy",
     async ({ reject, expected }, { credentialService, signer }) => {

--- a/packages/sdk/src/credentials/__tests__/permission-store.test.ts
+++ b/packages/sdk/src/credentials/__tests__/permission-store.test.ts
@@ -12,17 +12,9 @@ const PUBLIC_KEY = `0x${"11".repeat(32)}` as const;
 const OTHER_PUBLIC_KEY = `0x${"22".repeat(32)}` as const;
 const SIGNATURE = `0x${"33".repeat(65)}` as const;
 
-const directScope = {
-  signerAddress: USER,
-  chainId: 31337,
-  delegatorAddress: USER,
-};
+const directScope = { signerAddress: USER, chainId: 31337, delegatorAddress: USER };
 
-const delegatedScope = {
-  signerAddress: USER,
-  chainId: 31337,
-  delegatorAddress: DELEGATOR,
-};
+const delegatedScope = { signerAddress: USER, chainId: 31337, delegatorAddress: DELEGATOR };
 
 function makePermission(
   overrides: Partial<Permission> & {
@@ -75,10 +67,7 @@ describe("PermissionStore", () => {
   }) => {
     await store.append(directScope, [makePermission({ signedContractAddresses: [TOKEN_A] })]);
     await store.append(delegatedScope, [
-      makePermission({
-        signedContractAddresses: [TOKEN_B],
-        delegatorAddress: DELEGATOR,
-      }),
+      makePermission({ signedContractAddresses: [TOKEN_B], delegatorAddress: DELEGATOR }),
     ]);
 
     expect(await store.list(directScope)).toHaveLength(1);

--- a/packages/sdk/src/credentials/__tests__/permissions.test.ts
+++ b/packages/sdk/src/credentials/__tests__/permissions.test.ts
@@ -76,14 +76,8 @@ describe("findPermitToWiden", () => {
   });
 
   test("breaks ties by most-recent startTimestamp", () => {
-    const older = makePermission([T1, T2], {
-      signature: SIG_1,
-      startTimestamp: 1_700_000_000,
-    });
-    const newer = makePermission([T1, T2], {
-      signature: SIG_2,
-      startTimestamp: 1_700_000_500,
-    });
+    const older = makePermission([T1, T2], { signature: SIG_1, startTimestamp: 1_700_000_000 });
+    const newer = makePermission([T1, T2], { signature: SIG_2, startTimestamp: 1_700_000_500 });
     // Same overlap with requested. Newer wins.
     const picked = findPermitToWiden([older, newer], [T3], [T1, T2, T3]);
     expect(picked).toBe(newer);

--- a/packages/sdk/src/credentials/credential-service.ts
+++ b/packages/sdk/src/credentials/credential-service.ts
@@ -102,11 +102,7 @@ export class CredentialService {
       const candidate = findPermitToWiden(permits, uncovered, requested);
       if (candidate !== null) {
         const widenedSet = sortedUnion(candidate.signedContractAddresses, uncovered);
-        const widened = await this.#signPermit({
-          chunk: widenedSet,
-          keypair,
-          scope,
-        });
+        const widened = await this.#signPermit({ chunk: widenedSet, keypair, scope });
         await swallow(
           "replace permit",
           () => this.#store.replace(scope, candidate.signature, widened),

--- a/packages/sdk/src/errors/__tests__/decrypt.test.ts
+++ b/packages/sdk/src/errors/__tests__/decrypt.test.ts
@@ -46,9 +46,7 @@ describe("wrapDecryptError", () => {
 
   describe("HTTP status mapping", () => {
     test("maps statusCode 400 to NoCiphertextError preserving the message", () => {
-      const error = Object.assign(new Error("no ciphertext for handle"), {
-        statusCode: 400,
-      });
+      const error = Object.assign(new Error("no ciphertext for handle"), { statusCode: 400 });
       const wrapped = wrapDecryptError(error, "fallback");
       expect(wrapped).toBeInstanceOf(NoCiphertextError);
       expect(wrapped.message).toBe("no ciphertext for handle");
@@ -56,27 +54,21 @@ describe("wrapDecryptError", () => {
     });
 
     test("maps statusCode 500 + isDelegated=true to DelegationNotPropagatedError", () => {
-      const error = Object.assign(new Error("internal error"), {
-        statusCode: 500,
-      });
+      const error = Object.assign(new Error("internal error"), { statusCode: 500 });
       const wrapped = wrapDecryptError(error, "fallback", true);
       expect(wrapped).toBeInstanceOf(DelegationNotPropagatedError);
       expect((wrapped as { cause?: unknown }).cause).toBe(error);
     });
 
     test("maps statusCode 500 + isDelegated=false to RelayerRequestFailedError", () => {
-      const error = Object.assign(new Error("server error"), {
-        statusCode: 500,
-      });
+      const error = Object.assign(new Error("server error"), { statusCode: 500 });
       const wrapped = wrapDecryptError(error, "fallback", false);
       expect(wrapped).toBeInstanceOf(RelayerRequestFailedError);
       expect((wrapped as RelayerRequestFailedError).statusCode).toBe(500);
     });
 
     test("maps other HTTP status codes to RelayerRequestFailedError preserving the code", () => {
-      const error = Object.assign(new Error("rate limited"), {
-        statusCode: 429,
-      });
+      const error = Object.assign(new Error("rate limited"), { statusCode: 429 });
       const wrapped = wrapDecryptError(error, "fallback");
       expect(wrapped).toBeInstanceOf(RelayerRequestFailedError);
       expect((wrapped as RelayerRequestFailedError).statusCode).toBe(429);

--- a/packages/sdk/src/errors/__tests__/errors.test-d.ts
+++ b/packages/sdk/src/errors/__tests__/errors.test-d.ts
@@ -115,16 +115,12 @@ describe("matchZamaError", () => {
 
   test("narrowing is additive: base-typed and base-field handlers still compile", () => {
     // a handler reading only base fields still compiles and infers the return type
-    const fromBaseField = matchZamaError(new Error("any"), {
-      SIGNING_REJECTED: (e) => e.message,
-    });
+    const fromBaseField = matchZamaError(new Error("any"), { SIGNING_REJECTED: (e) => e.message });
     expectTypeOf(fromBaseField).toEqualTypeOf<string | undefined>();
 
     // a handler annotated with the base type stays assignable (params are contravariant)
     const baseHandler = (e: ZamaError) => e.code;
-    const fromBaseHandler = matchZamaError(new Error("any"), {
-      SIGNING_REJECTED: baseHandler,
-    });
+    const fromBaseHandler = matchZamaError(new Error("any"), { SIGNING_REJECTED: baseHandler });
     expectTypeOf(fromBaseHandler).toEqualTypeOf<ZamaErrorCode | undefined>();
   });
 });

--- a/packages/sdk/src/errors/__tests__/errors.test.ts
+++ b/packages/sdk/src/errors/__tests__/errors.test.ts
@@ -86,34 +86,25 @@ describe("RelayerRequestFailedError", () => {
 describe("matchZamaError", () => {
   test("dispatches to the correct handler by error code", () => {
     const error = new SigningRejectedError("rejected");
-    const result = matchZamaError(error, {
-      SIGNING_REJECTED: (e) => `handled: ${e.message}`,
-    });
+    const result = matchZamaError(error, { SIGNING_REJECTED: (e) => `handled: ${e.message}` });
     expect(result).toBe("handled: rejected");
   });
 
   test("falls through to wildcard when no specific handler matches", () => {
     const error = new EncryptionFailedError("failed");
-    const result = matchZamaError(error, {
-      SIGNING_REJECTED: () => "wrong",
-      _: () => "wildcard",
-    });
+    const result = matchZamaError(error, { SIGNING_REJECTED: () => "wrong", _: () => "wildcard" });
     expect(result).toBe("wildcard");
   });
 
   test("returns undefined for non-ZamaError without wildcard", () => {
     const error = new Error("random");
-    const result = matchZamaError(error, {
-      SIGNING_REJECTED: () => "wrong",
-    });
+    const result = matchZamaError(error, { SIGNING_REJECTED: () => "wrong" });
     expect(result).toBeUndefined();
   });
 
   test("passes non-ZamaError to wildcard handler", () => {
     const error = new Error("random");
-    const result = matchZamaError(error, {
-      _: (e) => `caught: ${(e as Error).message}`,
-    });
+    const result = matchZamaError(error, { _: (e) => `caught: ${(e as Error).message}` });
     expect(result).toBe("caught: random");
   });
 });
@@ -152,30 +143,21 @@ describe("wrapSigningError", () => {
   test("preserves non-Error cause instead of dropping it", () => {
     const stringError = "string error value";
     expect(() => wrapSigningError(stringError, "test")).toThrow(
-      expect.objectContaining({
-        code: "SIGNING_FAILED",
-        cause: stringError,
-      }),
+      expect.objectContaining({ code: "SIGNING_FAILED", cause: stringError }),
     );
   });
 
   test("preserves object cause instead of dropping it", () => {
     const objError = { message: "something went wrong", code: 42 };
     expect(() => wrapSigningError(objError, "test")).toThrow(
-      expect.objectContaining({
-        code: "SIGNING_FAILED",
-        cause: objError,
-      }),
+      expect.objectContaining({ code: "SIGNING_FAILED", cause: objError }),
     );
   });
 
   test("detects rejection from non-Error objects with code 4001", () => {
     const walletError = { code: 4001, message: "User rejected" };
     expect(() => wrapSigningError(walletError, "test")).toThrow(
-      expect.objectContaining({
-        code: "SIGNING_REJECTED",
-        cause: walletError,
-      }),
+      expect.objectContaining({ code: "SIGNING_REJECTED", cause: walletError }),
     );
   });
 

--- a/packages/sdk/src/errors/decrypt.ts
+++ b/packages/sdk/src/errors/decrypt.ts
@@ -62,7 +62,5 @@ export function wrapDecryptError(
     );
   }
 
-  return new DecryptionFailedError(fallbackMessage, {
-    cause: error,
-  });
+  return new DecryptionFailedError(fallbackMessage, { cause: error });
 }

--- a/packages/sdk/src/errors/encrypt.ts
+++ b/packages/sdk/src/errors/encrypt.ts
@@ -29,9 +29,7 @@ export function wrapEncryptError(error: unknown, fallbackMessage: string): ZamaE
     return new RelayerRequestFailedError(
       error instanceof Error ? error.message : fallbackMessage,
       statusCode,
-      {
-        cause: error,
-      },
+      { cause: error },
     );
   }
 

--- a/packages/sdk/src/ethers/__tests__/ethers.test.ts
+++ b/packages/sdk/src/ethers/__tests__/ethers.test.ts
@@ -39,12 +39,7 @@ const { mockContractMethod, MockContract, MockBrowserProvider, mockGetSigner } =
     }
   }
 
-  return {
-    mockContractMethod,
-    MockContract,
-    MockBrowserProvider,
-    mockGetSigner,
-  };
+  return { mockContractMethod, MockContract, MockBrowserProvider, mockGetSigner };
 });
 
 vi.mock(import("ethers"), async (importOriginal) => {
@@ -96,9 +91,7 @@ describe("EthersSigner", () => {
         removeListener: vi.fn(),
         request: vi.fn().mockRejectedValue(new Error("not connected")),
       };
-      const ethersSigner = new EthersSigner({
-        ethereum: mockEthereum as never,
-      });
+      const ethersSigner = new EthersSigner({ ethereum: mockEthereum as never });
 
       expect(ethersSigner.walletAccount.getSnapshot()).toBeUndefined();
       expect(mockGetSigner).not.toHaveBeenCalled();
@@ -111,9 +104,7 @@ describe("EthersSigner", () => {
         request: vi.fn().mockRejectedValue(new Error("not connected")),
       };
 
-      const ethersSigner = new EthersSigner({
-        ethereum: mockEthereum as never,
-      });
+      const ethersSigner = new EthersSigner({ ethereum: mockEthereum as never });
 
       const onWalletAccountChange = vi.fn();
       const unsub = ethersSigner.walletAccount.subscribe(onWalletAccountChange);
@@ -134,9 +125,7 @@ describe("EthersSigner", () => {
         request: vi.fn().mockRejectedValue(new Error("not connected")),
       };
 
-      const ethersSigner = new EthersSigner({
-        ethereum: mockEthereum as never,
-      });
+      const ethersSigner = new EthersSigner({ ethereum: mockEthereum as never });
 
       ethersSigner.dispose();
       ethersSigner.dispose();
@@ -168,9 +157,7 @@ describe("EthersSigner", () => {
         }),
       };
 
-      const ethersSigner = new EthersSigner({
-        ethereum: mockEthereum as never,
-      });
+      const ethersSigner = new EthersSigner({ ethereum: mockEthereum as never });
 
       const onWalletAccountChange = vi.fn();
       ethersSigner.walletAccount.subscribe(onWalletAccountChange);
@@ -309,9 +296,7 @@ describe("EthersSigner", () => {
       };
 
       await ethersSigner.writeContract(config);
-      expect(mockContractMethod).toHaveBeenCalledWith(userAddress, 500n, {
-        value: 500n,
-      });
+      expect(mockContractMethod).toHaveBeenCalledWith(userAddress, 500n, { value: 500n });
     });
 
     test("throws when tx hash does not start with 0x", async ({ tokenAddress }) => {
@@ -319,12 +304,7 @@ describe("EthersSigner", () => {
 
       mockContractMethod.mockResolvedValueOnce({ hash: "notHex" });
 
-      const config = {
-        address: tokenAddress,
-        abi: [],
-        functionName: "fn",
-        args: [],
-      };
+      const config = { address: tokenAddress, abi: [], functionName: "fn", args: [] };
 
       await expect(ethersSigner.writeContract(config)).rejects.toThrow("Expected hex string");
     });
@@ -355,9 +335,7 @@ describe("EthersProvider", () => {
 
   describe("getChainId", () => {
     test("returns the numeric chain ID from the provider network", async () => {
-      const mockProvider = {
-        getNetwork: vi.fn().mockResolvedValue({ chainId: 8009n }),
-      };
+      const mockProvider = { getNetwork: vi.fn().mockResolvedValue({ chainId: 8009n }) };
       const ethersProvider = new EthersProvider({ provider: mockProvider as never });
 
       const chainId = await ethersProvider.getChainId();
@@ -391,9 +369,11 @@ describe("EthersProvider", () => {
   describe("waitForTransactionReceipt", () => {
     test("waits for the transaction and maps logs correctly", async () => {
       const mockProvider = {
-        waitForTransaction: vi.fn().mockResolvedValue({
-          logs: [{ topics: ["0xtopic1", null, "0xtopic3"], data: "0xdata" }],
-        }),
+        waitForTransaction: vi
+          .fn()
+          .mockResolvedValue({
+            logs: [{ topics: ["0xtopic1", null, "0xtopic3"], data: "0xdata" }],
+          }),
       };
       const ethersProvider = new EthersProvider({ provider: mockProvider as never });
 
@@ -405,9 +385,9 @@ describe("EthersProvider", () => {
 
     test("filters out null topics from logs", async () => {
       const mockProvider = {
-        waitForTransaction: vi.fn().mockResolvedValue({
-          logs: [{ topics: [null, "0xa", null, "0xb"], data: "0x" }],
-        }),
+        waitForTransaction: vi
+          .fn()
+          .mockResolvedValue({ logs: [{ topics: [null, "0xa", null, "0xb"], data: "0x" }] }),
       };
       const ethersProvider = new EthersProvider({ provider: mockProvider as never });
 
@@ -416,9 +396,7 @@ describe("EthersProvider", () => {
     });
 
     test("throws when receipt is null", async () => {
-      const mockProvider = {
-        waitForTransaction: vi.fn().mockResolvedValue(null),
-      };
+      const mockProvider = { waitForTransaction: vi.fn().mockResolvedValue(null) };
       const ethersProvider = new EthersProvider({ provider: mockProvider as never });
 
       await expect(ethersProvider.waitForTransactionReceipt("0xhash" as Hex)).rejects.toThrow(
@@ -440,9 +418,7 @@ describe("EthersProvider", () => {
 
   describe("getBlockTimestamp", () => {
     test("returns the latest block timestamp as bigint", async () => {
-      const mockProvider = {
-        getBlock: vi.fn().mockResolvedValue({ timestamp: 1700000000 }),
-      };
+      const mockProvider = { getBlock: vi.fn().mockResolvedValue({ timestamp: 1700000000 }) };
       const ethersProvider = new EthersProvider({ provider: mockProvider as never });
 
       const timestamp = await ethersProvider.getBlockTimestamp();
@@ -451,9 +427,7 @@ describe("EthersProvider", () => {
     });
 
     test("throws when no block is returned", async () => {
-      const mockProvider = {
-        getBlock: vi.fn().mockResolvedValue(null),
-      };
+      const mockProvider = { getBlock: vi.fn().mockResolvedValue(null) };
       const ethersProvider = new EthersProvider({ provider: mockProvider as never });
 
       await expect(ethersProvider.getBlockTimestamp()).rejects.toThrow(
@@ -500,9 +474,7 @@ describe("ethers write contract helpers", () => {
   const mockSigner = { call: vi.fn(), sendTransaction: vi.fn() };
 
   test("writeConfidentialTransferContract", async ({ tokenAddress, userAddress }) => {
-    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({
-      hash: TX_HASH,
-    });
+    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({ hash: TX_HASH });
     const hash = await writeConfidentialTransferContract(
       mockSigner,
       tokenAddress,
@@ -514,9 +486,7 @@ describe("ethers write contract helpers", () => {
   });
 
   test("writeUnwrapContract", async ({ tokenAddress, userAddress }) => {
-    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({
-      hash: TX_HASH,
-    });
+    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({ hash: TX_HASH });
     const hash = await writeUnwrapContract(
       mockSigner,
       tokenAddress,
@@ -529,9 +499,7 @@ describe("ethers write contract helpers", () => {
   });
 
   test("writeUnwrapFromBalanceContract", async ({ tokenAddress, userAddress }) => {
-    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({
-      hash: TX_HASH,
-    });
+    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({ hash: TX_HASH });
     const balance = VALID_ENCRYPTED_VALUE;
     const hash = await writeUnwrapFromBalanceContract(
       mockSigner,
@@ -544,9 +512,7 @@ describe("ethers write contract helpers", () => {
   });
 
   test("writeFinalizeUnwrapContract", async ({ wrapperAddress }) => {
-    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({
-      hash: TX_HASH,
-    });
+    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({ hash: TX_HASH });
     const burnt = VALID_ENCRYPTED_VALUE;
     const proof = VALID_PROOF;
     const hash = await writeFinalizeUnwrapContract(mockSigner, wrapperAddress, burnt, 500n, proof);
@@ -554,33 +520,25 @@ describe("ethers write contract helpers", () => {
   });
 
   test("writeSetOperatorContract", async ({ tokenAddress }) => {
-    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({
-      hash: TX_HASH,
-    });
+    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({ hash: TX_HASH });
     const hash = await writeSetOperatorContract(mockSigner, tokenAddress, SPENDER, 12345);
     expect(hash).toBe(TX_HASH);
   });
 
   test("writeSetOperatorContract without explicit timestamp", async ({ tokenAddress }) => {
-    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({
-      hash: TX_HASH,
-    });
+    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({ hash: TX_HASH });
     const hash = await writeSetOperatorContract(mockSigner, tokenAddress, SPENDER);
     expect(hash).toBe(TX_HASH);
   });
 
   test("writeWrapContract", async ({ wrapperAddress, userAddress }) => {
-    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({
-      hash: TX_HASH,
-    });
+    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({ hash: TX_HASH });
     const hash = await writeWrapContract(mockSigner, wrapperAddress, userAddress, 1000n);
     expect(hash).toBe(TX_HASH);
   });
 
   test("write helpers reject when tx hash is not hex", async ({ wrapperAddress, userAddress }) => {
-    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({
-      hash: "notHex",
-    });
+    vi.mocked(mockSigner.sendTransaction).mockResolvedValueOnce({ hash: "notHex" });
     await expect(writeWrapContract(mockSigner, wrapperAddress, userAddress, 1000n)).rejects.toThrow(
       "Expected hex string",
     );

--- a/packages/sdk/src/events/sdk-events.ts
+++ b/packages/sdk/src/events/sdk-events.ts
@@ -256,12 +256,8 @@ export const transactionOperationMetadata = {
   transferFromAndCall: {
     submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.TransferFromSubmitted, txHash }),
   },
-  unwrap: {
-    submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }),
-  },
-  unwrapAll: {
-    submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }),
-  },
+  unwrap: { submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }) },
+  unwrapAll: { submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }) },
 } satisfies Record<string, { submittedEvent: (txHash: Hex) => ZamaSDKEventInput }>;
 
 /**

--- a/packages/sdk/src/namespaces/__tests__/permits.test.ts
+++ b/packages/sdk/src/namespaces/__tests__/permits.test.ts
@@ -98,9 +98,7 @@ describe("Permits", () => {
 
       await expect(
         sdk.permits.grantDelegationPermit(DELEGATOR, [CONTRACT_A]),
-      ).rejects.toMatchObject({
-        operation: "grantDelegationPermit",
-      });
+      ).rejects.toMatchObject({ operation: "grantDelegationPermit" });
     });
   });
 

--- a/packages/sdk/src/namespaces/decryption.ts
+++ b/packages/sdk/src/namespaces/decryption.ts
@@ -137,11 +137,7 @@ export class Decryption {
    */
   async decryptPublicValues(encryptedValues: EncryptedValue[]): Promise<PublicDecryptResult> {
     if (encryptedValues.length === 0) {
-      return {
-        clearValues: {},
-        decryptionProof: "0x",
-        abiEncodedClearValues: "0x",
-      };
+      return { clearValues: {}, decryptionProof: "0x", abiEncodedClearValues: "0x" };
     }
 
     try {

--- a/packages/sdk/src/query/__tests__/confidential-balance.test.ts
+++ b/packages/sdk/src/query/__tests__/confidential-balance.test.ts
@@ -12,10 +12,7 @@ describe("confidentialBalanceQueryOptions", () => {
     const walletAccount = signer.walletAccount.getSnapshot();
     const options = confidentialBalanceQueryOptions(
       token,
-      {
-        tokenAddress,
-        account: owner,
-      },
+      { tokenAddress, account: owner },
       { walletAccount },
     );
 
@@ -52,11 +49,7 @@ describe("confidentialBalanceQueryOptions", () => {
     const token = createMockToken(tokenAddress);
     const options = confidentialBalanceQueryOptions(
       token,
-      {
-        tokenAddress,
-        account: owner,
-        query: { enabled: false },
-      },
+      { tokenAddress, account: owner, query: { enabled: false } },
       { walletAccount: signer.walletAccount.getSnapshot() },
     );
 
@@ -82,10 +75,7 @@ describe("confidentialBalanceQueryOptions", () => {
 
     const options = confidentialBalanceQueryOptions(
       token,
-      {
-        tokenAddress,
-        account: owner,
-      },
+      { tokenAddress, account: owner },
       { walletAccount: signer.walletAccount.getSnapshot() },
     );
 

--- a/packages/sdk/src/query/__tests__/confidential-balances.test.ts
+++ b/packages/sdk/src/query/__tests__/confidential-balances.test.ts
@@ -61,10 +61,7 @@ describe("confidentialBalancesQueryOptions", () => {
     const t1 = createMockToken(tokenA);
     const options = confidentialBalancesQueryOptions(
       [t1],
-      {
-        account: owner,
-        query: { enabled: false },
-      },
+      { account: owner, query: { enabled: false } },
       { walletAccount: signer.walletAccount.getSnapshot() },
     );
 

--- a/packages/sdk/src/query/__tests__/confidential-is-operator.test.ts
+++ b/packages/sdk/src/query/__tests__/confidential-is-operator.test.ts
@@ -21,16 +21,12 @@ describe("confidentialIsOperatorQueryOptions", () => {
     const missingHolder = confidentialIsOperatorQueryOptions(
       sdk,
       "0x1a1A1A1A1a1A1A1a1A1a1a1a1a1a1a1A1A1a1a1a",
-      {
-        spender: "0x3C3C3C3C3c3C3c3C3C3C3C3C3c3c3c3c3c3c3c3C",
-      },
+      { spender: "0x3C3C3C3C3c3C3c3C3C3C3C3C3c3c3c3c3c3c3c3C" },
     );
     const missingSpender = confidentialIsOperatorQueryOptions(
       sdk,
       "0x1a1A1A1A1a1A1A1a1A1a1a1a1a1a1a1A1A1a1a1a",
-      {
-        holder: "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B",
-      },
+      { holder: "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B" },
     );
 
     expect(missingHolder.enabled).toBe(false);

--- a/packages/sdk/src/query/__tests__/decrypt-balance-as.test.ts
+++ b/packages/sdk/src/query/__tests__/decrypt-balance-as.test.ts
@@ -7,9 +7,7 @@ describe("decryptBalanceAsMutationOptions", () => {
     const options = decryptBalanceAsMutationOptions(readonlyToken);
 
     expect(options.mutationKey).toEqual(["zama.decryptBalanceAs", readonlyToken.address]);
-    await options.mutationFn({
-      delegatorAddress: "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B",
-    });
+    await options.mutationFn({ delegatorAddress: "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B" });
     expect(readonlyToken.decryptBalanceAs).toHaveBeenCalledWith({
       delegatorAddress: "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B",
       accountAddress: undefined,

--- a/packages/sdk/src/query/__tests__/encrypt.test.ts
+++ b/packages/sdk/src/query/__tests__/encrypt.test.ts
@@ -17,9 +17,6 @@ describe("encryptMutationOptions", () => {
     const result = await options.mutationFn(params);
 
     expect(encrypt).toHaveBeenCalledWith(params);
-    expect(result).toEqual({
-      encryptedValues: [handle],
-      inputProof,
-    });
+    expect(result).toEqual({ encryptedValues: [handle], inputProof });
   });
 });

--- a/packages/sdk/src/query/__tests__/grant-permit-revoke.test.ts
+++ b/packages/sdk/src/query/__tests__/grant-permit-revoke.test.ts
@@ -45,14 +45,12 @@ describe("hasPermitQueryOptions", () => {
     });
     expect(options.queryKey).toEqual([
       "zama.hasPermit",
-      {
-        contractAddresses: ["0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B"],
-      },
+      { contractAddresses: ["0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B"] },
     ]);
 
-    const result = await options.queryFn({
-      queryKey: options.queryKey,
-    } as Parameters<typeof options.queryFn>[0]);
+    const result = await options.queryFn({ queryKey: options.queryKey } as Parameters<
+      typeof options.queryFn
+    >[0]);
     expect(result).toBe(true);
     expect(isAllowedSpy).toHaveBeenCalledTimes(1);
   });
@@ -65,13 +63,9 @@ describe("hasPermitQueryOptions", () => {
       "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B",
     ] as [Address, ...Address[]];
 
-    const options = hasPermitQueryOptions(sdk, {
-      contractAddresses: contracts,
-    });
+    const options = hasPermitQueryOptions(sdk, { contractAddresses: contracts });
 
-    await options.queryFn({
-      queryKey: options.queryKey,
-    } as Parameters<typeof options.queryFn>[0]);
+    await options.queryFn({ queryKey: options.queryKey } as Parameters<typeof options.queryFn>[0]);
 
     expect(isAllowedSpy).toHaveBeenCalledWith(contracts);
   });
@@ -95,9 +89,7 @@ describe("hasPermitQueryOptions", () => {
   });
 
   test("is disabled when the contract list is empty", ({ sdk }) => {
-    const options = hasPermitQueryOptions(sdk, {
-      contractAddresses: [],
-    });
+    const options = hasPermitQueryOptions(sdk, { contractAddresses: [] });
 
     expect(options.enabled).toBe(false);
   });
@@ -111,9 +103,7 @@ describe("hasPermitQueryOptions", () => {
     expect(options.enabled).toBe(false);
     expect(options.queryKey).toEqual([
       "zama.hasPermit",
-      {
-        contractAddresses: ["0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B"],
-      },
+      { contractAddresses: ["0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B"] },
     ]);
   });
 
@@ -124,9 +114,9 @@ describe("hasPermitQueryOptions", () => {
       contractAddresses: ["0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B"],
     });
 
-    const result = await options.queryFn({
-      queryKey: options.queryKey,
-    } as Parameters<typeof options.queryFn>[0]);
+    const result = await options.queryFn({ queryKey: options.queryKey } as Parameters<
+      typeof options.queryFn
+    >[0]);
     expect(result).toBe(false);
   });
 
@@ -135,16 +125,12 @@ describe("hasPermitQueryOptions", () => {
 
     const optionsA = hasPermitQueryOptions(
       sdk,
-      {
-        contractAddresses: ["0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B"],
-      },
+      { contractAddresses: ["0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B"] },
       { walletAccount },
     );
     const optionsB = hasPermitQueryOptions(
       sdk,
-      {
-        contractAddresses: ["0x1a1A1A1A1a1A1A1a1A1a1a1a1a1a1a1A1A1a1a1a"],
-      },
+      { contractAddresses: ["0x1a1A1A1A1a1A1A1a1A1a1a1a1a1a1a1A1A1a1a1a"] },
       { walletAccount },
     );
 

--- a/packages/sdk/src/query/__tests__/invalidation.test.ts
+++ b/packages/sdk/src/query/__tests__/invalidation.test.ts
@@ -18,10 +18,7 @@ const OTHER_TOKEN = "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B";
 
 function createQueryClient(): QueryClient {
   return new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: Infinity },
-      mutations: { retry: false },
-    },
+    defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
   });
 }
 

--- a/packages/sdk/src/query/__tests__/query-keys.test.ts
+++ b/packages/sdk/src/query/__tests__/query-keys.test.ts
@@ -43,10 +43,7 @@ describe("zamaQueryKeys", () => {
 
     expect(withOwner).toEqual([
       "zama.confidentialBalance",
-      {
-        tokenAddress: getAddress(TOKEN_LOWER),
-        owner: getAddress(OWNER_LOWER),
-      },
+      { tokenAddress: getAddress(TOKEN_LOWER), owner: getAddress(OWNER_LOWER) },
     ]);
 
     expect(withoutOwner).toEqual([
@@ -62,17 +59,12 @@ describe("zamaQueryKeys", () => {
 
     expect(withOwner).toEqual([
       "zama.confidentialBalances",
-      {
-        tokenAddresses: [getAddress(TOKEN_LOWER)],
-        owner: getAddress(OWNER_LOWER),
-      },
+      { tokenAddresses: [getAddress(TOKEN_LOWER)], owner: getAddress(OWNER_LOWER) },
     ]);
 
     expect(withoutOwner).toEqual([
       "zama.confidentialBalances",
-      {
-        tokenAddresses: [getAddress(TOKEN_LOWER)],
-      },
+      { tokenAddresses: [getAddress(TOKEN_LOWER)] },
     ]);
     expect(withoutOwner[1]).not.toHaveProperty("owner");
   });
@@ -125,9 +117,7 @@ describe("zamaQueryKeys", () => {
     ];
 
     expect(lowerVariants).toEqual(upperVariants);
-    expect(lowerVariants[0][1]).toMatchObject({
-      tokenAddress: getAddress(TOKEN_LOWER),
-    });
+    expect(lowerVariants[0][1]).toMatchObject({ tokenAddress: getAddress(TOKEN_LOWER) });
   });
 
   test("normalizes address fields in all other address-bearing factories", () => {
@@ -177,9 +167,7 @@ describe("zamaQueryKeys", () => {
   test("isAllowed scope key includes contractAddresses", () => {
     expect(zamaQueryKeys.hasPermit.scope([TOKEN_LOWER])).toEqual([
       "zama.hasPermit",
-      {
-        contractAddresses: [getAddress(TOKEN_LOWER)],
-      },
+      { contractAddresses: [getAddress(TOKEN_LOWER)] },
     ]);
   });
 
@@ -190,10 +178,7 @@ describe("zamaQueryKeys", () => {
     ]);
     expect(zamaQueryKeys.confidentialIsOperator.scope(TOKEN_LOWER, OWNER_LOWER)).toEqual([
       "zama.confidentialIsOperator",
-      {
-        tokenAddress: getAddress(TOKEN_LOWER),
-        holder: getAddress(OWNER_LOWER),
-      },
+      { tokenAddress: getAddress(TOKEN_LOWER), holder: getAddress(OWNER_LOWER) },
     ]);
   });
 });

--- a/packages/sdk/src/query/__tests__/shield.test.ts
+++ b/packages/sdk/src/query/__tests__/shield.test.ts
@@ -7,9 +7,7 @@ describe("shieldMutationOptions", () => {
 
     expect(options.mutationKey).toEqual(["zama.shield", mockWrappedToken.address]);
     await options.mutationFn({ amount: 1n, approvalStrategy: "exact" });
-    expect(mockWrappedToken.shield).toHaveBeenCalledWith(1n, {
-      approvalStrategy: "exact",
-    });
+    expect(mockWrappedToken.shield).toHaveBeenCalledWith(1n, { approvalStrategy: "exact" });
   });
 
   test("passes undefined optional shield params", async ({ mockWrappedToken }) => {

--- a/packages/sdk/src/query/__tests__/underlying-allowance.test.ts
+++ b/packages/sdk/src/query/__tests__/underlying-allowance.test.ts
@@ -28,10 +28,7 @@ describe("underlyingAllowanceQueryOptions", () => {
 
     expect(options.queryKey).toEqual([
       "zama.underlyingAllowance",
-      {
-        tokenAddress: getAddress(WRAPPER),
-        owner: getAddress(OWNER),
-      },
+      { tokenAddress: getAddress(WRAPPER), owner: getAddress(OWNER) },
     ]);
   });
 

--- a/packages/sdk/src/query/__tests__/utils.test.ts
+++ b/packages/sdk/src/query/__tests__/utils.test.ts
@@ -32,11 +32,7 @@ describe("filterQueryOptions", () => {
       pollingInterval: 12_000,
     });
 
-    expect(filtered).toEqual({
-      address: "0xabc",
-      owner: "0xdef",
-      chainId: 1,
-    });
+    expect(filtered).toEqual({ address: "0xabc", owner: "0xdef", chainId: 1 });
   });
 
   test("returns empty object when only stripped options are present", () => {

--- a/packages/sdk/src/query/__tests__/wrappers-registry.test.ts
+++ b/packages/sdk/src/query/__tests__/wrappers-registry.test.ts
@@ -20,9 +20,7 @@ const C_TOKEN = "0x2b2B2B2b2B2b2B2b2B2b2b2b2B2B2b2b2B2b2B2B" as Address;
 
 describe("tokenPairsQueryOptions", () => {
   test("includes registry address in query key", ({ sdk }) => {
-    const options = tokenPairsQueryOptions(sdk, {
-      registryAddress: REGISTRY,
-    });
+    const options = tokenPairsQueryOptions(sdk, { registryAddress: REGISTRY });
     expect(options.queryKey).toEqual([
       "zama.wrappersRegistry",
       { type: "tokenPairs", registryAddress: getAddress(REGISTRY) },
@@ -31,17 +29,13 @@ describe("tokenPairsQueryOptions", () => {
   });
 
   test("disabled when registryAddress is undefined", ({ sdk }) => {
-    const options = tokenPairsQueryOptions(sdk, {
-      registryAddress: undefined,
-    });
+    const options = tokenPairsQueryOptions(sdk, { registryAddress: undefined });
     expect(options.enabled).toBe(false);
   });
 
   test("queryFn calls readContract", async ({ sdk, provider, mockQueryContext }) => {
     vi.mocked(provider.readContract).mockResolvedValue([]);
-    const options = tokenPairsQueryOptions(sdk, {
-      registryAddress: REGISTRY,
-    });
+    const options = tokenPairsQueryOptions(sdk, { registryAddress: REGISTRY });
     const result = await options.queryFn(mockQueryContext(options.queryKey));
     expect(result).toEqual([]);
     expect(provider.readContract).toHaveBeenCalledWith(
@@ -52,9 +46,7 @@ describe("tokenPairsQueryOptions", () => {
 
 describe("tokenPairsLengthQueryOptions", () => {
   test("includes registry address in query key", ({ sdk }) => {
-    const options = tokenPairsLengthQueryOptions(sdk, {
-      registryAddress: REGISTRY,
-    });
+    const options = tokenPairsLengthQueryOptions(sdk, { registryAddress: REGISTRY });
     expect(options.queryKey).toEqual([
       "zama.wrappersRegistry",
       { type: "tokenPairsLength", registryAddress: getAddress(REGISTRY) },
@@ -63,9 +55,7 @@ describe("tokenPairsLengthQueryOptions", () => {
 
   test("queryFn returns bigint", async ({ sdk, provider, mockQueryContext }) => {
     vi.mocked(provider.readContract).mockResolvedValue(5n);
-    const options = tokenPairsLengthQueryOptions(sdk, {
-      registryAddress: REGISTRY,
-    });
+    const options = tokenPairsLengthQueryOptions(sdk, { registryAddress: REGISTRY });
     const result = await options.queryFn(mockQueryContext(options.queryKey));
     expect(result).toBe(5n);
   });
@@ -116,20 +106,14 @@ describe("tokenPairsSliceQueryOptions", () => {
 describe("tokenPairQueryOptions", () => {
   test("disabled when index is undefined", ({ sdk }) => {
     expect(
-      tokenPairQueryOptions(sdk, {
-        registryAddress: REGISTRY,
-        index: undefined,
-      }).enabled,
+      tokenPairQueryOptions(sdk, { registryAddress: REGISTRY, index: undefined }).enabled,
     ).toBe(false);
   });
 
   test("queryFn passes bigint index", async ({ sdk, provider, mockQueryContext }) => {
     const pair = { tokenAddress: TOKEN, confidentialTokenAddress: C_TOKEN, isValid: true };
     vi.mocked(provider.readContract).mockResolvedValue(pair);
-    const options = tokenPairQueryOptions(sdk, {
-      registryAddress: REGISTRY,
-      index: 3n,
-    });
+    const options = tokenPairQueryOptions(sdk, { registryAddress: REGISTRY, index: 3n });
     const result = await options.queryFn(mockQueryContext(options.queryKey));
     expect(result).toEqual(pair);
   });
@@ -241,17 +225,13 @@ describe("listPairsQueryOptions", () => {
 
   test("staleTime equals registry.ttlMs", () => {
     const { registry } = makeRegistry(3_600_000);
-    const options = listPairsQueryOptions(registry, {
-      registryAddress: REGISTRY,
-    });
+    const options = listPairsQueryOptions(registry, { registryAddress: REGISTRY });
     expect(options.staleTime).toBe(3_600_000);
   });
 
   test("disabled when registryAddress is undefined", () => {
     const { registry } = makeRegistry();
-    const options = listPairsQueryOptions(registry, {
-      registryAddress: undefined,
-    });
+    const options = listPairsQueryOptions(registry, { registryAddress: undefined });
     expect(options.enabled).toBe(false);
   });
 
@@ -274,9 +254,7 @@ describe("listPairsQueryOptions", () => {
 
   test("uses zeroAddress in query key when registryAddress is undefined", () => {
     const { registry } = makeRegistry();
-    const options = listPairsQueryOptions(registry, {
-      registryAddress: undefined,
-    });
+    const options = listPairsQueryOptions(registry, { registryAddress: undefined });
     expect(options.queryKey[1]).toMatchObject({ registryAddress: zeroAddress });
   });
 });

--- a/packages/sdk/src/query/clear-credentials.ts
+++ b/packages/sdk/src/query/clear-credentials.ts
@@ -5,8 +5,5 @@ import type { MutationFactoryOptions } from "./factory-types";
 export function clearCredentialsMutationOptions(
   sdk: ZamaSDK,
 ): MutationFactoryOptions<readonly ["zama.clearCredentials"], void, void> {
-  return {
-    mutationKey: ["zama.clearCredentials"],
-    mutationFn: () => sdk.permits.clear(),
-  };
+  return { mutationKey: ["zama.clearCredentials"], mutationFn: () => sdk.permits.clear() };
 }

--- a/packages/sdk/src/query/encrypt.ts
+++ b/packages/sdk/src/query/encrypt.ts
@@ -5,8 +5,5 @@ import type { MutationFactoryOptions } from "./factory-types";
 export function encryptMutationOptions(
   sdk: ZamaSDK,
 ): MutationFactoryOptions<readonly ["zama.encrypt"], EncryptParams, EncryptResult> {
-  return {
-    mutationKey: ["zama.encrypt"],
-    mutationFn: async (params) => sdk.encrypt(params),
-  };
+  return { mutationKey: ["zama.encrypt"], mutationFn: async (params) => sdk.encrypt(params) };
 }

--- a/packages/sdk/src/query/query-keys.ts
+++ b/packages/sdk/src/query/query-keys.ts
@@ -8,10 +8,7 @@ const normalizeAddress = (address?: Address): Address | undefined =>
   address === undefined ? undefined : getAddress(address);
 const walletAccountKey = (walletAccount?: WalletAccount) =>
   walletAccount
-    ? {
-        walletAddress: getAddress(walletAccount.address),
-        walletChainId: walletAccount.chainId,
-      }
+    ? { walletAddress: getAddress(walletAccount.address), walletChainId: walletAccount.chainId }
     : {};
 
 /**
@@ -95,10 +92,7 @@ export const zamaQueryKeys = {
     scope: (tokenAddress: Address, owner?: Address) =>
       [
         "zama.underlyingAllowance",
-        {
-          tokenAddress: getAddress(tokenAddress),
-          ...(owner ? { owner: getAddress(owner) } : {}),
-        },
+        { tokenAddress: getAddress(tokenAddress), ...(owner ? { owner: getAddress(owner) } : {}) },
       ] as const,
   },
 
@@ -175,10 +169,7 @@ export const zamaQueryKeys = {
         },
       ] as const,
     encryptedInputs: (
-      encryptedInputs: readonly {
-        encryptedValue: string;
-        contractAddress: Address;
-      }[],
+      encryptedInputs: readonly { encryptedValue: string; contractAddress: Address }[],
       walletAccount?: WalletAccount,
     ) =>
       [
@@ -201,10 +192,7 @@ export const zamaQueryKeys = {
     tokenPairs: (registryAddress: Address) =>
       [
         "zama.wrappersRegistry",
-        {
-          type: "tokenPairs",
-          registryAddress: getAddress(registryAddress),
-        },
+        { type: "tokenPairs", registryAddress: getAddress(registryAddress) },
       ] as const,
     confidentialTokenAddress: (registryAddress: Address, tokenAddress: Address) =>
       [
@@ -227,10 +215,7 @@ export const zamaQueryKeys = {
     tokenPairsLength: (registryAddress: Address) =>
       [
         "zama.wrappersRegistry",
-        {
-          type: "tokenPairsLength",
-          registryAddress: getAddress(registryAddress),
-        },
+        { type: "tokenPairsLength", registryAddress: getAddress(registryAddress) },
       ] as const,
     tokenPairsSlice: (registryAddress: Address, fromIndex: string, toIndex: string) =>
       [
@@ -245,11 +230,7 @@ export const zamaQueryKeys = {
     tokenPair: (registryAddress: Address, index: string) =>
       [
         "zama.wrappersRegistry",
-        {
-          type: "tokenPair",
-          registryAddress: getAddress(registryAddress),
-          index,
-        },
+        { type: "tokenPair", registryAddress: getAddress(registryAddress), index },
       ] as const,
     isConfidentialTokenValid: (registryAddress: Address, confidentialTokenAddress: Address) =>
       [

--- a/packages/sdk/src/relayer/__tests__/fhe-artifact-cache.integration.test.ts
+++ b/packages/sdk/src/relayer/__tests__/fhe-artifact-cache.integration.test.ts
@@ -16,10 +16,7 @@ interface TestServer {
 /** Size of fake binary artifacts served by the test server (bytes). */
 const FAKE_BIN_SIZE = 1024;
 
-function createTestServer(): {
-  server: http.Server;
-  start: () => Promise<TestServer>;
-} {
+function createTestServer(): { server: http.Server; start: () => Promise<TestServer> } {
   let pkEtag = '"pk-etag-v1"';
   let crsEtag = '"crs-etag-v1"';
   let pkBody = randomBytes(FAKE_BIN_SIZE);
@@ -104,10 +101,7 @@ interface CacheFixtures {
   /** Create a fresh cache instance sharing the same storage (simulates app restart). */
   createCache: (opts?: { ttl?: number; relayerUrl?: string }) => FheArtifactCache;
   pkFetcher: () => Promise<{ publicKeyId: string; publicKey: Uint8Array }>;
-  paramsFetcher: () => Promise<{
-    publicParamsId: string;
-    publicParams: Uint8Array;
-  }>;
+  paramsFetcher: () => Promise<{ publicParamsId: string; publicParams: Uint8Array }>;
 }
 
 const test = base.extend<CacheFixtures>({
@@ -139,10 +133,7 @@ const test = base.extend<CacheFixtures>({
   },
 
   pkFetcher: async ({}, use) => {
-    await use(async () => ({
-      publicKeyId: "pk-id-1",
-      publicKey: new Uint8Array([1, 2, 3]),
-    }));
+    await use(async () => ({ publicKeyId: "pk-id-1", publicKey: new Uint8Array([1, 2, 3]) }));
   },
 
   paramsFetcher: async ({}, use) => {

--- a/packages/sdk/src/relayer/__tests__/fhe-artifact-cache.test.ts
+++ b/packages/sdk/src/relayer/__tests__/fhe-artifact-cache.test.ts
@@ -155,12 +155,7 @@ describe("FheArtifactCache", () => {
         set: vi.fn().mockResolvedValue(undefined),
         delete: vi.fn().mockResolvedValue(undefined),
       };
-      const logger = {
-        info: vi.fn(),
-        debug: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      };
+      const logger = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
       const cache = new FheArtifactCache({
         storage: badStorage,
@@ -221,10 +216,7 @@ describe("FheArtifactCache", () => {
         relayerUrl: DUMMY_RELAYER_URL,
         logger: new LoggerService(),
       });
-      const pp = {
-        publicParamsId: "pp1",
-        publicParams: new Uint8Array([4, 5, 6]),
-      };
+      const pp = { publicParamsId: "pp1", publicParams: new Uint8Array([4, 5, 6]) };
       const fetcher = vi.fn().mockResolvedValue(pp);
 
       const result1 = await cache.getPublicParams(2048, fetcher);
@@ -237,10 +229,7 @@ describe("FheArtifactCache", () => {
     });
 
     test("persists public params to storage and restores from a fresh cache instance", async () => {
-      const pp = {
-        publicParamsId: "pp1",
-        publicParams: new Uint8Array([7, 8]),
-      };
+      const pp = { publicParamsId: "pp1", publicParams: new Uint8Array([7, 8]) };
       const fetcher = vi.fn().mockResolvedValue(pp);
 
       const cache1 = new FheArtifactCache({
@@ -271,14 +260,8 @@ describe("FheArtifactCache", () => {
         relayerUrl: DUMMY_RELAYER_URL,
         logger: new LoggerService(),
       });
-      const pp2048 = {
-        publicParamsId: "pp-2048",
-        publicParams: new Uint8Array([1]),
-      };
-      const pp4096 = {
-        publicParamsId: "pp-4096",
-        publicParams: new Uint8Array([2]),
-      };
+      const pp2048 = { publicParamsId: "pp-2048", publicParams: new Uint8Array([1]) };
+      const pp4096 = { publicParamsId: "pp-4096", publicParams: new Uint8Array([2]) };
 
       await cache.getPublicParams(2048, vi.fn().mockResolvedValue(pp2048));
       const fetcher4096 = vi.fn().mockResolvedValue(pp4096);
@@ -388,20 +371,8 @@ describe("FheArtifactCache", () => {
     const MANIFEST = {
       status: "succeeded",
       response: {
-        fheKeyInfo: [
-          {
-            fhePublicKey: {
-              dataId: "pk-id-1",
-              urls: [PK_ARTIFACT_URL],
-            },
-          },
-        ],
-        crs: {
-          2048: {
-            dataId: "pp-id-1",
-            urls: [CRS_ARTIFACT_URL],
-          },
-        },
+        fheKeyInfo: [{ fhePublicKey: { dataId: "pk-id-1", urls: [PK_ARTIFACT_URL] } }],
+        crs: { 2048: { dataId: "pp-id-1", urls: [CRS_ARTIFACT_URL] } },
       },
     };
 
@@ -529,10 +500,7 @@ describe("FheArtifactCache", () => {
       );
 
       // PK returns 200 = changed
-      mockFetch({
-        pkStatus: 200,
-        pkHeaders: { etag: '"pk-etag-ROTATED"' },
-      });
+      mockFetch({ pkStatus: 200, pkHeaders: { etag: '"pk-etag-ROTATED"' } });
 
       const result = await cache.revalidateIfDue();
       expect(result).toBe(true);
@@ -551,11 +519,7 @@ describe("FheArtifactCache", () => {
       );
 
       // PK fresh (304), CRS changed (200)
-      mockFetch({
-        pkStatus: 304,
-        crsStatus: 200,
-        crsHeaders: { etag: '"pp-etag-ROTATED"' },
-      });
+      mockFetch({ pkStatus: 304, crsStatus: 200, crsHeaders: { etag: '"pp-etag-ROTATED"' } });
 
       const result = await cache.revalidateIfDue();
       expect(result).toBe(true);
@@ -603,11 +567,7 @@ describe("FheArtifactCache", () => {
       );
 
       // 304 with a new etag header (servers may update weak→strong)
-      mockFetch({
-        pkStatus: 304,
-        pkHeaders: { etag: '"refreshed-etag"' },
-        crsStatus: 304,
-      });
+      mockFetch({ pkStatus: 304, pkHeaders: { etag: '"refreshed-etag"' }, crsStatus: 304 });
 
       const result = await cache.revalidateIfDue();
       expect(result).toBe(false);
@@ -685,12 +645,7 @@ describe("FheArtifactCache", () => {
 
     test("logs warning on network error when logger is provided", async () => {
       const expired = Date.now() - CACHE_TTL_MS - 1000;
-      const logger = {
-        info: vi.fn(),
-        debug: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      };
+      const logger = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
       await storage.set(PK_STORAGE_KEY, makeCachedPk({ lastValidatedAt: expired }));
       await storage.set(PARAMS_STORAGE_KEY, makeCachedParams({ lastValidatedAt: expired }));
@@ -735,10 +690,7 @@ describe("FheArtifactCache", () => {
       );
 
       // PK artifact changed (200)
-      mockFetch({
-        pkStatus: 200,
-        pkHeaders: { etag: '"pk-etag-ROTATED"' },
-      });
+      mockFetch({ pkStatus: 200, pkHeaders: { etag: '"pk-etag-ROTATED"' } });
 
       const result = await cache.revalidateIfDue();
       expect(result).toBe(true);
@@ -781,10 +733,7 @@ describe("FheArtifactCache", () => {
       await cache.getPublicParams(2048, vi.fn().mockResolvedValue(null));
 
       // PK artifact changed (200)
-      mockFetch({
-        pkStatus: 200,
-        pkHeaders: { etag: '"pk-etag-ROTATED"' },
-      });
+      mockFetch({ pkStatus: 200, pkHeaders: { etag: '"pk-etag-ROTATED"' } });
 
       const result = await cache.revalidateIfDue();
       // Should still report stale even though storage delete failed
@@ -812,11 +761,7 @@ describe("FheArtifactCache", () => {
       await cache.fetchFheEncryptionKeyBytes(vi.fn().mockResolvedValue(null));
 
       // CRS artifact changed (200)
-      mockFetch({
-        pkStatus: 304,
-        crsStatus: 200,
-        crsHeaders: { etag: '"pp-etag-ROTATED"' },
-      });
+      mockFetch({ pkStatus: 304, crsStatus: 200, crsHeaders: { etag: '"pp-etag-ROTATED"' } });
 
       const result = await cache.revalidateIfDue();
       expect(result).toBe(true);
@@ -865,11 +810,7 @@ describe("FheArtifactCache", () => {
       globalThis.fetch = vi.fn().mockImplementation((url: string | URL) => {
         const urlStr = String(url);
         if (urlStr === `${RELAYER_URL}/keyurl`) {
-          return Promise.resolve({
-            ok: true,
-            status: 200,
-            json: () => Promise.resolve(MANIFEST),
-          });
+          return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(MANIFEST) });
         }
         if (urlStr === PK_ARTIFACT_URL || urlStr === CRS_ARTIFACT_URL) {
           return Promise.resolve({
@@ -906,19 +847,11 @@ describe("FheArtifactCache", () => {
       globalThis.fetch = vi.fn().mockImplementation((url: string | URL, opts?: RequestInit) => {
         const urlStr = String(url);
         if (urlStr === `${RELAYER_URL}/keyurl`) {
-          return Promise.resolve({
-            ok: true,
-            status: 200,
-            json: () => Promise.resolve(MANIFEST),
-          });
+          return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(MANIFEST) });
         }
         if (urlStr === PK_ARTIFACT_URL || urlStr === CRS_ARTIFACT_URL) {
           if (opts?.method === "HEAD") {
-            return Promise.resolve({
-              status: 405,
-              ok: false,
-              headers: new Headers(),
-            });
+            return Promise.resolve({ status: 405, ok: false, headers: new Headers() });
           }
           // GET fallback returns 304
           return Promise.resolve({
@@ -1055,13 +988,7 @@ describe("FheArtifactCache", () => {
           Promise.resolve({
             status: "succeeded",
             response: {
-              fheKeyInfo: [
-                {
-                  fhePublicKey: {
-                    urls: ["https://cdn.example.com/pk.bin"],
-                  },
-                },
-              ],
+              fheKeyInfo: [{ fhePublicKey: { urls: ["https://cdn.example.com/pk.bin"] } }],
               crs: {},
             },
           }),

--- a/packages/sdk/src/relayer/__tests__/relayer-auth.integration.test.ts
+++ b/packages/sdk/src/relayer/__tests__/relayer-auth.integration.test.ts
@@ -29,10 +29,7 @@ function makeSdk(auth?: Auth): ZamaSDK {
     chain: viemMainnet,
     transport,
   });
-  const chain = {
-    ...mainnet,
-    ...(auth ? { auth } : {}),
-  } as const satisfies FheChain;
+  const chain = { ...mainnet, ...(auth ? { auth } : {}) } as const satisfies FheChain;
   const config = createConfig({
     chains: [chain],
     publicClient,

--- a/packages/sdk/src/relayer/__tests__/relayer-dispatcher.test.ts
+++ b/packages/sdk/src/relayer/__tests__/relayer-dispatcher.test.ts
@@ -24,10 +24,7 @@ describe("RelayerDispatcher", () => {
       expect(
         () =>
           new RelayerDispatcher([chainA, chainB], {
-            [1]: {
-              type: "web",
-              createRelayer: () => createMockRelayer(),
-            },
+            [1]: { type: "web", createRelayer: () => createMockRelayer() },
           }),
       ).toThrow("Chain 2 has no relayer configured");
     });
@@ -165,11 +162,7 @@ describe("RelayerDispatcher", () => {
       const chainA = createMockChain({ id: 1 });
       const worker = makeMockWorker();
       const dispatcher = new RelayerDispatcher([chainA], {
-        [1]: {
-          type: "web",
-          createWorker: () => worker,
-          createRelayer: () => createMockRelayer(),
-        },
+        [1]: { type: "web", createWorker: () => worker, createRelayer: () => createMockRelayer() },
       });
       dispatcher.terminate();
       expect(worker.terminate).toHaveBeenCalledTimes(1);
@@ -184,16 +177,8 @@ describe("RelayerDispatcher", () => {
       const w1 = makeMockWorker();
       const w2 = makeMockWorker();
       const dispatcher = new RelayerDispatcher([chainA, chainB], {
-        [1]: {
-          type: "web",
-          createWorker: () => w1,
-          createRelayer: () => createMockRelayer(),
-        },
-        [2]: {
-          type: "web",
-          createWorker: () => w2,
-          createRelayer: () => createMockRelayer(),
-        },
+        [1]: { type: "web", createWorker: () => w1, createRelayer: () => createMockRelayer() },
+        [2]: { type: "web", createWorker: () => w2, createRelayer: () => createMockRelayer() },
       });
       dispatcher.terminate();
       expect(w1.terminate).toHaveBeenCalledTimes(1);
@@ -205,10 +190,7 @@ describe("RelayerDispatcher", () => {
       const chainB = createMockChain({ id: 2 });
       const shared = createMockRelayer();
       // Same config object → same group → one worker, one createRelayer call per chain but same mock
-      const sharedConfig: RelayerConfig = {
-        type: "web",
-        createRelayer: () => shared,
-      };
+      const sharedConfig: RelayerConfig = { type: "web", createRelayer: () => shared };
       const dispatcher = new RelayerDispatcher([chainA, chainB], {
         [1]: sharedConfig,
         [2]: sharedConfig,
@@ -273,11 +255,7 @@ describe("RelayerDispatcher", () => {
       const worker = makeMockWorker();
       const relayer = createMockRelayer();
       const dispatcher = new RelayerDispatcher([chainA], {
-        [1]: {
-          type: "web",
-          createWorker: () => worker,
-          createRelayer: () => relayer,
-        },
+        [1]: { type: "web", createWorker: () => worker, createRelayer: () => relayer },
       });
       dispatcher[Symbol.dispose]();
       expect(worker.terminate).toHaveBeenCalledTimes(1);
@@ -291,13 +269,5 @@ function relayerConfigs(
   chains: FheChain[],
   createRelayer: () => RelayerSDK,
 ): Record<number, RelayerConfig> {
-  return Object.fromEntries(
-    chains.map((c) => [
-      c.id,
-      {
-        type: "web",
-        createRelayer,
-      },
-    ]),
-  );
+  return Object.fromEntries(chains.map((c) => [c.id, { type: "web", createRelayer }]));
 }

--- a/packages/sdk/src/relayer/__tests__/relayer-utils-eip712.test.ts
+++ b/packages/sdk/src/relayer/__tests__/relayer-utils-eip712.test.ts
@@ -53,10 +53,7 @@ const MOCK_EIP712 = {
 };
 
 function createRelayer() {
-  return new RelayerWeb({
-    chain: { chainId: 1 } as any,
-    worker: mockWorkerClient as any,
-  });
+  return new RelayerWeb({ chain: { chainId: 1 } as any, worker: mockWorkerClient as any });
 }
 
 describe("createEIP712 includes EIP712Domain type", () => {

--- a/packages/sdk/src/relayer/__tests__/relayer.test.ts
+++ b/packages/sdk/src/relayer/__tests__/relayer.test.ts
@@ -52,10 +52,7 @@ import { RelayerWeb } from "../relayer-web";
 // Shared fixtures
 // ---------------------------------------------------------------------------
 
-const CHAIN_CONFIG = {
-  id: 11155111,
-  relayerUrl: "https://relayer.example.com",
-} as any;
+const CHAIN_CONFIG = { id: 11155111, relayerUrl: "https://relayer.example.com" } as any;
 
 function createWebRelayer(
   overrides: Partial<ConstructorParameters<typeof RelayerWeb>[0]> = {},
@@ -72,11 +69,7 @@ function createWebRelayer(
 function createNodeRelayer(
   overrides: Partial<ConstructorParameters<typeof RelayerNode>[0]> = {},
 ): RelayerNode {
-  return new RelayerNode({
-    chain: CHAIN_CONFIG,
-    pool: mockPool as any,
-    ...overrides,
-  });
+  return new RelayerNode({ chain: CHAIN_CONFIG, pool: mockPool as any, ...overrides });
 }
 
 function resetMocks(): void {
@@ -94,9 +87,7 @@ const MOCK_EIP712 = {
     chainId: 11155111,
     verifyingContract: "0xABC" as `0x${string}`,
   },
-  types: {
-    UserDecryptRequestVerification: [{ name: "publicKey", type: "bytes" }],
-  },
+  types: { UserDecryptRequestVerification: [{ name: "publicKey", type: "bytes" }] },
   message: {
     publicKey: "0xpub",
     contractAddresses: ["0x123"],
@@ -122,10 +113,7 @@ describe("RelayerWeb", () => {
   describe("terminate", () => {
     test("does not terminate the worker (lifecycle not owned)", async () => {
       const relayer = createWebRelayer();
-      mockWorkerClient.generateKeypair.mockResolvedValue({
-        publicKey: "pk",
-        privateKey: "sk",
-      });
+      mockWorkerClient.generateKeypair.mockResolvedValue({ publicKey: "pk", privateKey: "sk" });
 
       await relayer.generateTransportKeyPair();
       relayer.terminate();
@@ -140,10 +128,7 @@ describe("RelayerWeb", () => {
 
     test("[Symbol.dispose] delegates to terminate", async () => {
       const relayer = createWebRelayer();
-      mockWorkerClient.generateKeypair.mockResolvedValue({
-        publicKey: "pk",
-        privateKey: "sk",
-      });
+      mockWorkerClient.generateKeypair.mockResolvedValue({ publicKey: "pk", privateKey: "sk" });
       await relayer.generateTransportKeyPair();
 
       relayer[Symbol.dispose]();
@@ -159,10 +144,7 @@ describe("RelayerWeb", () => {
     test("refreshes CSRF token before encrypt", async () => {
       const getCsrfToken = vi.fn().mockReturnValue("csrf-token-123");
       const relayer = createWebRelayer({ security: { getCsrfToken } });
-      mockWorkerClient.encrypt.mockResolvedValue({
-        handles: [],
-        inputProof: new Uint8Array(),
-      });
+      mockWorkerClient.encrypt.mockResolvedValue({ handles: [], inputProof: new Uint8Array() });
 
       await relayer.encrypt({
         values: [{ value: 100n, type: "euint64" as const }],
@@ -175,10 +157,7 @@ describe("RelayerWeb", () => {
 
     test("skips CSRF refresh when getCsrfToken is not provided", async () => {
       const relayer = createWebRelayer();
-      mockWorkerClient.encrypt.mockResolvedValue({
-        handles: [],
-        inputProof: new Uint8Array(),
-      });
+      mockWorkerClient.encrypt.mockResolvedValue({ handles: [], inputProof: new Uint8Array() });
 
       await relayer.encrypt({
         values: [{ value: 100n, type: "euint64" as const }],
@@ -192,10 +171,7 @@ describe("RelayerWeb", () => {
     test("skips CSRF refresh when token is empty", async () => {
       const getCsrfToken = vi.fn().mockReturnValue("");
       const relayer = createWebRelayer({ security: { getCsrfToken } });
-      mockWorkerClient.encrypt.mockResolvedValue({
-        handles: [],
-        inputProof: new Uint8Array(),
-      });
+      mockWorkerClient.encrypt.mockResolvedValue({ handles: [], inputProof: new Uint8Array() });
 
       await relayer.encrypt({
         values: [{ value: 100n, type: "euint64" as const }],
@@ -214,10 +190,7 @@ describe("RelayerWeb", () => {
   describe("method delegation", () => {
     test("generateKeypair delegates to worker", async () => {
       const relayer = createWebRelayer();
-      mockWorkerClient.generateKeypair.mockResolvedValue({
-        publicKey: "pub",
-        privateKey: "priv",
-      });
+      mockWorkerClient.generateKeypair.mockResolvedValue({ publicKey: "pub", privateKey: "priv" });
 
       const result = await relayer.generateTransportKeyPair();
 
@@ -276,10 +249,7 @@ describe("RelayerWeb", () => {
       const result = await relayer.userDecrypt(params);
 
       expect(result).toEqual(clearValues);
-      expect(mockWorkerClient.userDecrypt).toHaveBeenCalledWith({
-        chainId: 11155111,
-        ...params,
-      });
+      expect(mockWorkerClient.userDecrypt).toHaveBeenCalledWith({ chainId: 11155111, ...params });
     });
 
     test("publicDecrypt delegates to worker and returns structured result", async () => {
@@ -329,9 +299,7 @@ describe("RelayerWeb", () => {
 
     test("delegatedUserDecrypt delegates to worker and returns clearValues", async () => {
       const relayer = createWebRelayer();
-      mockWorkerClient.delegatedUserDecrypt.mockResolvedValue({
-        clearValues: { [HANDLE]: 200n },
-      });
+      mockWorkerClient.delegatedUserDecrypt.mockResolvedValue({ clearValues: { [HANDLE]: 200n } });
 
       const params = {
         encryptedValues: [HANDLE],
@@ -420,10 +388,7 @@ describe("RelayerWeb", () => {
 
     test("caches getPublicParams when storage is provided", async () => {
       const storage = new MemoryStorage();
-      const pp = {
-        publicParamsId: "pp-1",
-        publicParams: new Uint8Array([4, 5]),
-      };
+      const pp = { publicParamsId: "pp-1", publicParams: new Uint8Array([4, 5]) };
       mockWorkerClient.getPublicParams.mockResolvedValue({ result: pp });
 
       const relayer = createWebRelayer({ fheArtifactStorage: storage });
@@ -483,10 +448,7 @@ describe("RelayerNode", () => {
   describe("terminate", () => {
     test("does not terminate the pool (lifecycle not owned)", async () => {
       const relayer = createNodeRelayer();
-      mockPool.generateKeypair.mockResolvedValue({
-        publicKey: "pk",
-        privateKey: "sk",
-      });
+      mockPool.generateKeypair.mockResolvedValue({ publicKey: "pk", privateKey: "sk" });
 
       await relayer.generateTransportKeyPair();
       relayer.terminate();
@@ -501,10 +463,7 @@ describe("RelayerNode", () => {
 
     test("[Symbol.dispose] delegates to terminate", async () => {
       const relayer = createNodeRelayer();
-      mockPool.generateKeypair.mockResolvedValue({
-        publicKey: "pk",
-        privateKey: "sk",
-      });
+      mockPool.generateKeypair.mockResolvedValue({ publicKey: "pk", privateKey: "sk" });
       await relayer.generateTransportKeyPair();
 
       relayer[Symbol.dispose]();
@@ -519,10 +478,7 @@ describe("RelayerNode", () => {
   describe("method delegation", () => {
     test("generateKeypair delegates to pool", async () => {
       const relayer = createNodeRelayer();
-      mockPool.generateKeypair.mockResolvedValue({
-        publicKey: "pub",
-        privateKey: "priv",
-      });
+      mockPool.generateKeypair.mockResolvedValue({ publicKey: "pub", privateKey: "priv" });
 
       const result = await relayer.generateTransportKeyPair();
 
@@ -581,10 +537,7 @@ describe("RelayerNode", () => {
       const result = await relayer.userDecrypt(params);
 
       expect(result).toEqual(clearValues);
-      expect(mockPool.userDecrypt).toHaveBeenCalledWith({
-        chainId: 11155111,
-        ...params,
-      });
+      expect(mockPool.userDecrypt).toHaveBeenCalledWith({ chainId: 11155111, ...params });
     });
 
     test("publicDecrypt delegates to pool and returns structured result", async () => {
@@ -634,9 +587,7 @@ describe("RelayerNode", () => {
 
     test("delegatedUserDecrypt delegates to pool and returns clearValues", async () => {
       const relayer = createNodeRelayer();
-      mockPool.delegatedUserDecrypt.mockResolvedValue({
-        clearValues: { [HANDLE]: 200n },
-      });
+      mockPool.delegatedUserDecrypt.mockResolvedValue({ clearValues: { [HANDLE]: 200n } });
 
       const params = {
         encryptedValues: [HANDLE],
@@ -695,10 +646,7 @@ describe("RelayerNode", () => {
       const result = await relayer.getPublicParams(2048);
 
       expect(result).toEqual(pp);
-      expect(mockPool.getPublicParams).toHaveBeenCalledWith({
-        chainId: 11155111,
-        bits: 2048,
-      });
+      expect(mockPool.getPublicParams).toHaveBeenCalledWith({ chainId: 11155111, bits: 2048 });
     });
   });
 
@@ -725,10 +673,7 @@ describe("RelayerNode", () => {
 
     test("caches getPublicParams when storage is provided", async () => {
       const storage = new MemoryStorage();
-      const pp = {
-        publicParamsId: "pp-1",
-        publicParams: new Uint8Array([4, 5]),
-      };
+      const pp = { publicParamsId: "pp-1", publicParams: new Uint8Array([4, 5]) };
       mockPool.getPublicParams.mockResolvedValue({ result: pp });
 
       const relayer = createNodeRelayer({ fheArtifactStorage: storage });

--- a/packages/sdk/src/relayer/cleartext/__tests__/relayer-cleartext.test.ts
+++ b/packages/sdk/src/relayer/cleartext/__tests__/relayer-cleartext.test.ts
@@ -61,10 +61,7 @@ function createMockProvider(options: MockClientOptions = {}) {
         const to = tx.to.toLowerCase();
 
         if (to === hardhatCleartextConfig.aclContractAddress.toLowerCase()) {
-          const parsed = decodeFunctionData({
-            abi: ACL_ABI,
-            data: tx.data as `0x${string}`,
-          });
+          const parsed = decodeFunctionData({ abi: ACL_ABI, data: tx.data as `0x${string}` });
           if (!parsed) {
             throw new Error("Unable to parse ACL call");
           }
@@ -109,10 +106,7 @@ function createMockProvider(options: MockClientOptions = {}) {
         }
 
         if (to === hardhatCleartextConfig.executorAddress.toLowerCase()) {
-          const parsed = decodeFunctionData({
-            abi: EXECUTOR_ABI,
-            data: tx.data as `0x${string}`,
-          });
+          const parsed = decodeFunctionData({ abi: EXECUTOR_ABI, data: tx.data as `0x${string}` });
           if (!parsed || parsed.functionName !== "plaintexts") {
             throw new Error("Unable to parse executor call");
           }
@@ -140,19 +134,11 @@ function createInstance(options: MockClientOptions = {}): {
   calls: MockCall[];
 } {
   const { provider, calls } = createMockProvider(options);
-  return {
-    fhevm: new RelayerCleartext({
-      ...hardhatCleartextConfig,
-      network: provider,
-    }),
-    calls,
-  };
+  return { fhevm: new RelayerCleartext({ ...hardhatCleartextConfig, network: provider }), calls };
 }
 
 function createUserDecryptParams(
-  overrides: Omit<Partial<UserDecryptParams>, "encryptedValues"> & {
-    encryptedValues: string[];
-  },
+  overrides: Omit<Partial<UserDecryptParams>, "encryptedValues"> & { encryptedValues: string[] },
 ): UserDecryptParams {
   const { encryptedValues, ...rest } = overrides;
   return {
@@ -218,12 +204,7 @@ describe("RelayerCleartext", () => {
     const { provider } = createMockProvider();
 
     expect(
-      () =>
-        new RelayerCleartext({
-          ...hardhatCleartextConfig,
-          network: provider,
-          id: 1,
-        }),
+      () => new RelayerCleartext({ ...hardhatCleartextConfig, network: provider, id: 1 }),
     ).toThrow(/not allowed on chain 1/);
   });
 
@@ -231,12 +212,7 @@ describe("RelayerCleartext", () => {
     const { provider } = createMockProvider();
 
     expect(
-      () =>
-        new RelayerCleartext({
-          ...hardhatCleartextConfig,
-          network: provider,
-          id: 11155111,
-        }),
+      () => new RelayerCleartext({ ...hardhatCleartextConfig, network: provider, id: 11155111 }),
     ).toThrow(/not allowed on chain 11155111/);
   });
 
@@ -418,16 +394,10 @@ describe("RelayerCleartext", () => {
 
   test("userDecrypt throws when ACL.persistAllowed returns false", async () => {
     const handle = asHandle("0x" + "12".repeat(32));
-    const { fhevm } = createInstance({
-      persistAllowed: () => false,
-    });
+    const { fhevm } = createInstance({ persistAllowed: () => false });
 
     await expect(
-      fhevm.userDecrypt(
-        createUserDecryptParams({
-          encryptedValues: [handle],
-        }),
-      ),
+      fhevm.userDecrypt(createUserDecryptParams({ encryptedValues: [handle] })),
     ).rejects.toThrow(/not authorized/i);
   });
 
@@ -436,10 +406,7 @@ describe("RelayerCleartext", () => {
     const handleB = asHandle("0x" + "02".repeat(32));
     const { fhevm, calls } = createInstance({
       persistAllowed: () => true,
-      plaintexts: {
-        [handleA.toLowerCase()]: 7n,
-        [handleB.toLowerCase()]: 11n,
-      },
+      plaintexts: { [handleA.toLowerCase()]: 7n, [handleB.toLowerCase()]: 11n },
     });
 
     const result = await fhevm.userDecrypt(
@@ -468,18 +435,11 @@ describe("RelayerCleartext", () => {
 
     const { fhevm, calls } = createInstance({
       persistAllowed: (handle) => handle.toLowerCase() !== normalizedB.toLowerCase(),
-      plaintexts: {
-        [handleA.toLowerCase()]: 1n,
-        [handleB.toLowerCase()]: 2n,
-      },
+      plaintexts: { [handleA.toLowerCase()]: 1n, [handleB.toLowerCase()]: 2n },
     });
 
     await expect(
-      fhevm.userDecrypt(
-        createUserDecryptParams({
-          encryptedValues: [handleA, handleB],
-        }),
-      ),
+      fhevm.userDecrypt(createUserDecryptParams({ encryptedValues: [handleA, handleB] })),
     ).rejects.toThrow(new RegExp(normalizedB));
 
     const plaintextCalls = filterEthCallsTo(calls, hardhatCleartextConfig.executorAddress);
@@ -498,11 +458,7 @@ describe("RelayerCleartext", () => {
       plaintexts: { [handle.toLowerCase()]: 42n },
     });
 
-    await fhevm.userDecrypt(
-      createUserDecryptParams({
-        encryptedValues: [handle],
-      }),
-    );
+    await fhevm.userDecrypt(createUserDecryptParams({ encryptedValues: [handle] }));
 
     expect(persistAllowedAccounts).toHaveLength(2);
     const normalized = persistAllowedAccounts.map((a) => a.toLowerCase());
@@ -550,9 +506,7 @@ describe("RelayerCleartext", () => {
     });
 
     const result = await fhevm.userDecrypt(
-      createUserDecryptParams({
-        encryptedValues: [handleUpper],
-      }),
+      createUserDecryptParams({ encryptedValues: [handleUpper] }),
     );
 
     const keys = Object.keys(result);
@@ -607,9 +561,7 @@ describe("RelayerCleartext", () => {
 
   test("publicDecrypt throws when ACL.isAllowedForDecryption returns false", async () => {
     const handle = asHandle("0x" + "34".repeat(32));
-    const { fhevm } = createInstance({
-      isAllowedForDecryption: () => false,
-    });
+    const { fhevm } = createInstance({ isAllowedForDecryption: () => false });
 
     await expect(fhevm.publicDecrypt([handle])).rejects.toThrow(/not allowed/i);
   });
@@ -621,10 +573,7 @@ describe("RelayerCleartext", () => {
 
     const { fhevm, calls } = createInstance({
       isAllowedForDecryption: (handle) => handle.toLowerCase() !== normalizedB.toLowerCase(),
-      plaintexts: {
-        [handleA.toLowerCase()]: 10n,
-        [handleB.toLowerCase()]: 20n,
-      },
+      plaintexts: { [handleA.toLowerCase()]: 10n, [handleB.toLowerCase()]: 20n },
     });
 
     await expect(fhevm.publicDecrypt([handleA, handleB])).rejects.toThrow(new RegExp(normalizedB));
@@ -639,10 +588,7 @@ describe("RelayerCleartext", () => {
 
     const { fhevm } = createInstance({
       isAllowedForDecryption: () => true,
-      plaintexts: {
-        [handleA.toLowerCase()]: 42n,
-        [handleB.toLowerCase()]: 99n,
-      },
+      plaintexts: { [handleA.toLowerCase()]: 42n, [handleB.toLowerCase()]: 99n },
     });
 
     const result = await fhevm.publicDecrypt([handleA, handleB]);
@@ -710,9 +656,7 @@ describe("RelayerCleartext", () => {
     const handle = asHandle("0x" + "12".repeat(32));
     const delegatorAddress = USER_ADDRESS;
     const delegateAddress = "0x3000000000000000000000000000000000000003";
-    const { fhevm, calls } = createInstance({
-      isHandleDelegatedForUserDecryption: () => false,
-    });
+    const { fhevm, calls } = createInstance({ isHandleDelegatedForUserDecryption: () => false });
 
     await expect(
       fhevm.delegatedUserDecrypt({
@@ -740,10 +684,7 @@ describe("RelayerCleartext", () => {
     const delegateAddress = "0x3000000000000000000000000000000000000003";
 
     const { fhevm, calls } = createInstance({
-      plaintexts: {
-        [handleA.toLowerCase()]: 7n,
-        [handleB.toLowerCase()]: 11n,
-      },
+      plaintexts: { [handleA.toLowerCase()]: 7n, [handleB.toLowerCase()]: 11n },
     });
 
     const result = await fhevm.delegatedUserDecrypt({
@@ -768,17 +709,11 @@ describe("RelayerCleartext", () => {
         const tx = call.params[0] as { to: string; data: string };
         const target = getAddress(tx.to);
         if (target === getAddress(hardhatCleartextConfig.aclContractAddress)) {
-          const parsed = decodeFunctionData({
-            abi: ACL_ABI,
-            data: tx.data as `0x${string}`,
-          });
+          const parsed = decodeFunctionData({ abi: ACL_ABI, data: tx.data as `0x${string}` });
           return parsed?.functionName ?? "unknown";
         }
         if (target === getAddress(hardhatCleartextConfig.executorAddress)) {
-          const parsed = decodeFunctionData({
-            abi: EXECUTOR_ABI,
-            data: tx.data as `0x${string}`,
-          });
+          const parsed = decodeFunctionData({ abi: EXECUTOR_ABI, data: tx.data as `0x${string}` });
           return parsed?.functionName ?? "unknown";
         }
         return "unknown";
@@ -801,10 +736,7 @@ describe("RelayerCleartext", () => {
     const { fhevm, calls } = createInstance({
       isHandleDelegatedForUserDecryption: (_delegator, _delegate, _contractAddress, handle) =>
         handle.toLowerCase() !== normalizedB.toLowerCase(),
-      plaintexts: {
-        [handleA.toLowerCase()]: 7n,
-        [handleB.toLowerCase()]: 11n,
-      },
+      plaintexts: { [handleA.toLowerCase()]: 7n, [handleB.toLowerCase()]: 11n },
     });
 
     await expect(
@@ -827,10 +759,7 @@ describe("RelayerCleartext", () => {
       getAddress(hardhatCleartextConfig.aclContractAddress),
     ).filter((call) => {
       const tx = call.params[0] as { data: string };
-      const parsed = decodeFunctionData({
-        abi: ACL_ABI,
-        data: tx.data as `0x${string}`,
-      });
+      const parsed = decodeFunctionData({ abi: ACL_ABI, data: tx.data as `0x${string}` });
       return parsed?.functionName === "isHandleDelegatedForUserDecryption";
     });
     expect(delegationCalls).toHaveLength(2);
@@ -847,10 +776,7 @@ describe("RelayerCleartext", () => {
     const handleB = asHandle("0x" + "02".repeat(32));
     const { fhevm } = createInstance({
       persistAllowed: () => true,
-      plaintexts: {
-        [handleA.toLowerCase()]: 7n,
-        [handleB.toLowerCase()]: 11n,
-      },
+      plaintexts: { [handleA.toLowerCase()]: 7n, [handleB.toLowerCase()]: 11n },
     });
 
     const result = await fhevm.delegatedUserDecrypt({
@@ -877,10 +803,7 @@ describe("RelayerCleartext", () => {
 
     const { fhevm } = createInstance({
       persistAllowed: () => true,
-      plaintexts: {
-        [boolHandle.toLowerCase()]: 1n,
-        [addressHandle.toLowerCase()]: addressValue,
-      },
+      plaintexts: { [boolHandle.toLowerCase()]: 1n, [addressHandle.toLowerCase()]: addressValue },
     });
 
     const result = await fhevm.delegatedUserDecrypt({

--- a/packages/sdk/src/relayer/cleartext/relayer-cleartext.ts
+++ b/packages/sdk/src/relayer/cleartext/relayer-cleartext.ts
@@ -230,9 +230,7 @@ export class RelayerCleartext implements RelayerSDK, Disposable {
         this.#config.gatewayChainId,
         this.#config.verifyingContractAddressInputVerification as Address,
       ),
-      types: {
-        CiphertextVerification: INPUT_VERIFICATION_EIP712.types.CiphertextVerification,
-      },
+      types: { CiphertextVerification: INPUT_VERIFICATION_EIP712.types.CiphertextVerification },
       primaryType: "CiphertextVerification",
       message: {
         ctHandles: handles,
@@ -309,11 +307,7 @@ export class RelayerCleartext implements RelayerSDK, Disposable {
 
     const decryptionProof = concat([toHex(new Uint8Array([1])), signature]);
 
-    return {
-      clearValues,
-      abiEncodedClearValues,
-      decryptionProof,
-    };
+    return { clearValues, abiEncodedClearValues, decryptionProof };
   }
 
   async createDelegatedUserDecryptEIP712(
@@ -361,17 +355,11 @@ export class RelayerCleartext implements RelayerSDK, Disposable {
   }
 
   async fetchFheEncryptionKeyBytes(): Promise<FheEncryptionKey | null> {
-    return {
-      publicKeyId: "mock-public-key-id",
-      publicKey: new Uint8Array([32]),
-    };
+    return { publicKeyId: "mock-public-key-id", publicKey: new Uint8Array([32]) };
   }
 
   async getPublicParams(_bits: number): Promise<PublicParamsData | null> {
-    return {
-      publicParams: new Uint8Array([32]),
-      publicParamsId: "mock-public-params-id",
-    };
+    return { publicParams: new Uint8Array([32]), publicParamsId: "mock-public-params-id" };
   }
 
   async getAclAddress(): Promise<Address> {

--- a/packages/sdk/src/relayer/fhe-artifact-cache.ts
+++ b/packages/sdk/src/relayer/fhe-artifact-cache.ts
@@ -42,19 +42,10 @@ const ManifestSchema = z.object({
   response: z.object({
     fheKeyInfo: z
       .array(
-        z.object({
-          fhePublicKey: z.object({
-            urls: z.array(z.string()).check(z.minLength(1)),
-          }),
-        }),
+        z.object({ fhePublicKey: z.object({ urls: z.array(z.string()).check(z.minLength(1)) }) }),
       )
       .check(z.minLength(1)),
-    crs: z.record(
-      z.string(),
-      z.object({
-        urls: z.array(z.string()).check(z.minLength(1)),
-      }),
-    ),
+    crs: z.record(z.string(), z.object({ urls: z.array(z.string()).check(z.minLength(1)) })),
   }),
 });
 
@@ -347,11 +338,7 @@ export class FheArtifactCache {
 
     // Track partial progress so the catch block can reuse already-read data
     let storedPk: CachedPublicKey | null = null;
-    let paramEntries: Array<{
-      bits: number;
-      key: string;
-      data: CachedPublicParams;
-    }> = [];
+    let paramEntries: Array<{ bits: number; key: string; data: CachedPublicParams }> = [];
 
     try {
       // 1. Read PK cache entry and collect params entries in parallel
@@ -394,10 +381,7 @@ export class FheArtifactCache {
         await this.#writeEntries(
           pkKey,
           { ...storedPk, lastValidatedAt: retryTimestamp },
-          paramEntries.map((e) => ({
-            ...e,
-            data: { ...e.data, lastValidatedAt: retryTimestamp },
-          })),
+          paramEntries.map((e) => ({ ...e, data: { ...e.data, lastValidatedAt: retryTimestamp } })),
         );
         this.#lastRevalidatedAt = retryTimestamp;
         return false;
@@ -410,20 +394,14 @@ export class FheArtifactCache {
       if (!manifestParsed.success) {
         this.#logger.error(
           "Relayer manifest has unexpected shape — check relayer URL and API version",
-          {
-            relayerUrl: this.#relayerUrl,
-            error: z.prettifyError(manifestParsed.error),
-          },
+          { relayerUrl: this.#relayerUrl, error: z.prettifyError(manifestParsed.error) },
         );
         // Fail-open with short retry — but the error-level log distinguishes this from transient failures
         const retryTimestamp = now - this.#ttlMs + SHORT_RETRY_MS;
         await this.#writeEntries(
           pkKey,
           { ...storedPk, lastValidatedAt: retryTimestamp },
-          paramEntries.map((e) => ({
-            ...e,
-            data: { ...e.data, lastValidatedAt: retryTimestamp },
-          })),
+          paramEntries.map((e) => ({ ...e, data: { ...e.data, lastValidatedAt: retryTimestamp } })),
         );
         this.#lastRevalidatedAt = retryTimestamp;
         return false;
@@ -470,10 +448,7 @@ export class FheArtifactCache {
           return true;
         }
 
-        let updatedData: CachedPublicParams = {
-          ...entry.data,
-          lastValidatedAt: now,
-        };
+        let updatedData: CachedPublicParams = { ...entry.data, lastValidatedAt: now };
         if (crsUrl) {
           const freshness = await this.#checkArtifactFreshness(crsUrl, entry.data);
           if (!freshness.fresh) {
@@ -507,11 +482,7 @@ export class FheArtifactCache {
         isProgrammingError
           ? "Unexpected error during revalidation (possible bug)"
           : "Revalidation failed, using cached artifacts (fail-open)",
-        {
-          chainId: this.#chainId,
-          relayerUrl: this.#relayerUrl,
-          error: error.message,
-        },
+        { chainId: this.#chainId, relayerUrl: this.#relayerUrl, error: error.message },
       );
 
       // Fail-open: use short retry interval (5 min) instead of full TTL

--- a/packages/sdk/src/relayer/relayer-node.ts
+++ b/packages/sdk/src/relayer/relayer-node.ts
@@ -104,10 +104,7 @@ export class RelayerNode extends BaseRelayer implements RelayerSDK, Disposable {
     await this.ensureInit();
     const chainId = this.chain.id;
     const result = await this.#pool.generateKeypair({ chainId });
-    return {
-      publicKey: result.publicKey,
-      privateKey: result.privateKey,
-    };
+    return { publicKey: result.publicKey, privateKey: result.privateKey };
   }
 
   async createEIP712(
@@ -188,10 +185,7 @@ export class RelayerNode extends BaseRelayer implements RelayerSDK, Disposable {
     await this.ensureInit();
     const chainId = this.chain.id;
     return withRetry(async () => {
-      const result = await this.#pool.delegatedUserDecrypt({
-        chainId,
-        ...params,
-      });
+      const result = await this.#pool.delegatedUserDecrypt({ chainId, ...params });
       return result.clearValues;
     });
   }

--- a/packages/sdk/src/relayer/relayer-sdk.types.ts
+++ b/packages/sdk/src/relayer/relayer-sdk.types.ts
@@ -78,28 +78,16 @@ export interface RelayerWebConfig {
 export type EncryptedValue = Bytes32Hex;
 
 /** Result from encryption — contract-ready hex encrypted values and input proof. */
-export type EncryptResult = {
-  encryptedValues: EncryptedValue[];
-  inputProof: Hex;
-};
+export type EncryptResult = { encryptedValues: EncryptedValue[]; inputProof: Hex };
 
 /** Canonical SDK type for a decrypted clear-text value (`bigint | boolean | string`). */
 export type ClearValue = ClearValueType;
 
 /** A single value to encrypt with its FHE type. */
 export type EncryptInput =
-  | {
-      value: boolean | bigint;
-      type: "ebool";
-    }
-  | {
-      value: bigint;
-      type: Exclude<SDK.FheTypeName, "ebool" | "eaddress">;
-    }
-  | {
-      value: Address;
-      type: "eaddress";
-    };
+  | { value: boolean | bigint; type: "ebool" }
+  | { value: bigint; type: Exclude<SDK.FheTypeName, "ebool" | "eaddress"> }
+  | { value: Address; type: "eaddress" };
 
 /** Parameters for encryption */
 export interface EncryptParams {

--- a/packages/sdk/src/relayer/relayer-web.ts
+++ b/packages/sdk/src/relayer/relayer-web.ts
@@ -115,10 +115,7 @@ export class RelayerWeb extends BaseRelayer implements RelayerSDK, Disposable {
     await this.ensureInit();
     const chainId = this.chain.id;
     const result = await this.#worker.generateKeypair({ chainId });
-    return {
-      publicKey: result.publicKey,
-      privateKey: result.privateKey,
-    };
+    return { publicKey: result.publicKey, privateKey: result.privateKey };
   }
 
   /**
@@ -152,12 +149,7 @@ export class RelayerWeb extends BaseRelayer implements RelayerSDK, Disposable {
 
     return withRetry(async () => {
       await this.#refreshCsrfToken();
-      const result = await this.#worker.encrypt({
-        chainId,
-        values,
-        contractAddress,
-        userAddress,
-      });
+      const result = await this.#worker.encrypt({ chainId, values, contractAddress, userAddress });
       return {
         encryptedValues: result.handles.map((handle) => toHex(handle)),
         inputProof: toHex(result.inputProof),
@@ -190,10 +182,7 @@ export class RelayerWeb extends BaseRelayer implements RelayerSDK, Disposable {
     const chainId = this.chain.id;
     return withRetry(async () => {
       await this.#refreshCsrfToken();
-      const result = await this.#worker.publicDecrypt({
-        chainId,
-        encryptedValues,
-      });
+      const result = await this.#worker.publicDecrypt({ chainId, encryptedValues });
       return {
         clearValues: result.clearValues,
         abiEncodedClearValues: result.abiEncodedClearValues,
@@ -235,10 +224,7 @@ export class RelayerWeb extends BaseRelayer implements RelayerSDK, Disposable {
     const chainId = this.chain.id;
     return withRetry(async () => {
       await this.#refreshCsrfToken();
-      const result = await this.#worker.delegatedUserDecrypt({
-        chainId,
-        ...params,
-      });
+      const result = await this.#worker.delegatedUserDecrypt({ chainId, ...params });
       return result.clearValues;
     });
   }

--- a/packages/sdk/src/services/__tests__/decryption-service.test.ts
+++ b/packages/sdk/src/services/__tests__/decryption-service.test.ts
@@ -15,10 +15,7 @@ const HANDLE_B = `0x${"bb".repeat(32)}` as EncryptedValue;
 const ZERO_ENCRYPTED_VALUE = `0x${"00".repeat(32)}` as EncryptedValue;
 
 function handles(items: Array<[EncryptedValue, Address]>): EncryptedInput[] {
-  return items.map(([encryptedValue, contractAddress]) => ({
-    encryptedValue,
-    contractAddress,
-  }));
+  return items.map(([encryptedValue, contractAddress]) => ({ encryptedValue, contractAddress }));
 }
 
 describe("DecryptionService", () => {
@@ -29,9 +26,7 @@ describe("DecryptionService", () => {
   }) => {
     await expect(
       decryptionService.userDecrypt(handles([[ZERO_ENCRYPTED_VALUE, CONTRACT_A]]), userAddress),
-    ).resolves.toEqual({
-      [ZERO_ENCRYPTED_VALUE]: 0n,
-    });
+    ).resolves.toEqual({ [ZERO_ENCRYPTED_VALUE]: 0n });
     expect(relayer.createEIP712).not.toHaveBeenCalled();
     expect(relayer.userDecrypt).not.toHaveBeenCalled();
   });
@@ -61,16 +56,10 @@ describe("DecryptionService", () => {
     await expect(cachingService.get(userAddress, CONTRACT_A, HANDLE_A)).resolves.toBe(10n);
     await expect(cachingService.get(userAddress, CONTRACT_B, HANDLE_B)).resolves.toBe(20n);
     expect(relayer.userDecrypt).toHaveBeenCalledWith(
-      expect.objectContaining({
-        encryptedValues: [HANDLE_A],
-        contractAddress: CONTRACT_A,
-      }),
+      expect.objectContaining({ encryptedValues: [HANDLE_A], contractAddress: CONTRACT_A }),
     );
     expect(relayer.userDecrypt).toHaveBeenCalledWith(
-      expect.objectContaining({
-        encryptedValues: [HANDLE_B],
-        contractAddress: CONTRACT_B,
-      }),
+      expect.objectContaining({ encryptedValues: [HANDLE_B], contractAddress: CONTRACT_B }),
     );
     expect(emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: events.DecryptStart }));
     expect(emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: events.DecryptEnd }));
@@ -86,9 +75,7 @@ describe("DecryptionService", () => {
 
     await expect(
       decryptionService.userDecrypt(handles([[HANDLE_A, CONTRACT_A]]), userAddress),
-    ).resolves.toEqual({
-      [HANDLE_A]: 42n,
-    });
+    ).resolves.toEqual({ [HANDLE_A]: 42n });
     expect(relayer.createEIP712).not.toHaveBeenCalled();
     expect(relayer.userDecrypt).not.toHaveBeenCalled();
   });
@@ -117,10 +104,7 @@ describe("DecryptionService", () => {
       expect.any(Number),
     );
     expect(relayer.userDecrypt).toHaveBeenCalledWith(
-      expect.objectContaining({
-        encryptedValues: [HANDLE_B],
-        contractAddress: CONTRACT_B,
-      }),
+      expect.objectContaining({ encryptedValues: [HANDLE_B], contractAddress: CONTRACT_B }),
     );
   });
 
@@ -179,12 +163,7 @@ describe("DecryptionService", () => {
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(MAX_UINT64);
     vi.mocked(relayer.createDelegatedUserDecryptEIP712).mockResolvedValue({
-      domain: {
-        name: "test",
-        version: "1",
-        chainId: 1,
-        verifyingContract: "0xkms",
-      },
+      domain: { name: "test", version: "1", chainId: 1, verifyingContract: "0xkms" },
       types: { DelegatedUserDecryptRequestVerification: [] },
       message: {
         publicKey: TEST_PUBLIC_KEY,

--- a/packages/sdk/src/services/__tests__/encryption-service.test.ts
+++ b/packages/sdk/src/services/__tests__/encryption-service.test.ts
@@ -35,10 +35,7 @@ describe("EncryptionService", () => {
       ENCRYPT_PARAMS.contractAddress,
     );
     expect(emitEvent).toHaveBeenCalledWith(
-      {
-        type: events.EncryptEnd,
-        durationMs: expect.any(Number),
-      },
+      { type: events.EncryptEnd, durationMs: expect.any(Number) },
       ENCRYPT_PARAMS.contractAddress,
     );
   });
@@ -94,11 +91,7 @@ describe("EncryptionService", () => {
 
     await expect(service.encrypt(ENCRYPT_PARAMS)).rejects.toBe(original);
     expect(emitEvent).toHaveBeenCalledWith(
-      {
-        type: events.EncryptError,
-        error: original,
-        durationMs: expect.any(Number),
-      },
+      { type: events.EncryptError, error: original, durationMs: expect.any(Number) },
       ENCRYPT_PARAMS.contractAddress,
     );
   });

--- a/packages/sdk/src/services/__tests__/lifecycle-service.test.ts
+++ b/packages/sdk/src/services/__tests__/lifecycle-service.test.ts
@@ -69,9 +69,7 @@ describe("LifecycleService", () => {
         await Promise.resolve();
         calls.push("credential");
       });
-      const credentialService = {
-        handleWalletAccountChange,
-      } as unknown as CredentialService;
+      const credentialService = { handleWalletAccountChange } as unknown as CredentialService;
       const clearForRequester = vi.fn(async () => {
         calls.push("cache");
       });
@@ -105,10 +103,7 @@ describe("LifecycleService", () => {
         address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         chainId: 31337,
       } as const;
-      const next = {
-        address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        chainId: 1,
-      } as const;
+      const next = { address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", chainId: 1 } as const;
       dispatch!({ previous: prev, next });
 
       await vi.waitFor(() => {
@@ -184,10 +179,7 @@ describe("LifecycleService", () => {
 
       dispatch!({
         previous: undefined,
-        next: {
-          address: "0x1111111111111111111111111111111111111111",
-          chainId: 31337,
-        },
+        next: { address: "0x1111111111111111111111111111111111111111", chainId: 31337 },
       });
 
       await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce());
@@ -217,10 +209,7 @@ describe("LifecycleService", () => {
       service.onWalletAccountChange(listener);
 
       dispatch!({
-        previous: {
-          address: "0x1111111111111111111111111111111111111111",
-          chainId: 31337,
-        },
+        previous: { address: "0x1111111111111111111111111111111111111111", chainId: 31337 },
         next: undefined,
       });
 
@@ -265,14 +254,8 @@ describe("LifecycleService", () => {
       service.onWalletAccountChange(listener);
 
       dispatch!({
-        previous: {
-          address: "0x1111111111111111111111111111111111111111",
-          chainId: 31337,
-        },
-        next: {
-          address: "0x2222222222222222222222222222222222222222",
-          chainId: 1,
-        },
+        previous: { address: "0x1111111111111111111111111111111111111111", chainId: 31337 },
+        next: { address: "0x2222222222222222222222222222222222222222", chainId: 1 },
       });
 
       await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce());

--- a/packages/sdk/src/services/decryption-service.ts
+++ b/packages/sdk/src/services/decryption-service.ts
@@ -148,10 +148,7 @@ export class DecryptionService {
 
     try {
       const decrypted = await this.delegatedUserDecrypt(
-        items.map(({ encryptedValue, contractAddress }) => ({
-          encryptedValue,
-          contractAddress,
-        })),
+        items.map(({ encryptedValue, contractAddress }) => ({ encryptedValue, contractAddress })),
         delegatorAddress,
         delegateAddress,
         normalizedAccount,
@@ -175,12 +172,7 @@ export class DecryptionService {
       items.map((item) => async () => {
         try {
           const decrypted = await this.delegatedUserDecrypt(
-            [
-              {
-                encryptedValue: item.encryptedValue,
-                contractAddress: item.contractAddress,
-              },
-            ],
+            [{ encryptedValue: item.encryptedValue, contractAddress: item.contractAddress }],
             delegatorAddress,
             delegateAddress,
             normalizedAccount,
@@ -341,13 +333,7 @@ export class DecryptionService {
 
   async #assertAllDelegationsActive(
     contractAddresses: readonly Address[],
-    {
-      delegatorAddress,
-      delegateAddress,
-    }: {
-      delegatorAddress: Address;
-      delegateAddress: Address;
-    },
+    { delegatorAddress, delegateAddress }: { delegatorAddress: Address; delegateAddress: Address },
   ): Promise<void> {
     const inactive = await this.#delegationService.findInactiveDelegations(
       contractAddresses,

--- a/packages/sdk/src/services/delegation-service.ts
+++ b/packages/sdk/src/services/delegation-service.ts
@@ -103,9 +103,7 @@ export class DelegationService {
         delegateAddress: normalizedDelegate,
       });
     } catch (error) {
-      this.#logger.warn("delegateDecryption: pre-flight expiry check failed", {
-        error,
-      });
+      this.#logger.warn("delegateDecryption: pre-flight expiry check failed", { error });
       currentExpiry = -1n;
     }
     if (currentExpiry === expDate) {
@@ -133,11 +131,7 @@ export class DelegationService {
       contractAddress,
       delegateAddress,
       delegatorAddress,
-    }: {
-      contractAddress: Address;
-      delegateAddress: Address;
-      delegatorAddress: Address;
-    },
+    }: { contractAddress: Address; delegateAddress: Address; delegatorAddress: Address },
   ): Promise<TransactionResult> {
     const normalizedContract = getAddress(contractAddress);
     const normalizedDelegate = getAddress(delegateAddress);

--- a/packages/sdk/src/services/encryption-service.ts
+++ b/packages/sdk/src/services/encryption-service.ts
@@ -29,20 +29,13 @@ export class EncryptionService {
       this.#emitEvent({ type: ZamaSDKEvents.EncryptStart }, params.contractAddress);
       const result = await this.#relayer.encrypt(params);
       this.#emitEvent(
-        {
-          type: ZamaSDKEvents.EncryptEnd,
-          durationMs: Date.now() - t0,
-        },
+        { type: ZamaSDKEvents.EncryptEnd, durationMs: Date.now() - t0 },
         params.contractAddress,
       );
       return result;
     } catch (error) {
       this.#emitEvent(
-        {
-          type: ZamaSDKEvents.EncryptError,
-          error: toError(error),
-          durationMs: Date.now() - t0,
-        },
+        { type: ZamaSDKEvents.EncryptError, error: toError(error), durationMs: Date.now() - t0 },
         params.contractAddress,
       );
       throw wrapEncryptError(error, "Encryption failed");

--- a/packages/sdk/src/signer/__tests__/eip1193-subscribe.test.ts
+++ b/packages/sdk/src/signer/__tests__/eip1193-subscribe.test.ts
@@ -220,20 +220,14 @@ describe("eip1193Subscribe", () => {
   });
 
   test("returns a no-op unsubscribe when provider is undefined", () => {
-    const unsub = eip1193Subscribe({
-      provider: undefined,
-      onWalletAccountChange: () => {},
-    });
+    const unsub = eip1193Subscribe({ provider: undefined, onWalletAccountChange: () => {} });
     expect(unsub).toBeTypeOf("function");
     unsub();
   });
 
   test("registers and removes all three native listeners", () => {
     const provider = createFakeProvider();
-    const unsub = eip1193Subscribe({
-      provider,
-      onWalletAccountChange: () => {},
-    });
+    const unsub = eip1193Subscribe({ provider, onWalletAccountChange: () => {} });
 
     expect(provider.listenerCount("accountsChanged")).toBe(1);
     expect(provider.listenerCount("disconnect")).toBe(1);
@@ -268,10 +262,7 @@ describe("eip1193Subscribe", () => {
     const onWalletAccountChange = vi.fn();
     eip1193Subscribe({
       provider,
-      getInitialWalletAccount: () => ({
-        address: ADDR_A,
-        chainId: CHAIN_31337,
-      }),
+      getInitialWalletAccount: () => ({ address: ADDR_A, chainId: CHAIN_31337 }),
       onWalletAccountChange,
     });
 
@@ -292,11 +283,7 @@ describe("eip1193Subscribe", () => {
     const getInitialWalletAccount = vi
       .fn()
       .mockResolvedValue({ address: ADDR_A, chainId: CHAIN_31337 });
-    eip1193Subscribe({
-      provider,
-      getInitialWalletAccount,
-      onWalletAccountChange,
-    });
+    eip1193Subscribe({ provider, getInitialWalletAccount, onWalletAccountChange });
 
     await vi.waitFor(() => {
       expect(getInitialWalletAccount).toHaveBeenCalledOnce();
@@ -318,11 +305,7 @@ describe("eip1193Subscribe", () => {
     const getInitialWalletAccount = vi
       .fn()
       .mockResolvedValue({ address: ADDR_A, chainId: CHAIN_31337 });
-    eip1193Subscribe({
-      provider,
-      getInitialWalletAccount,
-      onWalletAccountChange,
-    });
+    eip1193Subscribe({ provider, getInitialWalletAccount, onWalletAccountChange });
 
     await vi.waitFor(() => {
       expect(getInitialWalletAccount).toHaveBeenCalledOnce();
@@ -340,12 +323,11 @@ describe("eip1193Subscribe", () => {
 
   test("ignores initial wallet account when a provider event wins the race", async () => {
     let resolveInitial!: (walletAccount: { address: Address; chainId: number }) => void;
-    const initialWalletAccountPromise = new Promise<{
-      address: Address;
-      chainId: number;
-    }>((resolve) => {
-      resolveInitial = resolve;
-    });
+    const initialWalletAccountPromise = new Promise<{ address: Address; chainId: number }>(
+      (resolve) => {
+        resolveInitial = resolve;
+      },
+    );
     const provider = createFakeProvider();
     const onWalletAccountChange = vi.fn();
     eip1193Subscribe({
@@ -393,10 +375,7 @@ describe("eip1193Subscribe", () => {
   });
 
   test("does not request initial accounts or chain", () => {
-    const provider = createFakeProvider({
-      accounts: [ADDR_A],
-      chainId: "0x7a69",
-    });
+    const provider = createFakeProvider({ accounts: [ADDR_A], chainId: "0x7a69" });
     const onWalletAccountChange = vi.fn();
     eip1193Subscribe({ provider, onWalletAccountChange });
 

--- a/packages/sdk/src/test-fixtures/relayer.ts
+++ b/packages/sdk/src/test-fixtures/relayer.ts
@@ -17,33 +17,29 @@ export function createMockRelayer(overrides: Partial<RelayerSDK> = {}): RelayerS
     chains: [{ id: 31337 }],
     activeChain: { id: 31337 },
     switchChain: vi.fn(),
-    generateTransportKeyPair: vi.fn().mockResolvedValue({
-      publicKey: TEST_PUBLIC_KEY,
-      privateKey: TEST_PRIVATE_KEY,
-    }),
-    createEIP712: vi.fn().mockResolvedValue({
-      domain: {
-        name: "test",
-        version: "1",
-        chainId: 1,
-        verifyingContract: "0xkms",
-      },
-      types: { UserDecryptRequestVerification: [] },
-      message: {
-        publicKey: TEST_PUBLIC_KEY,
-        contractAddresses: [TOKEN],
-        startTimestamp: 1000n,
-        durationDays: 1n,
-        extraData: "0x",
-      },
-    }),
-    encrypt: vi.fn().mockResolvedValue({
-      encryptedValues: [VALID_ENCRYPTED_VALUE],
-      inputProof: VALID_INPUT_PROOF,
-    }),
-    userDecrypt: vi.fn().mockResolvedValue({
-      [VALID_ENCRYPTED_VALUE as string]: 1000n,
-    }),
+    generateTransportKeyPair: vi
+      .fn()
+      .mockResolvedValue({ publicKey: TEST_PUBLIC_KEY, privateKey: TEST_PRIVATE_KEY }),
+    createEIP712: vi
+      .fn()
+      .mockResolvedValue({
+        domain: { name: "test", version: "1", chainId: 1, verifyingContract: "0xkms" },
+        types: { UserDecryptRequestVerification: [] },
+        message: {
+          publicKey: TEST_PUBLIC_KEY,
+          contractAddresses: [TOKEN],
+          startTimestamp: 1000n,
+          durationDays: 1n,
+          extraData: "0x",
+        },
+      }),
+    encrypt: vi
+      .fn()
+      .mockResolvedValue({
+        encryptedValues: [VALID_ENCRYPTED_VALUE],
+        inputProof: VALID_INPUT_PROOF,
+      }),
+    userDecrypt: vi.fn().mockResolvedValue({ [VALID_ENCRYPTED_VALUE as string]: 1000n }),
     publicDecrypt: vi.fn().mockImplementation((handles: string[]) => {
       const clearValues: Record<string, bigint> = {};
       for (const h of handles) {
@@ -55,29 +51,22 @@ export function createMockRelayer(overrides: Partial<RelayerSDK> = {}): RelayerS
         decryptionProof: "0xproof",
       });
     }),
-    createDelegatedUserDecryptEIP712: vi.fn().mockResolvedValue({
-      domain: {
-        name: "test",
-        version: "1",
-        chainId: 1,
-        verifyingContract: "0xkms",
-      },
-      types: { DelegatedUserDecryptRequestVerification: [] },
-      message: {},
-    }),
-    delegatedUserDecrypt: vi.fn().mockResolvedValue({
-      [VALID_ENCRYPTED_VALUE as string]: 1000n,
-    }),
+    createDelegatedUserDecryptEIP712: vi
+      .fn()
+      .mockResolvedValue({
+        domain: { name: "test", version: "1", chainId: 1, verifyingContract: "0xkms" },
+        types: { DelegatedUserDecryptRequestVerification: [] },
+        message: {},
+      }),
+    delegatedUserDecrypt: vi.fn().mockResolvedValue({ [VALID_ENCRYPTED_VALUE as string]: 1000n }),
     requestZKProofVerification: vi.fn(),
     getAclAddress: vi.fn().mockResolvedValue(ACL),
-    fetchFheEncryptionKeyBytes: vi.fn().mockResolvedValue({
-      publicKeyId: "pk-1",
-      publicKey: new Uint8Array([1]),
-    }),
-    getPublicParams: vi.fn().mockResolvedValue({
-      publicParams: new Uint8Array([2]),
-      publicParamsId: "pp-1",
-    }),
+    fetchFheEncryptionKeyBytes: vi
+      .fn()
+      .mockResolvedValue({ publicKeyId: "pk-1", publicKey: new Uint8Array([1]) }),
+    getPublicParams: vi
+      .fn()
+      .mockResolvedValue({ publicParams: new Uint8Array([2]), publicParamsId: "pp-1" }),
     terminate: vi.fn(),
     ...overrides,
   } as unknown as RelayerSDK;

--- a/packages/sdk/src/test-fixtures/token.ts
+++ b/packages/sdk/src/test-fixtures/token.ts
@@ -16,21 +16,13 @@ export type CreateWrappedTokenFn = (sdk: ZamaSDK, address?: Address) => WrappedT
 export type CreateMockTokenFn = (
   addressOrArgs?:
     | Address
-    | {
-        address?: Address;
-        signer?: GenericSigner;
-        txResult?: TransactionResult;
-      },
+    | { address?: Address; signer?: GenericSigner; txResult?: TransactionResult },
 ) => Token;
 
 export type CreateMockWrappedTokenFn = (
   addressOrArgs?:
     | Address
-    | {
-        address?: Address;
-        signer?: GenericSigner;
-        txResult?: TransactionResult;
-      },
+    | { address?: Address; signer?: GenericSigner; txResult?: TransactionResult },
 ) => WrappedToken;
 
 function createMockTokenInternal(address: Address, signer: GenericSigner): Token {

--- a/packages/sdk/src/token/__tests__/batch-decrypt-as.test.ts
+++ b/packages/sdk/src/token/__tests__/batch-decrypt-as.test.ts
@@ -17,27 +17,26 @@ const HANDLE_B = ("0x" + "b2".repeat(32)) as EncryptedValue;
  * Token batching without priming the full EIP-712 sign flow.
  */
 function stubDelegatedBatchDecrypt(sdk: ZamaSDK, values: Record<EncryptedValue, bigint>) {
-  const stub = vi.fn().mockImplementation(
-    async ({
-      encryptedInputs,
-    }: {
-      encryptedInputs: {
-        encryptedValue: EncryptedValue;
-        contractAddress: Address;
-      }[];
-    }) => ({
-      items: encryptedInputs.map(({ encryptedValue, contractAddress }) => {
-        const value = values[encryptedValue];
-        return value !== undefined
-          ? { encryptedValue, contractAddress, value }
-          : {
-              encryptedValue,
-              contractAddress,
-              error: new Error(`No value for ${encryptedValue}`),
-            };
+  const stub = vi
+    .fn()
+    .mockImplementation(
+      async ({
+        encryptedInputs,
+      }: {
+        encryptedInputs: { encryptedValue: EncryptedValue; contractAddress: Address }[];
+      }) => ({
+        items: encryptedInputs.map(({ encryptedValue, contractAddress }) => {
+          const value = values[encryptedValue];
+          return value !== undefined
+            ? { encryptedValue, contractAddress, value }
+            : {
+                encryptedValue,
+                contractAddress,
+                error: new Error(`No value for ${encryptedValue}`),
+              };
+        }),
       }),
-    }),
-  );
+    );
   Object.defineProperty(sdk.decryption, "delegatedBatchDecryptValues", {
     value: stub,
     configurable: true,
@@ -54,10 +53,7 @@ describe("Token.batchDecryptBalancesAs", () => {
   }) => {
     const delegateSigner = createMockSigner(DELEGATE);
     const delegateProvider = createMockProvider();
-    const delegateSdk = createSDK({
-      signer: delegateSigner,
-      provider: delegateProvider,
-    });
+    const delegateSdk = createSDK({ signer: delegateSigner, provider: delegateProvider });
 
     vi.mocked(delegateProvider.readContract)
       .mockResolvedValueOnce(HANDLE_A) // confidentialBalanceOf(tokenA)
@@ -83,9 +79,7 @@ describe("Token.batchDecryptBalancesAs", () => {
   });
 
   test("returns empty map for empty token list", async () => {
-    const result = await Token.batchDecryptBalancesAs([], {
-      delegatorAddress: DELEGATOR,
-    });
+    const result = await Token.batchDecryptBalancesAs([], { delegatorAddress: DELEGATOR });
     expect(result.size).toBe(0);
   });
 
@@ -97,19 +91,14 @@ describe("Token.batchDecryptBalancesAs", () => {
   }) => {
     const delegateSigner = createMockSigner(DELEGATE);
     const delegateProvider = createMockProvider();
-    const delegateSdk = createSDK({
-      signer: delegateSigner,
-      provider: delegateProvider,
-    });
+    const delegateSdk = createSDK({ signer: delegateSigner, provider: delegateProvider });
     const ZERO = ("0x" + "00".repeat(32)) as EncryptedValue;
 
     vi.mocked(delegateProvider.readContract).mockResolvedValueOnce(ZERO);
 
     const token = new Token(delegateSdk, TOKEN_A);
 
-    const balances = await Token.batchDecryptBalancesAs([token], {
-      delegatorAddress: DELEGATOR,
-    });
+    const balances = await Token.batchDecryptBalancesAs([token], { delegatorAddress: DELEGATOR });
 
     expect(balances.get(TOKEN_A)).toBe(0n);
     expect(relayer.delegatedUserDecrypt).not.toHaveBeenCalled();
@@ -127,10 +116,7 @@ describe("Token.batchDecryptBalancesAs", () => {
   }) => {
     const delegateSigner = createMockSigner(DELEGATE);
     const delegateProvider = createMockProvider();
-    const delegateSdk = createSDK({
-      signer: delegateSigner,
-      provider: delegateProvider,
-    });
+    const delegateSdk = createSDK({ signer: delegateSigner, provider: delegateProvider });
     // Pre-populate cache via shared storage: ownerAddress = DELEGATOR
     await cachingService.set(DELEGATOR, TOKEN_A, HANDLE_A, 42n);
 
@@ -140,9 +126,7 @@ describe("Token.batchDecryptBalancesAs", () => {
 
     const token = new Token(delegateSdk, TOKEN_A);
 
-    const balances = await Token.batchDecryptBalancesAs([token], {
-      delegatorAddress: DELEGATOR,
-    });
+    const balances = await Token.batchDecryptBalancesAs([token], { delegatorAddress: DELEGATOR });
 
     // Delegation check now fires even when the cache resolves everything, so
     // revoked delegations can't leak stale cached values.
@@ -160,10 +144,7 @@ describe("Token.batchDecryptBalancesAs", () => {
   }) => {
     const delegateSigner = createMockSigner(DELEGATE);
     const delegateProvider = createMockProvider();
-    const delegateSdk = createSDK({
-      signer: delegateSigner,
-      provider: delegateProvider,
-    });
+    const delegateSdk = createSDK({ signer: delegateSigner, provider: delegateProvider });
     await cachingService.set(DELEGATOR, TOKEN_A, HANDLE_A, 42n);
 
     vi.mocked(delegateProvider.readContract)
@@ -173,9 +154,7 @@ describe("Token.batchDecryptBalancesAs", () => {
     const token = new Token(delegateSdk, TOKEN_A);
 
     await expect(
-      Token.batchDecryptBalancesAs([token], {
-        delegatorAddress: DELEGATOR,
-      }),
+      Token.batchDecryptBalancesAs([token], { delegatorAddress: DELEGATOR }),
     ).rejects.toMatchObject({
       code: "DECRYPTION_FAILED",
       message: expect.stringContaining(TOKEN_A),
@@ -191,10 +170,7 @@ describe("Token.batchDecryptBalancesAs", () => {
   }) => {
     const delegateSigner = createMockSigner(DELEGATE);
     const delegateProvider = createMockProvider();
-    const delegateSdk = createSDK({
-      signer: delegateSigner,
-      provider: delegateProvider,
-    });
+    const delegateSdk = createSDK({ signer: delegateSigner, provider: delegateProvider });
 
     vi.mocked(delegateProvider.readContract)
       .mockResolvedValueOnce(HANDLE_A)
@@ -221,10 +197,7 @@ describe("Token.batchDecryptBalancesAs", () => {
   }) => {
     const delegateSigner = createMockSigner(DELEGATE);
     const delegateProvider = createMockProvider();
-    const delegateSdk = createSDK({
-      signer: delegateSigner,
-      provider: delegateProvider,
-    });
+    const delegateSdk = createSDK({ signer: delegateSigner, provider: delegateProvider });
 
     vi.mocked(delegateProvider.readContract)
       .mockResolvedValueOnce(HANDLE_A) // confidentialBalanceOf → non-zero, goes to uncached
@@ -233,9 +206,7 @@ describe("Token.batchDecryptBalancesAs", () => {
     const token = new Token(delegateSdk, TOKEN_A);
 
     await expect(
-      Token.batchDecryptBalancesAs([token], {
-        delegatorAddress: DELEGATOR,
-      }),
+      Token.batchDecryptBalancesAs([token], { delegatorAddress: DELEGATOR }),
     ).rejects.toMatchObject({
       code: "DECRYPTION_FAILED",
       message: expect.stringContaining(TOKEN_A),
@@ -252,10 +223,7 @@ describe("Token.batchDecryptBalancesAs", () => {
   }) => {
     const delegateSigner = createMockSigner(DELEGATE);
     const delegateProvider = createMockProvider();
-    const delegateSdk = createSDK({
-      signer: delegateSigner,
-      provider: delegateProvider,
-    });
+    const delegateSdk = createSDK({ signer: delegateSigner, provider: delegateProvider });
 
     vi.mocked(delegateProvider.readContract)
       .mockResolvedValueOnce(HANDLE_A)
@@ -265,9 +233,7 @@ describe("Token.batchDecryptBalancesAs", () => {
     const token = new Token(delegateSdk, TOKEN_A);
 
     await expect(
-      Token.batchDecryptBalancesAs([token], {
-        delegatorAddress: DELEGATOR,
-      }),
+      Token.batchDecryptBalancesAs([token], { delegatorAddress: DELEGATOR }),
     ).rejects.toMatchObject({
       code: "DECRYPTION_FAILED",
       message: expect.stringContaining(TOKEN_A),
@@ -283,10 +249,7 @@ describe("Token.batchDecryptBalancesAs", () => {
   }) => {
     const delegateSigner = createMockSigner(DELEGATE);
     const delegateProvider = createMockProvider();
-    const delegateSdk = createSDK({
-      signer: delegateSigner,
-      provider: delegateProvider,
-    });
+    const delegateSdk = createSDK({ signer: delegateSigner, provider: delegateProvider });
 
     vi.mocked(delegateProvider.readContract)
       .mockResolvedValueOnce(HANDLE_A)
@@ -295,9 +258,7 @@ describe("Token.batchDecryptBalancesAs", () => {
     const token = new Token(delegateSdk, TOKEN_A);
     stubDelegatedBatchDecrypt(delegateSdk, { [HANDLE_A]: 42n });
 
-    const balances = await Token.batchDecryptBalancesAs([token], {
-      delegatorAddress: DELEGATOR,
-    });
+    const balances = await Token.batchDecryptBalancesAs([token], { delegatorAddress: DELEGATOR });
 
     expect(balances.get(TOKEN_A)).toBe(42n);
     expect(delegateProvider.getBlockTimestamp).not.toHaveBeenCalled();
@@ -310,10 +271,7 @@ describe("Token.batchDecryptBalancesAs", () => {
   }) => {
     const delegateSigner = createMockSigner(DELEGATE);
     const delegateProvider = createMockProvider();
-    const delegateSdk = createSDK({
-      signer: delegateSigner,
-      provider: delegateProvider,
-    });
+    const delegateSdk = createSDK({ signer: delegateSigner, provider: delegateProvider });
 
     vi.mocked(delegateProvider.readContract)
       .mockResolvedValueOnce(HANDLE_A)
@@ -343,11 +301,7 @@ describe("Token.batchDecryptBalancesAs", () => {
     const delegateSigner = createMockSigner(DELEGATE);
     const delegateProvider = createMockProvider();
     const storage = createMockStorage();
-    const delegateSdk = createSDK({
-      signer: delegateSigner,
-      provider: delegateProvider,
-      storage,
-    });
+    const delegateSdk = createSDK({ signer: delegateSigner, provider: delegateProvider, storage });
 
     vi.mocked(delegateProvider.readContract)
       .mockResolvedValueOnce(HANDLE_A)
@@ -359,9 +313,7 @@ describe("Token.batchDecryptBalancesAs", () => {
     // Sabotage the storage so any cache write fails — decrypt should still succeed.
     vi.spyOn(storage, "set").mockRejectedValue(new Error("storage full"));
 
-    const balances = await Token.batchDecryptBalancesAs([token], {
-      delegatorAddress: DELEGATOR,
-    });
+    const balances = await Token.batchDecryptBalancesAs([token], { delegatorAddress: DELEGATOR });
 
     expect(balances.get(TOKEN_A)).toBe(99n);
   });

--- a/packages/sdk/src/token/__tests__/callbacks.test.ts
+++ b/packages/sdk/src/token/__tests__/callbacks.test.ts
@@ -58,11 +58,7 @@ describe("Unshield callbacks (P4)", () => {
     const onFinalizing = vi.fn();
     const onFinalizeSubmitted = vi.fn();
 
-    await token.unshieldAll({
-      onUnwrapSubmitted,
-      onFinalizing,
-      onFinalizeSubmitted,
-    });
+    await token.unshieldAll({ onUnwrapSubmitted, onFinalizing, onFinalizeSubmitted });
 
     expect(onUnwrapSubmitted).toHaveBeenCalledWith("0xtxhash");
     expect(onFinalizing).toHaveBeenCalledOnce();
@@ -79,10 +75,7 @@ describe("Unshield callbacks (P4)", () => {
     const onFinalizing = vi.fn();
     const onFinalizeSubmitted = vi.fn();
 
-    await token.resumeUnshield("0xprevioustx", {
-      onFinalizing,
-      onFinalizeSubmitted,
-    });
+    await token.resumeUnshield("0xprevioustx", { onFinalizing, onFinalizeSubmitted });
 
     expect(provider.waitForTransactionReceipt).toHaveBeenCalledWith("0xprevioustx");
     expect(onFinalizing).toHaveBeenCalledOnce();
@@ -159,9 +152,7 @@ describe("Unshield callbacks (P4)", () => {
     wrappedToken: token,
     provider,
   }) => {
-    vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
-      logs: [],
-    });
+    vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({ logs: [] });
 
     await expect(token.unshield(50n, { skipBalanceCheck: true })).rejects.toThrow(
       TransactionRevertedError,

--- a/packages/sdk/src/token/__tests__/error-throwing.test.ts
+++ b/packages/sdk/src/token/__tests__/error-throwing.test.ts
@@ -10,9 +10,7 @@ describe("NoCiphertextError detection (P3)", () => {
     provider,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
-    const error = new Error("No ciphertext found") as Error & {
-      statusCode?: number;
-    };
+    const error = new Error("No ciphertext found") as Error & { statusCode?: number };
     error.statusCode = 400;
     vi.mocked(relayer.userDecrypt).mockRejectedValue(error);
 
@@ -27,9 +25,7 @@ describe("NoCiphertextError detection (P3)", () => {
     provider,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
-    const error = new Error("Internal server error") as Error & {
-      statusCode?: number;
-    };
+    const error = new Error("Internal server error") as Error & { statusCode?: number };
     error.statusCode = 500;
     vi.mocked(relayer.userDecrypt).mockRejectedValue(error);
 
@@ -113,10 +109,7 @@ describe("NoCiphertextError detection (P3)", () => {
     provider,
   }) => {
     vi.mocked(provider.readContract).mockResolvedValue(handle);
-    vi.mocked(relayer.userDecrypt).mockRejectedValue({
-      statusCode: 400,
-      message: "bad",
-    });
+    vi.mocked(relayer.userDecrypt).mockRejectedValue({ statusCode: 400, message: "bad" });
 
     await expect(token.balanceOf(userAddress)).rejects.toBeInstanceOf(NoCiphertextError);
   });

--- a/packages/sdk/src/token/__tests__/events.test.ts
+++ b/packages/sdk/src/token/__tests__/events.test.ts
@@ -73,10 +73,7 @@ describe("Token.balanceOf event emissions", () => {
     userAddress,
     provider,
   }) => {
-    const { readonlyToken, events } = setupSdkWithEvents({
-      createSDK,
-      tokenAddress,
-    });
+    const { readonlyToken, events } = setupSdkWithEvents({ createSDK, tokenAddress });
     vi.mocked(provider.readContract).mockResolvedValue(handle);
 
     await readonlyToken.balanceOf(userAddress);
@@ -95,10 +92,7 @@ describe("Token.balanceOf event emissions", () => {
     userAddress,
     provider,
   }) => {
-    const { readonlyToken, events } = setupSdkWithEvents({
-      createSDK,
-      tokenAddress,
-    });
+    const { readonlyToken, events } = setupSdkWithEvents({ createSDK, tokenAddress });
     vi.mocked(provider.readContract).mockResolvedValue(ZERO_ENCRYPTED_VALUE);
 
     await readonlyToken.balanceOf(userAddress);
@@ -115,10 +109,7 @@ describe("Token.balanceOf event emissions", () => {
     userAddress,
     provider,
   }) => {
-    const { readonlyToken, events } = setupSdkWithEvents({
-      createSDK,
-      tokenAddress,
-    });
+    const { readonlyToken, events } = setupSdkWithEvents({ createSDK, tokenAddress });
     vi.mocked(provider.readContract).mockResolvedValue(handle);
 
     await readonlyToken.balanceOf(userAddress);
@@ -139,10 +130,7 @@ describe("Token.balanceOf event emissions", () => {
     provider,
   }) => {
     relayer.userDecrypt = vi.fn().mockRejectedValue(new Error("decrypt boom"));
-    const { readonlyToken, events } = setupSdkWithEvents({
-      createSDK,
-      tokenAddress,
-    });
+    const { readonlyToken, events } = setupSdkWithEvents({ createSDK, tokenAddress });
     vi.mocked(provider.readContract).mockResolvedValue(handle);
 
     await expect(readonlyToken.balanceOf(userAddress)).rejects.toThrow();
@@ -181,32 +169,26 @@ describe("Token.decryptBalanceAs event emissions", () => {
     delegatorAddress,
     provider,
   }) => {
-    const { readonlyToken, events } = setupSdkWithEvents({
-      createSDK,
-      tokenAddress,
-    });
+    const { readonlyToken, events } = setupSdkWithEvents({ createSDK, tokenAddress });
     // readConfidentialBalanceOf → non-zero handle; getDelegationExpiry → permanent (skips block-timestamp RPC)
     vi.mocked(provider.readContract)
       .mockResolvedValueOnce(handle)
       .mockResolvedValue(2n ** 64n - 1n);
-    relayer.createDelegatedUserDecryptEIP712 = vi.fn().mockResolvedValue({
-      domain: {
-        name: "test",
-        version: "1",
-        chainId: 1,
-        verifyingContract: "0xkms",
-      },
-      types: { DelegatedUserDecryptRequestVerification: [] },
-      message: {
-        publicKey: TEST_PUBLIC_KEY,
-        contractAddresses: [tokenAddress],
-        delegatorAddress,
-        delegateAddress: signer.walletAccount.getSnapshot()!.address,
-        startTimestamp: 1000n,
-        durationDays: 1n,
-        extraData: "0x",
-      },
-    });
+    relayer.createDelegatedUserDecryptEIP712 = vi
+      .fn()
+      .mockResolvedValue({
+        domain: { name: "test", version: "1", chainId: 1, verifyingContract: "0xkms" },
+        types: { DelegatedUserDecryptRequestVerification: [] },
+        message: {
+          publicKey: TEST_PUBLIC_KEY,
+          contractAddresses: [tokenAddress],
+          delegatorAddress,
+          delegateAddress: signer.walletAccount.getSnapshot()!.address,
+          startTimestamp: 1000n,
+          durationDays: 1n,
+          extraData: "0x",
+        },
+      });
     relayer.delegatedUserDecrypt = vi.fn().mockResolvedValue({ [handle]: 42n });
 
     await readonlyToken.decryptBalanceAs({ delegatorAddress });

--- a/packages/sdk/src/token/__tests__/integration.test.ts
+++ b/packages/sdk/src/token/__tests__/integration.test.ts
@@ -34,10 +34,7 @@ describe("Integration: multi-step workflows", () => {
       expect(signer.writeContract).toHaveBeenCalledTimes(2);
       expect(signer.writeContract).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({
-          functionName: "approve",
-          args: expect.arrayContaining([500n]),
-        }),
+        expect.objectContaining({ functionName: "approve", args: expect.arrayContaining([500n]) }),
       );
       expect(signer.writeContract).toHaveBeenNthCalledWith(
         2,
@@ -50,10 +47,7 @@ describe("Integration: multi-step workflows", () => {
 
       // Step 4: Decrypt the balance through the SDK-level API
       const decryptResult = await wrappedToken.sdk.decryption.decryptValues([
-        {
-          encryptedValue: balanceHandle,
-          contractAddress: wrappedToken.address,
-        },
+        { encryptedValue: balanceHandle, contractAddress: wrappedToken.address },
       ]);
       expect(decryptResult[balanceHandle]).toBe(1000n);
       expect(relayer.userDecrypt).toHaveBeenCalledWith(
@@ -186,9 +180,7 @@ describe("Integration: multi-step workflows", () => {
         .mockResolvedValueOnce(eventReceipt) // #waitAndFinalizeUnshield receipt (parses event)
         .mockResolvedValueOnce({ logs: [] }); // finalizeUnwrap receipt
 
-      const unshieldResult = await wrappedToken.unshield(500n, {
-        skipBalanceCheck: true,
-      });
+      const unshieldResult = await wrappedToken.unshield(500n, { skipBalanceCheck: true });
       expect(unshieldResult.txHash).toBe("0xtxhash");
 
       // Verify full pipeline: encrypt → unwrap → waitForReceipt → publicDecrypt → finalizeUnwrap

--- a/packages/sdk/src/token/__tests__/pending-unshield.test.ts
+++ b/packages/sdk/src/token/__tests__/pending-unshield.test.ts
@@ -61,9 +61,7 @@ describe("pending-unshield persistence", () => {
   });
 
   test("deletes invalid persisted pending unshield data", async ({ storage, wrapperAddress }) => {
-    await storage.set(`zama:pending-unshield:${wrapperAddress}`, {
-      unwrapTxHash: 123,
-    });
+    await storage.set(`zama:pending-unshield:${wrapperAddress}`, { unwrapTxHash: 123 });
     expect(await loadPendingUnshield(storage, wrapperAddress)).toBeNull();
     expect(await storage.get(`zama:pending-unshield:${wrapperAddress}`)).toBeNull();
   });

--- a/packages/sdk/src/token/__tests__/shield.test.ts
+++ b/packages/sdk/src/token/__tests__/shield.test.ts
@@ -124,9 +124,7 @@ describe("WrappedToken.shield", () => {
       .mockResolvedValueOnce(1000n) // ERC-20 balanceOf
       .mockResolvedValueOnce(0n) // allowance
       .mockResolvedValue(fixtureHandle); // subsequent confidentialBalanceOf calls
-    vi.mocked(relayer.userDecrypt).mockResolvedValue({
-      [fixtureHandle]: 1000n,
-    });
+    vi.mocked(relayer.userDecrypt).mockResolvedValue({ [fixtureHandle]: 1000n });
 
     const shieldResult = await token.shield(500n);
     expect(shieldResult.txHash).toBe("0xtxhash");
@@ -134,10 +132,7 @@ describe("WrappedToken.shield", () => {
     expect(signer.writeContract).toHaveBeenCalledTimes(2);
     expect(signer.writeContract).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({
-        functionName: "approve",
-        args: expect.arrayContaining([500n]),
-      }),
+      expect.objectContaining({ functionName: "approve", args: expect.arrayContaining([500n]) }),
     );
     expect(signer.writeContract).toHaveBeenNthCalledWith(
       2,
@@ -449,9 +444,7 @@ describe("WrappedToken.shield", () => {
       tokenAddress,
     }) => {
       const emitted: unknown[] = [];
-      const sdk = createSDK({
-        onEvent: (event: unknown) => emitted.push(event),
-      });
+      const sdk = createSDK({ onEvent: (event: unknown) => emitted.push(event) });
       const { WrappedToken } = await import("../../token/wrapped-token");
       const token = new WrappedToken(sdk, tokenAddress);
 
@@ -480,9 +473,7 @@ describe("WrappedToken.shield", () => {
       tokenAddress,
     }) => {
       const emitted: unknown[] = [];
-      const sdk = createSDK({
-        onEvent: (event: unknown) => emitted.push(event),
-      });
+      const sdk = createSDK({ onEvent: (event: unknown) => emitted.push(event) });
       const { WrappedToken } = await import("../../token/wrapped-token");
       const token = new WrappedToken(sdk, tokenAddress);
 
@@ -512,9 +503,7 @@ describe("WrappedToken.shield", () => {
       tokenAddress,
     }) => {
       const emitted: unknown[] = [];
-      const sdk = createSDK({
-        onEvent: (event: unknown) => emitted.push(event),
-      });
+      const sdk = createSDK({ onEvent: (event: unknown) => emitted.push(event) });
       const { WrappedToken } = await import("../../token/wrapped-token");
       const token = new WrappedToken(sdk, tokenAddress);
 
@@ -547,9 +536,7 @@ describe("WrappedToken.shield", () => {
       tokenAddress,
     }) => {
       const emitted: unknown[] = [];
-      const sdk = createSDK({
-        onEvent: (event: unknown) => emitted.push(event),
-      });
+      const sdk = createSDK({ onEvent: (event: unknown) => emitted.push(event) });
       const { WrappedToken } = await import("../../token/wrapped-token");
       const token = new WrappedToken(sdk, tokenAddress);
 
@@ -583,8 +570,6 @@ describe("WrappedToken.shield", () => {
     const options = shieldMutationOptions(mockWrappedToken);
 
     await options.mutationFn({ amount: 1n, approvalStrategy: "max" });
-    expect(mockWrappedToken.shield).toHaveBeenCalledWith(1n, {
-      approvalStrategy: "max",
-    });
+    expect(mockWrappedToken.shield).toHaveBeenCalledWith(1n, { approvalStrategy: "max" });
   });
 });

--- a/packages/sdk/src/token/__tests__/token.test.ts
+++ b/packages/sdk/src/token/__tests__/token.test.ts
@@ -150,10 +150,7 @@ describe("Token", () => {
       token,
       inputProof,
     }) => {
-      vi.mocked(relayer.encrypt).mockResolvedValueOnce({
-        encryptedValues: [],
-        inputProof,
-      });
+      vi.mocked(relayer.encrypt).mockResolvedValueOnce({ encryptedValues: [], inputProof });
 
       await expect(
         token.confidentialTransfer("0x8b8b8b8b8B8B8b8B8B8b8b8b8b8B8B8B8B8b8B8b" as Address, 100n, {
@@ -186,9 +183,7 @@ describe("Token", () => {
         token.confidentialTransfer("0x8b8b8b8b8B8B8b8B8B8b8b8b8b8B8B8B8B8b8B8b" as Address, 100n, {
           skipBalanceCheck: true,
         }),
-      ).rejects.toMatchObject({
-        code: ZamaErrorCode.TransactionReverted,
-      });
+      ).rejects.toMatchObject({ code: ZamaErrorCode.TransactionReverted });
     });
   });
 
@@ -227,9 +222,7 @@ describe("Token", () => {
           "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" as Address,
           200n,
         ),
-      ).rejects.toMatchObject({
-        code: ZamaErrorCode.TransactionReverted,
-      });
+      ).rejects.toMatchObject({ code: ZamaErrorCode.TransactionReverted });
     });
   });
 
@@ -270,10 +263,7 @@ describe("Token", () => {
       token,
       inputProof,
     }) => {
-      vi.mocked(relayer.encrypt).mockResolvedValueOnce({
-        encryptedValues: [],
-        inputProof,
-      });
+      vi.mocked(relayer.encrypt).mockResolvedValueOnce({ encryptedValues: [], inputProof });
 
       await expect(
         token.confidentialTransferAndCall(RECIPIENT, 100n, DATA, { skipBalanceCheck: true }),
@@ -291,9 +281,7 @@ describe("Token", () => {
 
       await expect(
         token.confidentialTransferAndCall(RECIPIENT, 100n, DATA, { skipBalanceCheck: true }),
-      ).rejects.toMatchObject({
-        code: ZamaErrorCode.TransactionReverted,
-      });
+      ).rejects.toMatchObject({ code: ZamaErrorCode.TransactionReverted });
     });
 
     test("validates balance when skipBalanceCheck is not set", async ({ token, provider }) => {
@@ -352,9 +340,7 @@ describe("Token", () => {
 
       await expect(
         token.confidentialTransferFromAndCall(FROM, TO, 200n, DATA),
-      ).rejects.toMatchObject({
-        code: ZamaErrorCode.TransactionReverted,
-      });
+      ).rejects.toMatchObject({ code: ZamaErrorCode.TransactionReverted });
     });
 
     test("invokes onEncryptComplete callback", async ({ token }) => {
@@ -474,9 +460,7 @@ describe("Token", () => {
     });
 
     test("skipBalanceCheck: true bypasses validation", async ({ token }) => {
-      const result = await token.confidentialTransfer(RECIPIENT, 100n, {
-        skipBalanceCheck: true,
-      });
+      const result = await token.confidentialTransfer(RECIPIENT, 100n, { skipBalanceCheck: true });
       expect(result.txHash).toBe("0xtxhash");
     });
 
@@ -569,9 +553,7 @@ describe("Token", () => {
     }) => {
       vi.mocked(provider.readContract).mockResolvedValueOnce(ZERO_ENCRYPTED_VALUE);
 
-      const balance = await token.decryptBalanceAs({
-        delegatorAddress: DELEGATOR,
-      });
+      const balance = await token.decryptBalanceAs({ delegatorAddress: DELEGATOR });
 
       expect(balance).toBe(0n);
       expect(relayer.delegatedUserDecrypt).not.toHaveBeenCalled();
@@ -586,13 +568,9 @@ describe("Token", () => {
       vi.mocked(provider.readContract)
         .mockResolvedValueOnce(handle) // confidentialBalanceOf
         .mockResolvedValueOnce(2n ** 64n - 1n); // getDelegationExpiry → permanent
-      vi.mocked(relayer.delegatedUserDecrypt).mockResolvedValueOnce({
-        [handle]: 1234n,
-      });
+      vi.mocked(relayer.delegatedUserDecrypt).mockResolvedValueOnce({ [handle]: 1234n });
 
-      const balance = await token.decryptBalanceAs({
-        delegatorAddress: DELEGATOR,
-      });
+      const balance = await token.decryptBalanceAs({ delegatorAddress: DELEGATOR });
 
       expect(balance).toBe(1234n);
       expect(relayer.delegatedUserDecrypt).toHaveBeenCalledOnce();

--- a/packages/sdk/src/token/__tests__/wrapped-token.test.ts
+++ b/packages/sdk/src/token/__tests__/wrapped-token.test.ts
@@ -140,10 +140,7 @@ describe("WrappedToken", () => {
       expect(signer.writeContract).toHaveBeenCalledTimes(3);
       expect(signer.writeContract).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({
-          functionName: "approve",
-          args: expect.arrayContaining([0n]),
-        }),
+        expect.objectContaining({ functionName: "approve", args: expect.arrayContaining([0n]) }),
       );
     });
 
@@ -285,10 +282,7 @@ describe("WrappedToken", () => {
       wrappedToken,
       inputProof,
     }) => {
-      vi.mocked(relayer.encrypt).mockResolvedValueOnce({
-        encryptedValues: [],
-        inputProof,
-      });
+      vi.mocked(relayer.encrypt).mockResolvedValueOnce({ encryptedValues: [], inputProof });
 
       await expect(wrappedToken.unwrap(50n)).rejects.toMatchObject({
         code: ZamaErrorCode.EncryptionFailed,
@@ -384,9 +378,7 @@ describe("WrappedToken", () => {
         ],
       });
 
-      const result = await wrappedToken.unshield(50n, {
-        skipBalanceCheck: true,
-      });
+      const result = await wrappedToken.unshield(50n, { skipBalanceCheck: true });
 
       expect(relayer.encrypt).toHaveBeenCalled();
       expect(signer.writeContract).toHaveBeenCalledWith(
@@ -431,9 +423,7 @@ describe("WrappedToken", () => {
       wrappedToken,
       provider,
     }) => {
-      vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({
-        logs: [],
-      });
+      vi.mocked(provider.waitForTransactionReceipt).mockResolvedValue({ logs: [] });
 
       await expect(wrappedToken.unshield(50n, { skipBalanceCheck: true })).rejects.toThrow(
         "No UnwrapRequested event found in unshield receipt",
@@ -524,9 +514,7 @@ describe("WrappedToken", () => {
         ],
       });
 
-      const result = await wrappedToken.unshield(50n, {
-        skipBalanceCheck: true,
-      });
+      const result = await wrappedToken.unshield(50n, { skipBalanceCheck: true });
       expect(result.txHash).toBe("0xtxhash");
     });
 

--- a/packages/sdk/src/token/token.ts
+++ b/packages/sdk/src/token/token.ts
@@ -277,10 +277,7 @@ export class Token {
     const outcomes = await pLimit(
       tokens.map((t) => async () => {
         try {
-          return {
-            status: "fulfilled" as const,
-            value: await t.balanceOf(owner),
-          };
+          return { status: "fulfilled" as const, value: await t.balanceOf(owner) };
         } catch (reason) {
           return { status: "rejected" as const, reason };
         }
@@ -303,9 +300,7 @@ export class Token {
         const error =
           reason instanceof ZamaError
             ? reason
-            : new DecryptionFailedError(toError(reason).message, {
-                cause: reason,
-              });
+            : new DecryptionFailedError(toError(reason).message, { cause: reason });
         errors.set(tokenAddress, error);
       }
     }
@@ -368,10 +363,7 @@ export class Token {
       options.encryptedValues ??
       (await Token.readBalanceHandlesBatch(tokens, normalizedAccount, errors, maxConcurrency));
 
-    const decryptRequests: Array<{
-      token: Token;
-      encryptedValue: EncryptedValue;
-    }> = [];
+    const decryptRequests: Array<{ token: Token; encryptedValue: EncryptedValue }> = [];
     for (const [index, token] of tokens.entries()) {
       const encryptedValue = resolvedEncryptedValues[index];
       if (!encryptedValue || errors.has(token.address)) {
@@ -490,9 +482,7 @@ export class Token {
         token.address,
         outcome.reason instanceof ZamaError
           ? outcome.reason
-          : new DecryptionFailedError(toError(outcome.reason).message, {
-              cause: outcome.reason,
-            }),
+          : new DecryptionFailedError(toError(outcome.reason).message, { cause: outcome.reason }),
       );
     }
     return encryptedValues;

--- a/packages/sdk/src/token/wrapped-token.ts
+++ b/packages/sdk/src/token/wrapped-token.ts
@@ -288,10 +288,7 @@ export class WrappedToken extends Token {
       await this.assertConfidentialBalance(amount);
     }
 
-    const callbacks: UnshieldCallbacks = {
-      onFinalizing,
-      onFinalizeSubmitted,
-    };
+    const callbacks: UnshieldCallbacks = { onFinalizing, onFinalizeSubmitted };
     const operationId = crypto.randomUUID();
     const unwrapResult = await this.unwrap(amount);
     void swallow(
@@ -473,11 +470,7 @@ export class WrappedToken extends Token {
     operationId: string,
     callbacks: UnshieldCallbacks | undefined,
   ): Promise<TransactionResult> {
-    this.emit({
-      type: ZamaSDKEvents.UnshieldPhase1Submitted,
-      txHash: unshieldHash,
-      operationId,
-    });
+    this.emit({ type: ZamaSDKEvents.UnshieldPhase1Submitted, txHash: unshieldHash, operationId });
     let receipt;
     try {
       receipt = await this.sdk.provider.waitForTransactionReceipt(unshieldHash);
@@ -485,9 +478,7 @@ export class WrappedToken extends Token {
       if (error instanceof ZamaError) {
         throw error;
       }
-      throw new TransactionRevertedError("Failed to get unshield receipt", {
-        cause: error,
-      });
+      throw new TransactionRevertedError("Failed to get unshield receipt", { cause: error });
     }
     const event = findUnwrapRequested(receipt.logs);
     if (!event) {

--- a/packages/sdk/src/types/__tests__/signer.test-d.ts
+++ b/packages/sdk/src/types/__tests__/signer.test-d.ts
@@ -58,9 +58,7 @@ describe("WalletAccountChange", () => {
   });
 
   test("accepts connect shape (next only)", () => {
-    expectTypeOf<{
-      next: { address: Address; chainId: number };
-    }>().toExtend<WalletAccountChange>();
+    expectTypeOf<{ next: { address: Address; chainId: number } }>().toExtend<WalletAccountChange>();
   });
 
   test("accepts disconnect shape (previous only)", () => {

--- a/packages/sdk/src/utils/__tests__/alignment.test.ts
+++ b/packages/sdk/src/utils/__tests__/alignment.test.ts
@@ -35,9 +35,7 @@ describe("requireAlignedWalletAccount", () => {
     createMockProvider,
   }) => {
     const signer = createMockSigner();
-    const provider = createMockProvider({
-      getChainId: vi.fn().mockResolvedValue(1),
-    });
+    const provider = createMockProvider({ getChainId: vi.fn().mockResolvedValue(1) });
 
     await expect(requireAlignedWalletAccount("op", signer, provider)).rejects.toBeInstanceOf(
       ChainMismatchError,
@@ -59,10 +57,7 @@ describe("requireAlignedWalletAccount", () => {
       })
       .mockReturnValueOnce(account);
     const refreshWalletAccount = vi.fn().mockResolvedValue(account);
-    const signer = createMockSigner(undefined, {
-      requireWalletAccount,
-      refreshWalletAccount,
-    });
+    const signer = createMockSigner(undefined, { requireWalletAccount, refreshWalletAccount });
     const provider = createMockProvider();
 
     const result = await requireAlignedWalletAccount("op", signer, provider);

--- a/packages/sdk/src/utils/__tests__/error.test.ts
+++ b/packages/sdk/src/utils/__tests__/error.test.ts
@@ -52,9 +52,7 @@ describe("isContractCallError", () => {
   });
 
   test("detects ethers CALL_EXCEPTION", () => {
-    const err = Object.assign(new Error("call exception"), {
-      code: "CALL_EXCEPTION",
-    });
+    const err = Object.assign(new Error("call exception"), { code: "CALL_EXCEPTION" });
     expect(isContractCallError(err)).toBe(true);
   });
 
@@ -117,10 +115,7 @@ describe("extractHttpStatus", () => {
   });
 
   test("prefers a top-level statusCode over the cause", () => {
-    const error = Object.assign(new Error("boom"), {
-      cause: { status: 500 },
-      statusCode: 403,
-    });
+    const error = Object.assign(new Error("boom"), { cause: { status: 500 }, statusCode: 403 });
     expect(extractHttpStatus(error)).toBe(403);
   });
 

--- a/packages/sdk/src/utils/alignment.ts
+++ b/packages/sdk/src/utils/alignment.ts
@@ -32,11 +32,7 @@ export async function requireAlignedWalletAccount(
   }
   const providerChainId = await provider.getChainId();
   if (account.chainId !== providerChainId) {
-    throw new ChainMismatchError({
-      operation,
-      signerChainId: account.chainId,
-      providerChainId,
-    });
+    throw new ChainMismatchError({ operation, signerChainId: account.chainId, providerChainId });
   }
   return account;
 }

--- a/packages/sdk/src/utils/submit-transaction.ts
+++ b/packages/sdk/src/utils/submit-transaction.ts
@@ -45,15 +45,9 @@ export async function submitTransaction(params: {
     const failure =
       error instanceof ZamaError
         ? error
-        : new TransactionRevertedError(`Transaction failed during ${operation}`, {
-            cause: error,
-          });
+        : new TransactionRevertedError(`Transaction failed during ${operation}`, { cause: error });
 
-    emit({
-      type: ZamaSDKEvents.TransactionError,
-      operation,
-      error: failure,
-    });
+    emit({ type: ZamaSDKEvents.TransactionError, operation, error: failure });
     throw failure;
   }
 }

--- a/packages/sdk/src/viem/__tests__/viem.test.ts
+++ b/packages/sdk/src/viem/__tests__/viem.test.ts
@@ -187,11 +187,7 @@ describe("ViemSigner", () => {
           primaryType: "UserDecryptRequestVerification",
           types: { UserDecryptRequestVerification: typedData.types.UserDecryptRequestVerification },
           domain: typedData.domain,
-          message: {
-            ...typedData.message,
-            startTimestamp: 1000n,
-            durationDays: 1n,
-          },
+          message: { ...typedData.message, startTimestamp: 1000n, durationDays: 1n },
         });
       },
     );
@@ -286,9 +282,7 @@ describe("ViemProvider", () => {
       const viemProvider = new ViemProvider({ publicClient });
       const receipt = await viemProvider.waitForTransactionReceipt(TX_HASH);
       expect(receipt).toEqual({ logs: [] });
-      expect(publicClient.waitForTransactionReceipt).toHaveBeenCalledWith({
-        hash: TX_HASH,
-      });
+      expect(publicClient.waitForTransactionReceipt).toHaveBeenCalledWith({ hash: TX_HASH });
     });
   });
 
@@ -324,10 +318,7 @@ describe("Viem read contract helpers", () => {
     ({ wrapperAddress, publicClient }) => {
       readUnderlyingTokenContract(publicClient, wrapperAddress);
       expect(publicClient.readContract).toHaveBeenCalledWith(
-        expect.objectContaining({
-          address: wrapperAddress,
-          functionName: "underlying",
-        }),
+        expect.objectContaining({ address: wrapperAddress, functionName: "underlying" }),
       );
     },
   );

--- a/packages/sdk/src/viem/config.ts
+++ b/packages/sdk/src/viem/config.ts
@@ -9,10 +9,7 @@ import type { ZamaConfigViem } from "./types";
 export function createConfig<const TChains extends readonly [FheChain, ...FheChain[]]>(
   params: ZamaConfigViem<TChains>,
 ): ZamaConfig {
-  const signer = new ViemSigner({
-    walletClient: params.walletClient,
-    ethereum: params.ethereum,
-  });
+  const signer = new ViemSigner({ walletClient: params.walletClient, ethereum: params.ethereum });
   const provider = new ViemProvider({ publicClient: params.publicClient });
   return buildZamaConfig(signer, provider, params);
 }

--- a/packages/sdk/src/worker/__tests__/worker.base-client.test.ts
+++ b/packages/sdk/src/worker/__tests__/worker.base-client.test.ts
@@ -39,10 +39,7 @@ class TestWorkerClient extends BaseWorkerClient<TestWorker, TestConfig> {
 
   protected createWorker(): TestWorker {
     this.createWorkerCount++;
-    const worker: TestWorker = {
-      postMessage: vi.fn(),
-      terminate: vi.fn(),
-    };
+    const worker: TestWorker = { postMessage: vi.fn(), terminate: vi.fn() };
     this.lastWorker = worker;
     return worker;
   }
@@ -63,15 +60,10 @@ class TestWorkerClient extends BaseWorkerClient<TestWorker, TestConfig> {
     return `req-${++requestIdCounter}`;
   }
 
-  protected getInitPayload(): {
-    type: WorkerRequestType;
-    payload: WorkerRequest["payload"];
-  } {
+  protected getInitPayload(): { type: WorkerRequestType; payload: WorkerRequest["payload"] } {
     return {
       type: this.config.initType,
-      payload: {
-        fhevmConfig: { chainId: 1 },
-      } as unknown as WorkerRequest["payload"],
+      payload: { fhevmConfig: { chainId: 1 } } as unknown as WorkerRequest["payload"],
     };
   }
 
@@ -126,12 +118,7 @@ async function initClient(config?: Partial<TestConfig>): Promise<TestWorkerClien
 function autoResolvePostMessage(client: TestWorkerClient, data: unknown = {}): void {
   client.lastWorker!.postMessage.mockImplementation((req: WorkerRequest) => {
     Promise.resolve().then(() => {
-      client.simulateResponse({
-        id: req.id,
-        type: req.type,
-        success: true,
-        data,
-      });
+      client.simulateResponse({ id: req.id, type: req.type, success: true, data });
     });
   });
 }
@@ -139,12 +126,7 @@ function autoResolvePostMessage(client: TestWorkerClient, data: unknown = {}): v
 function autoRejectPostMessage(client: TestWorkerClient, error: string): void {
   client.lastWorker!.postMessage.mockImplementation((req: WorkerRequest) => {
     Promise.resolve().then(() => {
-      client.simulateResponse({
-        id: req.id,
-        type: req.type,
-        success: false,
-        error,
-      });
+      client.simulateResponse({ id: req.id, type: req.type, success: false, error });
     });
   });
 }
@@ -177,12 +159,7 @@ describe("BaseWorkerClient", () => {
   });
 
   test("logs a handled request failure at debug, never error", async () => {
-    const sink: GenericLogger = {
-      info: vi.fn(),
-      debug: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+    const sink: GenericLogger = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
     const client = await initClient({ logger: new LoggerService(sink) });
     autoRejectPostMessage(client, "decrypt failed");
 
@@ -198,12 +175,7 @@ describe("BaseWorkerClient", () => {
   });
 
   test("logs a genuine worker fault at error", async () => {
-    const sink: GenericLogger = {
-      info: vi.fn(),
-      debug: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+    const sink: GenericLogger = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
     const client = await initClient({ logger: new LoggerService(sink) });
 
     const pending = client.generateKeypair({ chainId: 1 });
@@ -248,12 +220,7 @@ describe("BaseWorkerClient", () => {
 
   test("logs warning for unknown response ID without crashing", async () => {
     const warn = vi.fn();
-    const mockLogger: GenericLogger = {
-      info: vi.fn(),
-      debug: vi.fn(),
-      warn,
-      error: vi.fn(),
-    };
+    const mockLogger: GenericLogger = { info: vi.fn(), debug: vi.fn(), warn, error: vi.fn() };
     const client = new TestWorkerClient({ logger: new LoggerService(mockLogger) });
 
     client.simulateResponse({
@@ -517,10 +484,7 @@ describe("BaseWorkerClient", () => {
     const client = await initClient();
     autoResolvePostMessage(client, "0xproof");
 
-    await client.requestZKProofVerification({
-      chainId: 1,
-      zkProof: { proof: "0x" } as never,
-    });
+    await client.requestZKProofVerification({ chainId: 1, zkProof: { proof: "0x" } as never });
 
     const lastCall = client.lastWorker!.postMessage.mock.calls.at(-1)![0];
     expect(lastCall.type).toBe("REQUEST_ZK_PROOF_VERIFICATION");

--- a/packages/sdk/src/worker/__tests__/worker.client.test.ts
+++ b/packages/sdk/src/worker/__tests__/worker.client.test.ts
@@ -73,9 +73,7 @@ let uuidCounter = 0;
 
 vi.stubGlobal(
   "crypto",
-  Object.create(globalThis.crypto, {
-    randomUUID: { value: () => `uuid-${++uuidCounter}` },
-  }),
+  Object.create(globalThis.crypto, { randomUUID: { value: () => `uuid-${++uuidCounter}` } }),
 );
 
 // ---------------------------------------------------------------------------
@@ -124,10 +122,7 @@ function defaultWebConfig() {
 }
 
 function defaultNodeConfig() {
-  return {
-    chains: [{ chainId: 1 } as never],
-    logger: new LoggerService(),
-  };
+  return { chains: [{ chainId: 1 } as never], logger: new LoggerService() };
 }
 
 /** Simulate a successful response for any request posted to a mock browser Worker. */
@@ -136,12 +131,7 @@ function autoResolveWebWorker(worker: MockWorker): void {
     Promise.resolve().then(() => {
       worker.onmessage?.(
         new MessageEvent("message", {
-          data: {
-            id: req.id,
-            type: req.type,
-            success: true,
-            data: { initialized: true },
-          },
+          data: { id: req.id, type: req.type, success: true, data: { initialized: true } },
         }),
       );
     });
@@ -153,12 +143,7 @@ function autoResolveNodeWorker(worker: MockNodeWorker): void {
   worker.postMessage.mockImplementation((req: WorkerRequest) => {
     Promise.resolve().then(() => {
       const handler = worker.listeners["message"]?.[0];
-      handler?.({
-        id: req.id,
-        type: req.type,
-        success: true,
-        data: { initialized: true },
-      });
+      handler?.({ id: req.id, type: req.type, success: true, data: { initialized: true } });
     });
   });
 }
@@ -317,12 +302,7 @@ describe("RelayerWorkerClient", () => {
       warn: vi.fn(),
       error: vi.fn(),
     });
-    const config = {
-      ...defaultWebConfig(),
-      logger,
-      integrity: "sha384-abc",
-      thread: 4,
-    };
+    const config = { ...defaultWebConfig(), logger, integrity: "sha384-abc", thread: 4 };
     const client = new RelayerWorkerClient(config);
     await client.initWorker();
 
@@ -428,12 +408,7 @@ describe("RelayerWorkerClient", () => {
       Promise.resolve().then(() => {
         worker.onmessage?.(
           new MessageEvent("message", {
-            data: {
-              id: req.id,
-              type: req.type,
-              success: true,
-              data: { updated: true },
-            },
+            data: { id: req.id, type: req.type, success: true, data: { updated: true } },
           }),
         );
       });

--- a/packages/sdk/src/worker/__tests__/worker.node-pool.test.ts
+++ b/packages/sdk/src/worker/__tests__/worker.node-pool.test.ts
@@ -15,11 +15,9 @@ vi.mock(import("../worker.node-client"), () => {
       createEIP712: vi.fn().mockResolvedValue({}),
       encrypt: vi.fn().mockResolvedValue({ handles: [], inputProof: "0x" }),
       userDecrypt: vi.fn().mockResolvedValue({ clearValues: {} }),
-      publicDecrypt: vi.fn().mockResolvedValue({
-        clearValues: {},
-        abiEncodedClearValues: "0x",
-        decryptionProof: "0x",
-      }),
+      publicDecrypt: vi
+        .fn()
+        .mockResolvedValue({ clearValues: {}, abiEncodedClearValues: "0x", decryptionProof: "0x" }),
       createDelegatedUserDecryptEIP712: vi.fn().mockResolvedValue({}),
       delegatedUserDecrypt: vi.fn().mockResolvedValue({ clearValues: {} }),
       requestZKProofVerification: vi.fn().mockResolvedValue("0x"),
@@ -33,9 +31,7 @@ vi.mock(import("../worker.node-client"), () => {
 // Must import after mock so the mock is in place
 const { NodeWorkerClient } = await import("../worker.node-client");
 
-const baseConfig = {
-  chains: [{ chainId: 1 }],
-} as unknown as NodeWorkerPoolConfig;
+const baseConfig = { chains: [{ chainId: 1 }] } as unknown as NodeWorkerPoolConfig;
 
 type MockClientInstance = Record<
   | "initWorker"
@@ -57,9 +53,7 @@ describe("NodeWorkerPool", () => {
   /** Get mock instances created by NodeWorkerClient constructor. */
   function getInstances(offset = 0): MockClientInstance[] {
     return (
-      NodeWorkerClient as unknown as {
-        mock: { results: { value: MockClientInstance }[] };
-      }
+      NodeWorkerClient as unknown as { mock: { results: { value: MockClientInstance }[] } }
     ).mock.results
       .slice(offset)
       .map((r) => r.value);
@@ -198,10 +192,7 @@ describe("NodeWorkerPool", () => {
     expect(instance.userDecrypt).toHaveBeenCalled();
 
     await pool.publicDecrypt({ chainId: 1, encryptedValues: [HANDLE] });
-    expect(instance.publicDecrypt).toHaveBeenCalledWith({
-      chainId: 1,
-      encryptedValues: [HANDLE],
-    });
+    expect(instance.publicDecrypt).toHaveBeenCalledWith({ chainId: 1, encryptedValues: [HANDLE] });
 
     await pool.createDelegatedUserDecryptEIP712({
       chainId: 1,
@@ -228,23 +219,14 @@ describe("NodeWorkerPool", () => {
     });
     expect(instance.delegatedUserDecrypt).toHaveBeenCalled();
 
-    await pool.requestZKProofVerification({
-      chainId: 1,
-      zkProof: {} as unknown as ZKProofLike,
-    });
-    expect(instance.requestZKProofVerification).toHaveBeenCalledWith({
-      chainId: 1,
-      zkProof: {},
-    });
+    await pool.requestZKProofVerification({ chainId: 1, zkProof: {} as unknown as ZKProofLike });
+    expect(instance.requestZKProofVerification).toHaveBeenCalledWith({ chainId: 1, zkProof: {} });
 
     await pool.getPublicKey({ chainId: 1 });
     expect(instance.getPublicKey).toHaveBeenCalledWith({ chainId: 1 });
 
     await pool.getPublicParams({ chainId: 1, bits: 2048 });
-    expect(instance.getPublicParams).toHaveBeenCalledWith({
-      chainId: 1,
-      bits: 2048,
-    });
+    expect(instance.getPublicParams).toHaveBeenCalledWith({ chainId: 1, bits: 2048 });
   });
 
   test("clears workers and active counts on terminate", async () => {

--- a/packages/sdk/src/worker/relayer-sdk.worker.ts
+++ b/packages/sdk/src/worker/relayer-sdk.worker.ts
@@ -131,12 +131,7 @@ function sendSuccess<T>(
   data: T,
   transfer?: Transferable[],
 ): void {
-  const response: SuccessResponse<T> = {
-    id,
-    type,
-    success: true,
-    data,
-  };
+  const response: SuccessResponse<T> = { id, type, success: true, data };
   return transfer ? self.postMessage(response, transfer) : self.postMessage(response);
 }
 
@@ -149,12 +144,7 @@ function sendError(
   error: string,
   statusCode?: number,
 ): void {
-  const response: ErrorResponse = {
-    id,
-    type,
-    success: false,
-    error,
-  };
+  const response: ErrorResponse = { id, type, success: false, error };
   if (statusCode !== undefined) {
     response.statusCode = statusCode;
   }
@@ -215,11 +205,7 @@ function setupFetchInterceptor(): void {
         headers.set(CSRF_HEADER_NAME, csrfTokenBase);
       }
 
-      return originalFetch(input, {
-        ...init,
-        headers,
-        credentials: "include",
-      });
+      return originalFetch(input, { ...init, headers, credentials: "include" });
     }
 
     // Pass through other requests unchanged

--- a/packages/sdk/src/worker/worker.base-client.ts
+++ b/packages/sdk/src/worker/worker.base-client.ts
@@ -147,9 +147,7 @@ export abstract class BaseWorkerClient<TWorker, TConfig> {
     const pending = this.#pendingRequests.get(response.id);
 
     if (!pending) {
-      this.logger.warn("[WorkerClient] Received response for unknown request", {
-        id: response.id,
-      });
+      this.logger.warn("[WorkerClient] Received response for unknown request", { id: response.id });
       return;
     }
 
@@ -159,10 +157,7 @@ export abstract class BaseWorkerClient<TWorker, TConfig> {
     this.#pendingRequests.delete(response.id);
 
     if (response.success) {
-      this.logger.debug(`[WorkerClient] ← ${pending.type} OK`, {
-        id: response.id,
-        elapsed,
-      });
+      this.logger.debug(`[WorkerClient] ← ${pending.type} OK`, { id: response.id, elapsed });
       pending.resolve(response.data);
     } else {
       // A failed worker response is a handled operation failure: it is
@@ -222,10 +217,7 @@ export abstract class BaseWorkerClient<TWorker, TConfig> {
         const elapsed = Math.round(performance.now() - startTime);
         // A timeout is surfaced via the rejected promise below, so it is a
         // handled failure and stays at `debug` rather than `error`.
-        this.logger.debug(`[WorkerClient] ${type} timed out after ${timeoutMs}ms`, {
-          id,
-          elapsed,
-        });
+        this.logger.debug(`[WorkerClient] ${type} timed out after ${timeoutMs}ms`, { id, elapsed });
         reject(new Error(`Request ${type} timed out after ${timeoutMs}ms`));
       }, timeoutMs);
 

--- a/packages/sdk/src/worker/worker.client.ts
+++ b/packages/sdk/src/worker/worker.client.ts
@@ -67,10 +67,7 @@ export class RelayerWorkerClient extends BaseWorkerClient<Worker, WorkerClientCo
     return crypto.randomUUID();
   }
 
-  protected getInitPayload(): {
-    type: WorkerRequestType;
-    payload: WorkerRequest["payload"];
-  } {
+  protected getInitPayload(): { type: WorkerRequestType; payload: WorkerRequest["payload"] } {
     // Explicitly construct the payload from serializable fields only.
     // Functions (e.g. `logger`) cannot be cloned by the structured clone
     // algorithm used by `worker.postMessage()`.
@@ -86,8 +83,6 @@ export class RelayerWorkerClient extends BaseWorkerClient<Worker, WorkerClientCo
    * Call this before making authenticated requests to ensure the token is fresh.
    */
   async updateCsrf(csrfToken: string): Promise<void> {
-    await this.sendRequest<UpdateCsrfResponseData>("UPDATE_CSRF", {
-      csrfToken,
-    });
+    await this.sendRequest<UpdateCsrfResponseData>("UPDATE_CSRF", { csrfToken });
   }
 }

--- a/packages/sdk/src/worker/worker.node-client.ts
+++ b/packages/sdk/src/worker/worker.node-client.ts
@@ -61,14 +61,8 @@ export class NodeWorkerClient extends BaseWorkerClient<Worker, NodeWorkerClientC
     return randomUUID();
   }
 
-  protected getInitPayload(): {
-    type: WorkerRequestType;
-    payload: WorkerRequest["payload"];
-  } {
-    return {
-      type: "INIT",
-      payload: { env: "node" as const, chains: this.config.chains },
-    };
+  protected getInitPayload(): { type: WorkerRequestType; payload: WorkerRequest["payload"] } {
+    return { type: "INIT", payload: { env: "node" as const, chains: this.config.chains } };
   }
 
   protected override onWorkerReady(worker: Worker): void {

--- a/packages/sdk/src/worker/worker.types.ts
+++ b/packages/sdk/src/worker/worker.types.ts
@@ -79,9 +79,7 @@ export interface InitRequest extends BaseRequest {
 
 export interface UpdateCsrfRequest extends BaseRequest {
   type: "UPDATE_CSRF";
-  payload: {
-    csrfToken: string;
-  };
+  payload: { csrfToken: string };
 }
 
 export interface EncryptRequest extends BaseRequest {
@@ -112,10 +110,7 @@ export interface UserDecryptRequest extends BaseRequest {
 
 export interface PublicDecryptRequest extends BaseRequest {
   type: "PUBLIC_DECRYPT";
-  payload: {
-    chainId: number;
-    encryptedValues: EncryptedValue[];
-  };
+  payload: { chainId: number; encryptedValues: EncryptedValue[] };
 }
 
 export interface GenerateKeypairRequest extends BaseRequest {
@@ -165,10 +160,7 @@ export interface DelegatedUserDecryptRequest extends BaseRequest {
 
 export interface RequestZKProofVerificationRequest extends BaseRequest {
   type: "REQUEST_ZK_PROOF_VERIFICATION";
-  payload: {
-    chainId: number;
-    zkProof: ZKProofLike;
-  };
+  payload: { chainId: number; zkProof: ZKProofLike };
 }
 
 export interface GetPublicKeyRequest extends BaseRequest {
@@ -178,10 +170,7 @@ export interface GetPublicKeyRequest extends BaseRequest {
 
 export interface GetPublicParamsRequest extends BaseRequest {
   type: "GET_PUBLIC_PARAMS";
-  payload: {
-    chainId: number;
-    bits: number;
-  };
+  payload: { chainId: number; bits: number };
 }
 
 export type WorkerRequest =

--- a/packages/sdk/src/wrappers-registry.ts
+++ b/packages/sdk/src/wrappers-registry.ts
@@ -161,10 +161,7 @@ export class WrappersRegistry {
   }
 
   #setCached<T>(key: string, data: T, ttlMs = this.#ttlMs): T {
-    this.#cache.set(key, {
-      data,
-      expiresAt: Date.now() + ttlMs,
-    });
+    this.#cache.set(key, { data, expiresAt: Date.now() + ttlMs });
     return data;
   }
 
@@ -297,12 +294,7 @@ export class WrappersRegistry {
           ? result.value
           : Object.assign({}, items[i], {
               metadataFailed: true as const,
-              underlying: {
-                name: "Unknown",
-                symbol: "???",
-                decimals: 0,
-                totalSupply: 0n,
-              },
+              underlying: { name: "Unknown", symbol: "???", decimals: 0, totalSupply: 0n },
               confidential: { name: "Unknown", symbol: "???", decimals: 0 },
             }),
       );
@@ -330,12 +322,7 @@ export class WrappersRegistry {
 
     return {
       ...pair,
-      underlying: {
-        name: uName,
-        symbol: uSymbol,
-        decimals: uDecimals,
-        totalSupply: uTotalSupply,
-      },
+      underlying: { name: uName, symbol: uSymbol, decimals: uDecimals, totalSupply: uTotalSupply },
       confidential: { name: cName, symbol: cSymbol, decimals: cDecimals },
     };
   }
@@ -368,10 +355,9 @@ export class WrappersRegistry {
     const normalized = getAddress(tokenAddress);
 
     const cacheKey = `ct:${registry}:${normalized}`;
-    const cached = this.#getCached<{
-      confidentialTokenAddress: Address;
-      isValid: boolean;
-    } | null>(cacheKey);
+    const cached = this.#getCached<{ confidentialTokenAddress: Address; isValid: boolean } | null>(
+      cacheKey,
+    );
     if (cached !== undefined) {
       return cached;
     }
@@ -410,10 +396,7 @@ export class WrappersRegistry {
     const normalized = getAddress(confidentialTokenAddress);
 
     const cacheKey = `ut:${registry}:${normalized}`;
-    const cached = this.#getCached<{
-      tokenAddress: Address;
-      isValid: boolean;
-    } | null>(cacheKey);
+    const cached = this.#getCached<{ tokenAddress: Address; isValid: boolean } | null>(cacheKey);
     if (cached !== undefined) {
       return cached;
     }

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -173,15 +173,9 @@ export class ZamaSDK {
    */
   emitEvent(input: ZamaSDKEventInput, tokenAddress?: Address): void {
     try {
-      this.#onEvent({
-        ...input,
-        tokenAddress,
-        timestamp: Date.now(),
-      } as ZamaSDKEvent);
+      this.#onEvent({ ...input, tokenAddress, timestamp: Date.now() } as ZamaSDKEvent);
     } catch (error) {
-      this.#logger.warn(`${input.type} event listener silently failed`, {
-        error,
-      });
+      this.#logger.warn(`${input.type} event listener silently failed`, { error });
     }
   }
 

--- a/packages/sdk/tsconfig.build.json
+++ b/packages/sdk/tsconfig.build.json
@@ -1,4 +1,1 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "**/__tests__/**", "**/*.test.ts"]
-}
+{ "extends": "./tsconfig.json", "exclude": ["node_modules", "**/__tests__/**", "**/*.test.ts"] }

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "tsBuildInfoFile": ".tsbuildinfo"
-  },
+  "compilerOptions": { "tsBuildInfoFile": ".tsbuildinfo" },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": [
     "src/**/*.test.ts",

--- a/scripts/abi/check.mjs
+++ b/scripts/abi/check.mjs
@@ -10,11 +10,7 @@ const steps = [
     command: "pnpm",
     args: ["exec", "vitest", "run", "--config", "vitest.abi.config.ts"],
   },
-  {
-    name: "verify-clean",
-    command: "git",
-    args: ["diff", "--exit-code", "--", ...generatedFiles],
-  },
+  { name: "verify-clean", command: "git", args: ["diff", "--exit-code", "--", ...generatedFiles] },
 ];
 
 for (const step of steps) {

--- a/scripts/api-report/diff.mjs
+++ b/scripts/api-report/diff.mjs
@@ -43,10 +43,7 @@ for (const name of names) {
   const result = spawnSync(
     "diff",
     ["-u", "--label", `a/${name}`, "--label", `b/${name}`, baseFile, prFile],
-    {
-      encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
-    },
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
   );
 
   // diff exits 0 when identical, 1 when different, >=2 on error.

--- a/scripts/llm/lib/corpus.mjs
+++ b/scripts/llm/lib/corpus.mjs
@@ -369,12 +369,7 @@ export function renderHints(content) {
   return content.replace(
     /\{%\s*hint\s+style="([^"]+)"\s*%\}([\s\S]*?)\{%\s*endhint\s*%\}/g,
     (_match, style, body) => {
-      const labelMap = {
-        info: "INFO",
-        warning: "WARNING",
-        danger: "DANGER",
-        success: "SUCCESS",
-      };
+      const labelMap = { info: "INFO", warning: "WARNING", danger: "DANGER", success: "SUCCESS" };
       const label = labelMap[style] ?? "NOTE";
       const lines = body
         .trim()

--- a/test/playwright/deployments.d.ts
+++ b/test/playwright/deployments.d.ts
@@ -4,9 +4,7 @@ declare module "*/hardhat/deployments.json" {
     cUSDT: string;
     erc20: string;
     cToken: string;
-    fhevm: {
-      acl: string;
-    };
+    fhevm: { acl: string };
   };
   export default deployments;
 }

--- a/test/playwright/fixtures/node-test.ts
+++ b/test/playwright/fixtures/node-test.ts
@@ -69,10 +69,7 @@ export const nodeTest = base.extend<NodeTestFixtures, NodeWorkerFixtures>({
   publicClient: [
     async ({ anvilPort }, use) => {
       await use(
-        createPublicClient({
-          chain: foundry,
-          transport: http(`http://127.0.0.1:${anvilPort}`),
-        }),
+        createPublicClient({ chain: foundry, transport: http(`http://127.0.0.1:${anvilPort}`) }),
       );
     },
     { scope: "worker" },

--- a/test/playwright/fixtures/relayer-sdk-cdn.mjs
+++ b/test/playwright/fixtures/relayer-sdk-cdn.mjs
@@ -146,10 +146,7 @@
       },
 
       generateKeypair() {
-        return {
-          publicKey: randomHex(32),
-          privateKey: randomHex(32),
-        };
+        return { publicKey: randomHex(32), privateKey: randomHex(32) };
       },
 
       createEIP712(publicKey, contractAddresses, startTimestamp, durationDays) {
@@ -329,10 +326,7 @@
       },
 
       getPublicKey() {
-        return {
-          publicKeyId: "mock-public-key-id",
-          publicKey: new Uint8Array([1, 2, 3, 4]),
-        };
+        return { publicKeyId: "mock-public-key-id", publicKey: new Uint8Array([1, 2, 3, 4]) };
       },
 
       getPublicParams(_bits) {

--- a/test/playwright/fixtures/relayer-sdk-server.mjs
+++ b/test/playwright/fixtures/relayer-sdk-server.mjs
@@ -61,16 +61,7 @@ const FHE_TYPE_NAME_TO_ID = {
  * Maps FHE type IDs to their bit-width (used for byte-length padding).
  * @type {Record<number, number>}
  */
-const FHE_TYPE_ID_TO_BITS = {
-  0: 2,
-  2: 8,
-  3: 16,
-  4: 32,
-  5: 64,
-  6: 128,
-  7: 160,
-  8: 256,
-};
+const FHE_TYPE_ID_TO_BITS = { 0: 2, 2: 8, 3: 16, 4: 32, 5: 64, 6: 128, 7: 160, 8: 256 };
 
 const ACL_ABI = parseAbi([
   "function persistAllowed(bytes32 handle, address account) view returns (bool)",
@@ -493,11 +484,7 @@ async function handlePublicDecrypt(req, res) {
       ],
     },
     primaryType: "PublicDecryptVerification",
-    message: {
-      ctHandles: handles,
-      decryptedResult: abiEncodedClearValues,
-      extraData: "0x",
-    },
+    message: { ctHandles: handles, decryptedResult: abiEncodedClearValues, extraData: "0x" },
   });
 
   const decryptionProof = toHex(toBytes(concat([toHex(new Uint8Array([1])), signature])));
@@ -569,13 +556,7 @@ async function handleDelegatedUserDecrypt(req, res) {
  * @param {import("node:http").ServerResponse} res
  */
 function handleKeyurl(_req, res) {
-  sendJson(res, {
-    fhePublicKey: {
-      dataId: "mock-public-key-id",
-      urls: [],
-    },
-    crs: {},
-  });
+  sendJson(res, { fhePublicKey: { dataId: "mock-public-key-id", urls: [] }, crs: {} });
 }
 
 // ── Server ──────────────────────────────────────────────────

--- a/test/playwright/fixtures/relayer-sdk.node-worker.mjs
+++ b/test/playwright/fixtures/relayer-sdk.node-worker.mjs
@@ -125,10 +125,7 @@ async function handleMessage(request) {
       case "GENERATE_KEYPAIR": {
         const instance = await getInstance(request.payload.chainId);
         const kp = instance.generateKeypair();
-        send(id, type, {
-          publicKey: ensure0x(kp.publicKey),
-          privateKey: ensure0x(kp.privateKey),
-        });
+        send(id, type, { publicKey: ensure0x(kp.publicKey), privateKey: ensure0x(kp.privateKey) });
         break;
       }
 
@@ -150,10 +147,7 @@ async function handleMessage(request) {
           },
           types: {
             UserDecryptRequestVerification: eip712.types.UserDecryptRequestVerification.map(
-              (f) => ({
-                name: f.name,
-                type: f.type,
-              }),
+              (f) => ({ name: f.name, type: f.type }),
             ),
           },
           message: {
@@ -205,10 +199,7 @@ async function handleMessage(request) {
         }
 
         const encrypted = await input.encrypt();
-        send(id, type, {
-          handles: encrypted.handles,
-          inputProof: encrypted.inputProof,
-        });
+        send(id, type, { handles: encrypted.handles, inputProof: encrypted.inputProof });
         break;
       }
 
@@ -284,10 +275,7 @@ async function handleMessage(request) {
 
       case "GET_PUBLIC_KEY": {
         send(id, type, {
-          result: {
-            publicKeyId: "mock-public-key-id",
-            publicKey: new Uint8Array([1, 2, 3, 4]),
-          },
+          result: { publicKeyId: "mock-public-key-id", publicKey: new Uint8Array([1, 2, 3, 4]) },
         });
         break;
       }

--- a/test/playwright/fixtures/test.ts
+++ b/test/playwright/fixtures/test.ts
@@ -127,9 +127,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   page: async ({ page, privateKey, account, viemClient, contracts }, use) => {
     // Mint ERC-20 tokens to the test account before snapshotting, so every test
     // starts from a funded state regardless of what the deploy script did.
-    const nonce = await viemClient.getTransactionCount({
-      address: account.address,
-    });
+    const nonce = await viemClient.getTransactionCount({ address: account.address });
     const usdcHash = await viemClient.writeContract({
       address: contracts.USDC,
       abi: mintAbi,
@@ -153,10 +151,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
     // Intercept the CDN request for the relayer SDK bundle and serve the mock
     await page.route("**/relayer-sdk-js*", async (route) => {
-      await route.fulfill({
-        contentType: "application/javascript",
-        body: mockCdnBundle,
-      });
+      await route.fulfill({ contentType: "application/javascript", body: mockCdnBundle });
     });
 
     // Inject wallet private key for the burner-connector
@@ -166,9 +161,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
     // Navigate to home and ensure wallet is connected
     await page.goto("/");
-    const connectButton = page.getByRole("button", {
-      name: "Connect Wallet",
-    });
+    const connectButton = page.getByRole("button", { name: "Connect Wallet" });
     const walletAddress = page.getByTestId("wallet-address");
 
     // Wallet may auto-reconnect from a previous session, or need a manual click

--- a/test/playwright/playwright.config.ts
+++ b/test/playwright/playwright.config.ts
@@ -18,13 +18,8 @@ export default defineConfig<{}, WorkerFixtures>({
   retries: CI ? 2 : 0,
   workers: 2,
   reporter: CI ? "github" : "list",
-  expect: {
-    timeout: CI ? 20000 : 5000,
-  },
-  use: {
-    trace: "retain-on-failure",
-    screenshot: "only-on-failure",
-  },
+  expect: { timeout: CI ? 20000 : 5000 },
+  use: { trace: "retain-on-failure", screenshot: "only-on-failure" },
   projects: [
     {
       name: "nextjs",
@@ -58,9 +53,7 @@ export default defineConfig<{}, WorkerFixtures>({
     {
       command: `./start-anvil.sh ${NEXTJS_ANVIL_PORT}`,
       name: "anvil-nextjs",
-      wait: {
-        stdout: /Anvil ready on port (\d+)/,
-      },
+      wait: { stdout: /Anvil ready on port (\d+)/ },
       timeout: 90_000,
     },
     {
@@ -73,9 +66,7 @@ export default defineConfig<{}, WorkerFixtures>({
     {
       command: `./start-anvil.sh ${VITE_ANVIL_PORT}`,
       name: "anvil-vite",
-      wait: {
-        stdout: /Anvil ready on port (\d+)/,
-      },
+      wait: { stdout: /Anvil ready on port (\d+)/ },
       timeout: 90_000,
     },
     {

--- a/test/playwright/playwright.nextjs.config.ts
+++ b/test/playwright/playwright.nextjs.config.ts
@@ -13,13 +13,8 @@ export default defineConfig<{}, WorkerFixtures>({
   retries: CI ? 2 : 0,
   workers: 1,
   reporter: CI ? "github" : "list",
-  expect: {
-    timeout: CI ? 20000 : 5000,
-  },
-  use: {
-    trace: "retain-on-failure",
-    screenshot: "only-on-failure",
-  },
+  expect: { timeout: CI ? 20000 : 5000 },
+  use: { trace: "retain-on-failure", screenshot: "only-on-failure" },
   projects: [
     {
       name: "nextjs",
@@ -35,9 +30,7 @@ export default defineConfig<{}, WorkerFixtures>({
     {
       command: `./start-anvil.sh ${NEXTJS_ANVIL_PORT}`,
       name: "anvil-nextjs",
-      wait: {
-        stdout: /Anvil ready on port (\d+)/,
-      },
+      wait: { stdout: /Anvil ready on port (\d+)/ },
       timeout: 90_000,
     },
     {

--- a/test/playwright/playwright.node.config.ts
+++ b/test/playwright/playwright.node.config.ts
@@ -15,25 +15,13 @@ export default defineConfig<{}, NodeWorkerFixtures>({
   retries: CI ? 2 : 0,
   workers: 1,
   reporter: CI ? "github" : "list",
-  expect: {
-    timeout: 10000,
-  },
-  projects: [
-    {
-      name: "node",
-      use: {
-        anvilPort: NODE_ANVIL_PORT,
-      },
-      timeout: 60000,
-    },
-  ],
+  expect: { timeout: 10000 },
+  projects: [{ name: "node", use: { anvilPort: NODE_ANVIL_PORT }, timeout: 60000 }],
   webServer: [
     {
       command: `./start-anvil.sh ${NODE_ANVIL_PORT}`,
       name: "anvil-node",
-      wait: {
-        stdout: /Anvil ready on port (\d+)/,
-      },
+      wait: { stdout: /Anvil ready on port (\d+)/ },
       timeout: 90_000,
     },
   ],

--- a/test/playwright/playwright.vite.config.ts
+++ b/test/playwright/playwright.vite.config.ts
@@ -13,13 +13,8 @@ export default defineConfig<{}, WorkerFixtures>({
   retries: CI ? 2 : 0,
   workers: 1,
   reporter: CI ? "github" : "list",
-  expect: {
-    timeout: CI ? 20000 : 5000,
-  },
-  use: {
-    trace: "retain-on-failure",
-    screenshot: "only-on-failure",
-  },
+  expect: { timeout: CI ? 20000 : 5000 },
+  use: { trace: "retain-on-failure", screenshot: "only-on-failure" },
   projects: [
     {
       name: "vite",
@@ -40,9 +35,7 @@ export default defineConfig<{}, WorkerFixtures>({
     {
       command: `./start-anvil.sh ${VITE_ANVIL_PORT}`,
       name: "anvil-vite",
-      wait: {
-        stdout: /Anvil ready on port (\d+)/,
-      },
+      wait: { stdout: /Anvil ready on port (\d+)/ },
       timeout: 90_000,
     },
     {

--- a/test/playwright/tests/node/error-handling.node.spec.ts
+++ b/test/playwright/tests/node/error-handling.node.spec.ts
@@ -35,9 +35,7 @@ function createZamaSDK({
       chains: [chainOverrides],
       publicClient,
       walletClient: viemClient,
-      relayers: {
-        [chainOverrides.id]: node(poolOptions),
-      },
+      relayers: { [chainOverrides.id]: node(poolOptions) },
     }),
   );
 }
@@ -53,36 +51,22 @@ test("operations after terminate throw", async ({ sdk }) => {
 test("matchZamaError routes to the correct handler", async () => {
   const decErr = new DecryptionFailedError("test decryption failure");
   expect(
-    matchZamaError(decErr, {
-      DECRYPTION_FAILED: () => "decryption_failed",
-      _: () => "other",
-    }),
+    matchZamaError(decErr, { DECRYPTION_FAILED: () => "decryption_failed", _: () => "other" }),
   ).toBe("decryption_failed");
 
   const noCipherErr = new NoCiphertextError("no ciphertext");
   expect(
-    matchZamaError(noCipherErr, {
-      NO_CIPHERTEXT: () => "no_ciphertext",
-      _: () => "other",
-    }),
+    matchZamaError(noCipherErr, { NO_CIPHERTEXT: () => "no_ciphertext", _: () => "other" }),
   ).toBe("no_ciphertext");
 
   expect(
-    matchZamaError(decErr, {
-      NO_CIPHERTEXT: () => "no_ciphertext",
-      _: () => "fallback",
-    }),
+    matchZamaError(decErr, { NO_CIPHERTEXT: () => "no_ciphertext", _: () => "fallback" }),
   ).toBe("fallback");
 });
 
 test("zero poolSize rejects at config creation", async ({ chain, publicClient, viemClient }) => {
   expect(() =>
-    createZamaSDK({
-      chain,
-      publicClient,
-      viemClient,
-      poolOptions: { poolSize: 0 },
-    }),
+    createZamaSDK({ chain, publicClient, viemClient, poolOptions: { poolSize: 0 } }),
   ).toThrow();
 });
 
@@ -91,10 +75,7 @@ test("init failure resets so next call retries", async ({ chain, publicClient, v
     chain,
     publicClient,
     viemClient,
-    transportOverrides: {
-      relayerUrl: "http://127.0.0.1:1",
-      network: "http://127.0.0.1:1",
-    },
+    transportOverrides: { relayerUrl: "http://127.0.0.1:1", network: "http://127.0.0.1:1" },
   });
 
   await expect(sdk.relayer.generateTransportKeyPair()).rejects.toThrow();

--- a/test/playwright/tests/node/worker-pool-concurrency.node.spec.ts
+++ b/test/playwright/tests/node/worker-pool-concurrency.node.spec.ts
@@ -31,12 +31,7 @@ test("2-worker pool generates 4 unique keypairs concurrently", async ({
   publicClient,
   viemClient,
 }) => {
-  using sdk = createZamaSDK({
-    chain,
-    publicClient,
-    walletClient: viemClient,
-    poolSize: 2,
-  });
+  using sdk = createZamaSDK({ chain, publicClient, walletClient: viemClient, poolSize: 2 });
   const results = await Promise.all([
     sdk.relayer.generateTransportKeyPair(),
     sdk.relayer.generateTransportKeyPair(),
@@ -54,12 +49,7 @@ test("4-worker pool handles parallel EIP-712 creation", async ({
   viemClient,
   contracts,
 }) => {
-  using sdk = createZamaSDK({
-    chain,
-    publicClient,
-    walletClient: viemClient,
-    poolSize: 4,
-  });
+  using sdk = createZamaSDK({ chain, publicClient, walletClient: viemClient, poolSize: 4 });
   const keypair = await sdk.relayer.generateTransportKeyPair();
   const now = Math.floor(Date.now() / 1000);
 
@@ -76,12 +66,7 @@ test("4-worker pool handles parallel EIP-712 creation", async ({
 });
 
 test("terminate and restart", async ({ chain, publicClient, viemClient }) => {
-  const sdk = createZamaSDK({
-    chain,
-    publicClient,
-    walletClient: viemClient,
-    poolSize: 2,
-  });
+  const sdk = createZamaSDK({ chain, publicClient, walletClient: viemClient, poolSize: 2 });
   await sdk.relayer.generateTransportKeyPair();
   sdk.terminate();
   // Post-terminate, operations restart the pool
@@ -96,12 +81,7 @@ test("concurrent init requests share pool initialization", async ({
   publicClient,
   viemClient,
 }) => {
-  using sdk = createZamaSDK({
-    chain,
-    publicClient,
-    walletClient: viemClient,
-    poolSize: 2,
-  });
+  using sdk = createZamaSDK({ chain, publicClient, walletClient: viemClient, poolSize: 2 });
   const [kp1, kp2] = await Promise.all([
     sdk.relayer.generateTransportKeyPair(),
     sdk.relayer.generateTransportKeyPair(),

--- a/test/playwright/tests/worker-iife.spec.ts
+++ b/test/playwright/tests/worker-iife.spec.ts
@@ -15,9 +15,7 @@ test("worker loads without SyntaxError in Vite ESM environment", async ({ page, 
   await page.getByTestId("shield-button").click();
 
   // Wait for the shield transaction to succeed (proves the worker round-tripped)
-  await expect(page.getByTestId("shield-success")).toContainText("Tx: 0x", {
-    timeout: 30000,
-  });
+  await expect(page.getByTestId("shield-success")).toContainText("Tx: 0x", { timeout: 30000 });
 
   // No SyntaxError in console — this is the IIFE fix validation
   const syntaxErrors = errors.filter((e) => e.includes("SyntaxError"));

--- a/test/playwright/tsconfig.json
+++ b/test/playwright/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "lib": ["ESNext", "DOM"],
-    "types": ["node"]
-  },
+  "compilerOptions": { "lib": ["ESNext", "DOM"], "types": ["node"] },
   "include": ["fixtures", "*.ts", "../../iife.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/test/playwright/tsconfig.node.json
+++ b/test/playwright/tsconfig.node.json
@@ -1,10 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "target": "ESNext",
-    "lib": ["ESNext"],
-    "types": ["node"]
-  },
+  "compilerOptions": { "target": "ESNext", "lib": ["ESNext"], "types": ["node"] },
   "include": ["fixtures", "tests/node", "**/*.node.spec.ts"],
   "exclude": ["node_modules"]
 }

--- a/test/test-components/src/burner-connector.ts
+++ b/test/test-components/src/burner-connector.ts
@@ -92,11 +92,7 @@ class BurnerWalletConnector {
   }
 
   private createClient(chain: Chain, account: PrivateKeyAccount): WalletClient {
-    return createWalletClient({
-      chain,
-      account,
-      transport: http(this.resolveRpcUrl(chain)),
-    });
+    return createWalletClient({ chain, account, transport: http(this.resolveRpcUrl(chain)) });
   }
 
   private async handleSendTransaction(
@@ -134,9 +130,7 @@ class BurnerWalletConnector {
     chainId: number;
   }> {
     const provider = await this.getProvider();
-    const accounts = (await provider.request({
-      method: "eth_accounts",
-    })) as Address[];
+    const accounts = (await provider.request({ method: "eth_accounts" })) as Address[];
     let currentChainId = await this.getChainId();
     if (chainId && currentChainId !== chainId) {
       const chain = await this.switchChain({ chainId });
@@ -164,10 +158,7 @@ class BurnerWalletConnector {
           return this.handleSendTransaction(client, account, (params as [TransactionParams])[0]);
 
         case "personal_sign":
-          return client.signMessage({
-            account,
-            message: { raw: (params as [Hex])[0] },
-          });
+          return client.signMessage({ account, message: { raw: (params as [Hex])[0] } });
 
         case "eth_signTypedData_v4": {
           const typedData = JSON.parse((params as [string, string])[1]);
@@ -218,9 +209,7 @@ class BurnerWalletConnector {
 
   async getChainId(): Promise<number> {
     const provider = await this.getProvider();
-    const hexChainId = (await provider.request({
-      method: "eth_chainId",
-    })) as Hex;
+    const hexChainId = (await provider.request({ method: "eth_chainId" })) as Hex;
     return fromHex(hexChainId, "number");
   }
 
@@ -236,9 +225,7 @@ class BurnerWalletConnector {
     if (accounts.length === 0) {
       this.onDisconnect();
     } else {
-      this.config.emitter.emit("change", {
-        accounts: accounts.map(getAddress),
-      });
+      this.config.emitter.emit("change", { accounts: accounts.map(getAddress) });
     }
   }
 

--- a/test/test-components/src/shield-form.tsx
+++ b/test/test-components/src/shield-form.tsx
@@ -13,10 +13,7 @@ export function ShieldForm({
 }) {
   const { address } = useAccount();
   const { data: metadata } = useMetadata(tokenAddress);
-  const { data: allowance } = useUnderlyingAllowance({
-    address: wrapperAddress,
-    owner: address,
-  });
+  const { data: allowance } = useUnderlyingAllowance({ address: wrapperAddress, owner: address });
   const shield = useShield({ address: wrapperAddress });
 
   return (

--- a/test/test-components/src/token-table.tsx
+++ b/test/test-components/src/token-table.tsx
@@ -18,11 +18,7 @@ function TokenRow({
   balance: bigint | undefined;
   revealed: boolean;
   isDecrypting: boolean;
-  LinkComponent: React.ComponentType<{
-    to: string;
-    className?: string;
-    children: React.ReactNode;
-  }>;
+  LinkComponent: React.ComponentType<{ to: string; className?: string; children: React.ReactNode }>;
 }) {
   const { data: metadata } = useMetadata(address);
 
@@ -57,11 +53,7 @@ function ERC20TokenRow({
 }: {
   tokenAddress: Address;
   wrapper: Address;
-  LinkComponent: React.ComponentType<{
-    to: string;
-    className?: string;
-    children: React.ReactNode;
-  }>;
+  LinkComponent: React.ComponentType<{ to: string; className?: string; children: React.ReactNode }>;
 }) {
   const { address: connectedAddress } = useConnection();
   const balanceContract = connectedAddress
@@ -106,11 +98,7 @@ export function TokenTable({
 }: {
   tokenAddresses: Address[];
   erc20Tokens?: { address: Address; wrapper: Address }[];
-  LinkComponent: React.ComponentType<{
-    to: string;
-    className?: string;
-    children: React.ReactNode;
-  }>;
+  LinkComponent: React.ComponentType<{ to: string; className?: string; children: React.ReactNode }>;
 }) {
   const [revealed, setRevealed] = useState(false);
   const { address } = useAccount();

--- a/test/test-components/src/wrapper-discovery-panel.tsx
+++ b/test/test-components/src/wrapper-discovery-panel.tsx
@@ -3,10 +3,7 @@
 import { useWrapperDiscovery, type UseWrapperDiscoveryConfig } from "@zama-fhe/react-sdk";
 
 export function WrapperDiscoveryPanel({ tokenAddress, erc20Address }: UseWrapperDiscoveryConfig) {
-  const wrapperDiscovery = useWrapperDiscovery({
-    tokenAddress,
-    erc20Address,
-  });
+  const wrapperDiscovery = useWrapperDiscovery({ tokenAddress, erc20Address });
 
   return (
     <section className="space-y-2">

--- a/test/test-nextjs/deployments.d.ts
+++ b/test/test-nextjs/deployments.d.ts
@@ -4,9 +4,7 @@ declare module "*/hardhat/deployments.json" {
     cUSDT: string;
     erc20: string;
     cToken: string;
-    fhevm: {
-      acl: string;
-    };
+    fhevm: { acl: string };
   };
   export default deployments;
 }

--- a/test/test-nextjs/postcss.config.mjs
+++ b/test/test-nextjs/postcss.config.mjs
@@ -1,7 +1,3 @@
-const config = {
-  plugins: {
-    "@tailwindcss/postcss": {},
-  },
-};
+const config = { plugins: { "@tailwindcss/postcss": {} } };
 
 export default config;

--- a/test/test-nextjs/src/app/layout.tsx
+++ b/test/test-nextjs/src/app/layout.tsx
@@ -4,9 +4,7 @@ import type { Metadata } from "next";
 import { SidebarNav } from "./sidebar-nav";
 import "./globals.css";
 
-export const metadata: Metadata = {
-  title: "Token SDK Test App",
-};
+export const metadata: Metadata = { title: "Token SDK Test App" };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/test/test-nextjs/src/providers.tsx
+++ b/test/test-nextjs/src/providers.tsx
@@ -25,11 +25,7 @@ const wagmiConfig = createConfig({
 
 const zamaConfig = createZamaConfig({
   chains: [
-    {
-      ...fheAnvil,
-      network: rpcUrl,
-      registryAddress: getAddress(deployments.wrappersRegistry),
-    },
+    { ...fheAnvil, network: rpcUrl, registryAddress: getAddress(deployments.wrappersRegistry) },
   ],
   relayers: { [fheAnvil.id]: cleartext() },
   wagmiConfig,

--- a/test/test-nextjs/tsconfig.json
+++ b/test/test-nextjs/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
+    "plugins": [{ "name": "next" }],
     "paths": {
       "@zama-fhe/sdk": ["../../packages/sdk/src/index.ts"],
       "@zama-fhe/sdk/cleartext": ["../../packages/sdk/src/relayer/cleartext/index.ts"],

--- a/test/test-vite/deployments.d.ts
+++ b/test/test-vite/deployments.d.ts
@@ -4,9 +4,7 @@ declare module "*/hardhat/deployments.json" {
     cUSDT: string;
     erc20: string;
     cToken: string;
-    fhevm: {
-      acl: string;
-    };
+    fhevm: { acl: string };
   };
   export default deployments;
 }

--- a/test/test-vite/src/providers.tsx
+++ b/test/test-vite/src/providers.tsx
@@ -31,9 +31,7 @@ const customHardhat = {
 
 const zamaConfig = createZamaConfig({
   chains: [customHardhat],
-  relayers: {
-    [customHardhat.id]: web({ security: { integrityCheck: false } }),
-  },
+  relayers: { [customHardhat.id]: web({ security: { integrityCheck: false } }) },
   wagmiConfig,
 });
 

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,8 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": ["node", "vitest/globals"]
-  },
+  "compilerOptions": { "types": ["node", "vitest/globals"] },
   "include": [
     "vitest.setup.ts",
     "packages/sdk/src/**/*.test.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,10 +32,7 @@ const sharedResolve = {
       find: /^@zama-fhe\/sdk\/(.+)/,
       replacement: path.resolve(__dirname, "./packages/sdk/src/$1"),
     },
-    {
-      find: "@zama-fhe/sdk",
-      replacement: path.resolve(__dirname, "./packages/sdk/src"),
-    },
+    { find: "@zama-fhe/sdk", replacement: path.resolve(__dirname, "./packages/sdk/src") },
     {
       find: /^@zama-fhe\/react-sdk\/(.+)/,
       replacement: path.resolve(__dirname, "./packages/react-sdk/src/$1"),
@@ -81,10 +78,7 @@ export default defineConfig({
         test: {
           name: "typecheck",
           include: ["packages/sdk/**/*.test-d.ts"],
-          typecheck: {
-            enabled: true,
-            tsconfig: "./packages/sdk/tsconfig.json",
-          },
+          typecheck: { enabled: true, tsconfig: "./packages/sdk/tsconfig.json" },
         },
         resolve: sharedResolve,
       },
@@ -131,11 +125,7 @@ export default defineConfig({
         "**/worker/relayer-sdk.worker.ts",
         "**/worker/relayer-sdk.node-worker.ts",
       ],
-      thresholds: {
-        lines: 80,
-        branches: 80,
-        functions: 80,
-      },
+      thresholds: { lines: 80, branches: 80, functions: 80 },
     },
   },
 });

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -17,10 +17,7 @@ export default defineConfig({
         find: /^@zama-fhe\/sdk\/(.+)/,
         replacement: path.resolve(__dirname, "./packages/sdk/src/$1"),
       },
-      {
-        find: "@zama-fhe/sdk",
-        replacement: path.resolve(__dirname, "./packages/sdk/src"),
-      },
+      { find: "@zama-fhe/sdk", replacement: path.resolve(__dirname, "./packages/sdk/src") },
     ],
   },
 });


### PR DESCRIPTION
## What

Enables `"objectWrap": "collapse"` in `.oxfmtrc.json` and reformats the repository.

With the default `objectWrap: "preserve"`, oxfmt keeps an object literal multi-line whenever the source has a newline after the opening `{` — so short objects that easily fit on one line stayed expanded (and a stray formatter pass had expanded a number of them). `collapse` instead formats any object literal that fits within `printWidth` (100) onto a single line.

## Why

Removes diff noise and makes object-literal wrapping deterministic (driven by line width, not authored line breaks). Example:

```ts
// before
const expectedContext = {
  requestId: "transfer-and-call-error-raw",
} as const;

// after
const expectedContext = { requestId: "transfer-and-call-error-raw" } as const;
```

## Scope

- `.oxfmtrc.json`: one line added (`"objectWrap": "collapse"`).
- 256 files reformatted, **958 insertions / 3932 deletions** — pure whitespace/wrapping, no token changes.
- Generated API reports (`packages/*/etc/*.api.md`) are untouched (already in oxfmt `ignorePatterns`).

## Verification

- `oxfmt --check` is clean after the run → idempotent; future `pnpm format` won't re-expand.
- Pre-commit hooks (lint-staged + oxlint, `pnpm typecheck`, `pnpm llm:stage`) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)