### PR TITLE
ci(abi): install fhevm submodule soldeer deps before abi:check

### DIFF
--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -50,17 +50,26 @@ jobs:
             contracts/dependencies
             contracts/lib/forge-fhevm/out
             contracts/lib/forge-fhevm/dependencies
-          key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml', 'contracts/soldeer.lock', 'contracts/lib/forge-fhevm/src/**/*.sol', 'contracts/lib/forge-fhevm/foundry.toml', 'contracts/lib/forge-fhevm/soldeer.lock') }}
+            contracts/lib/fhevm/sdk/js-sdk/contracts/out
+            contracts/lib/fhevm/sdk/js-sdk/contracts/dependencies
+          key: forge-build-${{ runner.os }}-${{ hashFiles('contracts/src/**/*.sol', 'contracts/foundry.toml', 'contracts/soldeer.lock', 'contracts/lib/forge-fhevm/src/**/*.sol', 'contracts/lib/forge-fhevm/foundry.toml', 'contracts/lib/forge-fhevm/soldeer.lock', 'contracts/lib/fhevm/sdk/js-sdk/contracts/foundry.toml', 'contracts/lib/fhevm/sdk/js-sdk/contracts/soldeer.lock') }}
 
       - name: Install Soldeer dependencies
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: |
           cd contracts/lib/forge-fhevm && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
+          cd "$GITHUB_WORKSPACE/contracts/lib/fhevm/sdk/js-sdk/contracts" && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
           cd "$GITHUB_WORKSPACE/contracts" && GIT_LFS_SKIP_SMUDGE=1 forge soldeer install
 
       - name: Build forge-fhevm contracts
         if: steps.forge-build-cache.outputs.cache-hit != 'true'
         run: cd contracts/lib/forge-fhevm && forge build
+
+      # Mirrors the `fhevm:build` package.json script. turbo's contracts:build
+      # runs this same step, so its soldeer deps must be installed (above) and cached.
+      - name: Build fhevm host contracts
+        if: steps.forge-build-cache.outputs.cache-hit != 'true'
+        run: cd contracts/lib/fhevm/sdk/js-sdk/contracts && FOUNDRY_PROFILE=v13 forge build scripts/v0.13.0/DeployCleartextFHEVMHost.s.sol
 
       - name: Build contracts
         if: steps.forge-build-cache.outputs.cache-hit != 'true'

--- a/examples/node-ethers/package-lock.json
+++ b/examples/node-ethers/package-lock.json
@@ -10,7 +10,7 @@
         "ethers": "^6.17.0"
       },
       "devDependencies": {
-        "tsx": "^4.22.4",
+        "tsx": "^4.23.0",
         "typescript": "^6.0.3"
       }
     },
@@ -952,9 +952,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
-      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/node-ethers/package.json
+++ b/examples/node-ethers/package.json
@@ -11,7 +11,7 @@
     "ethers": "^6.17.0"
   },
   "devDependencies": {
-    "tsx": "^4.22.4",
+    "tsx": "^4.23.0",
     "typescript": "^6.0.3"
   }
 }

--- a/examples/node-viem/package-lock.json
+++ b/examples/node-viem/package-lock.json
@@ -7,10 +7,10 @@
       "name": "node-viem-example",
       "dependencies": {
         "@zama-fhe/sdk": "^3.2.0",
-        "viem": "^2.30.0"
+        "viem": "^2.54.3"
       },
       "devDependencies": {
-        "tsx": "^4.22.4",
+        "tsx": "^4.23.0",
         "typescript": "^6.0.3"
       }
     },
