### PR TITLE
ci: bump foundry-toolchain to v1.9.1 for rust foundryup

### DIFF
--- a/.github/actions/build-contracts/action.yml
+++ b/.github/actions/build-contracts/action.yml
@@ -15,7 +15,7 @@ runs:
       run: git submodule update --init --recursive
 
     - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+      uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
       with:
         version: v1.5.1
 


### PR DESCRIPTION
> foundry-rs/foundry merged "feat: default to Rust foundryup" (PR #15498) today at 14:56 UTC. The install script — which foundry-toolchain v1.8.0 downloads from the foundry repo's unpinned HEAD at every run — now drops a compiled Rust binary at ~/.foundry/bin/foundryup instead of a shell script. v1.8.0 then invokes it as bash foundryup --install 1.5.1, and bash can't execute an ELF binary, hence "cannot execute binary file".
>
> foundry-toolchain v1.9.0+ was written for the Rust foundryup (pins the installer and execs the binary directly instead of through bash).