### PR TITLE
ci: resolve dev-tooling code-scanning alerts (CodeQL + Wiz)

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -8,9 +8,18 @@ const pkgEntry = require.resolve("conventional-changelog-conventionalcommits");
 const templatesPath = resolve(dirname(pkgEntry), "templates.js");
 const src = readFileSync(templatesPath, "utf8");
 
+// Extract the backtick-delimited body of `export const <name> = `...``. `name`
+// is a fixed literal from the two call sites below, so a string scan (opening
+// marker → next backtick) is enough — no need to build a RegExp from a variable.
 const extract = (name) => {
-  const re = new RegExp(`export const ${name} = \`([\\s\\S]*?)\``, "m");
-  return re.exec(src)?.[1] ?? "";
+  const marker = `export const ${name} = \``;
+  const start = src.indexOf(marker);
+  if (start === -1) {
+    return "";
+  }
+  const contentStart = start + marker.length;
+  const end = src.indexOf("`", contentStart);
+  return end === -1 ? "" : src.slice(contentStart, end);
 };
 
 const mainTemplate = extract("mainTemplate").replace(/^\* /gm, "- ");

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "oxfmt": "^0.61.0",
     "oxlint": "^1.76.0",
     "oxlint-tsgolint": "7.0.2001",
+    "re2js": "^2.8.6",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "rolldown": "1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       oxlint-tsgolint:
         specifier: 7.0.2001
         version: 7.0.2001
+      re2js:
+        specifier: ^2.8.6
+        version: 2.8.6
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -3200,6 +3203,10 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  re2js@2.8.6:
+    resolution: {integrity: sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==}
+    engines: {node: '>=18.0.0'}
+
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
@@ -6244,6 +6251,8 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  re2js@2.8.6: {}
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:

--- a/scripts/docs/__tests__/changelog.test.mjs
+++ b/scripts/docs/__tests__/changelog.test.mjs
@@ -289,6 +289,14 @@ describe("alphaHasSubstance", () => {
     const staged = `${emptyAlphaTemplate()}\n## New feature\n\nSome real notes.\n`;
     expect(alphaHasSubstance(staged)).toBe(true);
   });
+
+  test("comment noise that survives a single strip pass is not substance", () => {
+    // A single `<!--...-->` removal on this leaves `<!-- R -->` behind (the
+    // outer `<!-` joins the trailing `-->`); only stripping until stable empties
+    // it. Regression for the incomplete-multi-character-sanitization fix.
+    const noise = `${emptyAlphaTemplate()}\n<!-<!--x-->- R -->\n`;
+    expect(alphaHasSubstance(noise)).toBe(false);
+  });
 });
 
 // ──────────────────────────────────────────────── promoteChangelog (unit) ──

--- a/scripts/docs/changelog.mjs
+++ b/scripts/docs/changelog.mjs
@@ -38,6 +38,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { RE2JS } from "re2js";
 import { checkTree, extractHeadingSlugs, slug } from "./check-links.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -389,13 +390,11 @@ export function insertSection(pageContent, version, sectionMarkdown) {
   const lines = pageContent.split("\n");
   const block = `${sectionMarkdown.trimEnd()}\n`;
 