@@ -741,27 +741,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/ethers/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -855,9 +834,9 @@
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/ox": {
-      "version": "0.14.29",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
-      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "version": "0.14.30",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.30.tgz",
+      "integrity": "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==",
       "funding": [
         {
           "type": "github",
@@ -973,9 +952,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
-      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1018,9 +997,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.53.1",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.53.1.tgz",
-      "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
+      "version": "2.54.3",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.54.3.tgz",
+      "integrity": "sha512-hHXV/MLeGx+A/kHwEejf4TBSmpq2rtpxR3qMH21+BL62CQBLfCoMxQ0RV3V3QLQ1mKC/sAFEci1u83JEq1TQ6g==",
       "funding": [
         {
           "type": "github",
@@ -1035,8 +1014,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.29",
-        "ws": "8.20.1"
+        "ox": "0.14.30",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -1081,9 +1060,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/examples/node-viem/package.json
+++ b/examples/node-viem/package.json
@@ -8,10 +8,10 @@
   },
   "dependencies": {
     "@zama-fhe/sdk": "^3.2.0",
-    "viem": "^2.30.0"
+    "viem": "^2.54.3"
   },
   "devDependencies": {
-    "tsx": "^4.22.4",
+    "tsx": "^4.23.0",
     "typescript": "^6.0.3"
   }
 }

--- a/examples/react-turnkey-wallet/package-lock.json
+++ b/examples/react-turnkey-wallet/package-lock.json
@@ -16,7 +16,7 @@
         "next": "^16.2.9",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "viem": "^2.53.1"
+        "viem": "^2.54.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.1",
@@ -8811,9 +8811,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.53.1",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.53.1.tgz",
-      "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
+      "version": "2.54.3",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.54.3.tgz",
+      "integrity": "sha512-hHXV/MLeGx+A/kHwEejf4TBSmpq2rtpxR3qMH21+BL62CQBLfCoMxQ0RV3V3QLQ1mKC/sAFEci1u83JEq1TQ6g==",
       "funding": [
         {
           "type": "github",
@@ -8828,8 +8828,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.29",
-        "ws": "8.20.1"
+        "ox": "0.14.30",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -8877,9 +8877,9 @@
       }
     },
     "node_modules/viem/node_modules/ox": {
-      "version": "0.14.29",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
-      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "version": "0.14.30",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.30.tgz",
+      "integrity": "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==",
       "funding": [
         {
           "type": "github",
@@ -8907,9 +8907,9 @@
       }
     },
     "node_modules/viem/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/examples/react-turnkey-wallet/package.json
+++ b/examples/react-turnkey-wallet/package.json
@@ -18,7 +18,7 @@
     "next": "^16.2.9",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "viem": "^2.53.1"
+    "viem": "^2.54.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.1",

--- a/examples/react-viem/package-lock.json
+++ b/examples/react-viem/package-lock.json
@@ -12,7 +12,7 @@
         "next": "^16.2.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "viem": "^2.30.0"
+        "viem": "^2.54.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -1016,27 +1016,6 @@
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "license": "0BSD"
     },
-    "node_modules/ethers/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -1200,9 +1179,9 @@
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/ox": {
-      "version": "0.14.29",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
-      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "version": "0.14.30",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.30.tgz",
+      "integrity": "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==",
       "funding": [
         {
           "type": "github",
@@ -1527,9 +1506,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.53.1",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.53.1.tgz",
-      "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
+      "version": "2.54.3",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.54.3.tgz",
+      "integrity": "sha512-hHXV/MLeGx+A/kHwEejf4TBSmpq2rtpxR3qMH21+BL62CQBLfCoMxQ0RV3V3QLQ1mKC/sAFEci1u83JEq1TQ6g==",
       "funding": [
         {
           "type": "github",
@@ -1544,8 +1523,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.29",
-        "ws": "8.20.1"
+        "ox": "0.14.30",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -1590,9 +1569,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/examples/react-viem/package.json
+++ b/examples/react-viem/package.json
@@ -15,7 +15,7 @@
     "next": "^16.2.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "viem": "^2.30.0"
+    "viem": "^2.54.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",

--- a/examples/react-wagmi/package-lock.json
+++ b/examples/react-wagmi/package-lock.json
@@ -12,7 +12,7 @@
         "next": "^16.2.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "viem": "^2.47.0",
+        "viem": "^2.54.3",
         "wagmi": "^3.5.0"
       },
       "devDependencies": {
@@ -1083,27 +1083,6 @@
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "license": "0BSD"
     },
-    "node_modules/ethers/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -1287,9 +1266,9 @@
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/ox": {
-      "version": "0.14.29",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
-      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "version": "0.14.30",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.30.tgz",
+      "integrity": "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==",
       "funding": [
         {
           "type": "github",
@@ -1596,9 +1575,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.53.1",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.53.1.tgz",
-      "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
+      "version": "2.54.3",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.54.3.tgz",
+      "integrity": "sha512-hHXV/MLeGx+A/kHwEejf4TBSmpq2rtpxR3qMH21+BL62CQBLfCoMxQ0RV3V3QLQ1mKC/sAFEci1u83JEq1TQ6g==",
       "funding": [
         {
           "type": "github",
@@ -1613,8 +1592,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.29",
-        "ws": "8.20.1"
+        "ox": "0.14.30",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -1657,9 +1636,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/examples/react-wagmi/package.json
+++ b/examples/react-wagmi/package.json
@@ -15,7 +15,7 @@
     "next": "^16.2.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "viem": "^2.47.0",
+    "viem": "^2.54.3",
     "wagmi": "^3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

The `abi-check` job ([failing run](https://github.com/zama-ai/sdk/actions/runs/28871391959/job/85634873980?pr=458)) fails at `turbo run abi:check` with a cascade of `ParserError: Source "dependencies/forge-std-1.11.0/src/Script.sol" not found` (and OpenZeppelin, Vm.sol, etc.).

**Root cause:** `turbo abi:check → abi:build → contracts:build`, and `contracts:build` in `package.json` is now:

```
pnpm forge-fhevm:build && pnpm fhevm:build && cd contracts && forge build
```

The middle `pnpm fhevm:build` compiles inside the `contracts/lib/fhevm/sdk/js-sdk/contracts` submodule, which has its **own** soldeer `dependencies/`. The workflow only ran `forge soldeer install` for `forge-fhevm` and `contracts` — never for the fhevm submodule — so solc couldn't resolve its dependencies. This surfaced when `contracts:build` was extended to include `fhevm:build` during the `@fhevm/sdk` migration, but `abi.yml`'s manual setup wasn't updated to match.

## Fix

- Install the fhevm submodule's soldeer deps (mirrors the `fhevm:install` script), in the correct order relative to forge-fhevm/contracts.
- Add a `Build fhevm host contracts` step mirroring the `fhevm:build` script, so the pre-build populates the cache the same way turbo invokes it.
- Extend the forge build cache **paths** with `contracts/lib/fhevm/sdk/js-sdk/contracts/{out,dependencies}` and the cache **key** with that submodule's `foundry.toml`/`soldeer.lock`, so a submodule bump invalidates the cache and a cache hit carries the fhevm deps.

## Verification

- `pnpm fhevm:build` and `pnpm exec turbo run abi:check` pass locally (`abi:check passed`, 9 tests).
- Workflow YAML validates.

`ci.yml` is unaffected — it builds with `submodules: false` and does not run `contracts:build` through turbo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)