### PR TITLE
chore: ignore .codex/ and .agents/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ next-env.d.ts
 # claude code (opt-in via `pnpm setup:claude`)
 .claude/
 
+# codex / other agent tooling
+.codex/
+.agents/
+
 # worktrees
 .worktrees/
 


### PR DESCRIPTION
# Summary

Add `.codex/` and `.agents/` to `.gitignore`, matching the existing `.claude/` opt-in pattern — local Codex/agent tooling directories shouldn't be tracked.

## Scope

- [ ] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-components`
- [ ] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [ ] Examples (`examples/`)
- [ ] CI/workflows
- [ ] Docs

## Validation

`.gitignore` only — no code paths affected. Confirmed `.codex/` and `.agents/` no longer show as untracked in `git status`.

## Related

<!-- Link issue(s) / related PR(s), if any. -->

## Demo (if possible)

N/A