### PR TITLE
refactor(sdk): strip internal types from shipped .d.ts via stripInternal [SDK-209]

### DIFF
--- a/api-extractor.base.json
+++ b/api-extractor.base.json
@@ -24,7 +24,7 @@
     "compilerMessageReporting": { "default": { "logLevel": "warning" } },
     "extractorMessageReporting": {
       "default": { "logLevel": "warning" },
-      "ae-forgotten-export": { "logLevel": "none", "addToApiReportFile": false },
+      "ae-forgotten-export": { "logLevel": "warning", "addToApiReportFile": false },
       "ae-missing-release-tag": { "logLevel": "none" },
       "ae-unresolved-link": { "logLevel": "none" }
     },

--- a/docs/llm/corpus-manifest.json
+++ b/docs/llm/corpus-manifest.json
@@ -1364,7 +1364,7 @@
       "source_type": "api-report",
       "category": "api-reports",
       "logical_path": "packages/sdk/etc/sdk.api",
-      "description": "import { Abi } from 'viem'; import { Address } from 'viem'; import { ContractFunctionArgs } from 'viem'; import { ContractFunctionName } from 'viem'; import { ContractFunctionReturnType } from 'viem'; import { createFhevmClient } from '@fhevm/sdk/viem'; import { DecryptValuesParameters } from '@fhevm/sdk/actions/decrypt'; import { EIP1193Provider } from 'viem'; import { Eip712Like } from '@fhevm/sdk/types'; import { Hex } from 'viem'; import { Provider } from 'ethers'; import { PublicClient } from 'viem'; import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem'; import { Signer } from 'ethers'; import { TypedValue } from '@fhevm/sdk/types'; import { WalletClient } from 'viem'; import { z } from 'zod/mini';",
+      "description": "import { Abi } from 'viem'; import { Address } from 'viem'; import { ContractFunctionArgs } from 'viem'; import { ContractFunctionName } from 'viem'; import { ContractFunctionReturnType } from 'viem'; import { createFhevmClient } from '@fhevm/sdk/viem'; import { DecryptValuesParameters } from '@fhevm/sdk/actions/decrypt'; import { EIP1193Provider } from 'viem'; import { Eip712Like } from '@fhevm/sdk/types'; import { Hex } from 'viem'; import { Provider } from 'ethers'; import { PublicClient } from 'viem'; import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem'; import { Signer } from 'ethers'; import { TypedValue } from '@fhevm/sdk/types'; import { WalletClient } from 'viem';",
       "include_in_llms_txt": false,
       "include_in_llms_full": false
     },
@@ -1376,7 +1376,7 @@
       "source_type": "api-report",
       "category": "api-reports",
       "logical_path": "packages/sdk/etc/sdk-ethers.api",
-      "description": "import { Abi } from 'viem'; import { Address } from 'viem'; import { ContractFunctionArgs } from 'viem'; import { ContractFunctionName } from 'viem'; import { ContractFunctionReturnType } from 'viem'; import { createFhevmClient } from '@fhevm/sdk/viem'; import { EIP1193EventMap } from 'viem'; import { EIP1193Events } from 'viem'; import { EIP1193Provider } from 'viem'; import { Eip712Like } from '@fhevm/sdk/types'; import { ethers } from 'ethers'; import { Hex } from 'viem'; import { Provider } from 'ethers'; import { ProviderConnectInfo } from 'viem'; import { ProviderMessage } from 'viem'; import { ProviderRpcError } from 'viem'; import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem'; import { Signer } from 'ethers'; import { TypedValue } from '@fhevm/sdk/types';",
+      "description": "import { Abi } from 'viem'; import { Address } from 'viem'; import { ContractFunctionArgs } from 'viem'; import { ContractFunctionName } from 'viem'; import { ContractFunctionReturnType } from 'viem'; import { EIP1193EventMap } from 'viem'; import { EIP1193Events } from 'viem'; import { EIP1193Provider } from 'viem'; import { Eip712Like } from '@fhevm/sdk/types'; import { ethers } from 'ethers'; import { Hex } from 'viem'; import { Provider } from 'ethers'; import { ProviderConnectInfo } from 'viem'; import { ProviderMessage } from 'viem'; import { ProviderRpcError } from 'viem'; import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem'; import { Signer } from 'ethers'; import { TypedValue } from '@fhevm/sdk/types';",
       "include_in_llms_txt": false,
       "include_in_llms_full": false
     },
@@ -1400,7 +1400,7 @@
       "source_type": "api-report",
       "category": "api-reports",
       "logical_path": "packages/sdk/etc/sdk-query.api",
-      "description": "import { Abi } from 'viem'; import { Address } from 'viem'; import { ContractFunctionArgs } from 'viem'; import { ContractFunctionName } from 'viem'; import { ContractFunctionReturnType } from 'viem'; import { createFhevmClient } from '@fhevm/sdk/viem'; import { EIP1193Provider } from 'viem'; import { Eip712Like } from '@fhevm/sdk/types'; import { Hex } from 'viem'; import { MutationFunctionContext } from '@tanstack/query-core'; import { QueryKey } from '@tanstack/query-core'; import { QueryObserverOptions } from '@tanstack/query-core'; import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem'; import { skipToken } from '@tanstack/query-core'; import { TypedValue } from '@fhevm/sdk/types'; import { z } from 'zod/mini';",
+      "description": "import { Abi } from 'viem'; import { Address } from 'viem'; import { ContractFunctionArgs } from 'viem'; import { ContractFunctionName } from 'viem'; import { ContractFunctionReturnType } from 'viem'; import { EIP1193Provider } from 'viem'; import { Eip712Like } from '@fhevm/sdk/types'; import { Hex } from 'viem'; import { MutationFunctionContext } from '@tanstack/query-core'; import { QueryKey } from '@tanstack/query-core'; import { QueryObserverOptions } from '@tanstack/query-core'; import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem'; import { skipToken } from '@tanstack/query-core'; import { TypedValue } from '@fhevm/sdk/types';",
       "include_in_llms_txt": false,
       "include_in_llms_full": false
     },
@@ -1412,7 +1412,7 @@
       "source_type": "api-report",
       "category": "api-reports",
       "logical_path": "packages/sdk/etc/sdk-viem.api",
-      "description": "import { Abi } from 'viem'; import { Address } from 'viem'; import { ContractFunctionArgs } from 'viem'; import { ContractFunctionName } from 'viem'; import { ContractFunctionReturnType } from 'viem'; import { createFhevmClient } from '@fhevm/sdk/viem'; import { EIP1193Provider } from 'viem'; import { Eip712Like } from '@fhevm/sdk/types'; import { Hex } from 'viem'; import { PublicClient } from 'viem'; import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem'; import { TypedValue } from '@fhevm/sdk/types'; import { WalletClient } from 'viem';",
+      "description": "import { Abi } from 'viem'; import { Address } from 'viem'; import { ContractFunctionArgs } from 'viem'; import { ContractFunctionName } from 'viem'; import { ContractFunctionReturnType } from 'viem'; import { EIP1193Provider } from 'viem'; import { Eip712Like } from '@fhevm/sdk/types'; import { Hex } from 'viem'; import { PublicClient } from 'viem'; import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem'; import { TypedValue } from '@fhevm/sdk/types'; import { WalletClient } from 'viem';",
       "include_in_llms_txt": false,
       "include_in_llms_full": false
     },

--- a/packages/sdk/etc/sdk-ethers.api.md
+++ b/packages/sdk/etc/sdk-ethers.api.md
@@ -23,8 +23,89 @@ import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem';
 import { Signer } from 'ethers';
 import { TypedValue } from '@fhevm/sdk/types';
 
+// @public (undocumented)
+export interface ApproveUnderlyingSubmittedEvent extends BaseEvent {
+    step: "reset" | "approve";
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.ApproveUnderlyingSubmitted;
+}
+
+// @public
+export type AtLeastOneChain = readonly [FheChain, ...FheChain[]];
+
+// @public (undocumented)
+export interface BaseEvent {
+    operationId?: string;
+    // (undocumented)
+    timestamp: number;
+    // (undocumented)
+    tokenAddress?: Address;
+}
+
+// @public
+export abstract class BaseSigner implements GenericSigner, Disposable {
+    // (undocumented)
+    [Symbol.dispose](): void;
+    constructor(initial?: WalletAccount);
+    // (undocumented)
+    dispose(): void;
+    // (undocumented)
+    protected onDispose(): void;
+    // (undocumented)
+    requireWalletAccount(operation: string): WalletAccount;
+    // (undocumented)
+    abstract signTypedData(typedData: EIP712TypedData): Promise<Hex>;
+    // (undocumented)
+    readonly walletAccount: MutableWalletAccountStore;
+    // (undocumented)
+    abstract writeContract<const TAbi extends ContractAbi, TFunctionName extends WriteFunctionName<TAbi>, const TArgs extends WriteContractArgs<TAbi, TFunctionName>>(config: WriteContractConfig<TAbi, TFunctionName, TArgs>): Promise<Hex>;
+}
+
+// @public
+export type ClearValue = TypedValue["value"] | bigint | string | undefined;
+
+// @public
+export type ContractAbi = Abi | readonly unknown[];
+
 // @public
 export function createConfig<const TChains extends readonly [FheChain, ...FheChain[]]>(params: ZamaConfigEthers<TChains>): ZamaConfig;
+
+// @public (undocumented)
+export interface DecryptEndEvent extends BaseEvent {
+    // (undocumented)
+    durationMs: number;
+    encryptedValues: EncryptedValue[];
+    result: Record<EncryptedValue, ClearValue>;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.DecryptEnd;
+}
+
+// @public (undocumented)
+export interface DecryptErrorEvent extends BaseEvent {
+    // (undocumented)
+    durationMs: number;
+    encryptedValues: EncryptedValue[];
+    error: Error;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.DecryptError;
+}
+
+// @public (undocumented)
+export interface DecryptStartEvent extends BaseEvent {
+    encryptedValues: EncryptedValue[];
+    // (undocumented)
+    type: typeof ZamaSDKEvents.DecryptStart;
+}
+
+// @public (undocumented)
+export interface DelegationSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.DelegationSubmitted;
+}
 
 export { EIP1193EventMap }
 
@@ -33,7 +114,39 @@ export { EIP1193Events }
 export { EIP1193Provider }
 
 // @public
+export type EIP712TypedData = Eip712Like;
+
+// @public
 export type EncryptedValue = Hex;
+
+// @public (undocumented)
+export interface EncryptEndEvent extends BaseEvent {
+    // (undocumented)
+    durationMs: number;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.EncryptEnd;
+}
+
+// @public (undocumented)
+export interface EncryptErrorEvent extends BaseEvent {
+    // (undocumented)
+    durationMs: number;
+    error: Error;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.EncryptError;
+}
+
+// @public (undocumented)
+export interface EncryptStartEvent extends BaseEvent {
+    // (undocumented)
+    type: typeof ZamaSDKEvents.EncryptStart;
+}
+
+// @public
+export interface EthersCallProvider {
+    // (undocumented)
+    call(tx: EthersTransactionRequest): Promise<string>;
+}
 
 // @public
 export class EthersProvider implements GenericProvider {
@@ -77,7 +190,129 @@ export type EthersSignerConfig = {
     signer: Signer;
 };
 
+// @public
+export interface EthersTransactionRequest {
+    // (undocumented)
+    data: Hex;
+    // (undocumented)
+    gasLimit?: bigint;
+    // (undocumented)
+    to: Address;
+    // (undocumented)
+    value?: bigint;
+}
+
+// @public
+export interface EthersTransactionResponse {
+    // (undocumented)
+    hash: string;
+}
+
+// @public
+export interface EthersTransactionSigner extends EthersCallProvider {
+    // (undocumented)
+    sendTransaction(tx: EthersTransactionRequest): Promise<EthersTransactionResponse>;
+}
+
+// @public
+export interface FheChain<TId extends number = number> {
+    // (undocumented)
+    readonly aclContractAddress: Address;
+    readonly auth?: FheChainAuth;
+    readonly executorAddress?: Address | undefined;
+    // (undocumented)
+    readonly gatewayChainId: number;
+    // (undocumented)
+    readonly id: TId;
+    // (undocumented)
+    readonly inputVerifierContractAddress: Address;
+    // (undocumented)
+    readonly kmsContractAddress: Address;
+    // (undocumented)
+    readonly network: EIP1193Provider | string;
+    readonly registryAddress: Address | undefined;
+    // (undocumented)
+    readonly relayerUrl: string;
+    // (undocumented)
+    readonly verifyingContractAddressDecryption: Address;
+    // (undocumented)
+    readonly verifyingContractAddressInputVerification: Address;
+}
+
+// @public
+export type FheChainAuth = {
+    __type: "BearerToken";
+    token: string;
+} | {
+    __type: "ApiKeyHeader";
+    header?: string;
+    value: string;
+} | {
+    __type: "ApiKeyCookie";
+    cookie?: string;
+    value: string;
+};
+
+// @public
+export type FhevmRuntimeConfig = Parameters<typeof setFhevmRuntimeConfig>[0];
+
+// @public (undocumented)
+export interface FinalizeUnwrapSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.FinalizeUnwrapSubmitted;
+}
+
+// @public
+export interface GenericLogger {
+    // (undocumented)
+    debug: (message: string, data?: Record<string, unknown>) => void;
+    // (undocumented)
+    error: (message: string, data?: Record<string, unknown>) => void;
+    // (undocumented)
+    info: (message: string, data?: Record<string, unknown>) => void;
+    // (undocumented)
+    warn: (message: string, data?: Record<string, unknown>) => void;
+}
+
+// @public
+export interface GenericProvider {
+    getBlockTimestamp(): Promise<bigint>;
+    getChainId(): Promise<number>;
+    readContract<const TAbi extends ContractAbi, TFunctionName extends ReadFunctionName<TAbi>, const TArgs extends ReadContractArgs<TAbi, TFunctionName>>(config: ReadContractConfig<TAbi, TFunctionName, TArgs>): Promise<ReadContractReturnType<TAbi, TFunctionName, TArgs>>;
+    waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt>;
+}
+
+// @public
+export interface GenericSigner {
+    dispose?(): void;
+    refreshWalletAccount?(): Promise<WalletAccount | undefined>;
+    requireWalletAccount(operation: string): WalletAccount;
+    signTypedData(typedData: EIP712TypedData): Promise<Hex>;
+    readonly walletAccount: WalletAccountStore;
+    writeContract<const TAbi extends ContractAbi, TFunctionName extends WriteFunctionName<TAbi>, const TArgs extends WriteContractArgs<TAbi, TFunctionName>>(config: WriteContractConfig<TAbi, TFunctionName, TArgs>): Promise<Hex>;
+}
+
+// @public
+export interface GenericStorage {
+    delete(key: string): Promise<void>;
+    get<T = unknown>(key: string): Promise<T | null>;
+    set<T = unknown>(key: string, value: T): Promise<void>;
+}
+
 export { Hex }
+
+// @public
+export class MutableWalletAccountStore implements WalletAccountStore {
+    constructor(initial?: WalletAccount);
+    // (undocumented)
+    getSnapshot(): WalletAccount | undefined;
+    isReady(): boolean;
+    setSnapshot(next: WalletAccount | undefined): void;
+    // (undocumented)
+    subscribe(listener: WalletAccountListener): () => void;
+}
 
 export { ProviderConnectInfo }
 
@@ -85,11 +320,34 @@ export { ProviderMessage }
 
 export { ProviderRpcError }
 
+// @public
+export interface RawLog {
+    readonly data: Hex;
+    readonly topics: readonly Hex[];
+}
+
 // @public (undocumented)
 export function readConfidentialBalanceOfContract(provider: EthersCallProvider, tokenAddress: Address, userAddress: Address): Promise<unknown>;
 
 // @public (undocumented)
 export function readConfidentialTokenAddressContract(provider: EthersCallProvider, registry: Address, tokenAddress: Address): Promise<unknown>;
+
+// @public
+export type ReadContractArgs<TAbi extends ContractAbi = ContractAbi, TFunctionName extends ReadFunctionName<TAbi> = ReadFunctionName<TAbi>> = ContractFunctionArgs<TAbi, "pure" | "view", TFunctionName>;
+
+// @public
+export interface ReadContractConfig<TAbi extends ContractAbi = ContractAbi, TFunctionName extends ReadFunctionName<TAbi> = ReadFunctionName<TAbi>, TArgs extends ReadContractArgs<TAbi, TFunctionName> = ReadContractArgs<TAbi, TFunctionName>> {
+    readonly abi: TAbi;
+    readonly address: Address;
+    readonly args: TArgs;
+    readonly functionName: TFunctionName;
+}
+
+// @public
+export type ReadContractReturnType<TAbi extends ContractAbi = ContractAbi, TFunctionName extends ReadFunctionName<TAbi> = ReadFunctionName<TAbi>, TArgs extends ReadContractArgs<TAbi, TFunctionName> = ReadContractArgs<TAbi, TFunctionName>> = ContractFunctionReturnType<TAbi, "pure" | "view", TFunctionName, TArgs>;
+
+// @public
+export type ReadFunctionName<TAbi extends ContractAbi = ContractAbi> = ContractFunctionName<TAbi, "pure" | "view">;
 
 // @public (undocumented)
 export function readIsConfidentialTokenValidContract(provider: EthersCallProvider, registry: Address, confidentialTokenAddress: Address): Promise<unknown>;
