### PR TITLE
ci: remove CVE-2026-31431 (algif_aead) workaround from CI workflows [SDK-199]

### DIFF
--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -29,16 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/api-report.yml
+++ b/.github/workflows/api-report.yml
@@ -23,16 +23,6 @@ jobs:
   api-report:
     runs-on: ubuntu-latest
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -13,15 +13,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: "Wipe Github Actions cache"
         uses: easimon/wipe-cache@e7ab82e64c328fd39c2e96933d426cd72ac2beba # v2

--- a/.github/workflows/codemod.yml
+++ b/.github/workflows/codemod.yml
@@ -24,16 +24,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/example-hoodi-e2e.yml
+++ b/.github/workflows/example-hoodi-e2e.yml
@@ -23,17 +23,6 @@ jobs:
         working-directory: examples/example-hoodi
 
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        working-directory: /tmp
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,16 +38,6 @@ jobs:
       # needs muting while it's reconciled.
       ENABLE_RELAYER_AUTH_TESTS: ${{ vars.ENABLE_RELAYER_AUTH_TESTS }}
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/license-compat.yml
+++ b/.github/workflows/license-compat.yml
@@ -23,16 +23,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,16 +22,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,16 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -157,16 +147,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -275,16 +255,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,16 +16,6 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Validate Conventional Commit PR title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -24,16 +24,6 @@ jobs:
   validate-branch:
     runs-on: ubuntu-latest
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Validate target branch
         run: |
           if [[ "${GITHUB_REF_NAME}" != "main" && "${GITHUB_REF_NAME}" != "prerelease" ]]; then
@@ -45,16 +35,6 @@ jobs:
     needs: [validate-branch]
     runs-on: ubuntu-latest
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,16 +45,6 @@ jobs:
     if: inputs.publish-tag != ''
     runs-on: ubuntu-latest
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout tag
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -157,16 +147,6 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.publish-tag == ''
     runs-on: ubuntu-latest
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Validate target branch
         run: |
           if [[ "${GITHUB_REF_NAME}" != "main" && "${GITHUB_REF_NAME}" != "prerelease" ]]; then
@@ -204,16 +184,6 @@ jobs:
     if: ${{ !cancelled() && !failure() && inputs.publish-tag == '' }}
     runs-on: ubuntu-latest
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -23,16 +23,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      # TODO: remove once GitHub runner images ship the CVE-2026-31431 kernel fix
-      - name: Workaround CVE-2026-31431 (copy.fail)
-        run: |
-          echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif-aead.conf
-          if lsmod | grep -q algif_aead; then
-            sudo rmmod algif_aead || echo "WARNING: rmmod failed - module may be in use"
-          elif modinfo algif_aead 2>/dev/null | grep -q builtin; then
-            echo "WARNING: algif_aead built-in - modprobe.d blacklist has no effect"
-          fi
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
Part of [SDK-199](https://linear.app/zama/issue/SDK-199) — the `main` half of a twin cleanup.

## What

Removes the `Workaround CVE-2026-31431 (copy.fail)` step — which disabled the `algif_aead` kernel module at the start of every CI job — from **all 13 workflows** carrying it on `main` (18 occurrences, **181 deletions, 0 additions**, no behavioural change).

> `contracts-test.yml` is prerelease-only, so the prerelease twin PR touches one extra file (14 files / 19 occurrences).

## Why it's safe now (AC #1 verified)

- **[actions/runner-images#13987](https://github.com/actions/runner-images/issues/13987)** (closed 2026-05-15): the runner-images team confirmed `algif_aead` is **already disabled at the image level** — _"mitigation was effectively in place even before info about vulnerability was publicly announced."_
- Current `ubuntu-latest` ships kernel **6.17.0-1018-azure** (image `ubuntu24/20260628.225`), well past the vulnerable 6.8 / 5.15 kernels; upstream fix landed in mainline on 2026-04-01.
- **All affected jobs run on `ubuntu-latest`** (GitHub-hosted) — no self-hosted or custom images — so the step never had anything to remove.

## Verification

- `grep -ri algif .github/workflows/` → zero residue
- `git diff --numstat` → `+0 / -181` across 13 files
- All workflow files still parse as valid YAML; no orphan `steps:`

## Twin PR

Type `ci` (does not trigger a release). Merged close together with the prerelease twin so a later `main → prerelease` forward-merge cannot reintroduce the step.