### PR TITLE
chore: relax example SDK version ranges

### DIFF
--- a/examples/example-bnb/package-lock.json
+++ b/examples/example-bnb/package-lock.json
@@ -7,8 +7,8 @@
       "name": "example-bnb",
       "dependencies": {
         "@tanstack/react-query": "^5.90.0",
-        "@zama-fhe/react-sdk": "3.1.0",
-        "@zama-fhe/sdk": "3.1.0",
+        "@zama-fhe/react-sdk": "^3.2.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "ethers": "^6.17.0",
         "next": "^16.2.6",
         "react": "^19.2.0",
@@ -886,16 +886,16 @@
       }
     },
     "node_modules/@zama-fhe/react-sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.1.0.tgz",
-      "integrity": "sha512-RpFrGS+pG+Z4kiw9PWAiNij8cbntFWqA1Lz5VLBdu0KPEtoU5LByY2pniMI6fXMZikoN3RW0FPbuQSMGWgzLoQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.2.0.tgz",
+      "integrity": "sha512-MlHU2kw8C5EPtWPkzNxu3AvCTrgFu3GM1zdte9rOAZt9x6KGKurIo34rEc7W+KyZq15kC8BIzOnR7ddWFdySeg==",
       "license": "BSD-3-Clause-Clear",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5",
-        "@zama-fhe/sdk": "^3.1.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "react": ">=18",
         "viem": ">=2",
         "wagmi": ">=2"
@@ -930,14 +930,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0.tgz",
-      "integrity": "sha512-OTZxMLHOUhapGVkqnslLF9ENQfJmzU/lvI5nfvAjBzJXvQgTf+IUC2JRXpnifojFV+RFhmW12TYOuE8spUbpFw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-xcpMmx0BfqVbNI5NhWbHDJQhXifjFAw4L+o16xw2kYihcI6oN6RmOPDGjPTGN8/81MmQ7RnvjERyWmkXnXghBw==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@zama-fhe/relayer-sdk": "~0.4.4",
-        "viem": "^2.52.2",
-        "zod": "^4.4.3"
+        "viem": ">=2",
+        "zod": ">=4"
       },
       "engines": {
         "node": ">=22"

--- a/examples/example-bnb/package.json
+++ b/examples/example-bnb/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@zama-fhe/react-sdk": "3.1.0",
-    "@zama-fhe/sdk": "3.1.0",
+    "@zama-fhe/react-sdk": "^3.2.0",
+    "@zama-fhe/sdk": "^3.2.0",
     "ethers": "^6.17.0",
     "next": "^16.2.6",
     "react": "^19.2.0",

--- a/examples/example-hoodi/package-lock.json
+++ b/examples/example-hoodi/package-lock.json
@@ -7,8 +7,8 @@
       "name": "hoodi-example",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
-        "@zama-fhe/react-sdk": "3.1.0",
-        "@zama-fhe/sdk": "3.1.0",
+        "@zama-fhe/react-sdk": "^3.2.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "ethers": "^6.17.0",
         "next": "^16.2.6",
         "react": "^19.2.0",
@@ -825,16 +825,16 @@
       }
     },
     "node_modules/@zama-fhe/react-sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.1.0.tgz",
-      "integrity": "sha512-RpFrGS+pG+Z4kiw9PWAiNij8cbntFWqA1Lz5VLBdu0KPEtoU5LByY2pniMI6fXMZikoN3RW0FPbuQSMGWgzLoQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.2.0.tgz",
+      "integrity": "sha512-MlHU2kw8C5EPtWPkzNxu3AvCTrgFu3GM1zdte9rOAZt9x6KGKurIo34rEc7W+KyZq15kC8BIzOnR7ddWFdySeg==",
       "license": "BSD-3-Clause-Clear",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5",
-        "@zama-fhe/sdk": "^3.1.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "react": ">=18",
         "viem": ">=2",
         "wagmi": ">=2"
