### PR TITLE
fix(docs): format retargeted sources before rebuilding the LLM corpus

### DIFF
--- a/scripts/docs/retarget.mjs
+++ b/scripts/docs/retarget.mjs
@@ -112,18 +112,26 @@ function main() {
       : "No URL changes — sources already target this branch.",
   );
 
-  console.log("\nRebuilding the LLM corpus...");
-  const build = spawnSync("pnpm", ["llm:build"], { stdio: "inherit" });
-  if (build.status !== 0) {
-    process.exit(build.status ?? 1);
-  }
-
-  // Keep the result commit-clean (oxfmt also formats Markdown + JSON).
+  // Format the rewritten sources BEFORE building the corpus. oxfmt reflows
+  // Markdown tables to the content width, and changing a URL's length (e.g.
+  // inserting/removing the `alpha/` segment) changes the width of any table
+  // whose cells hold that URL. llm:build inlines these sources into
+  // llms-full.txt, so it must read the *formatted* version — otherwise the
+  // corpus captures the pre-reflow widths while the committed source has the
+  // post-reflow ones, and a fresh build (as `llm:check` runs in CI) no longer
+  // matches. (oxfmt also formats the JSON config; llms.txt/llms-full.txt are
+  // plain text and left as build emits them.)
   if (changed.length > 0) {
     const fmt = spawnSync("pnpm", ["exec", "oxfmt", ...changed], { stdio: "inherit" });
     if (fmt.status !== 0) {
       process.exit(fmt.status ?? 1);
     }
+  }
+
+  console.log("\nRebuilding the LLM corpus...");
+  const build = spawnSync("pnpm", ["llm:build"], { stdio: "inherit" });
+  if (build.status !== 0) {
+    process.exit(build.status ?? 1);
   }
 
   console.log(


### PR DESCRIPTION
## Problem

`pnpm docs:retarget <branch>` rebuilds the LLM corpus **before** it runs `oxfmt` on the rewritten Markdown sources. oxfmt reflows Markdown tables to the content width, and inserting/removing the `alpha/` URL segment changes the length of URLs that live inside a table — so the column widths change.

Because `llm:build` inlines those sources into `llms-full.txt`, the corpus captured the **pre-format** table widths while the committed source ended up with the **post-format** widths. A fresh `llm:build` — exactly what the `docs` job's `llm:check` (`verify-clean`) runs in CI — then produced a different `llms-full.txt`, so **the docs job failed after every promotion**.

This actually bit the 3.3.0 promotion: the `docs` job failed on a table-width diff in `llms-full.txt`, which gated the `release` job. It was patched by hand ([`58cb5fa1`](https://github.com/zama-ai/sdk/commit/58cb5fa1) on `main`), but the script would reintroduce it on the next retarget in either direction.

## Fix

Reorder `main()` in `scripts/docs/retarget.mjs`: run `oxfmt` on the rewritten sources **first**, then `llm:build` so the corpus is inlined from the already-formatted Markdown. The retarget output is now self-consistent. (`llms.txt`/`llms-full.txt` are plain text and left as `build` emits them; oxfmt still formats the JSON config.)

## Validation

On this branch, retargeted to `main` with the fixed script, then re-ran the exact CI check:

```
pnpm docs:retarget main
git add -A && pnpm llm:build
git diff --exit-code llms.txt llms-full.txt docs/llm/corpus-manifest.json   # exit 0 ✓
```

A fresh build now reproduces the retarget's corpus byte-for-byte (this fails on the old ordering). No test added: the logic that changed is process orchestration (shelling out to pnpm), and the `docs` job's `llm:check` already guards this exact invariant on every retarget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)