### PR TITLE
chore: upgrade fhevm sdk

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -166,7 +166,7 @@
     "api-report:check": "api-extractor run -c api-extractor.json && api-extractor run -c api-extractor.web.json && api-extractor run -c api-extractor.viem.json && api-extractor run -c api-extractor.ethers.json && api-extractor run -c api-extractor.node.json && api-extractor run -c api-extractor.query.json"
   },
   "dependencies": {
-    "@fhevm/sdk": "0.13.2",
+    "@fhevm/sdk": "0.14.1-0",
     "viem": ">=2",
     "zod": ">=4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,8 +198,8 @@ importers:
   packages/sdk:
     dependencies:
       '@fhevm/sdk':
-        specifier: 0.13.2
-        version: 0.13.2(ethers@6.17.0)(typescript@6.0.3)(viem@2.55.0(typescript@6.0.3)(zod@4.4.3))
+        specifier: 0.14.1-0
+        version: 0.14.1-0(ethers@6.17.0)(typescript@6.0.3)(viem@2.55.0(typescript@6.0.3)(zod@4.4.3))
       ethers:
         specifier: '>=6'
         version: 6.17.0
@@ -560,8 +560,8 @@ packages:
       typescript:
         optional: true
 
-  '@fhevm/sdk@0.13.2':
-    resolution: {integrity: sha512-M1ZUKdRJedxRa57bVeQ7jrzVP6hKAXjS8WabvMNJKBui7C2ZXDsvoyb7qpLqYib85obA+OQTwcPZV/oxWfciWA==}
+  '@fhevm/sdk@0.14.1-0':
+    resolution: {integrity: sha512-LLttIufmrBWNu4lss8zAyGFyadO3kd4eHzC9gN/jrQJpDPVs1E6n/NFRNzVvoMu5mYYE6As66H5kGalbNPtqfA==}
     engines: {node: '>=22.0'}
     peerDependencies:
       ethers: '>=6.8.0'
@@ -4380,7 +4380,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@fhevm/sdk@0.13.2(ethers@6.17.0)(typescript@6.0.3)(viem@2.55.0(typescript@6.0.3)(zod@4.4.3))':
+  '@fhevm/sdk@0.14.1-0(ethers@6.17.0)(typescript@6.0.3)(viem@2.55.0(typescript@6.0.3)(zod@4.4.3))':
     dependencies:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1

--- a/test/test-nextjs/package.json
+++ b/test/test-nextjs/package.json
@@ -16,7 +16,7 @@
     "@zama-fhe/react-sdk": "workspace:*",
     "@zama-fhe/sdk": "workspace:*",
     "@zama-fhe/test-components": "workspace:*",
-    "next": "^16.2.11",
+    "next": ">=16.2.11",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "viem": "^2.55.0",
@@ -34,5 +34,5 @@
     "node": ">=22",
     "pnpm": ">=10"
   },
-  "packageManager": "pnpm@10.30.2"
+  "packageManager": "pnpm@11.1.2"
 }


### PR DESCRIPTION
# Summary

- Bump `@fhevm/sdk` `0.13.2` → `0.14.1-0` with no SDK/react-sdk code changes and no public API diff. 
- `signDecryptionPermit` stays hard-pinned to V1; we never pass a `protocolConfig` address, so this adds no new RPC on any chain
- align `test-nextjs` `packageManager` with the repo and the `next` specifier with the workspace override so pre-commit typecheck can run that package.

## Scope

- [x] `@zama-fhe/sdk`
- [ ] `@zama-fhe/react-sdk`
- [ ] `@zama-fhe/test-components`
- [x] `@zama-fhe/test-nextjs`
- [ ] `@zama-fhe/test-vite`
- [ ] Examples (`examples/`)
- [ ] CI/workflows
- [ ] Docs

## Validation

- `pnpm typecheck` / `pnpm build` / `pnpm lint`
- `pnpm test:run` — 1864/1864
- `pnpm test:integration` — 23/23 (4 pre-existing skips) on six live v0.13 networks
- `pnpm api-report:check` — clean
- Playwright E2E (vite) — 60/60


## Related

- [SDK-303](https://linear.app/zama/issue/SDK-303) (this bump)
- [SDK-292](https://linear.app/zama/issue/SDK-292) (stacked unified-decryption work)

## Demo (if possible)

N/A