### PR TITLE
docs(readme): point CI badge at ci.yml, not the deleted vitest.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
     <img src="https://img.shields.io/npm/v/%40zama-fhe%2Fsdk/alpha?label=dev%20release&style=flat-square" alt="Dev release"></a>
   <a href="https://www.npmjs.com/package/@zama-fhe/sdk">
     <img src="https://img.shields.io/npm/last-update/%40zama-fhe%2Fsdk/alpha?style=flat-square" alt="Dev release last updated"></a>
-  <a href="https://github.com/zama-ai/sdk/actions/workflows/vitest.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/zama-ai/sdk/vitest.yml?style=flat-square&label=unit%20tests" alt="Unit tests"></a>
+  <a href="https://github.com/zama-ai/sdk/actions/workflows/ci.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/zama-ai/sdk/ci.yml?style=flat-square&label=CI" alt="CI"></a>
   <a href="https://github.com/zama-ai/sdk/actions/workflows/playwright.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/zama-ai/sdk/playwright.yml?style=flat-square&label=e2e%20tests" alt="E2E tests"></a>
 </p>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -21730,8 +21730,8 @@ npm run test:e2e                     # Playwright e2e tests (starts dev server a
     <img src="https://img.shields.io/npm/v/%40zama-fhe%2Fsdk/alpha?label=dev%20release&style=flat-square" alt="Dev release"></a>
   <a href="https://www.npmjs.com/package/@zama-fhe/sdk">
     <img src="https://img.shields.io/npm/last-update/%40zama-fhe%2Fsdk/alpha?style=flat-square" alt="Dev release last updated"></a>
-  <a href="https://github.com/zama-ai/sdk/actions/workflows/vitest.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/zama-ai/sdk/vitest.yml?style=flat-square&label=unit%20tests" alt="Unit tests"></a>
+  <a href="https://github.com/zama-ai/sdk/actions/workflows/ci.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/zama-ai/sdk/ci.yml?style=flat-square&label=CI" alt="CI"></a>
   <a href="https://github.com/zama-ai/sdk/actions/workflows/playwright.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/zama-ai/sdk/playwright.yml?style=flat-square&label=e2e%20tests" alt="E2E tests"></a>
 </p>


### PR DESCRIPTION
## Summary

The root README's "Unit tests" badge links to and renders from `.github/workflows/vitest.yml`, which was deleted five weeks ago (#523, "integrate Turborepo for cached build/typecheck/api-report/size") when its `test` job was folded into `ci.yml`. The README was never updated in that PR (nor in the later docs-refresh #581), so shields.io queries a workflow file that no longer exists and both the badge image and its link-through return "not found" — the error reported.

Confirmed isolated: a repo-wide grep for `vitest.yml` across `*.md`/`*.yml`/`*.yaml` turned up only these two lines. No other README or doc references it, and neither `packages/sdk/README.md` nor `packages/react-sdk/README.md` has any badges.

- **Filename**: `vitest.yml` → `ci.yml`
- **Label**: `unit tests` / `alt="Unit tests"` → `CI` / `alt="CI"`

The label change isn't cosmetic. The sibling "E2E tests" badge gets away with a label that doesn't match its workflow's declared name ("Playwright") because that workflow is homogeneous — every job in it (`test-nextjs`, `test-vite`, `test-node`) is an e2e run. `ci.yml` isn't: it bundles `build`, `lint`, `test`, and `api-report`, and this badge type (both the native GitHub badge and shields.io's wrapper) only reports whole-workflow status — there's no job-scoped variant. Keeping the label "Unit tests" on a badge now reporting all four jobs together would mean an unrelated build or lint failure shows up as a false "unit tests" failure, which is worse than the original bug. "CI" is accurate (it's genuinely reporting the whole pipeline) and non-arbitrary (it's `ci.yml`'s own declared `name: CI`).

## Test plan

- [x] `pnpm exec oxfmt --check README.md` — clean
- [x] `gh api repos/zama-ai/sdk/actions/workflows/ci.yml --jq '.name, .path'` → `CI`, `.github/workflows/ci.yml` — confirms the workflow the badge now points at actually exists
- [x] Repo-wide grep confirms no remaining `vitest.yml` / "Unit tests" references