### PR TITLE
feat(examples): demonstrate confidentialTransferAndCall vault deposit [SDK-244]

### DIFF
--- a/.github/workflows/contracts-test.yml
+++ b/.github/workflows/contracts-test.yml
@@ -1,0 +1,73 @@
+name: Contracts Test
+
+on:
+  pull_request:
+    branches: [main, prerelease]
+    paths:
+      - "contracts/src/**"
+      - "contracts/test/**"
+      - "contracts/foundry.toml"
+      - "contracts/soldeer.lock"
+      - "contracts/lib/forge-fhevm/src/**"
+      - "contracts/lib/forge-fhevm/foundry.toml"
+      - "contracts/lib/forge-fhevm/soldeer.lock"
+      - ".github/workflows/contracts-test.yml"
+  workflow_call:
+
+concurrency:
+  group: contracts-test-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  contracts-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
+      - name: Workaround CVE-2026-31431 (copy.fail)
+        run: |
+          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
+          if lsmod | grep -q algif_aead; then
+            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
+          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
+            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Init submodules
+        run: git submodule update --init --recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        with:
+          version: v1.5.1
+
+      - name: Restore Forge build cache
+        id: forge-build-cache
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            contracts/out
+            contracts/cache
+            contracts/dependencies
+            contracts/lib/forge-fhevm/out
+            contracts/lib/forge-fhevm/dependencies
+          key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml', 'contracts/soldeer.lock', 'contracts/lib/forge-fhevm/src/**/*.sol', 'contracts/lib/forge-fhevm/foundry.toml', 'contracts/lib/forge-fhevm/soldeer.lock') }}
+
+      - name: Install Soldeer dependencies
+        if: steps.forge-build-cache.outputs.cache-hit != 'true'
+        run: |
+          cd contracts/lib/forge-fhevm && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
+          cd "$GITHUB_WORKSPACE/contracts" && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
+
+      - name: Build forge-fhevm contracts
+        if: steps.forge-build-cache.outputs.cache-hit != 'true'
+        run: cd contracts/lib/forge-fhevm && forge build
+
+      - name: Run contract tests
+        run: cd contracts && forge test -vvv

--- a/contracts/script/DeployVault.s.sol
+++ b/contracts/script/DeployVault.s.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.27;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {IERC7984} from "@openzeppelin/confidential-contracts/interfaces/IERC7984.sol";
+import {ConfidentialVault} from "../src/ConfidentialVault.sol";
+
+/// @dev Deploys {ConfidentialVault} bound to an existing ERC-7984 confidential token.
+///      Pass the confidential token via the `CONFIDENTIAL_TOKEN` env var, e.g. on Sepolia
+///      cUSDC `0x7c5BF43B851c1dff1a4feE8dB225b87f2C223639`.
+///
+///      forge script script/DeployVault.s.sol \
+///        --rpc-url <SEPOLIA_RPC> --private-key <PK> --broadcast
+contract DeployVault is Script {
+    function run() external {
+        address confidentialToken = vm.envAddress("CONFIDENTIAL_TOKEN");
+
+        vm.startBroadcast();
+        ConfidentialVault vault = new ConfidentialVault(IERC7984(confidentialToken));
+        vm.stopBroadcast();
+
+        console.log("ConfidentialVault:", address(vault));
+        console.log("confidentialToken:", confidentialToken);
+    }
+}

