### PR TITLE
refactor(sdk): single source of truth for WrappersRegistry config [SDK-127]

### DIFF
--- a/docs/gitbook/src/reference/sdk/WrappersRegistry.md
+++ b/docs/gitbook/src/reference/sdk/WrappersRegistry.md
@@ -10,7 +10,7 @@ High-level read interface for the on-chain `ConfidentialTokenWrappersRegistry` c
 ## Import
 
 ```ts
-import { WrappersRegistry, DefaultRegistryAddresses } from "@zama-fhe/sdk";
+import { WrappersRegistry } from "@zama-fhe/sdk";
 ```
 
 ## Usage
@@ -250,12 +250,16 @@ if (await registry.isConfidentialTokenValid("0xcUSDC")) {
 
 `Record<number, Address>`
 
+{% hint style="warning" %}
+**Deprecated.** Read `registryAddress` from the chain presets instead (e.g. `sepolia.registryAddress` from `@zama-fhe/sdk/chains`). This export will be removed in the next major version.
+{% endhint %}
+
 Exported map of built-in registry addresses for known chains. Includes Mainnet (`1`), Sepolia (`11155111`), and Hoodi (`560048`). Addresses are EIP-55 checksummed.
 
 ```ts
-import { DefaultRegistryAddresses } from "@zama-fhe/sdk";
+import { sepolia } from "@zama-fhe/sdk/chains";
 
-console.log(DefaultRegistryAddresses[1]); // "0xeb5015fF021DB115aCe010f23F55C2591059bBA0"
+console.log(sepolia.registryAddress); // "0x2f0750Bb..."
 ```
 
 ## Related

--- a/docs/gitbook/src/reference/sdk/network-presets.md
+++ b/docs/gitbook/src/reference/sdk/network-presets.md
@@ -140,13 +140,19 @@ import { sepolia, mainnet } from "@zama-fhe/sdk/chains";
 
 ## DefaultRegistryAddresses
 
+{% hint style="warning" %}
+**Deprecated.** Read `registryAddress` from the chain presets instead (e.g. `sepolia.registryAddress`). This export will be removed in the next major version.
+{% endhint %}
+
 A convenience export of built-in registry addresses for known chains (Mainnet, Sepolia, Hoodi) as a `Record<number, Address>` map. Used internally by the [WrappersRegistry](./WrappersRegistry.md) class.
 
 ```ts
+// Deprecated
 import { DefaultRegistryAddresses } from "@zama-fhe/sdk";
 
-// { 1: "0xeb5015fF...", 11155111: "0x2f0750Bb...", 560048: "0x1807aE2f..." }
-console.log(DefaultRegistryAddresses);
+// Preferred
+import { sepolia } from "@zama-fhe/sdk/chains";
+console.log(sepolia.registryAddress);
 ```
 
 {% hint style="info" %}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6088,7 +6088,7 @@ High-level read interface for the on-chain `ConfidentialTokenWrappersRegistry` c
 ## Import
 
 ```ts
-import { WrappersRegistry, DefaultRegistryAddresses } from "@zama-fhe/sdk";
+import { WrappersRegistry } from "@zama-fhe/sdk";
 ```
 
 ## Usage
@@ -6328,12 +6328,17 @@ if (await registry.isConfidentialTokenValid("0xcUSDC")) {
 
 `Record<number, Address>`
 
+
+> [!WARNING]
+> **Deprecated.** Read `registryAddress` from the chain presets instead (e.g. `sepolia.registryAddress` from `@zama-fhe/sdk/chains`). This export will be removed in the next major version.
+
+
 Exported map of built-in registry addresses for known chains. Includes Mainnet (`1`), Sepolia (`11155111`), and Hoodi (`560048`). Addresses are EIP-55 checksummed.
 
 ```ts
-import { DefaultRegistryAddresses } from "@zama-fhe/sdk";
+import { sepolia } from "@zama-fhe/sdk/chains";
 
-console.log(DefaultRegistryAddresses[1]); // "0xeb5015fF021DB115aCe010f23F55C2591059bBA0"
+console.log(sepolia.registryAddress); // "0x2f0750Bb..."
 ```
 
 ## Related
@@ -9082,13 +9087,20 @@ import { sepolia, mainnet } from "@zama-fhe/sdk/chains";
 
 ## DefaultRegistryAddresses
 
+
+> [!WARNING]
+> **Deprecated.** Read `registryAddress` from the chain presets instead (e.g. `sepolia.registryAddress`). This export will be removed in the next major version.
+
+
 A convenience export of built-in registry addresses for known chains (Mainnet, Sepolia, Hoodi) as a `Record<number, Address>` map. Used internally by the [WrappersRegistry](https://raw.githubusercontent.com/zama-ai/sdk/prerelease/docs/gitbook/src/reference/sdk/WrappersRegistry.md) class.
 
 ```ts
+// Deprecated
 import { DefaultRegistryAddresses } from "@zama-fhe/sdk";
 
-// { 1: "0xeb5015fF...", 11155111: "0x2f0750Bb...", 560048: "0x1807aE2f..." }
-console.log(DefaultRegistryAddresses);
+// Preferred
+import { sepolia } from "@zama-fhe/sdk/chains";
+console.log(sepolia.registryAddress);
 ```
 
 

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -5471,7 +5471,7 @@ export interface DecryptValuesParams {
     startTimestamp: number;
 }
 
-// @public
+// @public @deprecated
 export const DefaultRegistryAddresses: Record<number, Address>;
 
 // @public

--- a/packages/sdk/src/__tests__/wrappers-registry.test.ts
+++ b/packages/sdk/src/__tests__/wrappers-registry.test.ts
@@ -548,6 +548,34 @@ describe("WrappersRegistry", () => {
       await expect(registry.getRegistryAddress()).resolves.toBe(CUSTOM_REGISTRY);
     });
 
+    test("inherits chain-derived registry addresses from the SDK", async ({
+      createSDK,
+      createMockChain,
+      provider,
+    }) => {
+      vi.mocked(provider.getChainId).mockResolvedValue(31337);
+      const sdk = createSDK({
+        chains: [createMockChain({ id: 31337, registryAddress: CUSTOM_REGISTRY })],
+      });
+      const registry = sdk.createWrappersRegistry();
+
+      await expect(registry.getRegistryAddress()).resolves.toBe(CUSTOM_REGISTRY);
+    });
+
+    test("overrides take precedence over chain-derived addresses", async ({
+      createSDK,
+      createMockChain,
+      provider,
+    }) => {
+      vi.mocked(provider.getChainId).mockResolvedValue(31337);
+      const sdk = createSDK({
+        chains: [createMockChain({ id: 31337, registryAddress: CUSTOM_REGISTRY })],
+      });
+      const registry = sdk.createWrappersRegistry({ [31337]: sepolia.registryAddress! });
+
+      await expect(registry.getRegistryAddress()).resolves.toBe(sepolia.registryAddress!);
+    });
+
     test("rejects invalid registryTTL from the SDK constructor", ({ createSDK }) => {
       expect(() => createSDK({ registryTTL: -1 })).toThrow();
     });

--- a/packages/sdk/src/query/__tests__/wrappers-registry.test.ts
+++ b/packages/sdk/src/query/__tests__/wrappers-registry.test.ts
@@ -258,3 +258,22 @@ describe("listPairsQueryOptions", () => {
     expect(options.queryKey[1]).toMatchObject({ registryAddress: zeroAddress });
   });
 });
+
+describe("registry TTL", () => {
+  test("staleTime equals sdk.registry.ttlMs for every sdk-based factory", ({ createSDK }) => {
+    const sdk = createSDK({ registryTTL: 3600 });
+    const config = { registryAddress: REGISTRY };
+    const allOptions = [
+      tokenPairsQueryOptions(sdk, config),
+      tokenPairsLengthQueryOptions(sdk, config),
+      tokenPairsSliceQueryOptions(sdk, { ...config, fromIndex: 0n, toIndex: 1n }),
+      tokenPairQueryOptions(sdk, { ...config, index: 0n }),
+      confidentialTokenAddressQueryOptions(sdk, { ...config, tokenAddress: TOKEN }),
+      tokenAddressQueryOptions(sdk, { ...config, confidentialTokenAddress: C_TOKEN }),
+      isConfidentialTokenValidQueryOptions(sdk, { ...config, confidentialTokenAddress: C_TOKEN }),
+    ];
+    for (const options of allOptions) {
+      expect(options.staleTime).toBe(3_600_000);
+    }
+  });
+});

--- a/packages/sdk/src/query/wrappers-registry.ts
+++ b/packages/sdk/src/query/wrappers-registry.ts
@@ -19,9 +19,6 @@ import type { QueryFactoryOptions } from "./factory-types";
 import { zamaQueryKeys } from "./query-keys";
 import { filterQueryOptions } from "./utils";
 
-/** Default registry TTL in milliseconds — matches {@link WrappersRegistry} default of 86400 s. */
-const DEFAULT_STALE_TIME_MS = 86400 * 1000;
-
 export interface WrappersRegistryQueryConfig {
   registryAddress: Address | undefined;
   query?: Record<string, unknown>;
@@ -45,7 +42,7 @@ export function tokenPairsQueryOptions(
       const [, { registryAddress }] = context.queryKey;
       return sdk.provider.readContract(getTokenPairsContract(registryAddress));
     },
-    staleTime: DEFAULT_STALE_TIME_MS,
+    staleTime: sdk.registry.ttlMs,
     enabled,
   };
 }