@@ -115,11 +373,157 @@ export function readTokenPairsSliceContract(provider: EthersCallProvider, regist
 // @public (undocumented)
 export function readUnderlyingTokenContract(provider: EthersCallProvider, wrapperAddress: Address): Promise<unknown>;
 
+// @public
+export interface RelayerConfig {
+    // (undocumented)
+    readonly type: string;
+}
+
+// @public (undocumented)
+export interface RevokeDelegationSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.RevokeDelegationSubmitted;
+}
+
+// @public (undocumented)
+export interface SetOperatorSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.SetOperatorSubmitted;
+}
+
+// @public
+export type ShieldPath = "transferAndCall" | "approveAndWrap";
+
+// @public (undocumented)
+export interface ShieldSubmittedEvent extends BaseEvent {
+    shieldPath: ShieldPath;
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.ShieldSubmitted;
+}
+
+// @public (undocumented)
+export interface TransactionErrorEvent extends BaseEvent {
+    error: Error;
+    operation: TransactionOperation;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.TransactionError;
+}
+
+// @public
+export type TransactionOperation = "approveUnderlying" | "approveUnderlying:reset" | "delegateDecryption" | "finalizeUnwrap" | "revokeDelegation" | "setOperator" | "shield:transferAndCall" | "shield:approveAndWrap" | "wrap" | "transfer" | "transferAndCall" | "transferFrom" | "transferFromAndCall" | "unwrap" | "unwrapAll";
+
+// @public
+export interface TransactionReceipt {
+    readonly logs: readonly RawLog[];
+}
+
+// @public (undocumented)
+export interface TransferFromSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.TransferFromSubmitted;
+}
+
+// @public (undocumented)
+export interface TransferSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.TransferSubmitted;
+}
+
+// @public (undocumented)
+export interface UnshieldPhase1SubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.UnshieldPhase1Submitted;
+}
+
+// @public (undocumented)
+export interface UnshieldPhase2StartedEvent extends BaseEvent {
+    // (undocumented)
+    type: typeof ZamaSDKEvents.UnshieldPhase2Started;
+}
+
+// @public (undocumented)
+export interface UnshieldPhase2SubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.UnshieldPhase2Submitted;
+}
+
+// @public (undocumented)
+export interface UnwrapSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.UnwrapSubmitted;
+}
+
+// @public
+export interface WalletAccount {
+    // (undocumented)
+    address: Address;
+    // (undocumented)
+    chainId: number;
+}
+
+// @public
+export interface WalletAccountChange {
+    // (undocumented)
+    next?: WalletAccount;
+    // (undocumented)
+    previous?: WalletAccount;
+}
+
+// @public
+export type WalletAccountListener = (change: WalletAccountChange) => void;
+
+// @public
+export interface WalletAccountStore {
+    getSnapshot(): WalletAccount | undefined;
+    isReady(): boolean;
+    subscribe(onWalletAccountChange: WalletAccountListener): () => void;
+}
+
+// @public
+export interface WrapSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.WrapSubmitted;
+}
+
 // @public (undocumented)
 export function writeConfidentialTransferContract(signer: EthersTransactionSigner, tokenAddress: Address, to: Address, encryptedAmount: EncryptedValue, inputProof: Hex): Promise<`0x${string}`>;
 
+// @public
+export type WriteContractArgs<TAbi extends ContractAbi = ContractAbi, TFunctionName extends WriteFunctionName<TAbi> = WriteFunctionName<TAbi>> = ContractFunctionArgs<TAbi, "nonpayable" | "payable", TFunctionName>;
+
+// @public
+export interface WriteContractConfig<TAbi extends ContractAbi = ContractAbi, TFunctionName extends WriteFunctionName<TAbi> = WriteFunctionName<TAbi>, TArgs extends WriteContractArgs<TAbi, TFunctionName> = WriteContractArgs<TAbi, TFunctionName>> {
+    readonly abi: TAbi;
+    readonly address: Address;
+    readonly args: TArgs;
+    readonly functionName: TFunctionName;
+    readonly gas?: bigint;
+    readonly value?: bigint;
+}
+
 // @public (undocumented)
 export function writeFinalizeUnwrapContract(signer: EthersTransactionSigner, wrapper: Address, unwrapRequestId: EncryptedValue, unwrapAmountCleartext: bigint, decryptionProof: Hex): Promise<`0x${string}`>;
+
+// @public
+export type WriteFunctionName<TAbi extends ContractAbi = ContractAbi> = ContractFunctionName<TAbi, "nonpayable" | "payable">;
 
 // @public (undocumented)
 export function writeSetOperatorContract(signer: EthersTransactionSigner, tokenAddress: Address, operator: Address, until?: number): Promise<`0x${string}`>;