@@ -869,14 +869,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0.tgz",
-      "integrity": "sha512-OTZxMLHOUhapGVkqnslLF9ENQfJmzU/lvI5nfvAjBzJXvQgTf+IUC2JRXpnifojFV+RFhmW12TYOuE8spUbpFw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-xcpMmx0BfqVbNI5NhWbHDJQhXifjFAw4L+o16xw2kYihcI6oN6RmOPDGjPTGN8/81MmQ7RnvjERyWmkXnXghBw==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@zama-fhe/relayer-sdk": "~0.4.4",
-        "viem": "^2.52.2",
-        "zod": "^4.4.3"
+        "viem": ">=2",
+        "zod": ">=4"
       },
       "engines": {
         "node": ">=22"

--- a/examples/example-hoodi/package.json
+++ b/examples/example-hoodi/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.0",
-    "@zama-fhe/react-sdk": "3.1.0",
-    "@zama-fhe/sdk": "3.1.0",
+    "@zama-fhe/react-sdk": "^3.2.0",
+    "@zama-fhe/sdk": "^3.2.0",
     "ethers": "^6.17.0",
     "next": "^16.2.6",
     "react": "^19.2.0",

--- a/examples/example-ingen/package-lock.json
+++ b/examples/example-ingen/package-lock.json
@@ -7,8 +7,8 @@
       "name": "example-ingen",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
-        "@zama-fhe/react-sdk": "3.1.0",
-        "@zama-fhe/sdk": "3.1.0",
+        "@zama-fhe/react-sdk": "^3.2.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "ethers": "^6.17.0",
         "next": "^16.2.5",
         "react": "^19.2.0",
@@ -867,16 +867,16 @@
       }
     },
     "node_modules/@zama-fhe/react-sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.1.0.tgz",
-      "integrity": "sha512-RpFrGS+pG+Z4kiw9PWAiNij8cbntFWqA1Lz5VLBdu0KPEtoU5LByY2pniMI6fXMZikoN3RW0FPbuQSMGWgzLoQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.2.0.tgz",
+      "integrity": "sha512-MlHU2kw8C5EPtWPkzNxu3AvCTrgFu3GM1zdte9rOAZt9x6KGKurIo34rEc7W+KyZq15kC8BIzOnR7ddWFdySeg==",
       "license": "BSD-3-Clause-Clear",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5",
-        "@zama-fhe/sdk": "^3.1.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "react": ">=18",
         "viem": ">=2",
         "wagmi": ">=2"