@@ -80,7 +77,7 @@ export function confidentialTokenAddressQueryOptions(
         getConfidentialTokenAddressContract(registryAddress, tokenAddress),
       );
     },
-    staleTime: DEFAULT_STALE_TIME_MS,
+    staleTime: sdk.registry.ttlMs,
     enabled,
   };
 }
@@ -115,7 +112,7 @@ export function tokenAddressQueryOptions(
         getTokenAddressContract(registryAddress, confidentialTokenAddress),
       );
     },
-    staleTime: DEFAULT_STALE_TIME_MS,
+    staleTime: sdk.registry.ttlMs,
     enabled,
   };
 }
@@ -140,7 +137,7 @@ export function tokenPairsLengthQueryOptions(
       const [, { registryAddress }] = context.queryKey;
       return sdk.provider.readContract(getTokenPairsLengthContract(registryAddress));
     },
-    staleTime: DEFAULT_STALE_TIME_MS,
+    staleTime: sdk.registry.ttlMs,
     enabled,
   };
 }
@@ -178,7 +175,7 @@ export function tokenPairsSliceQueryOptions(
         getTokenPairsSliceContract(registryAddress, BigInt(fromIndex), BigInt(toIndex)),
       );
     },
-    staleTime: DEFAULT_STALE_TIME_MS,
+    staleTime: sdk.registry.ttlMs,
     enabled,
   };
 }
