### PR TITLE
ci: verify Aikido Safe Chain installer instead of piping curl to sh

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -19,6 +19,8 @@ env:
   # pnpm-workspace.yaml — mirror both the age (72 h) and the exclusion here.
   SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: "72"
   SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS: "@fhevm/sdk,@zama-fhe/sdk,@zama-fhe/react-sdk"
+  # Pinned safe-chain release used by the verified installer below; bump as newer versions are vetted.
+  SAFE_CHAIN_VERSION: "1.5.15"
 
 jobs:
   validate-branch:
@@ -64,7 +66,17 @@ jobs:
           [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]
 
       - name: Install Aikido Safe Chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+        run: |
+          # Resolve the installer asset URL + its GitHub-published SHA-256, download it,
+          # verify the hash, then execute — no piping a remote script into a shell.
+          SAFECHAIN_URL="https://api.github.com/repos/AikidoSec/safe-chain/releases/tags/${SAFE_CHAIN_VERSION}"
+          SC_INSTALL_URL=$(curl -fsSL "$SAFECHAIN_URL" | jq -r '.assets[] | select(.name=="install-safe-chain.sh") | .browser_download_url')
+          SC_INSTALL_HASH=$(curl -fsSL "$SAFECHAIN_URL" | jq -r '.assets[] | select(.name=="install-safe-chain.sh") | .digest[7:]')
+          curl -fsSL "$SC_INSTALL_URL" -o install-safe-chain.sh
+          [ "$(sha256sum install-safe-chain.sh | awk '{print $1}')" = "$SC_INSTALL_HASH" ] \
+            && echo "=> SHA256 install script matched" \
+            || { echo "=> SHA256 mismatch — aborting"; rm -f install-safe-chain.sh; exit 1; }
+          bash ./install-safe-chain.sh --ci
 
       - name: Install dependencies
         run: pnpm ci --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ env:
   # pnpm-workspace.yaml — mirror both the age (72 h) and the exclusion here.
   SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: "72"
   SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS: "@fhevm/sdk,@zama-fhe/sdk,@zama-fhe/react-sdk"
+  # Pinned safe-chain release used by the verified installer below; bump as newer versions are vetted.
+  SAFE_CHAIN_VERSION: "1.5.15"
 
 jobs:
   # ── Publish from tag (manual recovery) ──────────────────────────────
@@ -73,7 +75,17 @@ jobs:
           [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]
 
       - name: Install Aikido Safe Chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+        run: |
+          # Resolve the installer asset URL + its GitHub-published SHA-256, download it,
+          # verify the hash, then execute — no piping a remote script into a shell.
+          SAFECHAIN_URL="https://api.github.com/repos/AikidoSec/safe-chain/releases/tags/${SAFE_CHAIN_VERSION}"
+          SC_INSTALL_URL=$(curl -fsSL "$SAFECHAIN_URL" | jq -r '.assets[] | select(.name=="install-safe-chain.sh") | .browser_download_url')
+          SC_INSTALL_HASH=$(curl -fsSL "$SAFECHAIN_URL" | jq -r '.assets[] | select(.name=="install-safe-chain.sh") | .digest[7:]')
+          curl -fsSL "$SC_INSTALL_URL" -o install-safe-chain.sh
+          [ "$(sha256sum install-safe-chain.sh | awk '{print $1}')" = "$SC_INSTALL_HASH" ] \
+            && echo "=> SHA256 install script matched" \
+            || { echo "=> SHA256 mismatch — aborting"; rm -f install-safe-chain.sh; exit 1; }
+          bash ./install-safe-chain.sh --ci
 
       - name: Install dependencies
         run: pnpm ci --ignore-scripts
@@ -206,7 +218,17 @@ jobs:
           [[ "$(npm --version | cut -d. -f1)" -ge 11 ]]
 
       - name: Install Aikido Safe Chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+        run: |
