### PR TITLE
ci(playwright): select browser channel per environment

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter @zama-fhe/playwright exec playwright install --with-deps chromium
+        run: pnpm --filter @zama-fhe/playwright exec playwright install --with-deps --no-shell
 
       - name: Save Playwright browsers cache
         if: steps.playwright-cache.outputs.cache-hit != 'true'
@@ -119,7 +119,7 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter @zama-fhe/playwright exec playwright install --with-deps chromium
+        run: pnpm --filter @zama-fhe/playwright exec playwright install --with-deps --no-shell
 
       - name: Save Playwright browsers cache
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/test/playwright/playwright.config.ts
+++ b/test/playwright/playwright.config.ts
@@ -13,7 +13,11 @@ export default defineConfig<{}, WorkerFixtures>({
   workers: 2,
   reporter: CI ? "github" : "list",
   expect: { timeout: CI ? 20000 : 5000 },
-  use: { trace: "retain-on-failure", screenshot: "only-on-failure" },
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    channel: CI ? "chromium" : "chrome",
+  },
   projects: [
     {
       name: "nextjs",

--- a/test/playwright/playwright.nextjs.config.ts
+++ b/test/playwright/playwright.nextjs.config.ts
@@ -14,7 +14,11 @@ export default defineConfig<{}, WorkerFixtures>({
   workers: 1,
   reporter: CI ? "github" : "list",
   expect: { timeout: CI ? 20000 : 5000 },
-  use: { trace: "retain-on-failure", screenshot: "only-on-failure" },
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    channel: CI ? "chromium" : "chrome",
+  },
   projects: [
     {
       name: "nextjs",

--- a/test/playwright/playwright.vite.config.ts
+++ b/test/playwright/playwright.vite.config.ts
@@ -14,7 +14,11 @@ export default defineConfig<{}, WorkerFixtures>({
   workers: 1,
   reporter: CI ? "github" : "list",
   expect: { timeout: CI ? 20000 : 5000 },
-  use: { trace: "retain-on-failure", screenshot: "only-on-failure" },
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    channel: CI ? "chromium" : "chrome",
+  },
   projects: [
     {
       name: "vite",


### PR DESCRIPTION
## Summary

- Select the Playwright browser channel per environment across all configs: `chromium` in CI, system `chrome` locally (base, nextjs, and vite configs).
- Install Playwright browsers with `--no-shell` instead of the chromium-only install in the CI workflow.

## Test plan

- CI Playwright jobs install browsers via `playwright install --with-deps --no-shell` and run against the `chromium` channel.
- Local runs use the installed `chrome` channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)