### PR TITLE
revert: pin conventional-changelog-conventionalcommits back to ^9.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@vitest/ui": "^4.1.9",
     "@zama-fhe/relayer-sdk": "~0.4.4",
     "codemod": "1.12.3",
-    "conventional-changelog-conventionalcommits": "^10.0.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "ethers": "^6.17.0",
     "fake-indexeddb": "^6.2.5",
     "happy-dom": "^20.10.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: 1.12.3
         version: 1.12.3
       conventional-changelog-conventionalcommits:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^9.3.1
+        version: 9.3.1
       ethers:
         specifier: ^6.17.0
         version: 6.17.0
@@ -495,10 +495,6 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@conventional-changelog/template@1.0.0':
-    resolution: {integrity: sha512-gJCWgneQIGfxZ22B4nGh7LF3cHbIdhwTHZi9octL7kagH4UHfnsLvp/yPl6tzWvdnIIRUutJtVNEih6Ln2YzFw==}
-    engines: {node: '>=22'}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -1879,9 +1875,9 @@ packages:
     resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
     engines: {node: '>=18'}
 
-  conventional-changelog-conventionalcommits@10.0.0:
-    resolution: {integrity: sha512-MI9NHlb+21eTLJyd6c8mgH2XHGz+ZaQanCFyH1A6AGtqqbTw+w9Ren4Oi5yWFi/pDehlmbnFU1pJzRqQXTOp+w==}
-    engines: {node: '>=22'}
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@8.4.0:
     resolution: {integrity: sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==}
@@ -3815,8 +3811,6 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@conventional-changelog/template@1.0.0': {}
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -4978,9 +4972,9 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-conventionalcommits@10.0.0:
+  conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
-      '@conventional-changelog/template': 1.0.0
+      compare-func: 2.0.0
 
   conventional-changelog-writer@8.4.0:
     dependencies:


### PR DESCRIPTION
## What

Pins `conventional-changelog-conventionalcommits` back to `^9.3.1`, reverting the Dependabot dev-dep bump to `10.0.0` (#505).

## Why

The `prerelease` Release run failed at the **Semantic release** step during config load, blocking the alpha release ([failed run](https://github.com/zama-ai/sdk/actions/runs/28448251949/job/84303913797)):

```
ERR_PACKAGE_PATH_NOT_EXPORTED: No "exports" main defined in
  node_modules/conventional-changelog-conventionalcommits/package.json
  at Object.<anonymous> (.releaserc.cjs:7:26)
```

`.releaserc.cjs` is CommonJS and `require.resolve("conventional-changelog-conventionalcommits")` (line 7) to read the package's `templates.js` and force `-` changelog bullets (avoids oxfmt drift). v10 changed its exports to `{ types, import }` — no `require`/`default` condition — so the CJS resolve throws and semantic-release never starts. No tag/publish happened (clean failure; latest tag is still `v3.2.0-alpha.3`). PR #495 was just the triggering push, unrelated to the break.

## Scope

- `package.json`: `^10.0.0` → `^9.3.1`
- `pnpm-lock.yaml`: reconciled to 9.3.1 (drops the v10 entry + its ESM-only `@conventional-changelog/template` dep); regenerated with the pinned pnpm 11.1.2 — no lockfile-format change.

## Follow-ups (separate)

- Dependabot only ignores *patch* `*` updates, so this *major* bump slipped through — add an `ignore` for major updates of `conventional-changelog-conventionalcommits` until a v10 migration is done.
- v10 migration: its templates moved to the ESM-only `@conventional-changelog/template`, so `.releaserc.cjs`'s template-reading approach needs reworking.

Once merged, the Release workflow runs on the next push to `prerelease` and should cut `v3.2.0-alpha.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