@@ -911,14 +911,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0.tgz",
-      "integrity": "sha512-OTZxMLHOUhapGVkqnslLF9ENQfJmzU/lvI5nfvAjBzJXvQgTf+IUC2JRXpnifojFV+RFhmW12TYOuE8spUbpFw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-xcpMmx0BfqVbNI5NhWbHDJQhXifjFAw4L+o16xw2kYihcI6oN6RmOPDGjPTGN8/81MmQ7RnvjERyWmkXnXghBw==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@zama-fhe/relayer-sdk": "~0.4.4",
-        "viem": "^2.52.2",
-        "zod": "^4.4.3"
+        "viem": ">=2",
+        "zod": ">=4"
       },
       "engines": {
         "node": ">=22"

--- a/examples/example-ingen/package.json
+++ b/examples/example-ingen/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.0",
-    "@zama-fhe/react-sdk": "3.1.0",
-    "@zama-fhe/sdk": "3.1.0",
+    "@zama-fhe/react-sdk": "^3.2.0",
+    "@zama-fhe/sdk": "^3.2.0",
     "ethers": "^6.17.0",
     "next": "^16.2.5",
     "react": "^19.2.0",

--- a/examples/node-ethers/package-lock.json
+++ b/examples/node-ethers/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "node-ethers-example",
       "dependencies": {
-        "@zama-fhe/sdk": "3.1.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "ethers": "^6.17.0"
       },
       "devDependencies": {
@@ -606,14 +606,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0.tgz",
-      "integrity": "sha512-OTZxMLHOUhapGVkqnslLF9ENQfJmzU/lvI5nfvAjBzJXvQgTf+IUC2JRXpnifojFV+RFhmW12TYOuE8spUbpFw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-xcpMmx0BfqVbNI5NhWbHDJQhXifjFAw4L+o16xw2kYihcI6oN6RmOPDGjPTGN8/81MmQ7RnvjERyWmkXnXghBw==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@zama-fhe/relayer-sdk": "~0.4.4",
-        "viem": "^2.52.2",
-        "zod": "^4.4.3"
+        "viem": ">=2",
+        "zod": ">=4"
       },
       "engines": {
         "node": ">=22"

--- a/examples/node-ethers/package.json
+++ b/examples/node-ethers/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@zama-fhe/sdk": "3.1.0",
+    "@zama-fhe/sdk": "^3.2.0",
     "ethers": "^6.17.0"
   },
   "devDependencies": {

--- a/examples/node-viem/package-lock.json
+++ b/examples/node-viem/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "node-viem-example",
       "dependencies": {
-        "@zama-fhe/sdk": "3.1.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "viem": "^2.30.0"
       },
       "devDependencies": {
@@ -606,14 +606,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0.tgz",
-      "integrity": "sha512-OTZxMLHOUhapGVkqnslLF9ENQfJmzU/lvI5nfvAjBzJXvQgTf+IUC2JRXpnifojFV+RFhmW12TYOuE8spUbpFw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-xcpMmx0BfqVbNI5NhWbHDJQhXifjFAw4L+o16xw2kYihcI6oN6RmOPDGjPTGN8/81MmQ7RnvjERyWmkXnXghBw==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@zama-fhe/relayer-sdk": "~0.4.4",
-        "viem": "^2.52.2",
-        "zod": "^4.4.3"
+        "viem": ">=2",
+        "zod": ">=4"
       },
       "engines": {
         "node": ">=22"

--- a/examples/node-viem/package.json
+++ b/examples/node-viem/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@zama-fhe/sdk": "3.1.0",
+    "@zama-fhe/sdk": "^3.2.0",
     "viem": "^2.30.0"
   },
   "devDependencies": {

--- a/examples/react-ethers/package-lock.json
+++ b/examples/react-ethers/package-lock.json
@@ -7,8 +7,8 @@
       "name": "react-ethers-example",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
-        "@zama-fhe/react-sdk": "3.1.0",
-        "@zama-fhe/sdk": "3.1.0",
+        "@zama-fhe/react-sdk": "^3.2.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "ethers": "^6.17.0",
         "next": "^16.2.5",
         "react": "^19.2.0",
@@ -824,16 +824,16 @@
       }
     },
     "node_modules/@zama-fhe/react-sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.1.0.tgz",
-      "integrity": "sha512-RpFrGS+pG+Z4kiw9PWAiNij8cbntFWqA1Lz5VLBdu0KPEtoU5LByY2pniMI6fXMZikoN3RW0FPbuQSMGWgzLoQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.2.0.tgz",
+      "integrity": "sha512-MlHU2kw8C5EPtWPkzNxu3AvCTrgFu3GM1zdte9rOAZt9x6KGKurIo34rEc7W+KyZq15kC8BIzOnR7ddWFdySeg==",
       "license": "BSD-3-Clause-Clear",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5",
-        "@zama-fhe/sdk": "^3.1.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "react": ">=18",
         "viem": ">=2",
         "wagmi": ">=2"
@@ -868,14 +868,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0.tgz",
-      "integrity": "sha512-OTZxMLHOUhapGVkqnslLF9ENQfJmzU/lvI5nfvAjBzJXvQgTf+IUC2JRXpnifojFV+RFhmW12TYOuE8spUbpFw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-xcpMmx0BfqVbNI5NhWbHDJQhXifjFAw4L+o16xw2kYihcI6oN6RmOPDGjPTGN8/81MmQ7RnvjERyWmkXnXghBw==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@zama-fhe/relayer-sdk": "~0.4.4",
-        "viem": "^2.52.2",
-        "zod": "^4.4.3"
+        "viem": ">=2",
+        "zod": ">=4"
       },
       "engines": {
         "node": ">=22"

--- a/examples/react-ethers/package.json
+++ b/examples/react-ethers/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.0",
-    "@zama-fhe/react-sdk": "3.1.0",
-    "@zama-fhe/sdk": "3.1.0",
+    "@zama-fhe/react-sdk": "^3.2.0",
+    "@zama-fhe/sdk": "^3.2.0",
     "ethers": "^6.17.0",
     "next": "^16.2.5",
     "react": "^19.2.0",

--- a/examples/react-viem/package-lock.json
+++ b/examples/react-viem/package-lock.json
@@ -7,8 +7,8 @@
       "name": "react-viem-example",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
-        "@zama-fhe/react-sdk": "3.1.0",
-        "@zama-fhe/sdk": "3.1.0",
+        "@zama-fhe/react-sdk": "^3.2.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "next": "^16.2.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -818,16 +818,16 @@
       }
     },
     "node_modules/@zama-fhe/react-sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.1.0.tgz",
