### PR TITLE
docs(gitbook): recommend 3.5.1 over the superseded 3.5.0

### DIFF
--- a/docs/gitbook/src/changelog/alpha.md
+++ b/docs/gitbook/src/changelog/alpha.md
@@ -9,4 +9,6 @@ description: Unreleased changes on the prerelease (alpha) line — not yet in a 
 **Unreleased.** The changes on this page are on the prerelease (`alpha`) line and are **not yet available in a stable release**. They ship with the next stable release, at which point this page is retitled to that version and folded into the version list above. Treat everything here as a preview — details may still change before release.
 {% endhint %}
 
-_Nothing is staged for the next release yet. As alpha builds land, run `pnpm docs:changelog` to refresh this page._
+## Reverted the unintended `@fhevm/sdk` upgrade
+
+3.5.1 pins `@fhevm/sdk` back to the stable `0.13.2`, reverting the accidental `0.14.1-0` bump that shipped in 3.5.0. No SDK API changes — upgrade from 3.5.0 to restore the intended dependency.

--- a/docs/gitbook/src/changelog/v3-5.md
+++ b/docs/gitbook/src/changelog/v3-5.md
@@ -11,6 +11,10 @@ This page covers the `3.5.x` line.
 
 _Released 2026-08-26._
 
+{% hint style="warning" %}
+**Superseded by 3.5.1.** 3.5.0 unintentionally shipped a pre-release `@fhevm/sdk` (`0.14.1-0`) instead of the stable `0.13.2`. Upgrade to **3.5.1**, which reverts that dependency; the features below are otherwise unchanged.
+{% endhint %}
+
 ### Polygon support
 
 The SDK now ships built-in presets for **Polygon**: `polygon` (mainnet, chain ID 137) and `polygonAmoy` (Amoy testnet, chain ID 80002). Import either from `@zama-fhe/sdk/chains` and pass it to `createConfig` like any other chain — no manual contract-address wiring.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2138,7 +2138,9 @@ Stuck on the migration, or spotted a step or rename this guide is missing? **Ope
 > **Unreleased.** The changes on this page are on the prerelease (`alpha`) line and are **not yet available in a stable release**. They ship with the next stable release, at which point this page is retitled to that version and folded into the version list above. Treat everything here as a preview — details may still change before release.
 
 
-_Nothing is staged for the next release yet. As alpha builds land, run `pnpm docs:changelog` to refresh this page._
+## Reverted the unintended `@fhevm/sdk` upgrade
+
+3.5.1 pins `@fhevm/sdk` back to the stable `0.13.2`, reverting the accidental `0.14.1-0` bump that shipped in 3.5.0. No SDK API changes — upgrade from 3.5.0 to restore the intended dependency.
 
 ## 3.x
 
@@ -2174,6 +2176,11 @@ This page covers the `3.5.x` line.
 ## 3.5.0
 
 _Released 2026-08-26._
+
+
+> [!WARNING]
+> **Superseded by 3.5.1.** 3.5.0 unintentionally shipped a pre-release `@fhevm/sdk` (`0.14.1-0`) instead of the stable `0.13.2`. Upgrade to **3.5.1**, which reverts that dependency; the features below are otherwise unchanged.
+
 
 ### Polygon support
 


### PR DESCRIPTION
## Summary

3.5.0 unintentionally shipped a pre-release `@fhevm/sdk` (`0.14.1-0`) instead of the stable `0.13.2`. 3.5.1 (revert #650, already on prerelease as `3.5.1-alpha.1`) pins it back. This updates the 3.5.x changelog to steer users to 3.5.1:

- **`v3-5.md`** — a `warning` hint on the shipped `## 3.5.0` section: *"Superseded by 3.5.1… upgrade."* (No intra-page anchor to `3.5.1` yet — that section only exists after promotion, so linking now would break `docs:check-links`.)
- **`alpha.md`** — the 3.5.1 revert note drafted as an Alpha topic. It **auto-promotes** into a `## 3.5.1` section on `v3-5.md` via `pnpm docs:retarget main` at the 3.5.1 stable release; it is intentionally **not** hand-written into `v3-5.md` here, to avoid colliding with the promoter.

Corpus regenerated (`pnpm llm:build`); `pnpm docs:check-links` green (111 pages); `pnpm format` applied.

## Notes

- Manual, human-in-the-loop drafting (sdk-changelog skill). No CI trigger.
- npm withdrawal/deprecation of 3.5.0 is handled separately (out of band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)