### PR TITLE
docs(gitbook): document skills update cycle and npx update gotchas [SDK-87]

### DIFF
--- a/docs/gitbook/src/tutorials/build-with-an-llm.md
+++ b/docs/gitbook/src/tutorials/build-with-an-llm.md
@@ -25,6 +25,8 @@ Install once and your agent has all three; ask an SDK question and `zama-typescr
 /plugin install zama-protocol@zama-skills
 ```
 
+Update later with `/plugin marketplace update zama-skills`.
+
 {% endtab %}
 {% tab title="Other agents (npx)" %}
 
@@ -32,7 +34,7 @@ Install once and your agent has all three; ask an SDK question and `zama-typescr
 npx skills add zama-ai/skills
 ```
 
-Works with most skill-aware agents. Add `--list` to choose which skills to install.
+Works with most skill-aware agents. Add `--list` to choose which skills to install. Update later with `npx skills update` — there is no version to pin; any change merged to `zama-ai/skills` is picked up automatically.
 
 {% endtab %}
 {% endtabs %}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1291,13 +1291,15 @@ Install once and your agent has all three; ask an SDK question and `zama-typescr
 /plugin install zama-protocol@zama-skills
 ```
 
+Update later with `/plugin marketplace update zama-skills`.
+
 ### Tab: Other agents (npx)
 
 ```text
 npx skills add zama-ai/skills
 ```
 
-Works with most skill-aware agents. Add `--list` to choose which skills to install.
+Works with most skill-aware agents. Add `--list` to choose which skills to install. Update later with `npx skills update` — there is no version to pin; any change merged to `zama-ai/skills` is picked up automatically.
 
 
 For Codex, Cursor, or manual setup, see the [skills README](https://github.com/zama-ai/skills).


### PR DESCRIPTION
## Why

[SDK-87](https://linear.app/zama/issue/SDK-87/track-npx-skills-ecosystem-gotchas-and-test-update-cycle-before) asks to test the `npx skills` update cycle for `zama-ai/skills` and make sure the docs answer the one user-facing question that matters: do installed skills receive our updates, and how? The cycle was tested empirically on 2026-07-03 (CLI `skills@1.5.14`, isolated `$HOME`, throwaway fork to trigger a detectable change); full evidence is on the Linear ticket.

## What

One update line per install tab on the *Build with an LLM* page:

- Claude Code: `/plugin marketplace update zama-skills`
- npx: `npx skills update` — no version to pin, changes merged to `zama-ai/skills` are picked up automatically

Everything else stays out on purpose: install-scope guidance and per-agent details live in the [skills README](https://github.com/zama-ai/skills) (already linked), and upstream CLI bugs (Windows lock file, silent stale-token failure found during testing) are tracked with dates on the Linear ticket so this page doesn't rot as vercel-labs/skills evolves.

`llms-full.txt` regenerated via `pnpm llm:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)