-      "integrity": "sha512-RpFrGS+pG+Z4kiw9PWAiNij8cbntFWqA1Lz5VLBdu0KPEtoU5LByY2pniMI6fXMZikoN3RW0FPbuQSMGWgzLoQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.2.0.tgz",
+      "integrity": "sha512-MlHU2kw8C5EPtWPkzNxu3AvCTrgFu3GM1zdte9rOAZt9x6KGKurIo34rEc7W+KyZq15kC8BIzOnR7ddWFdySeg==",
       "license": "BSD-3-Clause-Clear",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5",
-        "@zama-fhe/sdk": "^3.1.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "react": ">=18",
         "viem": ">=2",
         "wagmi": ">=2"
@@ -862,14 +862,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0.tgz",
-      "integrity": "sha512-OTZxMLHOUhapGVkqnslLF9ENQfJmzU/lvI5nfvAjBzJXvQgTf+IUC2JRXpnifojFV+RFhmW12TYOuE8spUbpFw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-xcpMmx0BfqVbNI5NhWbHDJQhXifjFAw4L+o16xw2kYihcI6oN6RmOPDGjPTGN8/81MmQ7RnvjERyWmkXnXghBw==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@zama-fhe/relayer-sdk": "~0.4.4",
-        "viem": "^2.52.2",
-        "zod": "^4.4.3"
+        "viem": ">=2",
+        "zod": ">=4"
       },
       "engines": {
         "node": ">=22"

--- a/examples/react-viem/package.json
+++ b/examples/react-viem/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.0",
-    "@zama-fhe/react-sdk": "3.1.0",
-    "@zama-fhe/sdk": "3.1.0",
+    "@zama-fhe/react-sdk": "^3.2.0",
+    "@zama-fhe/sdk": "^3.2.0",
     "next": "^16.2.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/examples/react-wagmi/package-lock.json
+++ b/examples/react-wagmi/package-lock.json
@@ -7,8 +7,8 @@
       "name": "react-wagmi-example",
       "dependencies": {
         "@tanstack/react-query": "^5.101.0",
-        "@zama-fhe/react-sdk": "3.1.0",
-        "@zama-fhe/sdk": "3.1.0",
+        "@zama-fhe/react-sdk": "^3.2.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "next": "^16.2.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -861,16 +861,16 @@
       }
     },
     "node_modules/@zama-fhe/react-sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.1.0.tgz",
-      "integrity": "sha512-RpFrGS+pG+Z4kiw9PWAiNij8cbntFWqA1Lz5VLBdu0KPEtoU5LByY2pniMI6fXMZikoN3RW0FPbuQSMGWgzLoQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/react-sdk/-/react-sdk-3.2.0.tgz",
+      "integrity": "sha512-MlHU2kw8C5EPtWPkzNxu3AvCTrgFu3GM1zdte9rOAZt9x6KGKurIo34rEc7W+KyZq15kC8BIzOnR7ddWFdySeg==",
       "license": "BSD-3-Clause-Clear",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5",
-        "@zama-fhe/sdk": "^3.1.0",
+        "@zama-fhe/sdk": "^3.2.0",
         "react": ">=18",
         "viem": ">=2",
         "wagmi": ">=2"
@@ -905,14 +905,14 @@
       }
     },
     "node_modules/@zama-fhe/sdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.1.0.tgz",
-      "integrity": "sha512-OTZxMLHOUhapGVkqnslLF9ENQfJmzU/lvI5nfvAjBzJXvQgTf+IUC2JRXpnifojFV+RFhmW12TYOuE8spUbpFw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-xcpMmx0BfqVbNI5NhWbHDJQhXifjFAw4L+o16xw2kYihcI6oN6RmOPDGjPTGN8/81MmQ7RnvjERyWmkXnXghBw==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@zama-fhe/relayer-sdk": "~0.4.4",
-        "viem": "^2.52.2",
-        "zod": "^4.4.3"
+        "viem": ">=2",
+        "zod": ">=4"
       },
       "engines": {
         "node": ">=22"

--- a/examples/react-wagmi/package.json
+++ b/examples/react-wagmi/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.0",
-    "@zama-fhe/react-sdk": "3.1.0",
-    "@zama-fhe/sdk": "3.1.0",
+    "@zama-fhe/react-sdk": "^3.2.0",
+    "@zama-fhe/sdk": "^3.2.0",
     "next": "^16.2.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
## Summary
- update example app dependencies on @zama-fhe/sdk and @zama-fhe/react-sdk from fixed 3.1.0 to ^3.2.0
- leave react-turnkey-wallet unchanged because it already used ^3.2.0

## Checks
- node -e JSON.parse over examples/*/package.json
- git diff --check