@@ -211,7 +208,7 @@ export function tokenPairQueryOptions(
       const [, { registryAddress, index }] = context.queryKey;
       return sdk.provider.readContract(getTokenPairContract(registryAddress, BigInt(index)));
     },
-    staleTime: DEFAULT_STALE_TIME_MS,
+    staleTime: sdk.registry.ttlMs,
     enabled,
   };
 }
@@ -246,7 +243,7 @@ export function isConfidentialTokenValidQueryOptions(
         isConfidentialTokenValidContract(registryAddress, confidentialTokenAddress),
       );
     },
-    staleTime: DEFAULT_STALE_TIME_MS,
+    staleTime: sdk.registry.ttlMs,
     enabled,
   };
 }

--- a/packages/sdk/src/wrappers-registry.ts
+++ b/packages/sdk/src/wrappers-registry.ts
@@ -23,6 +23,9 @@ import { parseConfiguration } from "./validation";
 /**
  * Default wrappers registry addresses for known chains.
  * Only includes chains where a registry is deployed (excludes Hardhat).
+ *
+ * @deprecated Read `registryAddress` from the chain presets instead (e.g.
+ * `sepolia.registryAddress`). Will be removed in the next major version.
  */
 export const DefaultRegistryAddresses: Record<number, Address> = {
   [mainnet.id]: mainnet.registryAddress,

--- a/packages/sdk/src/zama-sdk.ts
+++ b/packages/sdk/src/zama-sdk.ts
@@ -49,6 +49,7 @@ export class ZamaSDK {
   /** FHE decryption (user, delegated user, public). */
   readonly decryption: Decryption;
   readonly #registryTTL: number;
+  readonly #registryAddresses: Record<number, Address>;
   readonly #onEvent: ZamaSDKEventListener;
   readonly #logger: GenericLogger;
   readonly #cachingService: CachingService;
@@ -84,6 +85,7 @@ export class ZamaSDK {
       registryAddresses,
       registryTTL: config.registryTTL,
     });
+    this.#registryAddresses = registryAddresses;
     this.#registryTTL = config.registryTTL;
 
     if (config.signer) {
@@ -182,14 +184,15 @@ export class ZamaSDK {
 
   /**
    * Create a {@link WrappersRegistry} instance bound to this SDK's provider.
-   * On Mainnet and Sepolia the registry address is resolved automatically.
+   * Inherits the registry addresses derived from the SDK's chain configs, so
+   * the result is consistent with {@link ZamaSDK.registry}.
    *
    * @param registryAddresses - Optional per-chain overrides for this registry instance.
    * @returns A {@link WrappersRegistry} instance.
    *
    * @example
    * ```ts
-   * // Mainnet / Sepolia — resolved automatically
+   * // Addresses resolved from the SDK's chain configs
    * const registry = sdk.createWrappersRegistry();
    *
    * // Hardhat or custom chain — override per chain for this registry instance
@@ -201,7 +204,7 @@ export class ZamaSDK {
   createWrappersRegistry(registryAddresses?: Record<number, Address>): WrappersRegistry {
     return new WrappersRegistry({
       provider: this.provider,
-      registryAddresses,
+      registryAddresses: { ...this.#registryAddresses, ...registryAddresses },
       registryTTL: this.#registryTTL,
     });
   }


### PR DESCRIPTION
## Summary

Closes [SDK-127](https://linear.app/zama/issue/SDK-127) (see "Deliberate deviation" below).

`WrappersRegistry` received its configuration through too many inconsistent paths. This PR unifies them **without any breaking change**:

- **`registryTTL` is now honored by all 8 query factories.** The 7 factories that hardcoded `DEFAULT_STALE_TIME_MS = 86400 * 1000` now read `staleTime` from `sdk.registry.ttlMs` (matching `listPairsQueryOptions`, which already read `registry.ttlMs`). The default TTL equals the old hardcoded value, so behavior is unchanged unless `registryTTL` is configured — which is exactly the bug being fixed. The hardcoded constant (internal, never exported) is removed.
- **`createWrappersRegistry()` now produces a registry consistent with `sdk.registry`.** It previously dropped the chain-derived registry addresses (`FheChain.registryAddress` from `config.chains`), so a custom chain known to `sdk.registry` was silently unknown to a created instance. It now inherits them, with explicit per-call overrides still taking precedence. The `ZamaSDK.md` reference already documented this as the intended behavior — the code was the bug.
- **`DefaultRegistryAddresses` is deprecated** (`@deprecated` JSDoc + docs hints) in favor of reading `registryAddress` from the chain presets (`sepolia.registryAddress`, …). Removal is deferred to the next major since it is a public export; the constructor's default merge is untouched.

## Deliberate deviation from the ticket

The ticket's "route all 8 query factories through `WrappersRegistry` methods" item is **intentionally not done**:

1. **The premise doesn't hold.** The class-level TTL cache only backs `listPairs` / `getConfidentialToken` / `getUnderlyingToken` — already routed. The 7 low-level registry methods are uncached pass-throughs to `readContract`, so routing the remaining factories through them would unify nothing.
2. **It would introduce a cache-poisoning race.** Registry methods resolve the address at call time via `provider.getChainId()` (global mutable state with wagmi). A mid-flight chain switch would store the new chain's data under the old chain's query key for up to 24h. The current query-key-pinned `readContract` pattern (SDK-92) fails loudly instead.

Two real issues discovered during this analysis are worth their own tickets (Linear write access unavailable from this session — see PR checklist):

- **(a) Next major:** remove `DefaultRegistryAddresses` + settle `createWrappersRegistry()` fate.
- **(b) Registry lookup freshness inconsistency:** the class cache holds negative lookups ("no wrapper") for 5 min (`NEGATIVE_CACHE_TTL_MS`) while TanStack factories cache `[false, 0x0]` for 24h — so `useConfidentialTokenAddress` can report "no wrapper" for a day after registration while imperative discovery sees it after 5 min. Plus the pre-existing `listPairs` address-resolution race above.

## Test plan

- [x] New: `staleTime` assertion across all 7 sdk-based factories with a non-default `registryTTL`
- [x] New: `createWrappersRegistry()` inherits chain-derived addresses; overrides take precedence
- [x] Full `sdk` (1218) and `react-sdk` (331) suites green; typecheck, lint, format green
- [x] API reports regenerated — only diff is the `@deprecated` tag on `DefaultRegistryAddresses`; no signature changes
- [x] `llms-full.txt` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