@@ -132,6 +536,38 @@ export function writeUnwrapFromBalanceContract(signer: EthersTransactionSigner, 
 
 // @public (undocumented)
 export function writeWrapContract(signer: EthersTransactionSigner, wrapperAddress: Address, to: Address, amount: bigint): Promise<`0x${string}`>;
+
+// @public
+export type ZamaConfig = {
+    readonly chains: readonly FheChain[];
+    readonly provider: GenericProvider;
+    readonly signer: GenericSigner | undefined;
+    readonly storage: GenericStorage;
+    readonly permitStorage: GenericStorage;
+    readonly transportKeyPairTTL: number;
+    readonly permitTTL: number;
+    readonly transportKeyPairScope: string | undefined;
+    readonly registryTTL: number;
+    readonly onEvent: ZamaSDKEventListener | undefined;
+    readonly logger: GenericLogger;
+} & {
+    readonly [zamaConfigBrand]: true;
+};
+
+// @public
+export interface ZamaConfigBase<TChains extends AtLeastOneChain = AtLeastOneChain> {
+    chains: TChains;
+    logger?: GenericLogger;
+    onEvent?: ZamaSDKEventListener;
+    permitStorage?: GenericStorage;
+    permitTTL?: number;
+    registryTTL?: number;
+    relayers: { [K in TChains[number]["id"]]: RelayerConfig; };
+    runtime?: FhevmRuntimeConfig;
+    storage?: GenericStorage;
+    transportKeyPairScope?: string;
+    transportKeyPairTTL?: number;
+}
 
 // @public
 export type ZamaConfigEthers<TChains extends AtLeastOneChain = AtLeastOneChain> = ZamaConfigBase<TChains> & ({
@@ -147,6 +583,39 @@ export type ZamaConfigEthers<TChains extends AtLeastOneChain = AtLeastOneChain> 
     provider: Provider;
     signer?: never;
 });
+
+// @public
+export type ZamaSDKEvent = EncryptStartEvent | EncryptEndEvent | EncryptErrorEvent | DecryptStartEvent | DecryptEndEvent | DecryptErrorEvent | TransactionErrorEvent | ShieldSubmittedEvent | TransferSubmittedEvent | TransferFromSubmittedEvent | SetOperatorSubmittedEvent | ApproveUnderlyingSubmittedEvent | WrapSubmittedEvent | UnwrapSubmittedEvent | FinalizeUnwrapSubmittedEvent | DelegationSubmittedEvent | RevokeDelegationSubmittedEvent | UnshieldPhase1SubmittedEvent | UnshieldPhase2StartedEvent | UnshieldPhase2SubmittedEvent;
+
+// @public (undocumented)
+export type ZamaSDKEventListener = (event: ZamaSDKEvent) => void;
+
+// @public
+export const ZamaSDKEvents: {
+    readonly EncryptStart: "encrypt:start";
+    readonly EncryptEnd: "encrypt:end";
+    readonly EncryptError: "encrypt:error";
+    readonly DecryptStart: "decrypt:start";
+    readonly DecryptEnd: "decrypt:end";
+    readonly DecryptError: "decrypt:error";
+    readonly TransactionError: "transaction:error";
+    readonly ShieldSubmitted: "shield:submitted";
+    readonly TransferSubmitted: "transfer:submitted";
+    readonly TransferFromSubmitted: "transferFrom:submitted";
+    readonly SetOperatorSubmitted: "setOperator:submitted";
+    readonly ApproveUnderlyingSubmitted: "approveUnderlying:submitted";
+    readonly WrapSubmitted: "wrap:submitted";
+    readonly UnwrapSubmitted: "unwrap:submitted";
+    readonly FinalizeUnwrapSubmitted: "finalizeUnwrap:submitted";
+    readonly DelegationSubmitted: "delegation:submitted";
+    readonly RevokeDelegationSubmitted: "revokeDelegation:submitted";
+    readonly UnshieldPhase1Submitted: "unshield:phase1_submitted";
+    readonly UnshieldPhase2Started: "unshield:phase2_started";
+    readonly UnshieldPhase2Submitted: "unshield:phase2_submitted";
+};
+
+// @public
+export type ZamaSDKEventType = (typeof ZamaSDKEvents)[keyof typeof ZamaSDKEvents];
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/etc/sdk-ethers.api.md
+++ b/packages/sdk/etc/sdk-ethers.api.md
@@ -9,7 +9,6 @@ import { Address } from 'viem';
 import { ContractFunctionArgs } from 'viem';
 import { ContractFunctionName } from 'viem';
 import { ContractFunctionReturnType } from 'viem';
-import { createFhevmClient } from '@fhevm/sdk/viem';
 import { EIP1193EventMap } from 'viem';
 import { EIP1193Events } from 'viem';
 import { EIP1193Provider } from 'viem';

--- a/packages/sdk/etc/sdk-node.api.md
+++ b/packages/sdk/etc/sdk-node.api.md
@@ -63,6 +63,12 @@ export const chains: Record<number, FheChain>;
 export function cleartext(options?: RelayerOptions): CleartextRelayerConfig;
 
 // @public
+export interface CleartextRelayerConfig extends RelayerConfig {
+    // (undocumented)
+    readonly type: "cleartext";
+}
+
+// @public
 export type ClearValue = TypedValue["value"] | bigint | string | undefined;
 
 // @public
@@ -79,12 +85,52 @@ export interface DecryptPublicValuesResult {
 export type EIP712TypedData = Eip712Like;
 
 // @public
+export type EncryptedValue = Hex;
+
+// @public
+export type EncryptInput = {
+    readonly type: `e${Exclude<TypedValue["type"], "bool" | "address">}`;
+    readonly value: bigint;
+} | {
+    readonly type: `e${Extract<TypedValue["type"], "bool">}`;
+    readonly value: boolean | 1n | 0n;
+} | {
+    readonly type: `e${Extract<TypedValue["type"], "address">}`;
+    readonly value: Address;
+};
+
+// @public
 export interface EncryptParams {
     // (undocumented)
     contractAddress: Address;
     // (undocumented)
     userAddress: Address;
     readonly values: readonly EncryptInput[];
+}
+
+// @public
+export interface FheChain<TId extends number = number> {
+    // (undocumented)
+    readonly aclContractAddress: Address;
+    readonly auth?: FheChainAuth;
+    readonly executorAddress?: Address | undefined;
+    // (undocumented)
+    readonly gatewayChainId: number;
+    // (undocumented)
+    readonly id: TId;
+    // (undocumented)
+    readonly inputVerifierContractAddress: Address;
+    // (undocumented)
+    readonly kmsContractAddress: Address;
+    // (undocumented)
+    readonly network: EIP1193Provider | string;
+    readonly registryAddress: Address | undefined;
+    // (undocumented)
+    readonly relayerUrl: string;
+    // (undocumented)
+    readonly verifyingContractAddressDecryption: Address;
+    // (undocumented)
+    readonly verifyingContractAddressInputVerification: Address;
 }
 
 // @public
@@ -100,6 +146,23 @@ export type FheChainAuth = {
     cookie?: string;
     value: string;
 };
+
+// @public
+export type FhevmClientOptions = NonNullable<Parameters<typeof createFhevmClient>[0]["options"]>;
+
+// @public
+export interface FhevmRelayerOptions {
+    readonly auth?: FhevmRuntimeConfig["auth"];
+    readonly debug?: boolean;
+    readonly fetchRetries?: number;
+    readonly fetchRetryDelayInMilliseconds?: number;
+    readonly headers?: Record<string, string>;
+    readonly signal?: AbortSignal;
+    readonly timeout?: number;
+}
+
+// @public
+export type FhevmRuntimeConfig = Parameters<typeof setFhevmRuntimeConfig>[0];
 
 // @public
 export interface GenericLogger {
@@ -192,6 +255,13 @@ export interface NodeRelayerConfig extends RelayerConfig {
 export interface RelayerConfig {
     // (undocumented)
     readonly type: string;
+}
+
+// @public
+export interface RelayerOptions extends Pick<FhevmRelayerOptions, "timeout" | "debug"> {
+    readonly batchRpcCalls?: boolean;
+    readonly fheEncryptionKey?: FhevmClientOptions["fheEncryptionKey"];
+    readonly moduleVersions?: FhevmClientOptions["moduleVersions"];
 }
 
 // @public

--- a/packages/sdk/etc/sdk-node.api.md
+++ b/packages/sdk/etc/sdk-node.api.md
@@ -88,6 +88,20 @@ export interface EncryptParams {
 }
 
 // @public
+export type FheChainAuth = {
+    __type: "BearerToken";
+    token: string;
+} | {
+    __type: "ApiKeyHeader";
+    header?: string;
+    value: string;
+} | {
+    __type: "ApiKeyCookie";
+    cookie?: string;
+    value: string;
+};
+
+// @public
 export interface GenericLogger {
     // (undocumented)
     debug: (message: string, data?: Record<string, unknown>) => void;
@@ -97,6 +111,13 @@ export interface GenericLogger {
     info: (message: string, data?: Record<string, unknown>) => void;
     // (undocumented)
     warn: (message: string, data?: Record<string, unknown>) => void;
+}
+
+// @public
+export interface GenericStorage {
+    delete(key: string): Promise<void>;
+    get<T = unknown>(key: string): Promise<T | null>;
+    set<T = unknown>(key: string, value: T): Promise<void>;
 }
 
 // @public

--- a/packages/sdk/etc/sdk-node.api.md
+++ b/packages/sdk/etc/sdk-node.api.md
@@ -164,22 +164,13 @@ export function node(options?: RelayerOptions): NodeRelayerConfig;
 // @public
 export interface NodeRelayerConfig extends RelayerConfig {
     // (undocumented)
-    readonly createRelayer: (chain: FheChain) => FhevmRelayer;
-    // (undocumented)
     readonly type: "node";
 }
 
 // @public
 export interface RelayerConfig {
-    readonly createRelayer: (chain: FheChain) => RelayerSDK;
     // (undocumented)
     readonly type: string;
-}
-
-// @public
-export interface RelayerSDK extends Pick<FhevmClient, "encryptValue" | "encryptValues" | "decryptPublicValue" | "decryptPublicValues" | "decryptPublicValuesWithSignatures" | "decryptValue" | "decryptValues" | "decryptValuesFromPairs" | "fetchFheEncryptionKeyBytes" | "generateTransportKeyPair" | "serializeTransportKeyPair" | "serializeSignedDecryptionPermit" | "signDecryptionPermit" | "parseTransportKeyPair" | "parseSignedDecryptionPermit"> {
-    // (undocumented)
-    chain: FheChain;
 }
 
 // @public

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -9,7 +9,6 @@ import { Address } from 'viem';
 import { ContractFunctionArgs } from 'viem';
 import { ContractFunctionName } from 'viem';
 import { ContractFunctionReturnType } from 'viem';
-import { createFhevmClient } from '@fhevm/sdk/viem';
 import { EIP1193Provider } from 'viem';
 import { Eip712Like } from '@fhevm/sdk/types';
 import { Hex } from 'viem';
@@ -19,7 +18,6 @@ import { QueryObserverOptions } from '@tanstack/query-core';
 import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem';
 import { skipToken } from '@tanstack/query-core';
 import { TypedValue } from '@fhevm/sdk/types';
-import { z } from 'zod/mini';
 
 // @public
 export type ApprovalStrategy = "max" | "exact" | "skip";
@@ -551,12 +549,6 @@ export interface RawLog {
     readonly topics: readonly Hex[];
 }
 
-// @public
-export interface RelayerSDK extends Pick<FhevmClient, "encryptValue" | "encryptValues" | "decryptPublicValue" | "decryptPublicValues" | "decryptPublicValuesWithSignatures" | "decryptValue" | "decryptValues" | "decryptValuesFromPairs" | "fetchFheEncryptionKeyBytes" | "generateTransportKeyPair" | "serializeTransportKeyPair" | "serializeSignedDecryptionPermit" | "signDecryptionPermit" | "parseTransportKeyPair" | "parseSignedDecryptionPermit"> {
-    // (undocumented)
-    chain: FheChain;
-}
-
 // @public (undocumented)
 export function resumeUnshieldMutationOptions(token: WrappedToken): MutationFactoryOptions<readonly ["zama.resumeUnshield", Address], ResumeUnshieldParams, TransactionResult>;
 
@@ -649,8 +641,6 @@ export class Token {
     constructor(sdk: ZamaSDK, address: Address);
     // (undocumented)
     readonly address: Address;
-    // @internal
-    protected assertConfidentialBalance(amount: bigint): Promise<void>;
     balanceOf(owner: Address): Promise<bigint>;
     static batchBalancesOf(tokens: Token[], owner: Address): Promise<BatchBalancesResult>;
     static batchDecryptBalancesAs(tokens: Token[], options: BatchDecryptAsOptions): Promise<Map<Address, bigint>>;
@@ -664,23 +654,13 @@ export class Token {
         delegatorAddress: Address;
         accountAddress?: Address;
     }): Promise<bigint>;
-    // @internal
-    protected emit(input: ZamaSDKEventInput): void;
     isConfidential(): Promise<boolean>;
     isOperator(holder: Address, spender: Address): Promise<boolean>;
     isWrapper(): Promise<boolean>;
     name(): Promise<string>;
-    // @internal
-    protected readConfidentialBalanceOf(owner: Address): Promise<EncryptedValue>;
     // (undocumented)
     readonly sdk: ZamaSDK;
     setOperator(operator: Address, until?: number): Promise<TransactionResult>;
-    // @internal
-    protected submitTransaction(params: {
-        operation: TransactionOperation;
-        config: WriteContractConfig;
-        onSubmitted?: (txHash: Hex) => void;
-    }): Promise<TransactionResult>;
     symbol(): Promise<string>;
 }
 
@@ -756,7 +736,7 @@ export interface TransactionErrorEvent extends BaseEvent {
 }
 
 // @public
-export type TransactionOperation = keyof typeof transactionOperationMetadata;
+export type TransactionOperation = "approveUnderlying" | "approveUnderlying:reset" | "delegateDecryption" | "finalizeUnwrap" | "revokeDelegation" | "setOperator" | "shield:transferAndCall" | "shield:approveAndWrap" | "wrap" | "transfer" | "transferAndCall" | "transferFrom" | "transferFromAndCall" | "unwrap" | "unwrapAll";
 
 // @public
 export interface TransactionReceipt {
@@ -972,7 +952,6 @@ export interface WrappersRegistryQueryConfig {
 // @public
 export type ZamaConfig = {
     readonly chains: readonly FheChain[];
-    readonly router: ChainRouter;
     readonly provider: GenericProvider;
     readonly signer: GenericSigner | undefined;
     readonly storage: GenericStorage;
@@ -1190,19 +1169,11 @@ export class ZamaSDK {
     readonly decryption: Decryption;
     readonly delegations: Delegations;
     dispose(): void;
-    // @internal
-    emitEvent(input: ZamaSDKEventInput, tokenAddress?: Address): void;
     encrypt(params: EncryptParams, options?: Pick<FhevmRelayerOptions, "signal" | "timeout">): Promise<EncryptResult>;
-    // @internal
-    get logger(): GenericLogger;
-    // @internal
-    onWalletAccountChange(listener: WalletAccountListener): () => void;
     readonly permits: Permits;
     // (undocumented)
     readonly provider: GenericProvider;
     readonly registry: WrappersRegistry;
-    // @internal
-    get relayer(): RelayerSDK;
     // (undocumented)
     readonly signer: GenericSigner | undefined;
     // (undocumented)

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -1184,9 +1184,6 @@ export class ZamaSDK {
 // @public
 export type ZamaSDKEvent = EncryptStartEvent | EncryptEndEvent | EncryptErrorEvent | DecryptStartEvent | DecryptEndEvent | DecryptErrorEvent | TransactionErrorEvent | ShieldSubmittedEvent | TransferSubmittedEvent | TransferFromSubmittedEvent | SetOperatorSubmittedEvent | ApproveUnderlyingSubmittedEvent | WrapSubmittedEvent | UnwrapSubmittedEvent | FinalizeUnwrapSubmittedEvent | DelegationSubmittedEvent | RevokeDelegationSubmittedEvent | UnshieldPhase1SubmittedEvent | UnshieldPhase2StartedEvent | UnshieldPhase2SubmittedEvent;
 
-// @public
-export type ZamaSDKEventInput = ZamaSDKEvent extends (infer E) ? E extends ZamaSDKEvent ? Omit<E, "timestamp" | "tokenAddress"> : never : never;
-
 // @public (undocumented)
 export type ZamaSDKEventListener = (event: ZamaSDKEvent) => void;
 

--- a/packages/sdk/etc/sdk-query.api.md
+++ b/packages/sdk/etc/sdk-query.api.md
@@ -70,6 +70,24 @@ export function batchDecryptBalancesAsMutationOptions(tokens: Token[]): Mutation
 // @public
 export type BatchDecryptBalancesAsParams = BatchDecryptAsOptions;
 
+// @public (undocumented)
+export interface BatchDecryptItem {
+    // (undocumented)
+    contractAddress: Address;
+    // (undocumented)
+    encryptedValue: EncryptedValue;
+    // (undocumented)
+    error?: ZamaError;
+    // (undocumented)
+    value?: ClearValue;
+}
+
+// @public (undocumented)
+export interface BatchDecryptResult {
+    // (undocumented)
+    items: BatchDecryptItem[];
+}
+
 // @public
 export function clearCredentialsMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.clearCredentials"], void, void>;
 
@@ -194,6 +212,9 @@ export interface ConfidentialTransferParams extends TransferOptions {
     to: Address;
 }
 
+// @public
+export type ContractAbi = Abi | readonly unknown[];
+
 // @public (undocumented)
 export function decryptBalanceAsMutationOptions(token: Token): MutationFactoryOptions<readonly ["zama.decryptBalanceAs", Address], DecryptBalanceAsParams, bigint>;
 
@@ -233,6 +254,19 @@ export interface DecryptInput {
     encryptedValue: EncryptedValue;
 }
 
+// @public
+export class Decryption {
+    decryptPublicValues(encryptedValues: EncryptedValue[], options?: Pick<FhevmRelayerOptions, "signal" | "timeout">): Promise<DecryptPublicValuesResult>;
+    decryptValues(encryptedInput: DecryptInput[], options?: Pick<FhevmRelayerOptions, "signal" | "timeout">): Promise<Record<EncryptedValue, ClearValue>>;
+    delegatedBatchDecryptValues(input: {
+        encryptedInputs: DecryptInput[];
+        delegatorAddress: Address;
+        accountAddress?: Address;
+        maxConcurrency?: number;
+    } & DelegatedDecryptOptions): Promise<BatchDecryptResult>;
+    delegatedDecryptValues(encryptedInputs: DecryptInput[], delegatorAddress: Address, accountAddress?: Address, options?: DelegatedDecryptOptions): Promise<Record<EncryptedValue, ClearValue>>;
+}
+
 // @public (undocumented)
 export function decryptPublicValuesMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.decryptPublicValues"], EncryptedValue[], DecryptPublicValuesResult>;
 
@@ -259,6 +293,11 @@ export interface DecryptStartEvent extends BaseEvent {
 // @public (undocumented)
 export function decryptValuesQueryOptions(sdk: ZamaSDK, encryptedInputs: DecryptInput[], signerContext?: SignerQueryContext): QueryFactoryOptions<DecryptResult, Error, DecryptResult, ReturnType<typeof zamaQueryKeys.decryption.encryptedInputs>>;
 
+// @public
+export interface DelegatedDecryptOptions {
+    waitForPropagation?: boolean;
+}
+
 // @public (undocumented)
 export function delegatedDecryptValuesMutationOptions(sdk: ZamaSDK): MutationFactoryOptions<readonly ["zama.delegatedDecryptValues"], DelegatedDecryptValuesMutationParams, Readonly<Record<EncryptedValue, ClearValue>>>;
 
@@ -279,6 +318,29 @@ export interface DelegateDecryptionParams {
     delegateAddress: Address;
     // (undocumented)
     expirationDate?: Date;
+}
+
+// @public
+export class Delegations {
+    delegateDecryption(input: {
+        contractAddress: Address;
+        delegateAddress: Address;
+        expirationDate?: Date;
+    }): Promise<TransactionResult>;
+    getExpiry(params: {
+        contractAddress: Address;
+        delegatorAddress: Address;
+        delegateAddress: Address;
+    }): Promise<bigint>;
+    isActive(params: {
+        contractAddress: Address;
+        delegatorAddress: Address;
+        delegateAddress: Address;
+    }): Promise<boolean>;
+    revokeDelegation(input: {
+        contractAddress: Address;
+        delegateAddress: Address;
+    }): Promise<TransactionResult>;
 }
 
 // @public (undocumented)
@@ -374,6 +436,59 @@ export interface EncryptStartEvent extends BaseEvent {
 }
 
 // @public
+export interface FheChain<TId extends number = number> {
+    // (undocumented)
+    readonly aclContractAddress: Address;
+    readonly auth?: FheChainAuth;
+    readonly executorAddress?: Address | undefined;
+    // (undocumented)
+    readonly gatewayChainId: number;
+    // (undocumented)
+    readonly id: TId;
+    // (undocumented)
+    readonly inputVerifierContractAddress: Address;
+    // (undocumented)
+    readonly kmsContractAddress: Address;
+    // (undocumented)
+    readonly network: EIP1193Provider | string;
+    readonly registryAddress: Address | undefined;
+    // (undocumented)
+    readonly relayerUrl: string;
+    // (undocumented)
+    readonly verifyingContractAddressDecryption: Address;
+    // (undocumented)
+    readonly verifyingContractAddressInputVerification: Address;
+}
+
+// @public
+export type FheChainAuth = {
+    __type: "BearerToken";
+    token: string;
+} | {
+    __type: "ApiKeyHeader";
+    header?: string;
+    value: string;
+} | {
+    __type: "ApiKeyCookie";
+    cookie?: string;
+    value: string;
+};
+
+// @public
+export interface FhevmRelayerOptions {
+    readonly auth?: FhevmRuntimeConfig["auth"];
+    readonly debug?: boolean;
+    readonly fetchRetries?: number;
+    readonly fetchRetryDelayInMilliseconds?: number;
+    readonly headers?: Record<string, string>;
+    readonly signal?: AbortSignal;
+    readonly timeout?: number;
+}
+
+// @public
+export type FhevmRuntimeConfig = Parameters<typeof setFhevmRuntimeConfig>[0];
+
+// @public
 export function filterQueryOptions<TOptions extends Record<string, unknown>>(options: TOptions): Omit<TOptions, StrippedQueryOptionKeys>;
 
 // @public (undocumented)
@@ -390,6 +505,26 @@ export interface FinalizeUnwrapSubmittedEvent extends BaseEvent {
     txHash: Hex;
     // (undocumented)
     type: typeof ZamaSDKEvents.FinalizeUnwrapSubmitted;
+}
+
+// @public
+export interface GenericLogger {
+    // (undocumented)
+    debug: (message: string, data?: Record<string, unknown>) => void;
+    // (undocumented)
+    error: (message: string, data?: Record<string, unknown>) => void;
+    // (undocumented)
+    info: (message: string, data?: Record<string, unknown>) => void;
+    // (undocumented)
+    warn: (message: string, data?: Record<string, unknown>) => void;
+}
+
+// @public
+export interface GenericProvider {
+    getBlockTimestamp(): Promise<bigint>;
+    getChainId(): Promise<number>;
+    readContract<const TAbi extends ContractAbi, TFunctionName extends ReadFunctionName<TAbi>, const TArgs extends ReadContractArgs<TAbi, TFunctionName>>(config: ReadContractConfig<TAbi, TFunctionName, TArgs>): Promise<ReadContractReturnType<TAbi, TFunctionName, TArgs>>;
+    waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt>;
 }
 
 // @public
@@ -478,6 +613,13 @@ export function isConfidentialTokenValidQueryOptions(sdk: ZamaSDK, config: IsCon
 // @public (undocumented)
 export function isWrapperQueryOptions(sdk: ZamaSDK, tokenAddress: Address, config?: IsConfidentialQueryConfig): QueryFactoryOptions<boolean, Error, boolean, ReturnType<typeof zamaQueryKeys.isWrapper.token>>;
 
+// @public
+export interface ListPairsOptions {
+    metadata?: boolean;
+    page?: number;
+    pageSize?: number;
+}
+
 // @public (undocumented)
 export interface ListPairsQueryConfig {
     // (undocumented)
@@ -507,6 +649,18 @@ export interface MutationFactoryOptions<TMutationKey extends readonly unknown[],
 // @public
 export type OnChainEvent = ConfidentialTransferEvent | WrapEvent | UnwrapRequestedEvent | UnwrapFinalizedEvent;
 
+// @public
+export interface PaginatedResult<T> {
+    // (undocumented)
+    readonly items: readonly T[];
+    // (undocumented)
+    readonly page: number;
+    // (undocumented)
+    readonly pageSize: number;
+    // (undocumented)
+    readonly total: number;
+}
+
 // @public (undocumented)
 export interface PendingUnshieldQueryConfig {
     // (undocumented)
@@ -515,6 +669,19 @@ export interface PendingUnshieldQueryConfig {
 
 // @public
 export function pendingUnshieldQueryOptions(sdk: ZamaSDK, tokenAddress: Address, config?: PendingUnshieldQueryConfig): QueryFactoryOptions<Hex | null, Error, Hex | null, ReturnType<typeof zamaQueryKeys.pendingUnshield.token>>;
+
+// @public
+export class Permits {
+    clear(): Promise<void>;
+    grantDelegationPermit(delegator: Address, contracts: Address[]): Promise<void>;
+    grantPermit(contracts: Address[]): Promise<void>;
+    hasDelegationPermit(delegator: Address, contracts: Address[]): Promise<boolean>;
+    hasPermit(contracts: Address[]): Promise<boolean>;
+    revokePermits(contracts?: Address[]): Promise<void>;
+    revokeTransportKeyPair(scopeId: string): Promise<void>;
+    warmTransportKeyPair(): Promise<void>;
+    warmTransportKeyPairScope(scopeId: string): Promise<void>;
+}
 
 // @public (undocumented)
 export interface QueryClientLike {
@@ -525,7 +692,7 @@ export interface QueryClientLike {
 }
 
 // @public (undocumented)
-export type QueryFactoryOptions<TQueryFnData = unknown, TError = Error, TData = TQueryFnData, TQueryKey extends QueryKey = QueryKey> = Omit<RequiredBy<QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>, "queryKey">, "queryFn" | "queryHash" | "queryKeyHashFn" | "throwOnError"> & {
+export type QueryFactoryOptions<TQueryFnData = unknown, TError = Error, TData = TQueryFnData, TQueryKey extends QueryKey = QueryKey> = Omit<Omit<QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>, "queryKey"> & Required<Pick<QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>, "queryKey">>, "queryFn" | "queryHash" | "queryKeyHashFn" | "throwOnError"> & {
     queryFn: Exclude<QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>["queryFn"], typeof skipToken | undefined>;
 };
 
@@ -548,6 +715,23 @@ export interface RawLog {
     readonly data: Hex;
     readonly topics: readonly Hex[];
 }
+
+// @public
+export type ReadContractArgs<TAbi extends ContractAbi = ContractAbi, TFunctionName extends ReadFunctionName<TAbi> = ReadFunctionName<TAbi>> = ContractFunctionArgs<TAbi, "pure" | "view", TFunctionName>;
+
+// @public
+export interface ReadContractConfig<TAbi extends ContractAbi = ContractAbi, TFunctionName extends ReadFunctionName<TAbi> = ReadFunctionName<TAbi>, TArgs extends ReadContractArgs<TAbi, TFunctionName> = ReadContractArgs<TAbi, TFunctionName>> {
+    readonly abi: TAbi;
+    readonly address: Address;
+    readonly args: TArgs;
+    readonly functionName: TFunctionName;
+}
+
+// @public
+export type ReadContractReturnType<TAbi extends ContractAbi = ContractAbi, TFunctionName extends ReadFunctionName<TAbi> = ReadFunctionName<TAbi>, TArgs extends ReadContractArgs<TAbi, TFunctionName> = ReadContractArgs<TAbi, TFunctionName>> = ContractFunctionReturnType<TAbi, "pure" | "view", TFunctionName, TArgs>;
+
+// @public
+export type ReadFunctionName<TAbi extends ContractAbi = ContractAbi> = ContractFunctionName<TAbi, "pure" | "view">;
 
 // @public (undocumented)
 export function resumeUnshieldMutationOptions(token: WrappedToken): MutationFactoryOptions<readonly ["zama.resumeUnshield", Address], ResumeUnshieldParams, TransactionResult>;
@@ -719,6 +903,33 @@ export interface TokenPairsSliceQueryConfig extends WrappersRegistryQueryConfig 
 export function tokenPairsSliceQueryOptions(sdk: ZamaSDK, config: TokenPairsSliceQueryConfig): QueryFactoryOptions<readonly TokenWrapperPair[], Error, readonly TokenWrapperPair[], ReturnType<typeof zamaQueryKeys.wrappersRegistry.tokenPairsSlice>>;
 
 // @public (undocumented)
+export interface TokenWrapperPair {
+    // (undocumented)
+    readonly confidentialTokenAddress: Address;
+    // (undocumented)
+    readonly isValid: boolean;
+    // (undocumented)
+    readonly tokenAddress: Address;
+}
+
+// @public
+export interface TokenWrapperPairWithMetadata extends TokenWrapperPair {
+    // (undocumented)
+    readonly confidential: {
+        readonly name: string;
+        readonly symbol: string;
+        readonly decimals: number;
+    };
+    // (undocumented)
+    readonly underlying: {
+        readonly name: string;
+        readonly symbol: string;
+        readonly decimals: number;
+        readonly totalSupply: bigint;
+    };
+}
+
+// @public (undocumented)
 export interface TotalSupplyQueryConfig {
     // (undocumented)
     query?: Record<string, unknown>;
@@ -867,6 +1078,11 @@ export interface UnwrapRequestedEvent {
     readonly unwrapRequestId: EncryptedValue;
 }
 
+// @public
+export interface UnwrapResult extends TransactionResult {
+    unwrapRequestId: EncryptedValue;
+}
+
 // @public (undocumented)
 export interface UnwrapSubmittedEvent extends BaseEvent {
     // (undocumented)
@@ -895,6 +1111,13 @@ export interface WalletAccountChange {
 export type WalletAccountListener = (change: WalletAccountChange) => void;
 
 // @public
+export interface WalletAccountStore {
+    getSnapshot(): WalletAccount | undefined;
+    isReady(): boolean;
+    subscribe(onWalletAccountChange: WalletAccountListener): () => void;
+}
+
+// @public
 export interface WrapEvent {
     readonly encryptedWrappedAmount: EncryptedValue;
     // (undocumented)
@@ -905,6 +1128,12 @@ export interface WrapEvent {
 
 // @public (undocumented)
 export function wrapMutationOptions(token: WrappedToken): MutationFactoryOptions<readonly ["zama.wrap", Address], WrapParams, TransactionResult>;
+
+// @public
+export interface WrapOptions {
+    onWrapSubmitted?: (txHash: Hex) => void;
+    to?: Address;
+}
 
 // @public
 export interface WrapParams extends WrapOptions {
@@ -941,6 +1170,44 @@ export interface WrapperDiscoveryQueryConfig {
 // @public (undocumented)
 export function wrapperDiscoveryQueryOptions(registry: WrappersRegistry, config: WrapperDiscoveryQueryConfig): QueryFactoryOptions<Address | null, Error, Address | null, ReturnType<typeof zamaQueryKeys.wrapperDiscovery.token>>;
 
+// @public
+export class WrappersRegistry {
+    constructor(config: WrappersRegistryConfig);
+    getAddress(chainId: number): Address | undefined;
+    getConfidentialToken(tokenAddress: Address): Promise<{
+        confidentialTokenAddress: Address;
+        isValid: boolean;
+    } | null>;
+    getConfidentialTokenAddress(tokenAddress: Address): Promise<readonly [boolean, Address]>;
+    getRegistryAddress(): Promise<Address>;
+    getTokenAddress(confidentialTokenAddress: Address): Promise<readonly [boolean, Address]>;
+    getTokenPair(index: bigint): Promise<TokenWrapperPair>;
+    getTokenPairs(): Promise<readonly TokenWrapperPair[]>;
+    getTokenPairsLength(): Promise<bigint>;
+    getTokenPairsSlice(fromIndex: bigint, toIndex: bigint): Promise<readonly TokenWrapperPair[]>;
+    getUnderlyingToken(confidentialTokenAddress: Address): Promise<{
+        tokenAddress: Address;
+        isValid: boolean;
+    } | null>;
+    isConfidentialTokenValid(confidentialTokenAddress: Address): Promise<boolean>;
+    listPairs(options: ListPairsOptions & {
+        metadata: true;
+    }): Promise<PaginatedResult<TokenWrapperPairWithMetadata>>;
+    // (undocumented)
+    listPairs(options?: ListPairsOptions): Promise<PaginatedResult<TokenWrapperPair>>;
+    // (undocumented)
+    readonly provider: GenericProvider;
+    refresh(): void;
+    get ttlMs(): number;
+}
+
+// @public
+export interface WrappersRegistryConfig {
+    provider: GenericProvider;
+    registryAddresses?: Record<number, Address>;
+    registryTTL?: number;
+}
+
 // @public (undocumented)
 export interface WrappersRegistryQueryConfig {
     // (undocumented)
@@ -948,6 +1215,30 @@ export interface WrappersRegistryQueryConfig {
     // (undocumented)
     registryAddress: Address | undefined;
 }
+
+// @public
+export interface WrapSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.WrapSubmitted;
+}
+
+// @public
+export type WriteContractArgs<TAbi extends ContractAbi = ContractAbi, TFunctionName extends WriteFunctionName<TAbi> = WriteFunctionName<TAbi>> = ContractFunctionArgs<TAbi, "nonpayable" | "payable", TFunctionName>;
+
+// @public
+export interface WriteContractConfig<TAbi extends ContractAbi = ContractAbi, TFunctionName extends WriteFunctionName<TAbi> = WriteFunctionName<TAbi>, TArgs extends WriteContractArgs<TAbi, TFunctionName> = WriteContractArgs<TAbi, TFunctionName>> {
+    readonly abi: TAbi;
+    readonly address: Address;
+    readonly args: TArgs;
+    readonly functionName: TFunctionName;
+    readonly gas?: bigint;
+    readonly value?: bigint;
+}
+
+// @public
+export type WriteFunctionName<TAbi extends ContractAbi = ContractAbi> = ContractFunctionName<TAbi, "nonpayable" | "payable">;
 
 // @public
 export type ZamaConfig = {
@@ -965,6 +1256,53 @@ export type ZamaConfig = {
 } & {
     readonly [zamaConfigBrand]: true;
 };
+
+// @public
+export class ZamaError extends Error {
+    constructor(code: ZamaErrorCode, message: string, options?: ErrorOptions & {
+        retryable?: boolean;
+    });
+    readonly code: ZamaErrorCode;
+    readonly retryable: boolean;
+}
+
+// @public
+export const ZamaErrorCode: {
+    readonly SigningRejected: "SIGNING_REJECTED";
+    readonly SigningFailed: "SIGNING_FAILED";
+    readonly EncryptionFailed: "ENCRYPTION_FAILED";
+    readonly DecryptionFailed: "DECRYPTION_FAILED";
+    readonly TransactionReverted: "TRANSACTION_REVERTED";
+    readonly TransportKeyPairExpired: "KEYPAIR_EXPIRED";
+    readonly InvalidTransportKeyPair: "INVALID_KEYPAIR";
+    readonly NoCiphertext: "NO_CIPHERTEXT";
+    readonly RelayerRequestFailed: "RELAYER_REQUEST_FAILED";
+    readonly NotEntitled: "NOT_ENTITLED";
+    readonly RpcRateLimited: "RPC_RATE_LIMITED";
+    readonly Configuration: "CONFIGURATION";
+    readonly DelegationSelfNotAllowed: "DELEGATION_SELF_NOT_ALLOWED";
+    readonly DelegationCooldown: "DELEGATION_COOLDOWN";
+    readonly DelegationNotFound: "DELEGATION_NOT_FOUND";
+    readonly DelegationExpired: "DELEGATION_EXPIRED";
+    readonly InsufficientConfidentialBalance: "INSUFFICIENT_CONFIDENTIAL_BALANCE";
+    readonly InsufficientERC20Balance: "INSUFFICIENT_ERC20_BALANCE";
+    readonly InsufficientAllowance: "INSUFFICIENT_ALLOWANCE";
+    readonly BalanceCheckUnavailable: "BALANCE_CHECK_UNAVAILABLE";
+    readonly ERC20ReadFailed: "ERC20_READ_FAILED";
+    readonly DelegationExpiryUnchanged: "DELEGATION_EXPIRY_UNCHANGED";
+    readonly DelegationDelegateEqualsContract: "DELEGATION_DELEGATE_EQUALS_CONTRACT";
+    readonly DelegationContractIsSelf: "DELEGATION_CONTRACT_IS_SELF";
+    readonly AclPaused: "ACL_PAUSED";
+    readonly DelegationExpirationTooSoon: "DELEGATION_EXPIRATION_TOO_SOON";
+    readonly DelegationNotPropagated: "DELEGATION_NOT_PROPAGATED";
+    readonly ChainMismatch: "CHAIN_MISMATCH";
+    readonly SignerNotConfigured: "SIGNER_NOT_CONFIGURED";
+    readonly WalletNotConnected: "WALLET_NOT_CONNECTED";
+    readonly WalletAccountNotReady: "WALLET_ACCOUNT_NOT_READY";
+};
+
+// @public
+export type ZamaErrorCode = (typeof ZamaErrorCode)[keyof typeof ZamaErrorCode];
 
 // @public
 export const zamaQueryKeys: {

--- a/packages/sdk/etc/sdk-viem.api.md
+++ b/packages/sdk/etc/sdk-viem.api.md
@@ -17,8 +17,26 @@ import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem';
 import { TypedValue } from '@fhevm/sdk/types';
 import { WalletClient } from 'viem';
 
+// @public (undocumented)
+export interface ApproveUnderlyingSubmittedEvent extends BaseEvent {
+    step: "reset" | "approve";
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.ApproveUnderlyingSubmitted;
+}
+
 // @public
 export type AtLeastOneChain = readonly [FheChain, ...FheChain[]];
+
+// @public (undocumented)
+export interface BaseEvent {
+    operationId?: string;
+    // (undocumented)
+    timestamp: number;
+    // (undocumented)
+    tokenAddress?: Address;
+}
 
 // @public
 export abstract class BaseSigner implements GenericSigner, Disposable {
@@ -40,13 +58,77 @@ export abstract class BaseSigner implements GenericSigner, Disposable {
 }
 
 // @public
+export type ClearValue = TypedValue["value"] | bigint | string | undefined;
+
+// @public
+export type ContractAbi = Abi | readonly unknown[];
+
+// @public
 export function createConfig<const TChains extends readonly [FheChain, ...FheChain[]]>(params: ZamaConfigViem<TChains>): ZamaConfig;
+
+// @public (undocumented)
+export interface DecryptEndEvent extends BaseEvent {
+    // (undocumented)
+    durationMs: number;
+    encryptedValues: EncryptedValue[];
+    result: Record<EncryptedValue, ClearValue>;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.DecryptEnd;
+}
+
+// @public (undocumented)
+export interface DecryptErrorEvent extends BaseEvent {
+    // (undocumented)
+    durationMs: number;
+    encryptedValues: EncryptedValue[];
+    error: Error;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.DecryptError;
+}
+
+// @public (undocumented)
+export interface DecryptStartEvent extends BaseEvent {
+    encryptedValues: EncryptedValue[];
+    // (undocumented)
+    type: typeof ZamaSDKEvents.DecryptStart;
+}
+
+// @public (undocumented)
+export interface DelegationSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.DelegationSubmitted;
+}
 
 // @public
 export type EIP712TypedData = Eip712Like;
 
 // @public
 export type EncryptedValue = Hex;
+
+// @public (undocumented)
+export interface EncryptEndEvent extends BaseEvent {
+    // (undocumented)
+    durationMs: number;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.EncryptEnd;
+}
+
+// @public (undocumented)
+export interface EncryptErrorEvent extends BaseEvent {
+    // (undocumented)
+    durationMs: number;
+    error: Error;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.EncryptError;
+}
+
+// @public (undocumented)
+export interface EncryptStartEvent extends BaseEvent {
+    // (undocumented)
+    type: typeof ZamaSDKEvents.EncryptStart;
+}
 
 // @public
 export interface FheChain<TId extends number = number> {
@@ -74,6 +156,43 @@ export interface FheChain<TId extends number = number> {
 }
 
 // @public
+export type FheChainAuth = {
+    __type: "BearerToken";
+    token: string;
+} | {
+    __type: "ApiKeyHeader";
+    header?: string;
+    value: string;
+} | {
+    __type: "ApiKeyCookie";
+    cookie?: string;
+    value: string;
+};
+
+// @public
+export type FhevmRuntimeConfig = Parameters<typeof setFhevmRuntimeConfig>[0];
+
+// @public (undocumented)
+export interface FinalizeUnwrapSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.FinalizeUnwrapSubmitted;
+}
+
+// @public
+export interface GenericLogger {
+    // (undocumented)
+    debug: (message: string, data?: Record<string, unknown>) => void;
+    // (undocumented)
+    error: (message: string, data?: Record<string, unknown>) => void;
+    // (undocumented)
+    info: (message: string, data?: Record<string, unknown>) => void;
+    // (undocumented)
+    warn: (message: string, data?: Record<string, unknown>) => void;
+}
+
+// @public
 export interface GenericProvider {
     getBlockTimestamp(): Promise<bigint>;
     getChainId(): Promise<number>;
@@ -81,7 +200,41 @@ export interface GenericProvider {
     waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt>;
 }
 
+// @public
+export interface GenericSigner {
+    dispose?(): void;
+    refreshWalletAccount?(): Promise<WalletAccount | undefined>;
+    requireWalletAccount(operation: string): WalletAccount;
+    signTypedData(typedData: EIP712TypedData): Promise<Hex>;
+    readonly walletAccount: WalletAccountStore;
+    writeContract<const TAbi extends ContractAbi, TFunctionName extends WriteFunctionName<TAbi>, const TArgs extends WriteContractArgs<TAbi, TFunctionName>>(config: WriteContractConfig<TAbi, TFunctionName, TArgs>): Promise<Hex>;
+}
+
+// @public
+export interface GenericStorage {
+    delete(key: string): Promise<void>;
+    get<T = unknown>(key: string): Promise<T | null>;
+    set<T = unknown>(key: string, value: T): Promise<void>;
+}
+
 export { Hex }
+
+// @public
+export class MutableWalletAccountStore implements WalletAccountStore {
+    constructor(initial?: WalletAccount);
+    // (undocumented)
+    getSnapshot(): WalletAccount | undefined;
+    isReady(): boolean;
+    setSnapshot(next: WalletAccount | undefined): void;
+    // (undocumented)
+    subscribe(listener: WalletAccountListener): () => void;
+}
+
+// @public
+export interface RawLog {
+    readonly data: Hex;
+    readonly topics: readonly Hex[];
+}
 
 // @public (undocumented)
 export function readConfidentialBalanceOfContract(client: PublicClient, tokenAddress: Address, userAddress: Address): Promise<`0x${string}`>;
@@ -90,12 +243,21 @@ export function readConfidentialBalanceOfContract(client: PublicClient, tokenAdd
 export function readConfidentialTokenAddressContract(client: PublicClient, registry: Address, tokenAddress: Address): Promise<readonly [boolean, `0x${string}`]>;
 
 // @public
+export type ReadContractArgs<TAbi extends ContractAbi = ContractAbi, TFunctionName extends ReadFunctionName<TAbi> = ReadFunctionName<TAbi>> = ContractFunctionArgs<TAbi, "pure" | "view", TFunctionName>;
+
+// @public
 export interface ReadContractConfig<TAbi extends ContractAbi = ContractAbi, TFunctionName extends ReadFunctionName<TAbi> = ReadFunctionName<TAbi>, TArgs extends ReadContractArgs<TAbi, TFunctionName> = ReadContractArgs<TAbi, TFunctionName>> {
     readonly abi: TAbi;
     readonly address: Address;
     readonly args: TArgs;
     readonly functionName: TFunctionName;
 }
+
+// @public
+export type ReadContractReturnType<TAbi extends ContractAbi = ContractAbi, TFunctionName extends ReadFunctionName<TAbi> = ReadFunctionName<TAbi>, TArgs extends ReadContractArgs<TAbi, TFunctionName> = ReadContractArgs<TAbi, TFunctionName>> = ContractFunctionReturnType<TAbi, "pure" | "view", TFunctionName, TArgs>;
+
+// @public
+export type ReadFunctionName<TAbi extends ContractAbi = ContractAbi> = ContractFunctionName<TAbi, "pure" | "view">;
 
 // @public (undocumented)
 export function readIsConfidentialTokenValidContract(client: PublicClient, registry: Address, confidentialTokenAddress: Address): Promise<boolean>;
@@ -134,8 +296,99 @@ export function readTokenPairsSliceContract(client: PublicClient, registry: Addr
 export function readUnderlyingTokenContract(client: PublicClient, wrapperAddress: Address): Promise<`0x${string}`>;
 
 // @public
+export interface RelayerConfig {
+    // (undocumented)
+    readonly type: string;
+}
+
+// @public (undocumented)
+export interface RevokeDelegationSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.RevokeDelegationSubmitted;
+}
+
+// @public (undocumented)
+export interface SetOperatorSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.SetOperatorSubmitted;
+}
+
+// @public
+export type ShieldPath = "transferAndCall" | "approveAndWrap";
+
+// @public (undocumented)
+export interface ShieldSubmittedEvent extends BaseEvent {
+    shieldPath: ShieldPath;
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.ShieldSubmitted;
+}
+
+// @public (undocumented)
+export interface TransactionErrorEvent extends BaseEvent {
+    error: Error;
+    operation: TransactionOperation;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.TransactionError;
+}
+
+// @public
+export type TransactionOperation = "approveUnderlying" | "approveUnderlying:reset" | "delegateDecryption" | "finalizeUnwrap" | "revokeDelegation" | "setOperator" | "shield:transferAndCall" | "shield:approveAndWrap" | "wrap" | "transfer" | "transferAndCall" | "transferFrom" | "transferFromAndCall" | "unwrap" | "unwrapAll";
+
+// @public
 export interface TransactionReceipt {
     readonly logs: readonly RawLog[];
+}
+
+// @public (undocumented)
+export interface TransferFromSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.TransferFromSubmitted;
+}
+
+// @public (undocumented)
+export interface TransferSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.TransferSubmitted;
+}
+
+// @public (undocumented)
+export interface UnshieldPhase1SubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.UnshieldPhase1Submitted;
+}
+
+// @public (undocumented)
+export interface UnshieldPhase2StartedEvent extends BaseEvent {
+    // (undocumented)
+    type: typeof ZamaSDKEvents.UnshieldPhase2Started;
+}
+
+// @public (undocumented)
+export interface UnshieldPhase2SubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.UnshieldPhase2Submitted;
+}
+
+// @public (undocumented)
+export interface UnwrapSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.UnwrapSubmitted;
 }
 
 // @public
@@ -174,8 +427,45 @@ export interface ViemSignerConfig {
     walletClient: WalletClient;
 }
 
+// @public
+export interface WalletAccount {
+    // (undocumented)
+    address: Address;
+    // (undocumented)
+    chainId: number;
+}
+
+// @public
+export interface WalletAccountChange {
+    // (undocumented)
+    next?: WalletAccount;
+    // (undocumented)
+    previous?: WalletAccount;
+}
+
+// @public
+export type WalletAccountListener = (change: WalletAccountChange) => void;
+
+// @public
+export interface WalletAccountStore {
+    getSnapshot(): WalletAccount | undefined;
+    isReady(): boolean;
+    subscribe(onWalletAccountChange: WalletAccountListener): () => void;
+}
+
+// @public
+export interface WrapSubmittedEvent extends BaseEvent {
+    // (undocumented)
+    txHash: Hex;
+    // (undocumented)
+    type: typeof ZamaSDKEvents.WrapSubmitted;
+}
+
 // @public (undocumented)
 export function writeConfidentialTransferContract(client: WalletClient, tokenAddress: Address, to: Address, encryptedAmount: EncryptedValue, inputProof: Hex): Promise<`0x${string}`>;
+
+// @public
+export type WriteContractArgs<TAbi extends ContractAbi = ContractAbi, TFunctionName extends WriteFunctionName<TAbi> = WriteFunctionName<TAbi>> = ContractFunctionArgs<TAbi, "nonpayable" | "payable", TFunctionName>;
 
 // @public
 export interface WriteContractConfig<TAbi extends ContractAbi = ContractAbi, TFunctionName extends WriteFunctionName<TAbi> = WriteFunctionName<TAbi>, TArgs extends WriteContractArgs<TAbi, TFunctionName> = WriteContractArgs<TAbi, TFunctionName>> {
@@ -189,6 +479,9 @@ export interface WriteContractConfig<TAbi extends ContractAbi = ContractAbi, TFu
 
 // @public (undocumented)
 export function writeFinalizeUnwrapContract(client: WalletClient, wrapper: Address, unwrapRequestId: EncryptedValue, unwrapAmountCleartext: bigint, decryptionProof: Hex): Promise<`0x${string}`>;
+
+// @public
+export type WriteFunctionName<TAbi extends ContractAbi = ContractAbi> = ContractFunctionName<TAbi, "nonpayable" | "payable">;
 
 // @public (undocumented)
 export function writeSetOperatorContract(client: WalletClient, tokenAddress: Address, operator: Address, until?: number): Promise<`0x${string}`>;
@@ -243,6 +536,39 @@ export interface ZamaConfigViem<TChains extends AtLeastOneChain = AtLeastOneChai
     // (undocumented)
     walletClient: WalletClient;
 }
+
+// @public
+export type ZamaSDKEvent = EncryptStartEvent | EncryptEndEvent | EncryptErrorEvent | DecryptStartEvent | DecryptEndEvent | DecryptErrorEvent | TransactionErrorEvent | ShieldSubmittedEvent | TransferSubmittedEvent | TransferFromSubmittedEvent | SetOperatorSubmittedEvent | ApproveUnderlyingSubmittedEvent | WrapSubmittedEvent | UnwrapSubmittedEvent | FinalizeUnwrapSubmittedEvent | DelegationSubmittedEvent | RevokeDelegationSubmittedEvent | UnshieldPhase1SubmittedEvent | UnshieldPhase2StartedEvent | UnshieldPhase2SubmittedEvent;
+
+// @public (undocumented)
+export type ZamaSDKEventListener = (event: ZamaSDKEvent) => void;
+
+// @public
+export const ZamaSDKEvents: {
+    readonly EncryptStart: "encrypt:start";
+    readonly EncryptEnd: "encrypt:end";
+    readonly EncryptError: "encrypt:error";
+    readonly DecryptStart: "decrypt:start";
+    readonly DecryptEnd: "decrypt:end";
+    readonly DecryptError: "decrypt:error";
+    readonly TransactionError: "transaction:error";
+    readonly ShieldSubmitted: "shield:submitted";
+    readonly TransferSubmitted: "transfer:submitted";
+    readonly TransferFromSubmitted: "transferFrom:submitted";
+    readonly SetOperatorSubmitted: "setOperator:submitted";
+    readonly ApproveUnderlyingSubmitted: "approveUnderlying:submitted";
+    readonly WrapSubmitted: "wrap:submitted";
+    readonly UnwrapSubmitted: "unwrap:submitted";
+    readonly FinalizeUnwrapSubmitted: "finalizeUnwrap:submitted";
+    readonly DelegationSubmitted: "delegation:submitted";
+    readonly RevokeDelegationSubmitted: "revokeDelegation:submitted";
+    readonly UnshieldPhase1Submitted: "unshield:phase1_submitted";
+    readonly UnshieldPhase2Started: "unshield:phase2_started";
+    readonly UnshieldPhase2Submitted: "unshield:phase2_submitted";
+};
+
+// @public
+export type ZamaSDKEventType = (typeof ZamaSDKEvents)[keyof typeof ZamaSDKEvents];
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sdk/etc/sdk-viem.api.md
+++ b/packages/sdk/etc/sdk-viem.api.md
@@ -9,7 +9,6 @@ import { Address } from 'viem';
 import { ContractFunctionArgs } from 'viem';
 import { ContractFunctionName } from 'viem';
 import { ContractFunctionReturnType } from 'viem';
-import { createFhevmClient } from '@fhevm/sdk/viem';
 import { EIP1193Provider } from 'viem';
 import { Eip712Like } from '@fhevm/sdk/types';
 import { Hex } from 'viem';

--- a/packages/sdk/etc/sdk-viem.api.md
+++ b/packages/sdk/etc/sdk-viem.api.md
@@ -18,10 +18,68 @@ import { TypedValue } from '@fhevm/sdk/types';
 import { WalletClient } from 'viem';
 
 // @public
+export type AtLeastOneChain = readonly [FheChain, ...FheChain[]];
+
+// @public
+export abstract class BaseSigner implements GenericSigner, Disposable {
+    // (undocumented)
+    [Symbol.dispose](): void;
+    constructor(initial?: WalletAccount);
+    // (undocumented)
+    dispose(): void;
+    // (undocumented)
+    protected onDispose(): void;
+    // (undocumented)
+    requireWalletAccount(operation: string): WalletAccount;
+    // (undocumented)
+    abstract signTypedData(typedData: EIP712TypedData): Promise<Hex>;
+    // (undocumented)
+    readonly walletAccount: MutableWalletAccountStore;
+    // (undocumented)
+    abstract writeContract<const TAbi extends ContractAbi, TFunctionName extends WriteFunctionName<TAbi>, const TArgs extends WriteContractArgs<TAbi, TFunctionName>>(config: WriteContractConfig<TAbi, TFunctionName, TArgs>): Promise<Hex>;
+}
+
+// @public
 export function createConfig<const TChains extends readonly [FheChain, ...FheChain[]]>(params: ZamaConfigViem<TChains>): ZamaConfig;
 
 // @public
+export type EIP712TypedData = Eip712Like;
+
+// @public
 export type EncryptedValue = Hex;
+
+// @public
+export interface FheChain<TId extends number = number> {
+    // (undocumented)
+    readonly aclContractAddress: Address;
+    readonly auth?: FheChainAuth;
+    readonly executorAddress?: Address | undefined;
+    // (undocumented)
+    readonly gatewayChainId: number;
+    // (undocumented)
+    readonly id: TId;
+    // (undocumented)
+    readonly inputVerifierContractAddress: Address;
+    // (undocumented)
+    readonly kmsContractAddress: Address;
+    // (undocumented)
+    readonly network: EIP1193Provider | string;
+    readonly registryAddress: Address | undefined;
+    // (undocumented)
+    readonly relayerUrl: string;
+    // (undocumented)
+    readonly verifyingContractAddressDecryption: Address;
+    // (undocumented)
+    readonly verifyingContractAddressInputVerification: Address;
+}
+
+// @public
+export interface GenericProvider {
+    getBlockTimestamp(): Promise<bigint>;
+    getChainId(): Promise<number>;
+    readContract<const TAbi extends ContractAbi, TFunctionName extends ReadFunctionName<TAbi>, const TArgs extends ReadContractArgs<TAbi, TFunctionName>>(config: ReadContractConfig<TAbi, TFunctionName, TArgs>): Promise<ReadContractReturnType<TAbi, TFunctionName, TArgs>>;
+    waitForTransactionReceipt(hash: Hex): Promise<TransactionReceipt>;
+}
 
 export { Hex }
 
@@ -30,6 +88,14 @@ export function readConfidentialBalanceOfContract(client: PublicClient, tokenAdd
 
 // @public (undocumented)
 export function readConfidentialTokenAddressContract(client: PublicClient, registry: Address, tokenAddress: Address): Promise<readonly [boolean, `0x${string}`]>;
+
+// @public
+export interface ReadContractConfig<TAbi extends ContractAbi = ContractAbi, TFunctionName extends ReadFunctionName<TAbi> = ReadFunctionName<TAbi>, TArgs extends ReadContractArgs<TAbi, TFunctionName> = ReadContractArgs<TAbi, TFunctionName>> {
+    readonly abi: TAbi;
+    readonly address: Address;
+    readonly args: TArgs;
+    readonly functionName: TFunctionName;
+}
 
 // @public (undocumented)
 export function readIsConfidentialTokenValidContract(client: PublicClient, registry: Address, confidentialTokenAddress: Address): Promise<boolean>;
@@ -66,6 +132,11 @@ export function readTokenPairsSliceContract(client: PublicClient, registry: Addr
 
 // @public (undocumented)
 export function readUnderlyingTokenContract(client: PublicClient, wrapperAddress: Address): Promise<`0x${string}`>;
+
+// @public
+export interface TransactionReceipt {
+    readonly logs: readonly RawLog[];
+}
 
 // @public
 export class ViemProvider implements GenericProvider {
@@ -106,6 +177,16 @@ export interface ViemSignerConfig {
 // @public (undocumented)
 export function writeConfidentialTransferContract(client: WalletClient, tokenAddress: Address, to: Address, encryptedAmount: EncryptedValue, inputProof: Hex): Promise<`0x${string}`>;
 
+// @public
+export interface WriteContractConfig<TAbi extends ContractAbi = ContractAbi, TFunctionName extends WriteFunctionName<TAbi> = WriteFunctionName<TAbi>, TArgs extends WriteContractArgs<TAbi, TFunctionName> = WriteContractArgs<TAbi, TFunctionName>> {
+    readonly abi: TAbi;
+    readonly address: Address;
+    readonly args: TArgs;
+    readonly functionName: TFunctionName;
+    readonly gas?: bigint;
+    readonly value?: bigint;
+}
+
 // @public (undocumented)
 export function writeFinalizeUnwrapContract(client: WalletClient, wrapper: Address, unwrapRequestId: EncryptedValue, unwrapAmountCleartext: bigint, decryptionProof: Hex): Promise<`0x${string}`>;
 
@@ -120,6 +201,38 @@ export function writeUnwrapFromBalanceContract(client: WalletClient, encryptedEr
 
 // @public (undocumented)
 export function writeWrapContract(client: WalletClient, wrapperAddress: Address, to: Address, amount: bigint): Promise<`0x${string}`>;
+
+// @public
+export type ZamaConfig = {
+    readonly chains: readonly FheChain[];
+    readonly provider: GenericProvider;
+    readonly signer: GenericSigner | undefined;
+    readonly storage: GenericStorage;
+    readonly permitStorage: GenericStorage;
+    readonly transportKeyPairTTL: number;
+    readonly permitTTL: number;
+    readonly transportKeyPairScope: string | undefined;
+    readonly registryTTL: number;
+    readonly onEvent: ZamaSDKEventListener | undefined;
+    readonly logger: GenericLogger;
+} & {
+    readonly [zamaConfigBrand]: true;
+};
+
+// @public
+export interface ZamaConfigBase<TChains extends AtLeastOneChain = AtLeastOneChain> {
+    chains: TChains;
+    logger?: GenericLogger;
+    onEvent?: ZamaSDKEventListener;
+    permitStorage?: GenericStorage;
+    permitTTL?: number;
+    registryTTL?: number;
+    relayers: { [K in TChains[number]["id"]]: RelayerConfig; };
+    runtime?: FhevmRuntimeConfig;
+    storage?: GenericStorage;
+    transportKeyPairScope?: string;
+    transportKeyPairTTL?: number;
+}
 
 // @public
 export interface ZamaConfigViem<TChains extends AtLeastOneChain = AtLeastOneChain> extends ZamaConfigBase<TChains> {

--- a/packages/sdk/etc/sdk-web.api.md
+++ b/packages/sdk/etc/sdk-web.api.md
@@ -4,9 +4,7 @@
 
 ```ts
 
-import { Address } from 'viem';
 import { createFhevmClient } from '@fhevm/sdk/viem';
-import { EIP1193Provider } from 'viem';
 import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem';
 
 // @public

--- a/packages/sdk/etc/sdk-web.api.md
+++ b/packages/sdk/etc/sdk-web.api.md
@@ -8,6 +8,36 @@ import { createFhevmClient } from '@fhevm/sdk/viem';
 import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem';
 
 // @public
+export type FhevmClientOptions = NonNullable<Parameters<typeof createFhevmClient>[0]["options"]>;
+
+// @public
+export interface FhevmRelayerOptions {
+    readonly auth?: FhevmRuntimeConfig["auth"];
+    readonly debug?: boolean;
+    readonly fetchRetries?: number;
+    readonly fetchRetryDelayInMilliseconds?: number;
+    readonly headers?: Record<string, string>;
+    readonly signal?: AbortSignal;
+    readonly timeout?: number;
+}
+
+// @public
+export type FhevmRuntimeConfig = Parameters<typeof setFhevmRuntimeConfig>[0];
+
+// @public
+export interface RelayerConfig {
+    // (undocumented)
+    readonly type: string;
+}
+
+// @public
+export interface RelayerOptions extends Pick<FhevmRelayerOptions, "timeout" | "debug"> {
+    readonly batchRpcCalls?: boolean;
+    readonly fheEncryptionKey?: FhevmClientOptions["fheEncryptionKey"];
+    readonly moduleVersions?: FhevmClientOptions["moduleVersions"];
+}
+
+// @public
 export function web(options?: RelayerOptions): WebRelayerConfig;
 
 // @public

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -12690,12 +12690,6 @@ export class RelayerRequestFailedError extends ZamaError {
     readonly statusCode: number | undefined;
 }
 
-// @public (undocumented)
-export function resolveStorage(storage?: GenericStorage | undefined, permitStorage?: GenericStorage | undefined): {
-    storage: GenericStorage;
-    permitStorage: GenericStorage;
-};
-
 // @public
 export function retryAfterSeconds(error: unknown): number | undefined;
 
@@ -14173,18 +14167,6 @@ export class SigningFailedError extends ZamaError {
 // @public
 export class SigningRejectedError extends ZamaError {
     constructor(message: string, options?: ErrorOptions);
-}
-
-// @public
-export interface StoredTransportKeyPair {
-    // (undocumented)
-    createdAt: number;
-    // (undocumented)
-    expiresAt: number;
-    // (undocumented)
-    privateKey: Hex;
-    // (undocumented)
-    publicKey: Hex;
 }
 
 // @public
@@ -19643,9 +19625,6 @@ export class ZamaSDK {
 
 // @public
 export type ZamaSDKEvent = EncryptStartEvent | EncryptEndEvent | EncryptErrorEvent | DecryptStartEvent | DecryptEndEvent | DecryptErrorEvent | TransactionErrorEvent | ShieldSubmittedEvent | TransferSubmittedEvent | TransferFromSubmittedEvent | SetOperatorSubmittedEvent | ApproveUnderlyingSubmittedEvent | WrapSubmittedEvent | UnwrapSubmittedEvent | FinalizeUnwrapSubmittedEvent | DelegationSubmittedEvent | RevokeDelegationSubmittedEvent | UnshieldPhase1SubmittedEvent | UnshieldPhase2StartedEvent | UnshieldPhase2SubmittedEvent;
-
-// @public
-export type ZamaSDKEventInput = ZamaSDKEvent extends (infer E) ? E extends ZamaSDKEvent ? Omit<E, "timestamp" | "tokenAddress"> : never : never;
 
 // @public (undocumented)
 export type ZamaSDKEventListener = (event: ZamaSDKEvent) => void;

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -20,7 +20,6 @@ import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem';
 import { Signer } from 'ethers';
 import { TypedValue } from '@fhevm/sdk/types';
 import { WalletClient } from 'viem';
-import { z } from 'zod/mini';
 
 // @public
 export const ACL_TOPICS: readonly [`0x${string}`, `0x${string}`];
@@ -601,17 +600,6 @@ export class ChainMismatchError extends ZamaError {
     readonly providerChainId: number;
     // (undocumented)
     readonly signerChainId: number;
-}
-
-// @public
-export class ChainRouter {
-    constructor(chains: readonly [FheChain, ...FheChain[]], configs: Readonly<Record<number, RelayerConfig>>);
-    // (undocumented)
-    get chain(): FheChain;
-    // (undocumented)
-    get chains(): readonly FheChain[];
-    get relayer(): RelayerSDK;
-    switchChain(chainId: number): void;
 }
 
 // @public
@@ -5411,13 +5399,6 @@ export interface DecryptInput {
 
 // @public
 export class Decryption {
-    // @internal
-    constructor(opts: {
-        signer: GenericSigner | undefined;
-        provider: GenericProvider;
-        router: ChainRouter;
-        decryptionService: DecryptionService | undefined;
-    });
     decryptPublicValues(encryptedValues: EncryptedValue[], options?: Pick<FhevmRelayerOptions, "signal" | "timeout">): Promise<DecryptPublicValuesResult>;
     decryptValues(encryptedInput: DecryptInput[], options?: Pick<FhevmRelayerOptions, "signal" | "timeout">): Promise<Record<EncryptedValue, ClearValue>>;
     delegatedBatchDecryptValues(input: {
@@ -5728,12 +5709,6 @@ export class DelegationNotPropagatedError extends ZamaError {
 
 // @public
 export class Delegations {
-    // @internal
-    constructor(opts: {
-        signer: GenericSigner | undefined;
-        provider: GenericProvider;
-        delegationService: DelegationService;
-    });
     delegateDecryption(input: {
         contractAddress: Address;
         delegateAddress: Address;
@@ -5883,6 +5858,20 @@ export type FheChainAuth = {
     cookie?: string;
     value: string;
 };
+
+// @public
+export interface FhevmRelayerOptions {
+    readonly auth?: FhevmRuntimeConfig["auth"];
+    readonly debug?: boolean;
+    readonly fetchRetries?: number;
+    readonly fetchRetryDelayInMilliseconds?: number;
+    readonly headers?: Record<string, string>;
+    readonly signal?: AbortSignal;
+    readonly timeout?: number;
+}
+
+// @public
+export type FhevmRuntimeConfig = Parameters<typeof setFhevmRuntimeConfig>[0];
 
 // @public
 export function finalizeUnwrapContract(wrapper: Address, unwrapRequestId: EncryptedValue, unwrapAmountCleartext: bigint, decryptionProof: Hex): {
@@ -11419,18 +11408,21 @@ export interface PaginatedResult<T> {
 }
 
 // @public
-export type Permission = z.infer<typeof PermissionSchema>;
+export interface Permission {
+    // (undocumented)
+    contractAddresses: ChecksummedAddress[];
+    // (undocumented)
+    durationDays: number;
+    // (undocumented)
+    keypairPublicKey: Hex;
+    // (undocumented)
+    serializedPermit: SerializedPermit;
+    // (undocumented)
+    startTimestamp: number;
+}
 
 // @public
 export class Permits {
-    // @internal
-    constructor(opts: {
-        signer: GenericSigner | undefined;
-        provider: GenericProvider;
-        cachingService: CachingService;
-        credentialService: CredentialService | undefined;
-        logger: GenericLogger;
-    });
     clear(): Promise<void>;
     grantDelegationPermit(delegator: Address, contracts: Address[]): Promise<void>;
     grantPermit(contracts: Address[]): Promise<void>;
@@ -12603,9 +12595,15 @@ export type ReadFunctionName<TAbi extends ContractAbi = ContractAbi> = ContractF
 
 // @public
 export interface RelayerConfig {
-    readonly createRelayer: (chain: FheChain) => RelayerSDK;
     // (undocumented)
     readonly type: string;
+}
+
+// @public
+export interface RelayerOptions extends Pick<FhevmRelayerOptions, "timeout" | "debug"> {
+    readonly batchRpcCalls?: boolean;
+    readonly fheEncryptionKey?: FhevmClientOptions["fheEncryptionKey"];
+    readonly moduleVersions?: FhevmClientOptions["moduleVersions"];
 }
 
 // @public
@@ -12616,23 +12614,6 @@ export class RelayerRequestFailedError extends ZamaError {
     });
     readonly retryAfter: number | undefined;
     readonly statusCode: number | undefined;
-}
-
-// @public
-export interface RelayerSDK extends Pick<FhevmClient, "encryptValue" | "encryptValues" | "decryptPublicValue" | "decryptPublicValues" | "decryptPublicValuesWithSignatures" | "decryptValue" | "decryptValues" | "decryptValuesFromPairs" | "fetchFheEncryptionKeyBytes" | "generateTransportKeyPair" | "serializeTransportKeyPair" | "serializeSignedDecryptionPermit" | "signDecryptionPermit" | "parseTransportKeyPair" | "parseSignedDecryptionPermit"> {
-    // (undocumented)
-    chain: FheChain;
-}
-
-// @public (undocumented)
-export function resolveChainRelayers(chains: readonly FheChain[], relayers: Readonly<Record<number, RelayerConfig>>): Map<number, ResolvedChainRelayer>;
-
-// @public (undocumented)
-export interface ResolvedChainRelayer {
-    // (undocumented)
-    chain: FheChain;
-    // (undocumented)
-    relayerConfig: RelayerConfig;
 }
 
 // @public (undocumented)
@@ -14094,7 +14075,16 @@ export class SigningRejectedError extends ZamaError {
 }
 
 // @public
-export type StoredTransportKeyPair = z.infer<typeof StoredTransportKeyPairSchema>;
+export interface StoredTransportKeyPair {
+    // (undocumented)
+    createdAt: number;
+    // (undocumented)
+    expiresAt: number;
+    // (undocumented)
+    privateKey: Hex;
+    // (undocumented)
+    publicKey: Hex;
+}
 
 // @public
 export function supportsInterfaceContract(tokenAddress: Address, interfaceId: Address): {
@@ -14265,8 +14255,6 @@ export class Token {
     constructor(sdk: ZamaSDK, address: Address);
     // (undocumented)
     readonly address: Address;
-    // @internal
-    protected assertConfidentialBalance(amount: bigint): Promise<void>;
     balanceOf(owner: Address): Promise<bigint>;
     static batchBalancesOf(tokens: Token[], owner: Address): Promise<BatchBalancesResult>;
     static batchDecryptBalancesAs(tokens: Token[], options: BatchDecryptAsOptions): Promise<Map<Address, bigint>>;
@@ -14280,23 +14268,13 @@ export class Token {
         delegatorAddress: Address;
         accountAddress?: Address;
     }): Promise<bigint>;
-    // @internal
-    protected emit(input: ZamaSDKEventInput): void;
     isConfidential(): Promise<boolean>;
     isOperator(holder: Address, spender: Address): Promise<boolean>;
     isWrapper(): Promise<boolean>;
     name(): Promise<string>;
-    // @internal
-    protected readConfidentialBalanceOf(owner: Address): Promise<EncryptedValue>;
     // (undocumented)
     readonly sdk: ZamaSDK;
     setOperator(operator: Address, until?: number): Promise<TransactionResult>;
-    // @internal
-    protected submitTransaction(params: {
-        operation: TransactionOperation;
-        config: WriteContractConfig;
-        onSubmitted?: (txHash: Hex) => void;
-    }): Promise<TransactionResult>;
     symbol(): Promise<string>;
 }
 
@@ -14347,7 +14325,7 @@ export interface TransactionErrorEvent extends BaseEvent {
 }
 
 // @public
-export type TransactionOperation = keyof typeof transactionOperationMetadata;
+export type TransactionOperation = "approveUnderlying" | "approveUnderlying:reset" | "delegateDecryption" | "finalizeUnwrap" | "revokeDelegation" | "setOperator" | "shield:transferAndCall" | "shield:approveAndWrap" | "wrap" | "transfer" | "transferAndCall" | "transferFrom" | "transferFromAndCall" | "unwrap" | "unwrapAll";
 
 // @public
 export interface TransactionReceipt {
@@ -19432,7 +19410,6 @@ export type WriteFunctionName<TAbi extends ContractAbi = ContractAbi> = Contract
 // @public
 export type ZamaConfig = {
     readonly chains: readonly FheChain[];
-    readonly router: ChainRouter;
     readonly provider: GenericProvider;
     readonly signer: GenericSigner | undefined;
     readonly storage: GenericStorage;
@@ -19551,19 +19528,11 @@ export class ZamaSDK {
     readonly decryption: Decryption;
     readonly delegations: Delegations;
     dispose(): void;
-    // @internal
-    emitEvent(input: ZamaSDKEventInput, tokenAddress?: Address): void;
     encrypt(params: EncryptParams, options?: Pick<FhevmRelayerOptions, "signal" | "timeout">): Promise<EncryptResult>;
-    // @internal
-    get logger(): GenericLogger;
-    // @internal
-    onWalletAccountChange(listener: WalletAccountListener): () => void;
     readonly permits: Permits;
     // (undocumented)
     readonly provider: GenericProvider;
     readonly registry: WrappersRegistry;
-    // @internal
-    get relayer(): RelayerSDK;
     // (undocumented)
     readonly signer: GenericSigner | undefined;
     // (undocumented)

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -606,6 +606,11 @@ export class ChainMismatchError extends ZamaError {
 export const chains: Record<number, FheChain>;
 
 // @public
+export type ChecksummedAddress = Address & {
+    readonly [checksummedTag]: true;
+};
+
+// @public
 export class ChromeSessionStorage implements GenericStorage {
     // (undocumented)
     delete(key: string): Promise<void>;
@@ -5821,6 +5826,72 @@ export const ERC7984_INTERFACE_ID: "0x4958f2a4";
 export const ERC7984_WRAPPER_INTERFACE_ID: "0x1f1c62b2";
 
 // @public
+export interface ErrorForCode {
+    // (undocumented)
+    [ZamaErrorCode.AclPaused]: AclPausedError;
+    // (undocumented)
+    [ZamaErrorCode.BalanceCheckUnavailable]: BalanceCheckUnavailableError;
+    // (undocumented)
+    [ZamaErrorCode.ChainMismatch]: ChainMismatchError;
+    // (undocumented)
+    [ZamaErrorCode.Configuration]: ConfigurationError;
+    // (undocumented)
+    [ZamaErrorCode.DecryptionFailed]: DecryptionFailedError;
+    // (undocumented)
+    [ZamaErrorCode.DelegationContractIsSelf]: DelegationContractIsSelfError;
+    // (undocumented)
+    [ZamaErrorCode.DelegationCooldown]: DelegationCooldownError;
+    // (undocumented)
+    [ZamaErrorCode.DelegationDelegateEqualsContract]: DelegationDelegateEqualsContractError;
+    // (undocumented)
+    [ZamaErrorCode.DelegationExpirationTooSoon]: DelegationExpirationTooSoonError;
+    // (undocumented)
+    [ZamaErrorCode.DelegationExpired]: DelegationExpiredError;
+    // (undocumented)
+    [ZamaErrorCode.DelegationExpiryUnchanged]: DelegationExpiryUnchangedError;
+    // (undocumented)
+    [ZamaErrorCode.DelegationNotFound]: DelegationNotFoundError;
+    // (undocumented)
+    [ZamaErrorCode.DelegationNotPropagated]: DelegationNotPropagatedError;
+    // (undocumented)
+    [ZamaErrorCode.DelegationSelfNotAllowed]: DelegationSelfNotAllowedError;
+    // (undocumented)
+    [ZamaErrorCode.EncryptionFailed]: EncryptionFailedError;
+    // (undocumented)
+    [ZamaErrorCode.ERC20ReadFailed]: ERC20ReadFailedError;
+    // (undocumented)
+    [ZamaErrorCode.InsufficientAllowance]: InsufficientAllowanceError;
+    // (undocumented)
+    [ZamaErrorCode.InsufficientConfidentialBalance]: InsufficientConfidentialBalanceError;
+    // (undocumented)
+    [ZamaErrorCode.InsufficientERC20Balance]: InsufficientERC20BalanceError;
+    // (undocumented)
+    [ZamaErrorCode.InvalidTransportKeyPair]: InvalidTransportKeyPairError;
+    // (undocumented)
+    [ZamaErrorCode.TransportKeyPairExpired]: TransportKeyPairExpiredError;
+    // (undocumented)
+    [ZamaErrorCode.NoCiphertext]: NoCiphertextError;
+    // (undocumented)
+    [ZamaErrorCode.NotEntitled]: NotEntitledError;
+    // (undocumented)
+    [ZamaErrorCode.RelayerRequestFailed]: RelayerRequestFailedError;
+    // (undocumented)
+    [ZamaErrorCode.RpcRateLimited]: RpcRateLimitError;
+    // (undocumented)
+    [ZamaErrorCode.SignerNotConfigured]: SignerNotConfiguredError;
+    // (undocumented)
+    [ZamaErrorCode.SigningFailed]: SigningFailedError;
+    // (undocumented)
+    [ZamaErrorCode.SigningRejected]: SigningRejectedError;
+    // (undocumented)
+    [ZamaErrorCode.TransactionReverted]: TransactionRevertedError;
+    // (undocumented)
+    [ZamaErrorCode.WalletAccountNotReady]: WalletAccountNotReadyError;
+    // (undocumented)
+    [ZamaErrorCode.WalletNotConnected]: WalletNotConnectedError;
+}
+
+// @public
 export interface FheChain<TId extends number = number> {
     // (undocumented)
     readonly aclContractAddress: Address;
@@ -5858,6 +5929,9 @@ export type FheChainAuth = {
     cookie?: string;
     value: string;
 };
+
+// @public
+export type FhevmClientOptions = NonNullable<Parameters<typeof createFhevmClient>[0]["options"]>;
 
 // @public
 export interface FhevmRelayerOptions {
@@ -12875,6 +12949,33 @@ export const sepolia: {
     readonly verifyingContractAddressInputVerification: "0x483b9dE06E4E4C7D35CCf5837A1668487406D955";
     readonly registryAddress: "0x2f0750Bbb0A246059d80e94c454586a7F27a128e";
 };
+
+// @public
+export interface SerializedPermit {
+    // (undocumented)
+    eip712: SerializedPermitEip712;
+    // (undocumented)
+    signature: Hex;
+    // (undocumented)
+    signerAddress: ChecksummedAddress;
+    // (undocumented)
+    version: number;
+}
+
+// @public
+export interface SerializedPermitEip712 {
+    // (undocumented)
+    domain: Record<string, unknown>;
+    // (undocumented)
+    message: Record<string, unknown>;
+    // (undocumented)
+    primaryType?: string;
+    // (undocumented)
+    types: Record<string, {
+        name: string;
+        type: string;
+    }[]>;
+}
 
 // @public
 export interface SerializedTransportKeyPair {

--- a/packages/sdk/src/chains/router.ts
+++ b/packages/sdk/src/chains/router.ts
@@ -9,6 +9,8 @@ import type { FhevmRelayerSDK } from "../relayer/types";
  * hands out the single-chain {@link FhevmRelayerSDK} backend for the currently active
  * chain via {@link ChainRouter.relayer}. Builds one backend per chain from its
  * {@link RelayerConfig}.
+ *
+ * @internal
  */
 export class ChainRouter {
   readonly #chains: Map<number, FheChain>;

--- a/packages/sdk/src/config/index.ts
+++ b/packages/sdk/src/config/index.ts
@@ -12,5 +12,4 @@ export type {
 export type { ZamaConfigViem } from "../viem/types";
 export type { ZamaConfigEthers } from "../ethers/types";
 
-export { resolveChainRelayers, resolveStorage } from "./resolve";
-export type { ResolvedChainRelayer } from "./resolve";
+export { resolveStorage } from "./resolve";

--- a/packages/sdk/src/config/index.ts
+++ b/packages/sdk/src/config/index.ts
@@ -11,5 +11,3 @@ export type {
 } from "./types";
 export type { ZamaConfigViem } from "../viem/types";
 export type { ZamaConfigEthers } from "../ethers/types";
-
-export { resolveStorage } from "./resolve";

--- a/packages/sdk/src/config/resolve.ts
+++ b/packages/sdk/src/config/resolve.ts
@@ -13,6 +13,7 @@ function getDefaultStorage(): GenericStorage {
     : new MemoryStorage();
 }
 
+/** @internal */
 export function resolveStorage(
   storage: GenericStorage | undefined = getDefaultStorage(),
   permitStorage: GenericStorage | undefined = storage,

--- a/packages/sdk/src/config/resolve.ts
+++ b/packages/sdk/src/config/resolve.ts
@@ -22,11 +22,13 @@ export function resolveStorage(
 
 // ── Chain relayer resolution ────────────────────────────────────────────────
 
+/** @internal */
 export interface ResolvedChainRelayer {
   chain: FheChain;
   relayerConfig: RelayerConfig;
 }
 
+/** @internal */
 export function resolveChainRelayers(
   chains: readonly FheChain[],
   relayers: Readonly<Record<number, RelayerConfig>>,

--- a/packages/sdk/src/config/types.ts
+++ b/packages/sdk/src/config/types.ts
@@ -14,7 +14,10 @@ export type { AtLeastOneChain };
  */
 export interface RelayerConfig {
   readonly type: string;
-  /** Create a single-chain relayer. */
+  /**
+   * Create a single-chain relayer.
+   * @internal
+   */
   readonly createRelayer: (chain: FheChain) => FhevmRelayerSDK;
 }
 
@@ -92,6 +95,7 @@ declare const zamaConfigBrand: unique symbol;
  */
 export type ZamaConfig = {
   readonly chains: readonly FheChain[];
+  /** @internal */
   readonly router: ChainRouter;
   readonly provider: GenericProvider;
   readonly signer: GenericSigner | undefined;

--- a/packages/sdk/src/credentials/__tests__/schemas.test-d.ts
+++ b/packages/sdk/src/credentials/__tests__/schemas.test-d.ts
@@ -1,0 +1,27 @@
+import type { z } from "zod/mini";
+import { describe, expectTypeOf, test } from "vitest";
+import type {
+  PermissionSchema,
+  SerializedPermitSchema,
+  StoredTransportKeyPairSchema,
+} from "../schemas";
+import type { Permission, SerializedPermit, StoredTransportKeyPair } from "../types";
+
+// Drift guard: the public credential interfaces are hand-written (so the zod
+// schemas can stay `@internal` and be stripped from the shipped .d.ts). These
+// assertions fail typecheck if a schema and its public type ever diverge.
+describe("credential schema/type parity", () => {
+  test("StoredTransportKeyPair matches its schema", () => {
+    expectTypeOf<
+      z.infer<typeof StoredTransportKeyPairSchema>
+    >().toEqualTypeOf<StoredTransportKeyPair>();
+  });
+
+  test("SerializedPermit matches its schema", () => {
+    expectTypeOf<z.infer<typeof SerializedPermitSchema>>().toEqualTypeOf<SerializedPermit>();
+  });
+
+  test("Permission matches its schema", () => {
+    expectTypeOf<z.infer<typeof PermissionSchema>>().toEqualTypeOf<Permission>();
+  });
+});

--- a/packages/sdk/src/credentials/credential-service.ts
+++ b/packages/sdk/src/credentials/credential-service.ts
@@ -58,6 +58,8 @@ export interface CredentialServiceConfig {
  * stored there, so it's untouched. {@link revokeTransportKeyPair} (operator-level) is
  * the only way to invalidate a scope's shared key pair, and it does so for every signer
  * in the scope at once.
+ *
+ * @internal
  */
 export class CredentialService {
   readonly #vault: TransportKeyPairVault;

--- a/packages/sdk/src/credentials/index.ts
+++ b/packages/sdk/src/credentials/index.ts
@@ -1,7 +1,6 @@
 export type {
   SerializedTransportKeyPairWithPermissions,
   SerializedTransportKeyPair,
-  StoredTransportKeyPair,
   Permission,
 } from "./types";
 export type { ChecksummedAddress } from "../schemas/primitives";

--- a/packages/sdk/src/credentials/schemas.ts
+++ b/packages/sdk/src/credentials/schemas.ts
@@ -35,6 +35,7 @@ export const TransportKeyPairScopeSchema = z
   .string({ error: transportKeyPairScopeError })
   .check(z.minLength(1, transportKeyPairScopeError));
 
+/** @internal */
 export const StoredTransportKeyPairSchema = z.object({
   publicKey: hex,
   privateKey: hex,
@@ -56,6 +57,7 @@ export const SerializedPermitSchema = z.object({
   signerAddress: checksummedAddress,
 });
 
+/** @internal */
 export const PermissionSchema = z.object({
   keypairPublicKey: hex,
   contractAddresses: z.array(checksummedAddress).check(z.maxLength(MAX_CONTRACTS_PER_PERMIT)),

--- a/packages/sdk/src/credentials/types.ts
+++ b/packages/sdk/src/credentials/types.ts
@@ -17,6 +17,8 @@ export interface SerializedTransportKeyPair {
  *
  * The shape mirrors {@link StoredTransportKeyPairSchema} — a `.test-d.ts` guard
  * asserts the two stay in sync, so the schema can remain an internal detail.
+ *
+ * @internal
  */
 export interface StoredTransportKeyPair {
   publicKey: Hex;

--- a/packages/sdk/src/credentials/types.ts
+++ b/packages/sdk/src/credentials/types.ts
@@ -1,10 +1,5 @@
 import type { Hex } from "viem";
-import type { z } from "zod/mini";
-import type {
-  PermissionSchema,
-  SerializedPermitSchema,
-  StoredTransportKeyPairSchema,
-} from "./schemas";
+import type { ChecksummedAddress } from "../schemas/primitives";
 
 /**
  * Serialized transport key pair — ML-KEM public + private key as hex, the shape
@@ -17,22 +12,55 @@ export interface SerializedTransportKeyPair {
   privateKey: Hex;
 }
 
-/** Persisted transport key pair entry with a bounded lifetime. */
-export type StoredTransportKeyPair = z.infer<typeof StoredTransportKeyPairSchema>;
+/**
+ * Persisted transport key pair entry with a bounded lifetime.
+ *
+ * The shape mirrors {@link StoredTransportKeyPairSchema} — a `.test-d.ts` guard
+ * asserts the two stay in sync, so the schema can remain an internal detail.
+ */
+export interface StoredTransportKeyPair {
+  publicKey: Hex;
+  privateKey: Hex;
+  createdAt: number;
+  expiresAt: number;
+}
+
+/** EIP-712 typed-data payload carried by a {@link SerializedPermit}. */
+export interface SerializedPermitEip712 {
+  domain: Record<string, unknown>;
+  primaryType?: string;
+  types: Record<string, { name: string; type: string }[]>;
+  message: Record<string, unknown>;
+}
 
 /**
  * The reusable serialized `@fhevm/sdk` decryption permit persisted inside a
  * {@link Permission} — passed verbatim to `parseSignedDecryptionPermit`.
+ *
+ * Mirrors {@link SerializedPermitSchema}; kept in sync by a `.test-d.ts` guard.
  */
-export type SerializedPermit = z.infer<typeof SerializedPermitSchema>;
+export interface SerializedPermit {
+  version: number;
+  eip712: SerializedPermitEip712;
+  signature: Hex;
+  signerAddress: ChecksummedAddress;
+}
 
 /**
  * A signed EIP-712 permit binding a signer (and optional delegator) to a set of
  * contract addresses for a bounded time window. Wraps the serialized `@fhevm/sdk`
  * permit ({@link SerializedPermit}) alongside the scope/coverage metadata the
  * permission store indexes on.
+ *
+ * Mirrors {@link PermissionSchema}; kept in sync by a `.test-d.ts` guard.
  */
-export type Permission = z.infer<typeof PermissionSchema>;
+export interface Permission {
+  keypairPublicKey: Hex;
+  contractAddresses: ChecksummedAddress[];
+  serializedPermit: SerializedPermit;
+  startTimestamp: number;
+  durationDays: number;
+}
 
 /**
  * Credentials resolved for a decrypt operation: the transport key pair plus the

--- a/packages/sdk/src/errors/__tests__/errors.test-d.ts
+++ b/packages/sdk/src/errors/__tests__/errors.test-d.ts
@@ -21,6 +21,7 @@ import type {
   InsufficientERC20BalanceError,
   InsufficientAllowanceError,
   ChainMismatchError,
+  ErrorForCode,
 } from "..";
 import { ZamaError, ZamaErrorCode, isRetryable, retryAfterSeconds, matchZamaError } from "..";
 
@@ -167,5 +168,12 @@ describe("matchZamaError", () => {
     const baseHandler = (e: ZamaError) => e.code;
     const fromBaseHandler = matchZamaError(new Error("any"), { SIGNING_REJECTED: baseHandler });
     expectTypeOf(fromBaseHandler).toEqualTypeOf<ZamaErrorCode | undefined>();
+  });
+
+  describe("ErrorForCode", () => {
+    test("maps out each error code to an error", () => {
+      type Complete<T extends Record<ZamaErrorCode, ZamaError>> = T;
+      expectTypeOf<ErrorForCode>().toEqualTypeOf<Complete<ErrorForCode>>();
+    });
   });
 });

--- a/packages/sdk/src/errors/index.ts
+++ b/packages/sdk/src/errors/index.ts
@@ -1,5 +1,5 @@
 export { ZamaError, ZamaErrorCode, isRetryable, retryAfterSeconds } from "./base";
-export { matchZamaError } from "./match";
+export { matchZamaError, type ErrorForCode } from "./match";
 export { SigningRejectedError, SigningFailedError } from "./signing";
 export { EncryptionFailedError, DecryptionFailedError } from "./encryption";
 export { TransactionRevertedError } from "./transaction";

--- a/packages/sdk/src/errors/match.ts
+++ b/packages/sdk/src/errors/match.ts
@@ -38,21 +38,12 @@ import type { SigningFailedError, SigningRejectedError } from "./signing";
 import type { TransactionRevertedError } from "./transaction";
 
 /**
- * Identity type that fails to instantiate unless `T` maps every code to a `ZamaError`.
- * Guards presence + value type only: a wrong-but-valid mapping (a code pointing at a
- * structurally identical sibling class) still compiles — `errors.test-d.ts` backstops that.
- */
-type Complete<T extends Record<ZamaErrorCode, ZamaError>> = T;
-
-/**
  * Maps each {@link ZamaErrorCode} to the error class thrown with that code, so
  * {@link matchZamaError} handlers receive the matched subtype instead of the base
- * `ZamaError`. Hand-maintained; the `Complete` wrapper fails the build if a code is
- * added without an entry here (or mapped to a non-`ZamaError`). Kept local (not
- * exported) so it stays inline in `matchZamaError`'s signature rather than becoming
- * a named public type.
+ * `ZamaError`. Hand-maintained; the `Complete` guard below fails the build if a code
+ * is added without an entry here (or mapped to a non-`ZamaError`).
  */
-type ErrorForCode = Complete<{
+export interface ErrorForCode {
   [ZamaErrorCode.SigningRejected]: SigningRejectedError;
   [ZamaErrorCode.SigningFailed]: SigningFailedError;
   [ZamaErrorCode.EncryptionFailed]: EncryptionFailedError;
@@ -84,7 +75,7 @@ type ErrorForCode = Complete<{
   [ZamaErrorCode.SignerNotConfigured]: SignerNotConfiguredError;
   [ZamaErrorCode.WalletNotConnected]: WalletNotConnectedError;
   [ZamaErrorCode.WalletAccountNotReady]: WalletAccountNotReadyError;
-}>;
+}
 
 /**
  * Pattern-match on a {@link ZamaError} by its error code. Each handler receives the

--- a/packages/sdk/src/errors/match.ts
+++ b/packages/sdk/src/errors/match.ts
@@ -48,7 +48,9 @@ type Complete<T extends Record<ZamaErrorCode, ZamaError>> = T;
  * Maps each {@link ZamaErrorCode} to the error class thrown with that code, so
  * {@link matchZamaError} handlers receive the matched subtype instead of the base
  * `ZamaError`. Hand-maintained; the `Complete` wrapper fails the build if a code is
- * added without an entry here (or mapped to a non-`ZamaError`).
+ * added without an entry here (or mapped to a non-`ZamaError`). Kept local (not
+ * exported) so it stays inline in `matchZamaError`'s signature rather than becoming
+ * a named public type.
  */
 type ErrorForCode = Complete<{
   [ZamaErrorCode.SigningRejected]: SigningRejectedError;

--- a/packages/sdk/src/ethers/contracts.ts
+++ b/packages/sdk/src/ethers/contracts.ts
@@ -37,22 +37,26 @@ interface TransactionRequestConfig {
   value?: bigint;
 }
 
-interface EthersTransactionRequest {
+/** Minimal transaction request accepted by the ethers contract helpers. */
+export interface EthersTransactionRequest {
   to: Address;
   data: Hex;
   gasLimit?: bigint;
   value?: bigint;
 }
 
-interface EthersTransactionResponse {
+/** Minimal transaction response returned by an {@link EthersTransactionSigner}. */
+export interface EthersTransactionResponse {
   hash: string;
 }
 
-interface EthersCallProvider {
+/** Minimal read-only ethers provider shape used by the read contract helpers. */
+export interface EthersCallProvider {
   call(tx: EthersTransactionRequest): Promise<string>;
 }
 
-interface EthersTransactionSigner extends EthersCallProvider {
+/** Minimal ethers signer shape used by the write contract helpers. */
+export interface EthersTransactionSigner extends EthersCallProvider {
   sendTransaction(tx: EthersTransactionRequest): Promise<EthersTransactionResponse>;
 }
 

--- a/packages/sdk/src/ethers/index.ts
+++ b/packages/sdk/src/ethers/index.ts
@@ -20,7 +20,71 @@ export type {
   Hex,
 } from "viem";
 export { ProviderRpcError } from "viem";
-export type { EncryptedValue } from "../relayer/types";
+export type {
+  EncryptedValue,
+  EIP712TypedData,
+  FhevmRuntimeConfig,
+  ClearValue,
+} from "../relayer/types";
+export type { AtLeastOneChain, FheChain, FheChainAuth } from "../chains/types";
+export type { ZamaConfig, ZamaConfigBase, RelayerConfig } from "../config/types";
+export type {
+  GenericProvider,
+  GenericStorage,
+  GenericLogger,
+  GenericSigner,
+  WalletAccount,
+  WalletAccountChange,
+  WalletAccountListener,
+  WalletAccountStore,
+  ContractAbi,
+  ReadFunctionName,
+  ReadContractArgs,
+  ReadContractReturnType,
+  ReadContractConfig,
+  WriteFunctionName,
+  WriteContractArgs,
+  WriteContractConfig,
+  TransactionReceipt,
+  ShieldPath,
+} from "../types";
+export type { MutableWalletAccountStore } from "../signer/wallet-account-store";
+export type { RawLog } from "../events";
+export { ZamaSDKEvents } from "../events/sdk-events";
+export type {
+  BaseEvent,
+  ZamaSDKEvent,
+  ZamaSDKEventType,
+  ZamaSDKEventListener,
+  TransactionOperation,
+  EncryptStartEvent,
+  EncryptEndEvent,
+  EncryptErrorEvent,
+  DecryptStartEvent,
+  DecryptEndEvent,
+  DecryptErrorEvent,
+  TransactionErrorEvent,
+  ShieldSubmittedEvent,
+  TransferSubmittedEvent,
+  TransferFromSubmittedEvent,
+  SetOperatorSubmittedEvent,
+  ApproveUnderlyingSubmittedEvent,
+  WrapSubmittedEvent,
+  UnwrapSubmittedEvent,
+  FinalizeUnwrapSubmittedEvent,
+  DelegationSubmittedEvent,
+  RevokeDelegationSubmittedEvent,
+  UnshieldPhase1SubmittedEvent,
+  UnshieldPhase2StartedEvent,
+  UnshieldPhase2SubmittedEvent,
+} from "../events/sdk-events";
+export { BaseSigner } from "../signer/base-signer";
+export type {
+  EthersCallProvider,
+  EthersTransactionSigner,
+  EthersTransactionRequest,
+  EthersTransactionResponse,
+} from "./contracts";
 export {
   readConfidentialBalanceOfContract,
   readUnderlyingTokenContract,

--- a/packages/sdk/src/events/sdk-events.ts
+++ b/packages/sdk/src/events/sdk-events.ts
@@ -199,7 +199,11 @@ export type ZamaSDKEvent =
 
 export type ZamaSDKEventListener = (event: ZamaSDKEvent) => void;
 
-/** Distributive Omit that preserves the discriminated union. */
+/**
+ * Distributive Omit that preserves the discriminated union. Internal emit-side
+ * shape — consumers only ever receive fully-populated {@link ZamaSDKEvent}.
+ * @internal
+ */
 export type ZamaSDKEventInput = ZamaSDKEvent extends infer E
   ? E extends ZamaSDKEvent
     ? Omit<E, "timestamp" | "tokenAddress">

--- a/packages/sdk/src/events/sdk-events.ts
+++ b/packages/sdk/src/events/sdk-events.ts
@@ -207,14 +207,38 @@ export type ZamaSDKEventInput = ZamaSDKEvent extends infer E
   : never;
 
 /**
+ * SDK transaction operations that emit submitted/error lifecycle events.
+ *
+ * Operation strings encode the execution-path discriminator for flows that have
+ * one (`shield:transferAndCall` vs. `shield:approveAndWrap`), routing both error
+ * and success events on a single field — see {@link transactionOperationMetadata}.
+ */
+export type TransactionOperation =
+  | "approveUnderlying"
+  | "approveUnderlying:reset"
+  | "delegateDecryption"
+  | "finalizeUnwrap"
+  | "revokeDelegation"
+  | "setOperator"
+  | "shield:transferAndCall"
+  | "shield:approveAndWrap"
+  | "wrap"
+  | "transfer"
+  | "transferAndCall"
+  | "transferFrom"
+  | "transferFromAndCall"
+  | "unwrap"
+  | "unwrapAll";
+
+/**
  * Single source of truth for each transaction operation's submitted-event payload.
  *
- * Adding a write op = adding one entry here. `TransactionOperation` is then
- * `keyof typeof transactionOperationMetadata`, so the dispatch table and the
- * operation union cannot drift.
+ * Adding a write op = adding one entry here plus its {@link TransactionOperation}
+ * member; the `satisfies Record<TransactionOperation, …>` check enforces that the
+ * table and the union stay in lockstep (missing or extra keys fail the build) and
+ * that every entry produces a valid {@link ZamaSDKEventInput}.
  *
- * The `satisfies` check enforces that every entry produces a valid
- * {@link ZamaSDKEventInput}.
+ * @internal
  */
 export const transactionOperationMetadata = {
   approveUnderlying: {
@@ -272,13 +296,4 @@ export const transactionOperationMetadata = {
   },
   unwrap: { submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }) },
   unwrapAll: { submittedEvent: (txHash: Hex) => ({ type: ZamaSDKEvents.UnwrapSubmitted, txHash }) },
-} satisfies Record<string, { submittedEvent: (txHash: Hex) => ZamaSDKEventInput }>;
-
-/**
- * SDK transaction operations that emit submitted/error lifecycle events.
- *
- * Operation strings encode the execution-path discriminator for flows that have
- * one (`shield:transferAndCall` vs. `shield:approveAndWrap`), routing both error
- * and success events on a single field — see {@link transactionOperationMetadata}.
- */
-export type TransactionOperation = keyof typeof transactionOperationMetadata;
+} satisfies Record<TransactionOperation, { submittedEvent: (txHash: Hex) => ZamaSDKEventInput }>;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -10,7 +10,7 @@
 // Note: web() and node() transport factories live in their own entry points
 // (@zama-fhe/sdk/web and @zama-fhe/sdk/node) to keep environment-specific
 // dependencies out of this barrel.
-export { createConfig, cleartext, resolveChainRelayers, resolveStorage } from "./config";
+export { createConfig, cleartext, resolveStorage } from "./config";
 export type {
   ZamaConfig,
   ZamaConfigBase,
@@ -20,10 +20,7 @@ export type {
   RelayerConfig,
   CleartextRelayerConfig,
   AtLeastOneChain,
-  ResolvedChainRelayer,
 } from "./config";
-export type { ChainRouter } from "./chains/router";
-export type { FhevmRelayerSDK as RelayerSDK } from "./relayer/types";
 export type {
   EncryptResult,
   EncryptParams,
@@ -33,6 +30,9 @@ export type {
   EIP712TypedData,
   TypedValue,
   DecryptValuesParameters,
+  RelayerOptions,
+  FhevmRelayerOptions,
+  FhevmRuntimeConfig,
 } from "./relayer/types";
 
 // Decrypt parameter/result types — aligned with the canonical Zama glossary.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -10,7 +10,7 @@
 // Note: web() and node() transport factories live in their own entry points
 // (@zama-fhe/sdk/web and @zama-fhe/sdk/node) to keep environment-specific
 // dependencies out of this barrel.
-export { createConfig, cleartext, resolveStorage } from "./config";
+export { createConfig, cleartext } from "./config";
 export type {
   ZamaConfig,
   ZamaConfigBase,
@@ -82,12 +82,7 @@ export {
   ChromeSessionStorage,
   chromeSessionStorage,
 } from "./storage";
-export type {
-  SerializedTransportKeyPair,
-  StoredTransportKeyPair,
-  Permission,
-  ChecksummedAddress,
-} from "./credentials";
+export type { SerializedTransportKeyPair, Permission, ChecksummedAddress } from "./credentials";
 export type { SerializedPermit, SerializedPermitEip712 } from "./credentials/types";
 export type {
   GenericSigner,
@@ -123,7 +118,6 @@ export { ZamaSDKEvents } from "./events";
 export type {
   ZamaSDKEventType,
   ZamaSDKEvent,
-  ZamaSDKEventInput,
   ZamaSDKEventListener,
   BaseEvent,
   ShieldSubmittedEvent,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -33,6 +33,7 @@ export type {
   RelayerOptions,
   FhevmRelayerOptions,
   FhevmRuntimeConfig,
+  FhevmClientOptions,
 } from "./relayer/types";
 
 // Decrypt parameter/result types — aligned with the canonical Zama glossary.
@@ -81,7 +82,13 @@ export {
   ChromeSessionStorage,
   chromeSessionStorage,
 } from "./storage";
-export type { SerializedTransportKeyPair, StoredTransportKeyPair, Permission } from "./credentials";
+export type {
+  SerializedTransportKeyPair,
+  StoredTransportKeyPair,
+  Permission,
+  ChecksummedAddress,
+} from "./credentials";
+export type { SerializedPermit, SerializedPermitEip712 } from "./credentials/types";
 export type {
   GenericSigner,
   GenericProvider,
@@ -180,6 +187,7 @@ export {
   DelegationExpirationTooSoonError,
   DelegationNotPropagatedError,
   matchZamaError,
+  type ErrorForCode,
 } from "./errors";
 export { BaseSigner } from "./signer/base-signer";
 export { createWalletAccountStore, MutableWalletAccountStore } from "./signer/wallet-account-store";

--- a/packages/sdk/src/node/config.ts
+++ b/packages/sdk/src/node/config.ts
@@ -6,6 +6,7 @@ import type { RelayerOptions } from "../relayer/types";
 /** Node transport — drives the FHE backend directly on the calling thread. */
 export interface NodeRelayerConfig extends RelayerConfig {
   readonly type: "node";
+  /** @internal */
   readonly createRelayer: (chain: FheChain) => FhevmRelayer;
 }
 

--- a/packages/sdk/src/node/index.ts
+++ b/packages/sdk/src/node/index.ts
@@ -10,7 +10,8 @@
 export { node } from "./config";
 export type { NodeRelayerConfig } from "./config";
 export { cleartext } from "../config/cleartext";
-export type { RelayerConfig } from "../config/types";
+export type { RelayerConfig, CleartextRelayerConfig } from "../config/types";
+export type { FheChain } from "../chains/types";
 export type { GenericLogger } from "../types/logger";
 // Surfaced by the node entry's public API: `AsyncLocalMapStorage implements GenericStorage`,
 // and the exported chain presets carry `auth?: FheChainAuth`.
@@ -18,7 +19,17 @@ export type { GenericStorage } from "../types/storage";
 export type { FheChainAuth } from "../chains/types";
 
 // Relayer types used in the node transport's public API
-export type { ClearValue, EIP712TypedData, EncryptParams } from "../relayer/types";
+export type {
+  ClearValue,
+  EIP712TypedData,
+  EncryptParams,
+  EncryptInput,
+  EncryptedValue,
+  RelayerOptions,
+  FhevmRelayerOptions,
+  FhevmClientOptions,
+  FhevmRuntimeConfig,
+} from "../relayer/types";
 // Decrypt parameter/result types — aligned with the canonical Zama glossary (see main entry).
 export type { DecryptPublicValuesResult } from "../relayer/types";
 

--- a/packages/sdk/src/node/index.ts
+++ b/packages/sdk/src/node/index.ts
@@ -11,7 +11,6 @@ export { node } from "./config";
 export type { NodeRelayerConfig } from "./config";
 export { cleartext } from "../config/cleartext";
 export type { RelayerConfig } from "../config/types";
-export type { FhevmRelayerSDK as RelayerSDK } from "../relayer/types";
 export type { GenericLogger } from "../types/logger";
 
 // Relayer types used in the node transport's public API

--- a/packages/sdk/src/node/index.ts
+++ b/packages/sdk/src/node/index.ts
@@ -12,6 +12,10 @@ export type { NodeRelayerConfig } from "./config";
 export { cleartext } from "../config/cleartext";
 export type { RelayerConfig } from "../config/types";
 export type { GenericLogger } from "../types/logger";
+// Surfaced by the node entry's public API: `AsyncLocalMapStorage implements GenericStorage`,
+// and the exported chain presets carry `auth?: FheChainAuth`.
+export type { GenericStorage } from "../types/storage";
+export type { FheChainAuth } from "../chains/types";
 
 // Relayer types used in the node transport's public API
 export type { ClearValue, EIP712TypedData, EncryptParams } from "../relayer/types";

--- a/packages/sdk/src/query/factory-types.ts
+++ b/packages/sdk/src/query/factory-types.ts
@@ -5,18 +5,16 @@ import type {
   skipToken,
 } from "@tanstack/query-core";
 
-type RequiredBy<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
-
 export type QueryFactoryOptions<
   TQueryFnData = unknown,
   TError = Error,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 > = Omit<
-  RequiredBy<
-    QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>,
-    "queryKey"
-  >,
+  Omit<QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>, "queryKey"> &
+    Required<
+      Pick<QueryObserverOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>, "queryKey">
+    >,
   "queryFn" | "queryHash" | "queryKeyHashFn" | "throwOnError"
 > & {
   queryFn: Exclude<

--- a/packages/sdk/src/query/index.ts
+++ b/packages/sdk/src/query/index.ts
@@ -140,7 +140,6 @@ export type { ClearValue, EncryptParams, EncryptResult, EncryptedValue } from ".
 export type { EncryptInput, EIP712TypedData } from "../relayer/types";
 // Decrypt parameter/result types — aligned with the canonical Zama glossary (see main entry).
 export type { DecryptPublicValuesResult } from "../relayer/types";
-export type { FhevmRelayerSDK as RelayerSDK } from "../relayer/types";
 export type { BatchBalancesResult, BatchDecryptAsOptions } from "../token/token";
 export type { Token } from "../token/token";
 export type { WrappedToken } from "../token/wrapped-token";

--- a/packages/sdk/src/query/index.ts
+++ b/packages/sdk/src/query/index.ts
@@ -185,7 +185,6 @@ export type {
   UnshieldPhase2SubmittedEvent,
   UnwrapSubmittedEvent,
   ZamaSDKEvent,
-  ZamaSDKEventInput,
   ZamaSDKEventListener,
   DelegationSubmittedEvent,
   RevokeDelegationSubmittedEvent,

--- a/packages/sdk/src/query/index.ts
+++ b/packages/sdk/src/query/index.ts
@@ -148,12 +148,19 @@ export type { ZamaConfig } from "../config";
 export type { SerializedTransportKeyPair } from "../credentials";
 export type {
   GenericSigner,
+  GenericProvider,
   GenericStorage,
+  GenericLogger,
   ApprovalStrategy,
   ShieldCallbacks,
   WalletAccount,
   WalletAccountChange,
   WalletAccountListener,
+  WalletAccountStore,
+  ContractAbi,
+  WriteFunctionName,
+  WriteContractArgs,
+  WriteContractConfig,
   TransactionReceipt,
   TransactionResult,
   ShieldOptions,
@@ -162,7 +169,30 @@ export type {
   TransferOptions,
   UnshieldCallbacks,
   UnshieldOptions,
+  WrapOptions,
+  UnwrapResult,
 } from "../types";
+export type { FheChain, FheChainAuth } from "../chains/types";
+export type { FhevmRelayerOptions, FhevmRuntimeConfig } from "../relayer/types";
+export type {
+  ReadFunctionName,
+  ReadContractArgs,
+  ReadContractConfig,
+  ReadContractReturnType,
+} from "../types";
+export type { ZamaError, ZamaErrorCode } from "../errors";
+export type {
+  WrappersRegistry,
+  WrappersRegistryConfig,
+  ListPairsOptions,
+} from "../wrappers-registry";
+export type { PaginatedResult, TokenWrapperPair, TokenWrapperPairWithMetadata } from "../contracts";
+export type { Permits, Delegations, Decryption } from "../namespaces";
+export type {
+  DelegatedDecryptOptions,
+  BatchDecryptResult,
+  BatchDecryptItem,
+} from "../services/decryption-service";
 export { ZamaSDKEvents } from "../events/sdk-events";
 export type {
   SetOperatorSubmittedEvent,
@@ -184,6 +214,7 @@ export type {
   UnshieldPhase2StartedEvent,
   UnshieldPhase2SubmittedEvent,
   UnwrapSubmittedEvent,
+  WrapSubmittedEvent,
   ZamaSDKEvent,
   ZamaSDKEventListener,
   DelegationSubmittedEvent,

--- a/packages/sdk/src/relayer/fhevm-relayer.ts
+++ b/packages/sdk/src/relayer/fhevm-relayer.ts
@@ -58,6 +58,8 @@ export interface FhevmRelayerConfig {
  *   are spread in first, then the per-call `options`, so a per-call value always
  *   wins over the chain default. Serialization helpers make no relayer
  *   round-trip, so they inject no options.
+ *
+ * @internal
  */
 export class FhevmRelayer implements FhevmRelayerSDK {
   readonly #chain: FheChain;

--- a/packages/sdk/src/relayer/types.ts
+++ b/packages/sdk/src/relayer/types.ts
@@ -69,7 +69,10 @@ export interface DecryptPublicValuesResult {
  */
 export type EIP712TypedData = Eip712Like;
 
-/** The underlying client returned by `@fhevm/sdk`'s `createFhevmClient`. */
+/**
+ * The underlying client returned by `@fhevm/sdk`'s `createFhevmClient`.
+ * @internal
+ */
 export type FhevmClient = ReturnType<typeof createFhevmClient>;
 
 /** @internal Capability-scoped `@fhevm/sdk` clients used by {@link FhevmRelayer}. */
@@ -201,6 +204,8 @@ export interface FhevmRelayerOptions {
 /**
  * Single-chain FHE backend contract. Implemented by `FhevmRelayer` (drives
  * `@fhevm/sdk`); translates between the domain shapes above and the engine's API.
+ *
+ * @internal
  */
 export interface FhevmRelayerSDK extends Pick<
   FhevmClient,

--- a/packages/sdk/src/relayer/types.ts
+++ b/packages/sdk/src/relayer/types.ts
@@ -134,7 +134,6 @@ export type FhevmRuntimeConfig = Parameters<typeof setFhevmRuntimeConfig>[0];
  * round-trip (mirrors its `RelayerCommonOptions`). Distinct from
  * {@link RelayerOptions}, which configures a transport once at construction —
  * these are applied per call.
- *
  */
 export interface FhevmRelayerOptions {
   /** Relayer authentication for the chain. Defaulted from the chain's config. */

--- a/packages/sdk/src/services/caching-service.ts
+++ b/packages/sdk/src/services/caching-service.ts
@@ -12,6 +12,8 @@ const CacheIndexSchema = z.array(z.string());
  *
  * Each entry is keyed by `(requester, contractAddress, handle)` so different
  * signers cannot read each other's cached decryptions.
+ *
+ * @internal
  */
 export class CachingService {
   readonly #storage: GenericStorage;

--- a/packages/sdk/src/services/decryption-service.ts
+++ b/packages/sdk/src/services/decryption-service.ts
@@ -75,6 +75,7 @@ export interface BatchDecryptResult {
   items: BatchDecryptItem[];
 }
 
+/** @internal */
 export class DecryptionService {
   readonly #cache: CachingService;
   readonly #credentialService: CredentialService;

--- a/packages/sdk/src/services/delegation-service.ts
+++ b/packages/sdk/src/services/delegation-service.ts
@@ -31,6 +31,7 @@ type AclTransactionOperation = Extract<
   "delegateDecryption" | "revokeDelegation"
 >;
 
+/** @internal */
 export class DelegationService {
   readonly #router: ChainRouter;
   readonly #provider: GenericProvider;

--- a/packages/sdk/src/viem/index.ts
+++ b/packages/sdk/src/viem/index.ts
@@ -7,7 +7,16 @@
 
 export type { ZamaConfigViem } from "./types";
 export type { Hex } from "viem";
-export type { EncryptedValue } from "../relayer/types";
+export type { EncryptedValue, EIP712TypedData } from "../relayer/types";
+export type { AtLeastOneChain, FheChain } from "../chains/types";
+export type { ZamaConfig, ZamaConfigBase } from "../config/types";
+export type {
+  GenericProvider,
+  ReadContractConfig,
+  WriteContractConfig,
+  TransactionReceipt,
+} from "../types";
+export { BaseSigner } from "../signer/base-signer";
 
 export { createConfig } from "./config";
 

--- a/packages/sdk/src/viem/index.ts
+++ b/packages/sdk/src/viem/index.ts
@@ -7,15 +7,64 @@
 
 export type { ZamaConfigViem } from "./types";
 export type { Hex } from "viem";
-export type { EncryptedValue, EIP712TypedData } from "../relayer/types";
-export type { AtLeastOneChain, FheChain } from "../chains/types";
-export type { ZamaConfig, ZamaConfigBase } from "../config/types";
+export type {
+  EncryptedValue,
+  EIP712TypedData,
+  FhevmRuntimeConfig,
+  ClearValue,
+} from "../relayer/types";
+export type { AtLeastOneChain, FheChain, FheChainAuth } from "../chains/types";
+export type { ZamaConfig, ZamaConfigBase, RelayerConfig } from "../config/types";
 export type {
   GenericProvider,
+  GenericStorage,
+  GenericLogger,
+  GenericSigner,
+  WalletAccount,
+  WalletAccountChange,
+  WalletAccountListener,
+  WalletAccountStore,
+  ContractAbi,
+  ReadFunctionName,
+  ReadContractArgs,
+  ReadContractReturnType,
   ReadContractConfig,
+  WriteFunctionName,
+  WriteContractArgs,
   WriteContractConfig,
   TransactionReceipt,
+  ShieldPath,
 } from "../types";
+export type { MutableWalletAccountStore } from "../signer/wallet-account-store";
+export type { RawLog } from "../events";
+export { ZamaSDKEvents } from "../events/sdk-events";
+export type {
+  BaseEvent,
+  ZamaSDKEvent,
+  ZamaSDKEventType,
+  ZamaSDKEventListener,
+  TransactionOperation,
+  EncryptStartEvent,
+  EncryptEndEvent,
+  EncryptErrorEvent,
+  DecryptStartEvent,
+  DecryptEndEvent,
+  DecryptErrorEvent,
+  TransactionErrorEvent,
+  ShieldSubmittedEvent,
+  TransferSubmittedEvent,
+  TransferFromSubmittedEvent,
+  SetOperatorSubmittedEvent,
+  ApproveUnderlyingSubmittedEvent,
+  WrapSubmittedEvent,
+  UnwrapSubmittedEvent,
+  FinalizeUnwrapSubmittedEvent,
+  DelegationSubmittedEvent,
+  RevokeDelegationSubmittedEvent,
+  UnshieldPhase1SubmittedEvent,
+  UnshieldPhase2StartedEvent,
+  UnshieldPhase2SubmittedEvent,
+} from "../events/sdk-events";
 export { BaseSigner } from "../signer/base-signer";
 
 export { createConfig } from "./config";

--- a/packages/sdk/src/web/index.ts
+++ b/packages/sdk/src/web/index.ts
@@ -9,4 +9,10 @@
  */
 
 export { web } from "../config/web";
-export type { WebRelayerConfig } from "../config/types";
+export type { WebRelayerConfig, RelayerConfig } from "../config/types";
+export type {
+  RelayerOptions,
+  FhevmRelayerOptions,
+  FhevmClientOptions,
+  FhevmRuntimeConfig,
+} from "../relayer/types";

--- a/packages/sdk/tsconfig.build.json
+++ b/packages/sdk/tsconfig.build.json
@@ -1,1 +1,5 @@
-{ "extends": "./tsconfig.json", "exclude": ["node_modules", "**/__tests__/**", "**/*.test.ts"] }
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "stripInternal": true },
+  "exclude": ["node_modules", "**/__tests__/**", "**/*.test.ts"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://v2-10-4.turborepo.dev/schema.json",
-  "globalDependencies": ["pnpm-lock.yaml", "tsconfig.base.json", "tsconfig.json"],
+  "globalDependencies": [
+    "pnpm-lock.yaml",
+    "tsconfig.base.json",
+    "tsconfig.json",
+    "api-extractor.base.json"
+  ],
   "tasks": {
     "typecheck": { "outputs": [] },
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**"] },


### PR DESCRIPTION
## Summary

Hides implementation-detail types from the published `@zama-fhe/sdk` type surface. A second pass at the SDK-209 API-surface audit ("bis"), on top of the current `prerelease`.

The shipped `.d.ts` is produced by **rolldown-plugin-dts** (tsc mode), not API Extractor — so the lever is **`stripInternal: true`** in `packages/sdk/tsconfig.build.json`. tsc physically drops every `@internal`-tagged declaration/member from the emitted types.

## What's tagged `@internal`

- The four services: `DecryptionService`, `DelegationService`, `CachingService`, `CredentialService`
- The relayer backend layer: `FhevmClient`, `FhevmRelayer`, `FhevmRelayerSDK`, `ChainRouter`, `ResolvedChainRelayer`, `resolveChainRelayers`
- The credential zod schemas and `transactionOperationMetadata`
- Members: `ZamaConfig.router`, `RelayerConfig.createRelayer`, `NodeRelayerConfig.createRelayer`

## Decouplings (required — the dts bundler hard-fails on a public→stripped-internal dangling ref)

- **Credential types** (`StoredTransportKeyPair`, `SerializedPermit`, `Permission`) rewritten as explicit interfaces instead of `z.infer<typeof Schema>`, guarded by a new `schemas.test-d.ts` drift test so they can't silently diverge from the schemas.
- **`TransactionOperation`** rewritten as an explicit union with `satisfies Record<TransactionOperation, …>` on the metadata (completeness-checked both ways).
- **`ErrorForCode`** made local (inlined into `matchZamaError`'s signature).

## Public surface change ⚠️

- **Added** `RelayerOptions`, `FhevmRelayerOptions`, `FhevmRuntimeConfig` to the barrel — named by the public `web()`/`node()`/`cleartext()` factories and per-call option params; they were missing.
- **Removed** (now `@internal`) `RelayerSDK`, `ChainRouter`, `ResolvedChainRelayer`, `resolveChainRelayers` from the main, `node`, and `query` entry points. **Breaking** for anyone importing them directly — construction goes through `createConfig` / `ZamaSDK`. Needs a changeset / major-bump note before release.

## Notes

- `ae-forgotten-export` is intentionally left at `none`. It enforces *self-contained entry points* (a different goal) and fights this multi-entry package. `stripInternal` + the dts build's dangling-ref check are the real guards for hiding internals.
- `turbo.json` adds `api-extractor.base.json` to `globalDependencies` so the api-report cache invalidates when the config changes.

## Verification

- ✅ SDK build green with `stripInternal`
- ✅ internals confirmed absent from the shipped `.d.ts` (only cosmetic `{@link}` doc refs remain); public types confirmed present
- ✅ `tsc --noEmit` clean
- ✅ 915 tests pass, including the credential/type drift guards
- ✅ all 8 API reports regenerate cleanly (`pnpm api-report`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
