### PR TITLE
fix(sdk): guard ACL revert lookup against prototype-chain error names

### DIFF
--- a/packages/sdk/src/errors/acl-revert.ts
+++ b/packages/sdk/src/errors/acl-revert.ts
@@ -64,7 +64,7 @@ const ACL_ERROR_MAP = {
 } satisfies Record<string, (cause: unknown) => ZamaError>;
 
 function isAclRevertName(name: string): name is keyof typeof ACL_ERROR_MAP {
-  return name in ACL_ERROR_MAP;
+  return Object.hasOwn(ACL_ERROR_MAP, name);
 }
 
 /**


### PR DESCRIPTION
Fixes a real (low-severity) bug in **shipped SDK code** flagged by Wiz code scanning.

## The bug (alert #130)

`matchAclRevert` (`packages/sdk/src/errors/acl-revert.ts`) used `name in ACL_ERROR_MAP` to decide whether a decoded Solidity revert-error name maps to a typed `ZamaError`. `in` walks the prototype chain, so a contract reverting with a custom error named `valueOf`, `constructor`, `toString`, … (all valid Solidity identifiers) passes the check — and the lookup then invokes the inherited `Object.prototype` member, so `matchAclRevert` returns a **non-`ZamaError` object** instead of `null`, violating its `ZamaError | null` contract.

## Fix

```diff
- return name in ACL_ERROR_MAP;
+ return Object.hasOwn(ACL_ERROR_MAP, name);   // own keys only
```

## Regression test

Asserts `matchAclRevert` returns `null` for `valueOf`/`constructor`/`toString`/`hasOwnProperty` revert names. Proven meaningful by a differential run: it **fails on the old `in` code** (`expected { …(8) } to be null` — the returned value is the 8-entry map object) and passes on the fix.

## Verification

`format:check`, `lint` (oxlint + ast-grep), `typecheck` (6/6), full sdk suite (**1224 tests**) — all green.

## Not in this PR (→ dismissal batch, for your sign-off)

- **#155** `match.ts` — `handlers[error.code]` uses a controlled internal enum key + a caller-owned object, so it's not reachable; a guard wouldn't remove the flagged computed access. → false positive.
- **#41** `concurrency.ts` — numeric bounded array index. → false positive.
- **#16** `zama-sdk.test.ts` — `sdk[Symbol.dispose]()` well-known symbol in a test. → false positive.

> Wiz only scans `main`, so #130 clears after this reaches `main` and the daily scan re-runs. The bracket-lookup syntax remains, so if Wiz doesn't auto-clear post-fix it can be dismissed — the underlying bug is fixed either way (see the differential test).