+          # Resolve the installer asset URL + its GitHub-published SHA-256, download it,
+          # verify the hash, then execute — no piping a remote script into a shell.
+          SAFECHAIN_URL="https://api.github.com/repos/AikidoSec/safe-chain/releases/tags/${SAFE_CHAIN_VERSION}"
+          SC_INSTALL_URL=$(curl -fsSL "$SAFECHAIN_URL" | jq -r '.assets[] | select(.name=="install-safe-chain.sh") | .browser_download_url')
+          SC_INSTALL_HASH=$(curl -fsSL "$SAFECHAIN_URL" | jq -r '.assets[] | select(.name=="install-safe-chain.sh") | .digest[7:]')
+          curl -fsSL "$SC_INSTALL_URL" -o install-safe-chain.sh
+          [ "$(sha256sum install-safe-chain.sh | awk '{print $1}')" = "$SC_INSTALL_HASH" ] \
+            && echo "=> SHA256 install script matched" \
+            || { echo "=> SHA256 mismatch — aborting"; rm -f install-safe-chain.sh; exit 1; }
+          bash ./install-safe-chain.sh --ci
 
       - name: Install dependencies
         run: pnpm ci --ignore-scripts


### PR DESCRIPTION
Replaces the `curl … | sh` pipe-to-shell that installs Aikido Safe Chain in the release workflows with the security team's **pinned + download-then-verify** pattern.

## Alerts

Wiz IaC **#126 / #127 / #128** — *"workflow should not execute suspicious remote payloads"* — at `release.yml` (publish-from-tag + release jobs) and `release-preview.yml`.

## Before

```sh
curl -fsSL .../releases/latest/download/install-safe-chain.sh | sh -s -- --ci
```

No integrity check; pipes an unpinned remote script straight into a shell — in a repo that otherwise SHA-pins its Actions and enforces a 72h package-age floor.

## After (Aikido Safe-Chain user guide, GitHub CI section)

The pinned version lives in one workflow-level env var per file:

```yaml
env:
  # Pinned safe-chain release used by the verified installer below; bump as newer versions are vetted.
  SAFE_CHAIN_VERSION: "1.5.15"
```

Each step resolves the installer asset URL **and its GitHub-published SHA-256 digest** from the releases API for that pinned tag, downloads the script, **verifies the hash**, then executes:

```sh
SAFECHAIN_URL="https://api.github.com/repos/AikidoSec/safe-chain/releases/tags/${SAFE_CHAIN_VERSION}"
SC_INSTALL_URL=$(curl -fsSL "$SAFECHAIN_URL"  | jq -r '.assets[] | select(.name=="install-safe-chain.sh") | .browser_download_url')
SC_INSTALL_HASH=$(curl -fsSL "$SAFECHAIN_URL" | jq -r '.assets[] | select(.name=="install-safe-chain.sh") | .digest[7:]')
curl -fsSL "$SC_INSTALL_URL" -o install-safe-chain.sh
[ "$(sha256sum install-safe-chain.sh | awk '{print $1}')" = "$SC_INSTALL_HASH" ] \
  && echo "=> SHA256 install script matched" \
  || { echo "=> SHA256 mismatch — aborting"; rm -f install-safe-chain.sh; exit 1; }
bash ./install-safe-chain.sh --ci
```

- **Pinned** to `releases/tags/${SAFE_CHAIN_VERSION}` (currently `1.5.15`, the latest), matching the Notion doc's pinned-tag structure. Bumping the version is a one-line change per file.
- `curl` / `jq` / `sha256sum` are preinstalled on `ubuntu-latest`; steps already run under `bash -euo pipefail` (so the step `shell:` is left at the repo default rather than downgraded to plain `bash`), meaning any failed fetch/verify aborts the install.

## Verification

- Ran the exact block against real GitHub for `releases/tags/1.5.15`: resolves the asset, hash `de0565…` **matches**, downloaded script is valid bash (**not** executed), and a **tampered hash is correctly rejected**.
- Simulated the workflow env var (`SAFE_CHAIN_VERSION=1.5.15`) → URL builds and the API resolves `tag_name: 1.5.15`.
- YAML parses; `actionlint`/shellcheck clean on the new blocks; oxfmt + typecheck green.

> Security team owns #126–128 — this implements the Aikido user-guide pattern for their review. Wiz IaC only scans `main`, so clearance appears after this reaches `main` and the daily scan re-runs.