-  const headingRe = /^##\s+(\d+\.\d+\.\d+(?:-\S+)?)\s*$/;
   for (let i = 0; i < lines.length; i++) {
-    const match = headingRe.exec(lines[i]);
-    if (!match) {
+    if (!lines[i].startsWith("## ")) {
       continue;
     }
-    const existing = parseVersion(match[1]);
+    const existing = parseVersion(lines[i].slice(3).trim());
     if (existing && compareVersions(existing, target) < 0) {
       lines.splice(i, 0, ...block.split("\n"), "");
       return lines.join("\n");
@@ -419,8 +418,9 @@ export function insertMinorIntoSummary(summaryContent, version) {
     return summaryContent;
   }
   const lines = summaryContent.split("\n");
-  const anchor = lines.findIndex((line) =>
-    new RegExp(`^-\\s*\\[[^\\]]+\\]\\(changelog/v${major}\\.md\\)\\s*$`).test(line),
+  const suffix = `](changelog/v${major}.md)`;
+  const anchor = lines.findIndex(
+    (line) => line.startsWith("- [") && line.trimEnd().endsWith(suffix),
   );
   if (anchor === -1) {
     return summaryContent;
@@ -547,13 +547,24 @@ export function extractAlphaProse(alphaContent) {
  *  Semantic check: after stripping frontmatter/banner/raw-material/comments and the
  *  known placeholder, is there any substance left? Robust to oxfmt reflow. */
 export function alphaHasSubstance(alphaContent) {
-  const remainder = extractAlphaProse(alphaContent)
-    .replace(/<!--[\s\S]*?-->/gu, "")
+  const remainder = stripHtmlComments(extractAlphaProse(alphaContent))
     .split("\n")
     .filter((line) => normalizeWhitespace(line) !== normalizeWhitespace(ALPHA_EMPTY_PLACEHOLDER))
     .join("\n")
     .trim();
   return remainder.length > 0;
+}
+
+/** Strip HTML comments, repeating until stable so a nested or adjacent construct
+ *  like `<!--<!-- -->-->` can't leave a live `<!--` behind after a single pass. */
+function stripHtmlComments(text) {
+  let previous;
+  let current = text;
+  do {
+    previous = current;
+    current = current.replace(/<!--[\s\S]*?-->/gu, "");
+  } while (current !== previous);
+  return current;
 }
 
 function normalizeWhitespace(text) {
@@ -825,8 +836,8 @@ function repointAlphaAnchors(edits, root, movedSlugs, targetBasename) {
   // Path-boundary the prefix: an optional group that must END in `/` (a directory
   // separator) or be absent (start-of-path, right after `](`). Otherwise a sibling
   // like `myalpha.md#slug` would spuriously match (`my` as the prefix).
-  const patterns = [...movedSlugs].map(
-    (movedSlug) => new RegExp(`\\]\\(([^)#]*\\/)?alpha\\.md#(${escapeRegExp(movedSlug)})\\)`, "gu"),
+  const patterns = [...movedSlugs].map((movedSlug) =>
+    RE2JS.compile(`\\]\\(([^)#]*\\/)?alpha\\.md#(${escapeRegExp(movedSlug)})\\)`),
   );
   for (const relPath of docPagesRelative(root)) {
     const content = edits.read(relPath);
@@ -835,7 +846,7 @@ function repointAlphaAnchors(edits, root, movedSlugs, targetBasename) {
     }
     let updated = content;
     for (const pattern of patterns) {
-      updated = updated.replace(pattern, (_match, prefix, anchor) => {
+      updated = pattern.matcher(updated).replaceAll((_match, prefix, anchor) => {
         return `](${prefix ?? ""}${targetBasename}#${anchor})`;
       });
     }

--- a/scripts/llm/lib/corpus.mjs
+++ b/scripts/llm/lib/corpus.mjs
@@ -394,7 +394,11 @@ export function renderTabs(content) {
 }
 
 function normalizeMarkdownLinkTarget(target, currentSourcePath) {
-  if (!target || target.startsWith("#") || /^(?:https?:|mailto:|tel:)/u.test(target)) {
+  if (
+    !target ||
+    target.startsWith("#") ||
+    ["http:", "https:", "mailto:", "tel:"].some((scheme) => target.startsWith(scheme))
+  ) {
     return target;
   }
 

--- a/scripts/release/check-license-compat.mjs
+++ b/scripts/release/check-license-compat.mjs
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from "node:fs";
+import { RE2JS } from "re2js";
 
 const [licensesPath, policyPath, reportPath] = process.argv.slice(2);
 
@@ -64,8 +65,12 @@ const visit = (node) => {
 visit(licensesData);
 
 const allowSet = new Set(policy.allow.map((item) => item.toUpperCase()));
-const denyPatterns = policy.denyPatterns.map((item) => new RegExp(item, "i"));
-const reviewPatterns = policy.reviewPatterns.map((item) => new RegExp(item, "i"));
+// Patterns come from the trusted license policy (config-supplied), so build them
+// with RE2JS — a linear-time engine that can't catastrophically backtrack (ReDoS).
+const denyPatterns = policy.denyPatterns.map((item) => RE2JS.compile(item, RE2JS.CASE_INSENSITIVE));
+const reviewPatterns = policy.reviewPatterns.map((item) =>
+  RE2JS.compile(item, RE2JS.CASE_INSENSITIVE),
+);
 
 const denied = [];
 const review = [];
@@ -80,12 +85,12 @@ for (const [pkg, licenseExpr] of packageLicenses.entries()) {
     continue;
   }
 
-  if (denyPatterns.some((re) => re.test(licenseExpr))) {
+  if (denyPatterns.some((re) => re.matcher(licenseExpr).find())) {
     denied.push({ pkg, license: licenseExpr });
     continue;
   }
 
-  if (reviewPatterns.some((re) => re.test(licenseExpr))) {
+  if (reviewPatterns.some((re) => re.matcher(licenseExpr).find())) {
     review.push({ pkg, license: licenseExpr });
     continue;
   }


### PR DESCRIPTION
Resolves the **dev-tooling / CI** GitHub code-scanning alerts (CodeQL + Wiz SAST), keeping the published `@zama-fhe/sdk` / `react-sdk` untouched. SDK-code and Aikido-workflow alerts are handled in separate PRs.

## Alerts resolved

| Alert | Rule | File | Fix |
|-------|------|------|-----|
| #261 (HIGH) | CodeQL incomplete-multi-char-sanitization | `changelog.mjs` | strip HTML comments until stable (+ regression test) |
| #263 / #265 | Wiz non-literal RegExp | `changelog.mjs` | drop regex for constant/int input → string ops |
| #264 / #266 | Wiz non-literal RegExp | `changelog.mjs` | build per-slug anchor pattern with RE2JS |
| #262 | Wiz ReDoS-on-input | `changelog.mjs` | `startsWith` + existing `parseVersion` |
| #136 | Wiz ReDoS-on-input | `corpus.mjs` | `startsWith` instead of scheme regex |
| #30 / #36 | Wiz non-literal RegExp | `.releaserc.cjs` | string scan instead of `RegExp` from a variable |
| #34 / #35 / #37 / #38 | Wiz non-literal RegExp / ReDoS | `check-license-compat.mjs` | RE2JS (linear-time, ReDoS-safe) for config-driven patterns |

## Regex policy (consistent)

- **Genuinely-dynamic** patterns → **RE2JS** (pure-JS RE2 port, MIT, added as a **devDependency** — no native build, no build-script approval).
- **Constant / integer** "patterns" → plain string ops.

## Not in this PR

- **#137** (`new Function` in `abi-build.test.mjs`): a clean eval-free rewrite is disproportionate — committed ABIs are `oxfmt(buildAbiSource output)` (so a string compare is wrong) and the unquoted keys block `JSON.parse`. It is a test-only `eval` on trusted, repo-generated input (already justified + oxlint-suppressed). → being dismissed as `used_in_tests`.
- **SDK-code** alerts (#130, #155, #41, #16) → separate PR.
- **Aikido** workflow alerts (#126–128) → separate PR.

## Verification

`format:check`, `lint` (oxlint + ast-grep), `typecheck` (all 6 packages), changelog test (36, incl. new regression), corpus test (11), `llm:check`, `docs:check-links`, plus an end-to-end `check-license-compat` smoke test (`GPL-3.0`→denied, `LGPL-2.1`→review, `AGPL-3.0`→denied, `CC-BY-NC-4.0`→denied) — all green.

> Wiz constructor-rule clearance (#264/266, #34–38) can only be observed after this reaches `main` and the daily Wiz scan re-runs; CodeQL #261 is verifiable on this PR's own scan.
