### PR TITLE
docs(gitbook): draft 3.5.0 Alpha changelog — Polygon support + bug fixes

### DIFF
--- a/docs/gitbook/src/changelog/alpha.md
+++ b/docs/gitbook/src/changelog/alpha.md
@@ -9,6 +9,23 @@ description: Unreleased changes on the prerelease (alpha) line — not yet in a 
 **Unreleased.** The changes on this page are on the prerelease (`alpha`) line and are **not yet available in a stable release**. They ship with the next stable release, at which point this page is retitled to that version and folded into the version list above. Treat everything here as a preview — details may still change before release.
 {% endhint %}
 
+## Polygon support
+
+The SDK now ships built-in presets for **Polygon**: `polygon` (mainnet, chain ID 137) and `polygonAmoy` (Amoy testnet, chain ID 80002). Import either from `@zama-fhe/sdk/chains` and pass it to `createConfig` like any other chain — no manual contract-address wiring.
+
+```ts
+import { polygon, polygonAmoy } from "@zama-fhe/sdk/chains";
+
+const config = createConfig({
+  chains: [polygonAmoy],
+  publicClient,
+  walletClient,
+  relayers: { [polygonAmoy.id]: web() },
+});
+```
+
+The shared Zama **testnet** relayer needs no API key, so `polygonAmoy` works as-is; the **mainnet** relayer used by `polygon` requires one — see [Authentication](../guides/authentication.md). A full `example-polygon-amoy` reference app is included in the examples. See [Configuration](../guides/configuration.md#1-pick-your-chains) for the complete preset list.
+
 ## Offline signing
 
 A new `sdk.offline.prepare` builds an unsigned transaction that the caller signs and broadcasts out-of-process: institutional custody, HSM ceremonies, policy engines with human approval. The signer is now optional in the SDK config, so the preparing process never holds the wallet private key. Atomic call sites are unchanged; `Token.confidentialTransfer` and friends keep their online path.
@@ -54,3 +71,8 @@ Failures surface as a new `KeyWrappingError` (`KEY_WRAPPING_FAILED`); `hasPermit
 ## Automatic recovery from KMS context rotation
 
 When a permit's KMS context is revoked on-chain, the SDK now re-grants the permit (one wallet prompt) and retries the decrypt instead of failing. No API change; existing decrypt and balance calls pick this up automatically. A new `RevokedKmsContextError` (`REVOKED_KMS_CONTEXT`) surfaces when the retry also fails, or when the re-grant itself fails (a signing failure attached as `cause`); on a failed re-grant the other permits of the scope are kept. See the [error reference](../reference/sdk/errors.md#revokedkmscontexterror) for the recovery mechanics.
+
+## Bug fixes
+
+- **Operator transfers bind the input proof to the caller, not the token owner.** `confidentialTransferFrom` and `confidentialTransferFromAndCall` now build the encrypted-amount proof against the transaction sender (the operator), matching how the contract verifies it against `msg.sender`; previously it was bound to the `from` owner, so an operator-initiated transfer could fail proof verification. No API change — `Token.confidentialTransferFrom` / `confidentialTransferFromAndCall` and their `useConfidentialTransferFrom` / `useConfidentialTransferFromAndCall` hooks pick it up automatically. See [Operator approvals](../guides/operator-approvals.md).
+- **ACL revert decoding ignores inherited property names.** Decoding a Solidity revert whose custom error is named like a built-in object member (`valueOf`, `toString`, `constructor`, …) no longer returns a spurious match — the lookup checks own properties only, so an unmapped error correctly falls through to `null` instead of surfacing a non-[`ZamaError`](../reference/sdk/errors.md) object.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2138,6 +2138,23 @@ Stuck on the migration, or spotted a step or rename this guide is missing? **Ope
 > **Unreleased.** The changes on this page are on the prerelease (`alpha`) line and are **not yet available in a stable release**. They ship with the next stable release, at which point this page is retitled to that version and folded into the version list above. Treat everything here as a preview — details may still change before release.
 
 
+## Polygon support
+
+The SDK now ships built-in presets for **Polygon**: `polygon` (mainnet, chain ID 137) and `polygonAmoy` (Amoy testnet, chain ID 80002). Import either from `@zama-fhe/sdk/chains` and pass it to `createConfig` like any other chain — no manual contract-address wiring.
+
+```ts
+import { polygon, polygonAmoy } from "@zama-fhe/sdk/chains";
+
+const config = createConfig({
+  chains: [polygonAmoy],
+  publicClient,
+  walletClient,
+  relayers: { [polygonAmoy.id]: web() },
+});
+```
+
+The shared Zama **testnet** relayer needs no API key, so `polygonAmoy` works as-is; the **mainnet** relayer used by `polygon` requires one — see [Authentication](https://raw.githubusercontent.com/zama-ai/sdk/prerelease/docs/gitbook/src/guides/authentication.md). A full `example-polygon-amoy` reference app is included in the examples. See [Configuration](https://raw.githubusercontent.com/zama-ai/sdk/prerelease/docs/gitbook/src/guides/configuration.md#1-pick-your-chains) for the complete preset list.
+
 ## Offline signing
 
 A new `sdk.offline.prepare` builds an unsigned transaction that the caller signs and broadcasts out-of-process: institutional custody, HSM ceremonies, policy engines with human approval. The signer is now optional in the SDK config, so the preparing process never holds the wallet private key. Atomic call sites are unchanged; `Token.confidentialTransfer` and friends keep their online path.
@@ -2183,6 +2200,11 @@ Failures surface as a new `KeyWrappingError` (`KEY_WRAPPING_FAILED`); `hasPermit
 ## Automatic recovery from KMS context rotation
 
 When a permit's KMS context is revoked on-chain, the SDK now re-grants the permit (one wallet prompt) and retries the decrypt instead of failing. No API change; existing decrypt and balance calls pick this up automatically. A new `RevokedKmsContextError` (`REVOKED_KMS_CONTEXT`) surfaces when the retry also fails, or when the re-grant itself fails (a signing failure attached as `cause`); on a failed re-grant the other permits of the scope are kept. See the [error reference](https://raw.githubusercontent.com/zama-ai/sdk/prerelease/docs/gitbook/src/reference/sdk/errors.md#revokedkmscontexterror) for the recovery mechanics.
+
+## Bug fixes
+
+- **Operator transfers bind the input proof to the caller, not the token owner.** `confidentialTransferFrom` and `confidentialTransferFromAndCall` now build the encrypted-amount proof against the transaction sender (the operator), matching how the contract verifies it against `msg.sender`; previously it was bound to the `from` owner, so an operator-initiated transfer could fail proof verification. No API change — `Token.confidentialTransferFrom` / `confidentialTransferFromAndCall` and their `useConfidentialTransferFrom` / `useConfidentialTransferFromAndCall` hooks pick it up automatically. See [Operator approvals](https://raw.githubusercontent.com/zama-ai/sdk/prerelease/docs/gitbook/src/guides/operator-approvals.md).
+- **ACL revert decoding ignores inherited property names.** Decoding a Solidity revert whose custom error is named like a built-in object member (`valueOf`, `toString`, `constructor`, …) no longer returns a spurious match — the lookup checks own properties only, so an unmapped error correctly falls through to `null` instead of surfacing a non-[`ZamaError`](https://raw.githubusercontent.com/zama-ai/sdk/prerelease/docs/gitbook/src/reference/sdk/errors.md) object.
 
 ## 3.x
 


### PR DESCRIPTION
## Summary

Fills the gaps in the 3.5.0 **Alpha** changelog page (`docs/gitbook/src/changelog/alpha.md`) that the `sdk-changelog` skill's self-check surfaced. The four feature topics (offline signing, offline permits, at-rest keypair wrapping, KMS-context recovery) were already drafted; this adds:

- **Polygon support** — the `polygon` (mainnet, 137) and `polygonAmoy` (Amoy testnet, 80002) chain presets plus the `example-polygon-amoy` app (#602, #603, #638), with import/`createConfig` usage and the testnet-vs-mainnet relayer-auth note.
- **Bug fixes** — `confidentialTransferFrom` / `confidentialTransferFromAndCall` now bind the encrypted input proof to the transaction sender rather than the `from` owner (#611, SDK-288); ACL revert decoding uses own-property lookup so a custom error named like an `Object.prototype` member no longer returns a non-`ZamaError` (#624).

Corpus regenerated from the drafted prose (`pnpm llm:build`); `pnpm docs:check-links` green (110 pages); `pnpm format` applied.

## Notes

- Manual, human-in-the-loop drafting per the `sdk-changelog` skill. No CI trigger.
- Promotion (Alpha → version page) is **not** done here — it rides on `pnpm docs:retarget main` at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)