--- a/contracts/src/ConfidentialVault.sol
+++ b/contracts/src/ConfidentialVault.sol
@@ -32,6 +32,9 @@ contract ConfidentialVault is IERC7984Receiver, ZamaEthereumConfig {
     {
         require(msg.sender == address(confidentialToken), UnauthorizedToken(msg.sender));
 
+        // Malformed `data` (< 32 bytes) reverts here, which reverts the whole transfer
+        // atomically — the deposit fails rather than refunding. The bound UI always encodes
+        // a full address, so this only guards against direct callers.
         address beneficiary = abi.decode(data, (address));
 
         // No beneficiary: return encrypted `false` so the token refunds the transfer atomically.
@@ -58,11 +61,12 @@ contract ConfidentialVault is IERC7984Receiver, ZamaEthereumConfig {
         euint64 amount = _shares[msg.sender];
         require(FHE.isInitialized(amount), NothingToWithdraw(msg.sender));
 
-        // Checks-effects-interactions: zero the balance before the outbound transfer.
-        euint64 zero = FHE.asEuint64(0);
-        FHE.allowThis(zero);
-        FHE.allow(zero, msg.sender);
-        _shares[msg.sender] = zero;
+        // Checks-effects-interactions: clear the balance before the outbound transfer.
+        // Reset the slot to the uninitialized (bytes32(0)) sentinel — not `FHE.asEuint64(0)`,
+        // which is an initialized handle. This makes `sharesOf` report empty and a repeat
+        // withdraw revert on the `isInitialized` guard above. (`euint64` is a user-defined
+        // value type, so `delete` is unavailable; wrap the zero handle directly.)
+        _shares[msg.sender] = euint64.wrap(bytes32(0));
 
         // The token runs the FHE ops inside `confidentialTransfer`, so it needs access to `amount`.
         FHE.allowTransient(amount, address(confidentialToken));

--- a/contracts/src/ConfidentialVault.sol
+++ b/contracts/src/ConfidentialVault.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.27;
+
+import {FHE, ebool, euint64} from "@fhevm/solidity/lib/FHE.sol";
+import {ZamaEthereumConfig} from "@fhevm/solidity/config/ZamaConfig.sol";
+import {IERC7984} from "@openzeppelin/confidential-contracts/interfaces/IERC7984.sol";
+import {IERC7984Receiver} from "@openzeppelin/confidential-contracts/interfaces/IERC7984Receiver.sol";
+
+/// @dev Minimal confidential escrow vault demonstrating the ERC-7984 `confidentialTransferAndCall`
+///      receiver-callback pattern. A depositor moves confidential tokens into the vault in a single
+///      transaction; `data` carries the beneficiary to credit. The beneficiary withdraws later.
+///      Illustrative example for the Zama SDK — not a production contract.
+contract ConfidentialVault is IERC7984Receiver, ZamaEthereumConfig {
+    IERC7984 public immutable confidentialToken;
+
+    mapping(address account => euint64 shares) private _shares;
+
+    event Deposit(address indexed from, address indexed beneficiary);
+    event Withdraw(address indexed beneficiary);
+
+    error UnauthorizedToken(address caller);
+    error NothingToWithdraw(address account);
+
+    constructor(IERC7984 token) {
+        confidentialToken = token;
+    }
+
+    /// @inheritdoc IERC7984Receiver
+    function onConfidentialTransferReceived(address, address from, euint64 amount, bytes calldata data)
+        external
+        returns (ebool)
+    {
+        require(msg.sender == address(confidentialToken), UnauthorizedToken(msg.sender));
+
+        address beneficiary = abi.decode(data, (address));
+
+        // No beneficiary: return encrypted `false` so the token refunds the transfer atomically.
+        if (beneficiary == address(0)) {
+            ebool rejected = FHE.asEbool(false);
+            FHE.allowTransient(rejected, msg.sender);
+            return rejected;
+        }
+
+        euint64 credited = FHE.add(_shares[beneficiary], amount);
+        FHE.allowThis(credited);
+        FHE.allow(credited, beneficiary);
+        _shares[beneficiary] = credited;
+
+        emit Deposit(from, beneficiary);
+
+        ebool accepted = FHE.asEbool(true);
+        FHE.allowTransient(accepted, msg.sender);
+        return accepted;
+    }
+
+    /// @dev Withdraw the caller's full vault balance back to their wallet.
+    function withdraw() external {
+        euint64 amount = _shares[msg.sender];
+        require(FHE.isInitialized(amount), NothingToWithdraw(msg.sender));
+
+        // Checks-effects-interactions: zero the balance before the outbound transfer.
+        euint64 zero = FHE.asEuint64(0);
+        FHE.allowThis(zero);
+        FHE.allow(zero, msg.sender);
+        _shares[msg.sender] = zero;
+
+        // The token runs the FHE ops inside `confidentialTransfer`, so it needs access to `amount`.
+        FHE.allowTransient(amount, address(confidentialToken));
+        confidentialToken.confidentialTransfer(msg.sender, amount);
+
+        emit Withdraw(msg.sender);
+    }
+
+    /// @dev Caller-decryptable confidential balance held for `account`.
+    function sharesOf(address account) external view returns (euint64) {
+        return _shares[account];
+    }
+}

--- a/contracts/test/ConfidentialVault.t.sol
+++ b/contracts/test/ConfidentialVault.t.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.27;
+
+import {FhevmTest} from "forge-fhevm/FhevmTest.sol";
+
+import {euint64, externalEuint64} from "@fhevm/solidity/lib/FHE.sol";
+import {IERC7984} from "@openzeppelin/confidential-contracts/interfaces/IERC7984.sol";
+import {ERC7984Mock} from "@openzeppelin/confidential-contracts/mocks/token/ERC7984Mock.sol";
+
+import {ConfidentialVault} from "../src/ConfidentialVault.sol";
+
+/// @dev Coverage for the ConfidentialVault example: the `confidentialTransferAndCall` deposit
+///      callback, beneficiary crediting/accumulation, the zero-beneficiary atomic refund, the
+///      anti-spoof guard, and `withdraw()` (funds returned + slot cleared to the empty sentinel).
+///      Runs against the forge-fhevm cleartext harness (chainid 31337 == `_getLocalConfig`).
+contract ConfidentialVaultTest is FhevmTest {
+    uint256 internal constant HOLDER_PK = 0xA11CE;
+    uint256 internal constant ALICE_PK = 0xB0B;
+    uint256 internal constant STRANGER_PK = 0xCAFE;
+
+    bytes32 internal constant EMPTY = bytes32(0);
+    uint64 internal constant MINT = 1000;
+
+    ERC7984Mock internal token;
+    ConfidentialVault internal vault;
+
+    address internal holder;
+    address internal alice;
+    address internal stranger;
+
+    function setUp() public override {
+        super.setUp();
+
+        holder = vm.addr(HOLDER_PK);
+        alice = vm.addr(ALICE_PK);
+        stranger = vm.addr(STRANGER_PK);
+
+        token = new ERC7984Mock("Confidential Mock", "cMOCK", "https://example.com");
+        vault = new ConfidentialVault(IERC7984(address(token)));
+
+        token.$_mint(holder, MINT);
+    }
+
+    // ── Wiring ──────────────────────────────────────────────────────────────
+
+    function test_constructor_bindsToken() public view {
+        assertEq(address(vault.confidentialToken()), address(token));
+    }
+
+    // ── Deposit (confidentialTransferAndCall) ───────────────────────────────
+
+    function test_deposit_creditsBeneficiaryAndDebitsDepositor() public {
+        _deposit(HOLDER_PK, 400, holder);
+
+        assertEq(_decryptShares(HOLDER_PK, holder), 400);
+        assertEq(_decryptBalance(HOLDER_PK, holder), 600);
+    }
+
+    function test_deposit_creditsADifferentBeneficiary() public {
+        _deposit(HOLDER_PK, 400, alice);
+
+        assertEq(_decryptShares(ALICE_PK, alice), 400);
+        assertEq(_decryptBalance(HOLDER_PK, holder), 600);
+        // The depositor holds no position of their own.
+        assertEq(euint64.unwrap(vault.sharesOf(holder)), EMPTY);
+    }
+
+    function test_deposit_accumulatesAcrossDeposits() public {
+        _deposit(HOLDER_PK, 300, alice);
+        _deposit(HOLDER_PK, 200, alice);
+
+        assertEq(_decryptShares(ALICE_PK, alice), 500);
+        assertEq(_decryptBalance(HOLDER_PK, holder), 500);
+    }
+
+    function test_deposit_emitsDepositEvent() public {
+        (externalEuint64 ext, bytes memory proof) = encryptUint64(100, holder, address(token));
+
+        vm.expectEmit(true, true, false, false, address(vault));
+        emit ConfidentialVault.Deposit(holder, alice);
+
+        vm.prank(holder);
+        token.confidentialTransferAndCall(address(vault), ext, proof, abi.encode(alice));
+    }
+
+    // ── Zero-beneficiary atomic refund ──────────────────────────────────────
+
+    function test_deposit_zeroBeneficiary_refundsAtomically() public {
+        _deposit(HOLDER_PK, 400, address(0));
+
+        // The receiver returned encrypted `false`, so the token reverses the transfer:
+        // the depositor's balance is whole again and nothing was credited.
+        assertEq(_decryptBalance(HOLDER_PK, holder), 1000);
+        assertEq(euint64.unwrap(vault.sharesOf(address(0))), EMPTY);
+    }
+
+    // ── Anti-spoof guard ────────────────────────────────────────────────────
+
+    function test_onReceived_revertsForUnauthorizedCaller() public {
+        // A direct caller that is not the bound token cannot forge a credit.
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(ConfidentialVault.UnauthorizedToken.selector, stranger));
+        vault.onConfidentialTransferReceived(stranger, holder, euint64.wrap(EMPTY), abi.encode(alice));
+    }
+
+    // ── Withdraw (returns funds + clears slot to the empty sentinel) ─────────
+
+    function test_withdraw_returnsFundsAndClearsSlot() public {
+        _deposit(HOLDER_PK, 400, holder);
+        assertEq(_decryptBalance(HOLDER_PK, holder), 600);
+
+        vm.prank(holder);
+        vault.withdraw();
+
+        // Funds are back with the holder…
+        assertEq(_decryptBalance(HOLDER_PK, holder), 1000);
+        // …and the slot is the uninitialized bytes32(0) sentinel (UI reads "no position").
+        assertEq(euint64.unwrap(vault.sharesOf(holder)), EMPTY);
+    }
+
+    function test_withdraw_emitsWithdrawEvent() public {
+        _deposit(HOLDER_PK, 250, holder);
+
+        vm.expectEmit(true, false, false, false, address(vault));
+        emit ConfidentialVault.Withdraw(holder);
+
+        vm.prank(holder);
+        vault.withdraw();
+    }
+
+    function test_withdraw_repeatReverts() public {
+        _deposit(HOLDER_PK, 400, holder);
+
+        vm.prank(holder);
+        vault.withdraw();
+
+        // The cleared slot is uninitialized, so the guard now reverts a second withdraw.
+        vm.prank(holder);
+        vm.expectRevert(abi.encodeWithSelector(ConfidentialVault.NothingToWithdraw.selector, holder));
+        vault.withdraw();
+    }
+
+    function test_withdraw_withoutPositionReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(ConfidentialVault.NothingToWithdraw.selector, stranger));
+        vault.withdraw();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    /// @notice Deposits `amount` into the vault crediting `beneficiary`, via the AndCall callback.
+    function _deposit(uint256 signerPk, uint64 amount, address beneficiary) internal {
+        address signer = vm.addr(signerPk);
+        (externalEuint64 ext, bytes memory proof) = encryptUint64(amount, signer, address(token));
+        vm.prank(signer);
+        token.confidentialTransferAndCall(address(vault), ext, proof, abi.encode(beneficiary));
+    }
+
+    /// @notice Decrypts `account`'s vault position (ACL granted to both the holder and the vault).
+    function _decryptShares(uint256 pk, address account) internal returns (uint64) {
+        bytes memory sig = signUserDecrypt(pk, address(vault));
+        return uint64(userDecrypt(euint64.unwrap(vault.sharesOf(account)), account, address(vault), sig));
+    }
+
+    /// @notice Decrypts `account`'s confidential token balance.
+    function _decryptBalance(uint256 pk, address account) internal returns (uint64) {
+        bytes memory sig = signUserDecrypt(pk, address(token));
+        return uint64(userDecrypt(euint64.unwrap(token.confidentialBalanceOf(account)), account, address(token), sig));
+    }
+}

--- a/examples/react-wagmi/.env.example
+++ b/examples/react-wagmi/.env.example
@@ -6,3 +6,9 @@
 
 # Optional: override the default Sepolia RPC (https://ethereum-sepolia-rpc.publicnode.com)
 # NEXT_PUBLIC_SEPOLIA_RPC_URL=https://sepolia.infura.io/v3/YOUR_KEY
+
+# Optional: ConfidentialVault demo (confidentialTransferAndCall). Defaults point at a vault
+# deployed on Sepolia bound to cUSDC. Override to use your own deployment
+# (contracts/script/DeployVault.s.sol). The vault cards only render when the bound token is selected.
+# NEXT_PUBLIC_VAULT_ADDRESS=0x1A50c30364A711e14930A4fd9Ebd6709A81Ec423
+# NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN=0x7c5BF43B851c1dff1a4feE8dB225b87f2C223639

--- a/examples/react-wagmi/.env.example
+++ b/examples/react-wagmi/.env.example
@@ -10,5 +10,5 @@
 # Optional: ConfidentialVault demo (confidentialTransferAndCall). Defaults point at a vault
 # deployed on Sepolia bound to cUSDC. Override to use your own deployment
 # (contracts/script/DeployVault.s.sol). The vault cards only render when the bound token is selected.
-# NEXT_PUBLIC_VAULT_ADDRESS=0x1A50c30364A711e14930A4fd9Ebd6709A81Ec423
+# NEXT_PUBLIC_VAULT_ADDRESS=0xb13720bec167A576D715F5aA7C7d68b3dB0A4Ad7
 # NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN=0x7c5BF43B851c1dff1a4feE8dB225b87f2C223639

--- a/examples/react-wagmi/README.md
+++ b/examples/react-wagmi/README.md
@@ -31,13 +31,13 @@ If your wallet is on the wrong network, the app shows a message and offers a **S
 
 ## Environment variables
 
-| Variable                      | Required | Description                                                                                 |
-| ----------------------------- | -------- | ------------------------------------------------------------------------------------------- |
-| `RELAYER_URL`                 | No       | Relayer base URL incl. API version path. Defaults to `https://relayer.testnet.zama.org/v2`. |
-| `RELAYER_API_KEY`             | No       | API key added as `x-api-key` header by the proxy. Not required for Sepolia testnet.         |
-| `NEXT_PUBLIC_SEPOLIA_RPC_URL` | No       | Sepolia RPC override. Defaults to the public PublicNode endpoint.                           |
-| `NEXT_PUBLIC_VAULT_ADDRESS`   | No       | `ConfidentialVault` demo address (`confidentialTransferAndCall`). Defaults to a Sepolia deployment. |
-| `NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN` | No | Confidential token the vault is bound to (cUSDC). Vault cards render only when it is selected. |
+| Variable                               | Required | Description                                                                                         |
+| -------------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `RELAYER_URL`                          | No       | Relayer base URL incl. API version path. Defaults to `https://relayer.testnet.zama.org/v2`.         |
+| `RELAYER_API_KEY`                      | No       | API key added as `x-api-key` header by the proxy. Not required for Sepolia testnet.                 |
+| `NEXT_PUBLIC_SEPOLIA_RPC_URL`          | No       | Sepolia RPC override. Defaults to the public PublicNode endpoint.                                   |
+| `NEXT_PUBLIC_VAULT_ADDRESS`            | No       | `ConfidentialVault` demo address (`confidentialTransferAndCall`). Defaults to a Sepolia deployment. |
+| `NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN` | No       | Confidential token the vault is bound to (cUSDC). Vault cards render only when it is selected.      |
 
 ## Running e2e tests
 

--- a/examples/react-wagmi/README.md
+++ b/examples/react-wagmi/README.md
@@ -3,14 +3,14 @@
 Next.js 16 example app demonstrating how to integrate `@zama-fhe/react-sdk` with
 [wagmi v3](https://wagmi.sh/) on Sepolia testnet.
 
-Covers: connect wallet, shield ERC-20 → confidential, confidential transfer, unshield, grant/revoke/use delegation, pending unshield recovery.
+Covers: connect wallet, shield ERC-20 → confidential, confidential transfer, unshield, grant/revoke/use delegation, pending unshield recovery, deposit into a reacting contract (`confidentialTransferAndCall`).
 
 ## Stack
 
 - **Next.js 16** (App Router, Webpack — Turbopack not yet supported with WASM)
 - **React 19** + **wagmi v3** + **viem v2**
 - **TanStack Query v5** for async state
-- **@zama-fhe/react-sdk** — `ZamaProvider`, `useConfidentialBalance`, `useUnshield`, `useDelegateDecryption`, etc.
+- **@zama-fhe/react-sdk** — `ZamaProvider`, `useConfidentialBalance`, `useUnshield`, `useConfidentialTransferAndCall`, `useDelegateDecryption`, etc.
 - **@zama-fhe/react-sdk/wagmi** — `createConfig` adapter for wagmi signer/provider wiring
 - **@zama-fhe/sdk/web** — browser FHE worker transport via `web()`, routed through a local Next.js proxy (`/api/relayer`)
 
@@ -36,6 +36,8 @@ If your wallet is on the wrong network, the app shows a message and offers a **S
 | `RELAYER_URL`                 | No       | Relayer base URL incl. API version path. Defaults to `https://relayer.testnet.zama.org/v2`. |
 | `RELAYER_API_KEY`             | No       | API key added as `x-api-key` header by the proxy. Not required for Sepolia testnet.         |
 | `NEXT_PUBLIC_SEPOLIA_RPC_URL` | No       | Sepolia RPC override. Defaults to the public PublicNode endpoint.                           |
+| `NEXT_PUBLIC_VAULT_ADDRESS`   | No       | `ConfidentialVault` demo address (`confidentialTransferAndCall`). Defaults to a Sepolia deployment. |
+| `NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN` | No | Confidential token the vault is bound to (cUSDC). Vault cards render only when it is selected. |
 
 ## Running e2e tests
 

--- a/examples/react-wagmi/WALKTHROUGH.md
+++ b/examples/react-wagmi/WALKTHROUGH.md
@@ -276,7 +276,54 @@ The `savePendingUnshield` call in `onEvent` and the `storage` prop in `ZamaProvi
 
 ---
 
-## 10. Running locally
+## 10. Deposit into a reacting contract (`confidentialTransferAndCall`)
+
+The `Reacting contract — ConfidentialVault` section demonstrates the ERC-7984
+`confidentialTransferAndCall` pattern: a confidential transfer that also invokes the
+recipient contract's `onConfidentialTransferReceived` hook **in the same transaction**, so
+value moves and the receiver reacts atomically — no two-step transfer-then-notify race.
+
+The receiver is a minimal confidential escrow, [`contracts/src/ConfidentialVault.sol`](../../contracts/src/ConfidentialVault.sol),
+deployed on Sepolia and bound to one confidential token (cUSDC). The cards only render when
+that token is selected. Configure the addresses via `NEXT_PUBLIC_VAULT_ADDRESS` and
+`NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN` (see `src/lib/config.ts`); deploy your own with
+[`contracts/script/DeployVault.s.sol`](../../contracts/script/DeployVault.s.sol).
+
+**Deposit (`VaultDepositCard.tsx`).** The `data` payload carries a real domain message — the
+beneficiary to credit — not an opaque blob. The contract decodes and routes the credit on it:
+
+```ts
+const deposit = useConfidentialTransferAndCall({ address: tokenAddress }, { onSuccess });
+
+// The vault decodes `data` as the beneficiary address to credit.
+const data = encodeAbiParameters([{ type: "address" }], [beneficiary]);
+deposit.mutate({ to: vaultAddress, amount: parsedAmount, data });
+```
+
+**Position + withdraw (`VaultPositionCard.tsx`).** The vault stores an `euint64` share per
+beneficiary and grants that beneficiary FHE decrypt rights. Reading the position needs a
+permit scoped to the **vault** address — distinct from the confidential-token permits the main
+page grants:
+
+```ts
+const { data: handle } = useReadContract({ address: vaultAddress, abi: VAULT_ABI,
+  functionName: "sharesOf", args: [connectedAddress] });
+
+await grantPermit.mutateAsync([vaultAddress]);               // permit scoped to the vault
+const shares = useDecryptValues([{ encryptedValue: handle, contractAddress: vaultAddress }]);
+```
+
+Withdraw calls the vault's `withdraw()` directly (`signer.writeContract`) — it is a custom
+contract method, not part of the `Token` surface. The vault transfers the caller's full
+confidential balance back via `confidentialTransfer`.
+
+> Depositing with `beneficiary == address(0)` makes the vault return an encrypted `false` from
+> the hook, and the token **refunds the transfer atomically** — a useful safety property of the
+> receiver-callback pattern.
+
+---
+
+## 11. Running locally
 
 ```bash
 cd examples/react-wagmi

--- a/examples/react-wagmi/WALKTHROUGH.md
+++ b/examples/react-wagmi/WALKTHROUGH.md
@@ -304,10 +304,14 @@ permit scoped to the **vault** address — distinct from the confidential-token 
 page grants:
 
 ```ts
-const { data: handle } = useReadContract({ address: vaultAddress, abi: VAULT_ABI,
-  functionName: "sharesOf", args: [connectedAddress] });
+const { data: handle } = useReadContract({
+  address: vaultAddress,
+  abi: VAULT_ABI,
+  functionName: "sharesOf",
+  args: [connectedAddress],
+});
 
-await grantPermit.mutateAsync([vaultAddress]);               // permit scoped to the vault
+await grantPermit.mutateAsync([vaultAddress]); // permit scoped to the vault
 const shares = useDecryptValues([{ encryptedValue: handle, contractAddress: vaultAddress }]);
 ```
 

--- a/examples/react-wagmi/e2e/vault.spec.ts
+++ b/examples/react-wagmi/e2e/vault.spec.ts
@@ -30,9 +30,7 @@ test.describe("confidential vault — confidentialTransferAndCall", () => {
 
   test("renders the vault section for the bound token", async ({ page }) => {
     await expect(page.getByText("Reacting contract — ConfidentialVault")).toBeVisible();
-    await expect(
-      page.getByText("Deposit into Vault — confidentialTransferAndCall"),
-    ).toBeVisible();
+    await expect(page.getByText("Deposit into Vault — confidentialTransferAndCall")).toBeVisible();
     await expect(page.getByText("Your Vault Position")).toBeVisible();
   });
 
@@ -55,8 +53,6 @@ test.describe("confidential vault — confidentialTransferAndCall", () => {
   test("hides the vault section for an unbound token", async ({ page }) => {
     await page.getByRole("combobox").selectOption(MOCK_CTOKEN2_ADDRESS);
     await expect(page.getByText("Reacting contract — ConfidentialVault")).toBeHidden();
-    await expect(
-      page.getByText("Deposit into Vault — confidentialTransferAndCall"),
-    ).toBeHidden();
+    await expect(page.getByText("Deposit into Vault — confidentialTransferAndCall")).toBeHidden();
   });
 });

--- a/examples/react-wagmi/e2e/vault.spec.ts
+++ b/examples/react-wagmi/e2e/vault.spec.ts
@@ -1,0 +1,62 @@
+import {
+  test,
+  expect,
+  SEPOLIA_CHAIN_ID_HEX,
+  TEST_ADDRESS,
+  MOCK_CTOKEN1_ADDRESS,
+  MOCK_CTOKEN2_ADDRESS,
+} from "./fixtures";
+
+// The ConfidentialVault demo (confidentialTransferAndCall) is bound to one confidential
+// token. playwright.config.ts sets NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN to the mocked cUSDC
+// pair (MOCK_CTOKEN1_ADDRESS), so the vault cards render when cUSDC is the selected token.
+//
+// These tests exercise the rendered states only — the relayer is aborted in this harness,
+// so no real encryption/decryption runs (same constraint as the other react-wagmi e2e specs).
+test.describe("confidential vault — confidentialTransferAndCall", () => {
+  test.beforeEach(async ({ page, mockRpc, mockWallet }) => {
+    await mockRpc();
+    await mockWallet({
+      accounts: [],
+      chainId: SEPOLIA_CHAIN_ID_HEX,
+      requestAccounts: [TEST_ADDRESS],
+    });
+    await page.goto("/");
+    await page.getByRole("button", { name: "Connect Wallet" }).click({ force: true });
+    await expect(page.getByText("Balances")).toBeVisible();
+    // cUSDC (MOCK_CTOKEN1) is the auto-selected first pair.
+    await expect(page.getByRole("combobox")).toHaveValue(MOCK_CTOKEN1_ADDRESS);
+  });
+
+  test("renders the vault section for the bound token", async ({ page }) => {
+    await expect(page.getByText("Reacting contract — ConfidentialVault")).toBeVisible();
+    await expect(
+      page.getByText("Deposit into Vault — confidentialTransferAndCall"),
+    ).toBeVisible();
+    await expect(page.getByText("Your Vault Position")).toBeVisible();
+  });
+
+  test("beneficiary defaults to the connected wallet", async ({ page }) => {
+    await expect(page.getByTestId("vault-beneficiary-input")).toHaveValue(TEST_ADDRESS);
+  });
+
+  test("deposit is gated until the balance is decrypted", async ({ page }) => {
+    await page.getByTestId("vault-amount-input").fill("5");
+    // No permit is granted in the mocked harness, so the deposit stays disabled and the
+    // hint is shown.
+    await expect(page.getByTestId("vault-deposit-button")).toBeDisabled();
+    await expect(page.getByText("Decrypt your balance first to enable deposits.")).toBeVisible();
+  });
+
+  test("shows no position before any deposit", async ({ page }) => {
+    await expect(page.getByTestId("vault-no-position")).toBeVisible();
+  });
+
+  test("hides the vault section for an unbound token", async ({ page }) => {
+    await page.getByRole("combobox").selectOption(MOCK_CTOKEN2_ADDRESS);
+    await expect(page.getByText("Reacting contract — ConfidentialVault")).toBeHidden();
+    await expect(
+      page.getByText("Deposit into Vault — confidentialTransferAndCall"),
+    ).toBeHidden();
+  });
+});

--- a/examples/react-wagmi/package-lock.json
+++ b/examples/react-wagmi/package-lock.json
@@ -7,8 +7,8 @@
       "name": "react-wagmi-example",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
-        "@zama-fhe/react-sdk": "3.1.0",
-        "@zama-fhe/sdk": "3.1.0",
+        "@zama-fhe/react-sdk": "3.3.0-alpha.3",
+        "@zama-fhe/sdk": "3.3.0-alpha.3",
         "next": "^16.2.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -861,16 +861,16 @@
       }
     },
     "node_modules/@zama-fhe/react-sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.1.0.tgz",
-      "integrity": "sha512-RpFrGS+pG+Z4kiw9PWAiNij8cbntFWqA1Lz5VLBdu0KPEtoU5LByY2pniMI6fXMZikoN3RW0FPbuQSMGWgzLoQ==",
+      "version": "3.3.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.3.0-alpha.3.tgz",
+      "integrity": "sha512-82Hmza9l4/s6hjyjm1VOg9VQ4TjD4xhadPBDqBCO4pHR+k7r1SKx9PuQKGUHf66GsL+7O3kVEMGpyuoRSkwIJA==",
       "license": "BSD-3-Clause-Clear",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5",
-        "@zama-fhe/sdk": "^3.1.0",
+        "@zama-fhe/sdk": "^3.3.0-alpha.3",
         "react": ">=18",
         "viem": ">=2",
         "wagmi": ">=2"
@@ -905,14 +905,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0.tgz",
-      "integrity": "sha512-OTZxMLHOUhapGVkqnslLF9ENQfJmzU/lvI5nfvAjBzJXvQgTf+IUC2JRXpnifojFV+RFhmW12TYOuE8spUbpFw==",
+      "version": "3.3.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.3.0-alpha.3.tgz",
+      "integrity": "sha512-e3piCr3ZPseMR76J3cRmfgDGwhmTmQQ8kVBnLDDWIs5t3/NglEwh7zcVvVCHVzujT2rA1UOKynf8PR38IG8Q+Q==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@zama-fhe/relayer-sdk": "~0.4.4",
-        "viem": "^2.52.2",
-        "zod": "^4.4.3"
+        "viem": ">=2",
+        "zod": ">=4"
       },
       "engines": {
         "node": ">=22"

--- a/examples/react-wagmi/package.json
+++ b/examples/react-wagmi/package.json
@@ -2,7 +2,7 @@
   "name": "react-wagmi-example",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",

--- a/examples/react-wagmi/package.json
+++ b/examples/react-wagmi/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.0",
-    "@zama-fhe/react-sdk": "3.1.0",
-    "@zama-fhe/sdk": "3.1.0",
+    "@zama-fhe/react-sdk": "3.3.0-alpha.3",
+    "@zama-fhe/sdk": "3.3.0-alpha.3",
     "next": "^16.2.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/examples/react-wagmi/playwright.config.ts
+++ b/examples/react-wagmi/playwright.config.ts
@@ -14,7 +14,13 @@ export default defineConfig({
     timeout: 120_000,
     // Force the default RPC URL so mockRpc's intercept pattern always matches.
     // Without this, a dev's .env.local override would bypass the route mock.
-    env: { NEXT_PUBLIC_SEPOLIA_RPC_URL: "" },
+    // Bind the vault demo to the mocked cUSDC pair (MOCK_CTOKEN1_ADDRESS) so the
+    // ConfidentialVault cards render when that token is selected in e2e.
+    env: {
+      NEXT_PUBLIC_SEPOLIA_RPC_URL: "",
+      NEXT_PUBLIC_VAULT_ADDRESS: "0x5555555555555555555555555555555555555555",
+      NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN: "0x2222222222222222222222222222222222222222",
+    },
   },
   projects: [
     {

--- a/examples/react-wagmi/src/app/page.tsx
+++ b/examples/react-wagmi/src/app/page.tsx
@@ -24,11 +24,7 @@ import { RevokeDelegationCard } from "@/components/RevokeDelegationCard";
 import { DecryptAsCard } from "@/components/DecryptAsCard";
 import { VaultDepositCard } from "@/components/VaultDepositCard";
 import { VaultPositionCard } from "@/components/VaultPositionCard";
-import {
-  SEPOLIA_CHAIN_ID,
-  VAULT_ADDRESS,
-  VAULT_CONFIDENTIAL_TOKEN,
-} from "@/lib/config";
+import { SEPOLIA_CHAIN_ID, VAULT_ADDRESS, VAULT_CONFIDENTIAL_TOKEN } from "@/lib/config";
 
 // Standard ERC-20 balanceOf ABI — used by useReadContract for public balance polling.
 // parseAbi is required — viem does not parse human-readable ABI strings automatically.
@@ -290,6 +286,10 @@ function TokenWorkspace({ address, token, validPairs, refetchEth }: TokenWorkspa
     allowTokens.mutate(validPairs.map((p) => p.confidentialTokenAddress));
   }
 
+  // Bumped after a vault deposit to remount VaultPositionCard so it re-reads sharesOf
+  // (the deposit changed the position; the previously revealed value is now stale).
+  const [vaultNonce, setVaultNonce] = useState(0);
+
   // ERC-20 balance via wagmi — auto-refetches when args (address) change on account switch.
   // Uses the wagmi HTTP transport, not window.ethereum, so polling is fast.
   const { data: erc20Balance, refetch: refetchErc20 } = useReadContract({
@@ -413,8 +413,7 @@ function TokenWorkspace({ address, token, validPairs, refetchEth }: TokenWorkspa
           Only rendered for the confidential token the example vault is bound to.
           Deposit moves tokens into the vault and credits a beneficiary atomically;
           the beneficiary reveals and withdraws their confidential position. */}
-      {token.confidentialTokenAddress.toLowerCase() ===
-        VAULT_CONFIDENTIAL_TOKEN.toLowerCase() && (
+      {token.confidentialTokenAddress.toLowerCase() === VAULT_CONFIDENTIAL_TOKEN.toLowerCase() && (
         <>
           <div className="section-label">Reacting contract — ConfidentialVault</div>
 
@@ -427,11 +426,14 @@ function TokenWorkspace({ address, token, validPairs, refetchEth }: TokenWorkspa
             symbol={confidentialSymbol}
             disabled={false}
             balanceDecryptRequired={!isAllowed}
-            onSuccess={refreshPublicBalances}
+            onSuccess={() => {
+              refreshPublicBalances();
+              setVaultNonce((n) => n + 1);
+            }}
           />
 
           <VaultPositionCard
-            key={`vault-position-${address}-${token.confidentialTokenAddress}`}
+            key={`vault-position-${address}-${token.confidentialTokenAddress}-${vaultNonce}`}
             vaultAddress={VAULT_ADDRESS}
             connectedAddress={address}
             decimals={decimals}

--- a/examples/react-wagmi/src/app/page.tsx
+++ b/examples/react-wagmi/src/app/page.tsx
@@ -22,7 +22,13 @@ import { PendingUnshieldCard } from "@/components/PendingUnshieldCard";
 import { DelegateDecryptionCard } from "@/components/DelegateDecryptionCard";
 import { RevokeDelegationCard } from "@/components/RevokeDelegationCard";
 import { DecryptAsCard } from "@/components/DecryptAsCard";
-import { SEPOLIA_CHAIN_ID } from "@/lib/config";
+import { VaultDepositCard } from "@/components/VaultDepositCard";
+import { VaultPositionCard } from "@/components/VaultPositionCard";
+import {
+  SEPOLIA_CHAIN_ID,
+  VAULT_ADDRESS,
+  VAULT_CONFIDENTIAL_TOKEN,
+} from "@/lib/config";
 
 // Standard ERC-20 balanceOf ABI — used by useReadContract for public balance polling.
 // parseAbi is required — viem does not parse human-readable ABI strings automatically.
@@ -402,6 +408,38 @@ function TokenWorkspace({ address, token, validPairs, refetchEth }: TokenWorkspa
         balanceDecryptRequired={!isAllowed}
         onSuccess={refreshPublicBalances}
       />
+
+      {/* ── Reacting contract — confidentialTransferAndCall demo ───────────────
+          Only rendered for the confidential token the example vault is bound to.
+          Deposit moves tokens into the vault and credits a beneficiary atomically;
+          the beneficiary reveals and withdraws their confidential position. */}
+      {token.confidentialTokenAddress.toLowerCase() ===
+        VAULT_CONFIDENTIAL_TOKEN.toLowerCase() && (
+        <>
+          <div className="section-label">Reacting contract — ConfidentialVault</div>
+
+          <VaultDepositCard
+            key={`vault-deposit-${address}-${token.confidentialTokenAddress}`}
+            tokenAddress={token.confidentialTokenAddress}
+            vaultAddress={VAULT_ADDRESS}
+            connectedAddress={address}
+            decimals={decimals}
+            symbol={confidentialSymbol}
+            disabled={false}
+            balanceDecryptRequired={!isAllowed}
+            onSuccess={refreshPublicBalances}
+          />
+
+          <VaultPositionCard
+            key={`vault-position-${address}-${token.confidentialTokenAddress}`}
+            vaultAddress={VAULT_ADDRESS}
+            connectedAddress={address}
+            decimals={decimals}
+            symbol={confidentialSymbol}
+            onWithdraw={refreshPublicBalances}
+          />
+        </>
+      )}
 
       {/* ── Delegation — token owner perspective ──────────────────────────────
           These cards are used by the wallet that OWNS the token.

--- a/examples/react-wagmi/src/components/VaultDepositCard.tsx
+++ b/examples/react-wagmi/src/components/VaultDepositCard.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { encodeAbiParameters, isAddress } from "viem";
+import { useConfidentialTransferAndCall } from "@zama-fhe/react-sdk";
+import type { Address } from "@zama-fhe/sdk";
+import { parseAmount } from "@/lib/parseAmount";
+import { SEPOLIA_EXPLORER_URL } from "@/lib/config";
+
+interface VaultDepositCardProps {
+  /** The confidential token bound to the vault (cUSDC). */
+  tokenAddress: Address;
+  /** The ConfidentialVault contract — the receiver of the `…AndCall`. */
+  vaultAddress: Address;
+  /** The connected wallet, used as the default beneficiary. */
+  connectedAddress: Address;
+  decimals: number;
+  symbol: string;
+  disabled: boolean;
+  balanceDecryptRequired: boolean;
+  onSuccess?: () => void;
+}
+
+export function VaultDepositCard({
+  tokenAddress,
+  vaultAddress,
+  connectedAddress,
+  decimals,
+  symbol,
+  disabled,
+  balanceDecryptRequired,
+  onSuccess,
+}: VaultDepositCardProps) {
+  const [amount, setAmount] = useState("");
+  const [beneficiary, setBeneficiary] = useState<string>(connectedAddress);
+  const [step, setStep] = useState<1 | 2>(1);
+
+  const deposit = useConfidentialTransferAndCall({ address: tokenAddress }, { onSuccess });
+
+  const parsedAmount = parseAmount(amount, decimals);
+  const pendingLabel = step === 2 ? "Submitting…" : "Encrypting…";
+
+  function handleDeposit() {
+    setStep(1);
+    // The vault decodes `data` as the beneficiary address to credit. Encoding a real
+    // domain message — not an opaque blob — is the whole point of the AndCall pattern:
+    // value moves and the receiver reacts to it in a single atomic transaction.
+    const data = encodeAbiParameters([{ type: "address" }], [beneficiary as Address]);
+    deposit.mutate({
+      to: vaultAddress,
+      amount: parsedAmount,
+      data,
+      onEncryptComplete: () => setStep(2),
+    });
+  }
+
+  return (
+    <div className="card">
+      <div className="card-title">Deposit into Vault — confidentialTransferAndCall</div>
+      <div className="input-row card-gap">
+        <input
+          className="input"
+          type="text"
+          inputMode="decimal"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="0.00"
+        />
+        <span className="input-unit">{symbol}</span>
+      </div>
+      <label className="token-meta">Beneficiary (credited in the vault)</label>
+      <input
+        className="input card-gap"
+        type="text"
+        value={beneficiary}
+        onChange={(e) => setBeneficiary(e.target.value)}
+        placeholder="0x…"
+      />
+      <button
+        type="button"
+        className="btn btn-primary btn-full"
+        onClick={handleDeposit}
+        disabled={
+          disabled ||
+          balanceDecryptRequired ||
+          parsedAmount === 0n ||
+          !isAddress(beneficiary) ||
+          deposit.isPending
+        }
+      >
+        {deposit.isPending ? pendingLabel : "Deposit"}
+      </button>
+      {balanceDecryptRequired && !disabled && (
+        <p className="token-meta">Decrypt your balance first to enable deposits.</p>
+      )}
+      {deposit.isError && (
+        <div className="alert alert-error card-status">{deposit.error?.message}</div>
+      )}
+      {deposit.isSuccess && deposit.data?.txHash && (
+        <div className="alert alert-success card-status">
+          Deposited!{" "}
+          <a
+            href={`${SEPOLIA_EXPLORER_URL}/tx/${deposit.data.txHash}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {deposit.data.txHash.slice(0, 10)}…
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/react-wagmi/src/components/VaultDepositCard.tsx
+++ b/examples/react-wagmi/src/components/VaultDepositCard.tsx
@@ -65,6 +65,7 @@ export function VaultDepositCard({
           value={amount}
           onChange={(e) => setAmount(e.target.value)}
           placeholder="0.00"
+          data-testid="vault-amount-input"
         />
         <span className="input-unit">{symbol}</span>
       </div>
@@ -75,11 +76,13 @@ export function VaultDepositCard({
         value={beneficiary}
         onChange={(e) => setBeneficiary(e.target.value)}
         placeholder="0x…"
+        data-testid="vault-beneficiary-input"
       />
       <button
         type="button"
         className="btn btn-primary btn-full"
         onClick={handleDeposit}
+        data-testid="vault-deposit-button"
         disabled={
           disabled ||
           balanceDecryptRequired ||

--- a/examples/react-wagmi/src/components/VaultDepositCard.tsx
+++ b/examples/react-wagmi/src/components/VaultDepositCard.tsx
@@ -27,7 +27,8 @@ function depositErrorText(error: (Error & { cause?: unknown }) | null): string {
   if (!error) return "";
   const cause = error.cause as { shortMessage?: string; message?: string } | undefined;
   const causeMsg = cause?.shortMessage ?? cause?.message;
-  return causeMsg ? `${error.message} — ${causeMsg}` : error.message;
+  const base = error.message || "Deposit failed";
+  return causeMsg ? `${base} — ${causeMsg}` : base;
 }
 
 export function VaultDepositCard({

--- a/examples/react-wagmi/src/components/VaultDepositCard.tsx
+++ b/examples/react-wagmi/src/components/VaultDepositCard.tsx
@@ -21,6 +21,15 @@ interface VaultDepositCardProps {
   onSuccess?: () => void;
 }
 
+// The SDK wraps transaction failures as `TransactionRevertedError` with the underlying
+// viem/RPC error in `cause`. Surface that reason so reverts aren't hidden behind a generic message.
+function depositErrorText(error: (Error & { cause?: unknown }) | null): string {
+  if (!error) return "";
+  const cause = error.cause as { shortMessage?: string; message?: string } | undefined;
+  const causeMsg = cause?.shortMessage ?? cause?.message;
+  return causeMsg ? `${error.message} — ${causeMsg}` : error.message;
+}
+
 export function VaultDepositCard({
   tokenAddress,
   vaultAddress,
@@ -97,7 +106,7 @@ export function VaultDepositCard({
         <p className="token-meta">Decrypt your balance first to enable deposits.</p>
       )}
       {deposit.isError && (
-        <div className="alert alert-error card-status">{deposit.error?.message}</div>
+        <div className="alert alert-error card-status">{depositErrorText(deposit.error)}</div>
       )}
       {deposit.isSuccess && deposit.data?.txHash && (
         <div className="alert alert-success card-status">

--- a/examples/react-wagmi/src/components/VaultPositionCard.tsx
+++ b/examples/react-wagmi/src/components/VaultPositionCard.tsx
@@ -92,11 +92,15 @@ export function VaultPositionCard({
       <div className="card-title">Your Vault Position</div>
 
       {!hasPosition ? (
-        <p className="token-meta">No vault position yet — deposit above to credit a beneficiary.</p>
+        <p className="token-meta" data-testid="vault-no-position">
+          No vault position yet — deposit above to credit a beneficiary.
+        </p>
       ) : (
         <>
           <div className="input-row card-gap">
-            <span className="input-unit">{revealed ? formattedShares : "•••••"}</span>
+            <span className="input-unit" data-testid="vault-position-amount">
+              {revealed ? formattedShares : "•••••"}
+            </span>
           </div>
 
           <button
@@ -104,6 +108,7 @@ export function VaultPositionCard({
             className="btn btn-secondary btn-full card-gap"
             onClick={handleReveal}
             disabled={grantPermit.isPending || decrypt.isFetching || revealed}
+            data-testid="vault-reveal-button"
           >
             {grantPermit.isPending
               ? "Signing…"
@@ -119,6 +124,7 @@ export function VaultPositionCard({
             className="btn btn-primary btn-full"
             onClick={() => withdraw.mutate()}
             disabled={withdraw.isPending}
+            data-testid="vault-withdraw-button"
           >
             {withdraw.isPending ? "Withdrawing…" : "Withdraw all"}
           </button>

--- a/examples/react-wagmi/src/components/VaultPositionCard.tsx
+++ b/examples/react-wagmi/src/components/VaultPositionCard.tsx
@@ -132,10 +132,14 @@ export function VaultPositionCard({
         </div>
       )}
       {decrypt.isError && (
-        <div className="alert alert-error card-status">{decrypt.error?.message}</div>
+        <div className="alert alert-error card-status">
+          {decrypt.error?.message ?? "Decryption failed"}
+        </div>
       )}
       {withdraw.isError && (
-        <div className="alert alert-error card-status">{withdraw.error?.message}</div>
+        <div className="alert alert-error card-status">
+          {withdraw.error?.message ?? "Withdrawal failed"}
+        </div>
       )}
       {withdraw.isSuccess && withdraw.data && (
         <div className="alert alert-success card-status">

--- a/examples/react-wagmi/src/components/VaultPositionCard.tsx
+++ b/examples/react-wagmi/src/components/VaultPositionCard.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { formatUnits } from "viem";
+import { useReadContract } from "wagmi";
+import { useMutation } from "@tanstack/react-query";
+import {
+  useDecryptValues,
+  useGrantPermit,
+  useHasPermit,
+  useZamaSDK,
+} from "@zama-fhe/react-sdk";
+import type { Address, EncryptedValue } from "@zama-fhe/sdk";
+import { isEncryptedValueZero } from "@zama-fhe/sdk";
+import { VAULT_ABI } from "@/lib/vaultAbi";
+import { SEPOLIA_EXPLORER_URL } from "@/lib/config";
+
+interface VaultPositionCardProps {
+  vaultAddress: Address;
+  connectedAddress: Address;
+  decimals: number;
+  symbol: string;
+  onWithdraw?: () => void;
+}
+
+export function VaultPositionCard({
+  vaultAddress,
+  connectedAddress,
+  decimals,
+  symbol,
+  onWithdraw,
+}: VaultPositionCardProps) {
+  const sdk = useZamaSDK();
+  const [revealed, setRevealed] = useState(false);
+
+  // The vault holds an euint64 share per beneficiary; reading returns its handle.
+  const { data: shareHandle, refetch: refetchShares } = useReadContract({
+    address: vaultAddress,
+    abi: VAULT_ABI,
+    functionName: "sharesOf",
+    args: [connectedAddress],
+  });
+
+  const handle = shareHandle as EncryptedValue | undefined;
+  const hasPosition = handle !== undefined && !isEncryptedValueZero(handle);
+
+  // Decrypting a vault handle needs a permit scoped to the vault address — distinct from
+  // the confidential-token permits the main page grants. The vault's `FHE.allow(..., beneficiary)`
+  // is what authorizes this wallet to decrypt its own position.
+  const { data: hasVaultPermit } = useHasPermit({ contractAddresses: [vaultAddress] });
+  const grantPermit = useGrantPermit();
+
+  const decrypt = useDecryptValues(
+    hasPosition ? [{ encryptedValue: handle, contractAddress: vaultAddress }] : [],
+    { enabled: revealed && hasPosition },
+  );
+
+  function handleReveal() {
+    if (hasVaultPermit) {
+      setRevealed(true);
+      return;
+    }
+    grantPermit.mutate([vaultAddress], { onSuccess: () => setRevealed(true) });
+  }
+
+  const withdraw = useMutation({
+    mutationFn: async () => {
+      const signer = sdk.signer;
+      if (!signer) throw new Error("Connect a wallet before withdrawing.");
+      const txHash = await signer.writeContract({
+        address: vaultAddress,
+        abi: VAULT_ABI,
+        functionName: "withdraw",
+        args: [],
+      });
+      await sdk.provider.waitForTransactionReceipt(txHash);
+      return txHash;
+    },
+    onSuccess: () => {
+      setRevealed(false);
+      void refetchShares();
+      onWithdraw?.();
+    },
+  });
+
+  const clearShares = handle && decrypt.data ? decrypt.data[handle] : undefined;
+  const formattedShares =
+    clearShares !== undefined ? `${formatUnits(BigInt(clearShares), decimals)} ${symbol}` : "—";
+
+  return (
+    <div className="card">
+      <div className="card-title">Your Vault Position</div>
+
+      {!hasPosition ? (
+        <p className="token-meta">No vault position yet — deposit above to credit a beneficiary.</p>
+      ) : (
+        <>
+          <div className="input-row card-gap">
+            <span className="input-unit">{revealed ? formattedShares : "•••••"}</span>
+          </div>
+
+          <button
+            type="button"
+            className="btn btn-secondary btn-full card-gap"
+            onClick={handleReveal}
+            disabled={grantPermit.isPending || decrypt.isFetching || revealed}
+          >
+            {grantPermit.isPending
+              ? "Signing…"
+              : decrypt.isFetching
+                ? "Decrypting…"
+                : revealed
+                  ? "Revealed"
+                  : "Reveal position"}
+          </button>
+
+          <button
+            type="button"
+            className="btn btn-primary btn-full"
+            onClick={() => withdraw.mutate()}
+            disabled={withdraw.isPending}
+          >
+            {withdraw.isPending ? "Withdrawing…" : "Withdraw all"}
+          </button>
+        </>
+      )}
+
+      {grantPermit.isError && (
+        <div className="alert alert-error card-status">
+          {grantPermit.error?.message ?? "Signing failed"}
+        </div>
+      )}
+      {decrypt.isError && (
+        <div className="alert alert-error card-status">{decrypt.error?.message}</div>
+      )}
+      {withdraw.isError && (
+        <div className="alert alert-error card-status">{withdraw.error?.message}</div>
+      )}
+      {withdraw.isSuccess && withdraw.data && (
+        <div className="alert alert-success card-status">
+          Withdrawn!{" "}
+          <a href={`${SEPOLIA_EXPLORER_URL}/tx/${withdraw.data}`} target="_blank" rel="noreferrer">
+            {withdraw.data.slice(0, 10)}…
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/react-wagmi/src/components/VaultPositionCard.tsx
+++ b/examples/react-wagmi/src/components/VaultPositionCard.tsx
@@ -4,12 +4,7 @@ import { useState } from "react";
 import { formatUnits } from "viem";
 import { useReadContract } from "wagmi";
 import { useMutation } from "@tanstack/react-query";
-import {
-  useDecryptValues,
-  useGrantPermit,
-  useHasPermit,
-  useZamaSDK,
-} from "@zama-fhe/react-sdk";
+import { useDecryptValues, useGrantPermit, useHasPermit, useZamaSDK } from "@zama-fhe/react-sdk";
 import type { Address, EncryptedValue } from "@zama-fhe/sdk";
 import { isEncryptedValueZero } from "@zama-fhe/sdk";
 import { VAULT_ABI } from "@/lib/vaultAbi";

--- a/examples/react-wagmi/src/lib/config.ts
+++ b/examples/react-wagmi/src/lib/config.ts
@@ -16,6 +16,6 @@ export const SEPOLIA_RPC_URL = process.env.NEXT_PUBLIC_SEPOLIA_RPC_URL || SEPOLI
 // (cUSDC) at deployment — the vault cards only render when that token is selected.
 // See contracts/src/ConfidentialVault.sol and contracts/script/DeployVault.s.sol.
 export const VAULT_ADDRESS = (process.env.NEXT_PUBLIC_VAULT_ADDRESS ||
-  "0x1A50c30364A711e14930A4fd9Ebd6709A81Ec423") as `0x${string}`;
+  "0xb13720bec167A576D715F5aA7C7d68b3dB0A4Ad7") as `0x${string}`;
 export const VAULT_CONFIDENTIAL_TOKEN = (process.env.NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN ||
   "0x7c5BF43B851c1dff1a4feE8dB225b87f2C223639") as `0x${string}`;

--- a/examples/react-wagmi/src/lib/config.ts
+++ b/examples/react-wagmi/src/lib/config.ts
@@ -8,3 +8,14 @@ const SEPOLIA_RPC_DEFAULT = "https://ethereum-sepolia-rpc.publicnode.com";
 // at build time, not undefined. The nullish coalescing operator (??) treats "" as a
 // valid value and would use it as the RPC URL, causing a runtime error.
 export const SEPOLIA_RPC_URL = process.env.NEXT_PUBLIC_SEPOLIA_RPC_URL || SEPOLIA_RPC_DEFAULT;
+
+// ─── ConfidentialVault example (confidentialTransferAndCall demo) ───────────────
+// A minimal confidential escrow deployed on Sepolia. A deposit moves confidential
+// tokens into the vault in a single `confidentialTransferAndCall`; the `data`
+// payload names the beneficiary to credit. Bound to one confidential token
+// (cUSDC) at deployment — the vault cards only render when that token is selected.
+// See contracts/src/ConfidentialVault.sol and contracts/script/DeployVault.s.sol.
+export const VAULT_ADDRESS = (process.env.NEXT_PUBLIC_VAULT_ADDRESS ||
+  "0x1A50c30364A711e14930A4fd9Ebd6709A81Ec423") as `0x${string}`;
+export const VAULT_CONFIDENTIAL_TOKEN = (process.env.NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN ||
+  "0x7c5BF43B851c1dff1a4feE8dB225b87f2C223639") as `0x${string}`;

--- a/examples/react-wagmi/src/lib/vaultAbi.ts
+++ b/examples/react-wagmi/src/lib/vaultAbi.ts
@@ -1,0 +1,9 @@
+import { parseAbi } from "viem";
+
+// Minimal ABI for the example ConfidentialVault (contracts/src/ConfidentialVault.sol).
+// euint64 handles are bytes32 on the wire; `sharesOf` returns the caller-decryptable
+// handle for an account's vault balance.
+export const VAULT_ABI = parseAbi([
+  "function sharesOf(address account) view returns (bytes32)",
+  "function withdraw()",
+]);

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18022,13 +18022,13 @@ If your wallet is on the wrong network, the app shows a message and offers a **S
 
 ## Environment variables
 
-| Variable                      | Required | Description                                                                                 |
-| ----------------------------- | -------- | ------------------------------------------------------------------------------------------- |
-| `RELAYER_URL`                 | No       | Relayer base URL incl. API version path. Defaults to `https://relayer.testnet.zama.org/v2`. |
-| `RELAYER_API_KEY`             | No       | API key added as `x-api-key` header by the proxy. Not required for Sepolia testnet.         |
-| `NEXT_PUBLIC_SEPOLIA_RPC_URL` | No       | Sepolia RPC override. Defaults to the public PublicNode endpoint.                           |
-| `NEXT_PUBLIC_VAULT_ADDRESS`   | No       | `ConfidentialVault` demo address (`confidentialTransferAndCall`). Defaults to a Sepolia deployment. |
-| `NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN` | No | Confidential token the vault is bound to (cUSDC). Vault cards render only when it is selected. |
+| Variable                               | Required | Description                                                                                         |
+| -------------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `RELAYER_URL`                          | No       | Relayer base URL incl. API version path. Defaults to `https://relayer.testnet.zama.org/v2`.         |
+| `RELAYER_API_KEY`                      | No       | API key added as `x-api-key` header by the proxy. Not required for Sepolia testnet.                 |
+| `NEXT_PUBLIC_SEPOLIA_RPC_URL`          | No       | Sepolia RPC override. Defaults to the public PublicNode endpoint.                                   |
+| `NEXT_PUBLIC_VAULT_ADDRESS`            | No       | `ConfidentialVault` demo address (`confidentialTransferAndCall`). Defaults to a Sepolia deployment. |
+| `NEXT_PUBLIC_VAULT_CONFIDENTIAL_TOKEN` | No       | Confidential token the vault is bound to (cUSDC). Vault cards render only when it is selected.      |
 
 ## Running e2e tests
 
@@ -18355,10 +18355,14 @@ permit scoped to the **vault** address — distinct from the confidential-token 
 page grants:
 
 ```ts
-const { data: handle } = useReadContract({ address: vaultAddress, abi: VAULT_ABI,
-  functionName: "sharesOf", args: [connectedAddress] });
+const { data: handle } = useReadContract({
+  address: vaultAddress,
+  abi: VAULT_ABI,
+  functionName: "sharesOf",
+  args: [connectedAddress],
+});
 
-await grantPermit.mutateAsync([vaultAddress]);               // permit scoped to the vault
+await grantPermit.mutateAsync([vaultAddress]); // permit scoped to the vault
 const shares = useDecryptValues([{ encryptedValue: handle, contractAddress: vaultAddress }]);
 ```
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prepare": "husky",
     "submodule:update": "git submodule update --remote --merge",
     "contracts:build": "cd contracts && forge build",
+    "contracts:test": "cd contracts && forge test",
     "anvil": "anvil --port 8545 --chain-id 31337 --silent",
     "e2e:test": "pnpm --filter @zama-fhe/playwright e2e:test",
     "e2e:test:ui": "pnpm --filter @zama-fhe/playwright e2e:test:ui",


### PR DESCRIPTION
## What

Demonstrates the ERC-7984 `confidentialTransferAndCall` receiver-callback pattern (SDK-244, child of SDK-242) with a **real reacting contract** — a minimal confidential escrow vault — wired into the `react-wagmi` example. Until now the pattern was only exercised mechanically in the `test/` harness against OpenZeppelin's `ERC7984ReceiverMock` with a raw `data` field; no example app demonstrated the real use case.

## Changes

**Contract** (`contracts/`)
- `src/ConfidentialVault.sol` — minimal confidential escrow implementing `onConfidentialTransferReceived`: decodes the beneficiary from `data`, credits `shares[beneficiary]` via `FHE.add` + ACL, rejects a zero beneficiary by returning an encrypted `false` (atomic refund), guards `msg.sender == confidentialToken`. `withdraw()` returns the full balance and clears the slot to the uninitialized `bytes32(0)` sentinel — so the position reads as empty again and a repeat withdraw reverts (`NothingToWithdraw`). Plus `sharesOf()`.
- `script/DeployVault.s.sol` — deployment (env `CONFIDENTIAL_TOKEN`).

**Example** (`examples/react-wagmi/`)
- `VaultDepositCard` (`useConfidentialTransferAndCall`, `data = abi.encode(beneficiary)`), `VaultPositionCard` (vault-scoped permit + `useDecryptValues` + `withdraw`), gated on the bound confidential token. Config + `.env.example` vars.
- The position auto-refreshes after a deposit, and deposit failures surface the underlying revert reason (the SDK's wrapped `cause`) instead of a generic message.
- Bumps the example to `@zama-fhe/sdk` / `@zama-fhe/react-sdk` `3.3.0-alpha.3` (the `…AndCall` API is not in stable 3.2.0). No migration of existing app code was required.
- Docs: WALKTHROUGH section + README.
- Playwright e2e (`e2e/vault.spec.ts`, 5 tests).

## Verification

- `tsc --noEmit`, `next build`, `forge fmt`/`forge build` — green.
- Playwright suite **27/27** (5 new vault + 22 existing, no regressions).
- **End-to-end on real Sepolia**: deposit via `confidentialTransferAndCall` → decrypted vault position equals the deposited amount → withdraw → cUSDC round-trip conserved → post-withdraw `sharesOf` returns the empty sentinel and a repeat withdraw reverts. Vault deployed at `0xb13720bec167A576D715F5aA7C7d68b3dB0A4Ad7` (bound to cUSDC).

## Scope notes

- Scoped to `confidentialTransferAndCall` only. The `unwrapAndCall` leg of SDK-244 stays deferred (no on-chain `unwrapAndCall` yet; owned by Protocol Apps).
- The alpha pin should move back to stable once `3.3.0` ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
