### PR TITLE
docs(changelog): explain the stable/beta/alpha release channels

### DIFF
--- a/docs/agents/changelog.md
+++ b/docs/agents/changelog.md
@@ -14,6 +14,7 @@ The repo has **two** changelog surfaces — keep them distinct:
 - **Legacy pages are historical record** — write them in the API vocabulary of their era (don't modernize names) and don't link into the current-API `guides/`/`reference/` trees, the migration guide excepted.
 - **Nav is newest-to-oldest** (Beta → active line → Legacy) and nests with **2-space indent** — the SUMMARY-driven LLM corpus derives page depth from indentation, so an off-indent entry miscategorizes the page.
 - **Release datelines are real dates by design.** The no-calendar-dates rule is about forward-looking promises, not the historical record of when a version shipped.
+- **`changelog/README.md` is static, not scaffolded.** It's the section's landing page — explains the three release channels (stable/beta/alpha) and what's covered here — and sits outside the `docs:changelog`/`sdk-changelog` machinery entirely. Edit it by hand; it's never touched by promotion or scaffolding.
 
 ## Automation
 

--- a/docs/gitbook/src/SUMMARY.md
+++ b/docs/gitbook/src/SUMMARY.md
@@ -16,6 +16,7 @@
 
 ## Changelog
 
+- [Release channels](changelog/README.md)
 - [Beta (unreleased)](changelog/beta.md)
 - [3.x (current)](changelog/v3.md)
   - [3.5.x](changelog/v3-5.md)

--- a/docs/gitbook/src/changelog/README.md
+++ b/docs/gitbook/src/changelog/README.md
@@ -1,0 +1,30 @@
+---
+title: Release channels
+description: What stable, beta, and alpha mean for @zama-fhe/sdk, and where to find what changed in each.
+---
+
+# Release channels
+
+`@zama-fhe/sdk` and `@zama-fhe/react-sdk` publish to three npm dist-tags, one per branch:
+
+| Channel    | Install                     | Branch  | Tracks                                      |
+| ---------- | --------------------------- | ------- | ------------------------------------------- |
+| **Stable** | `npm i @zama-fhe/sdk`       | `main`  | Currently deployed mainnet/testnet protocol |
+| **Beta**   | `npm i @zama-fhe/sdk@beta`  | `beta`  | Currently deployed mainnet/testnet protocol |
+| **Alpha**  | `npm i @zama-fhe/sdk@alpha` | `alpha` | Upcoming, not-yet-deployed protocol changes |
+
+Stable and beta both target the protocol version actually running on mainnet and testnet today — beta simply carries changes that haven't had a stable release yet. **Alpha is different in kind, not just in stability.** It tracks upcoming protocol changes that aren't deployed anywhere yet, closer to a DevNet than a "more bleeding-edge beta." Code that works on alpha can depend on protocol behavior that doesn't exist on any network you can actually reach yet.
+
+{% hint style="warning" %}
+If you didn't pick `alpha` on purpose, you almost certainly want `beta` or stable instead.
+{% endhint %}
+
+## What's covered here
+
+This changelog section covers `main` and `beta` — the two lines with real deployments behind them:
+
+- [**Beta (unreleased)**](beta.md) — changes on `beta` that haven't shipped in a stable release yet.
+- [**3.x (current)**](v3.md) — plain-language release notes for the current stable major line, one page per minor version.
+- [**Legacy versions**](legacy.md) — release notes for superseded major versions.
+
+`alpha` doesn't get its own page or docs space here: its commits aren't written up until they're synced into `beta`, or reach a stable release on `main`.

--- a/docs/gitbook/src/changelog/README.md
+++ b/docs/gitbook/src/changelog/README.md
@@ -13,7 +13,7 @@ description: What stable, beta, and alpha mean for @zama-fhe/sdk, and where to f
 | **Beta**   | `npm i @zama-fhe/sdk@beta`  | `beta`  | Currently deployed mainnet/testnet protocol |
 | **Alpha**  | `npm i @zama-fhe/sdk@alpha` | `alpha` | Upcoming, not-yet-deployed protocol changes |
 
-Stable and beta both target the protocol version actually running on mainnet and testnet today — beta simply carries changes that haven't had a stable release yet. **Alpha is different in kind, not just in stability.** It tracks upcoming protocol changes that aren't deployed anywhere yet, closer to a DevNet than a "more bleeding-edge beta." Code that works on alpha can depend on protocol behavior that doesn't exist on any network you can actually reach yet.
+Stable and beta both target the protocol version [actually running on mainnet and testnet today](https://docs.zama.org/protocol/changelog) — beta simply carries changes that haven't had a stable release yet. **Alpha is different in kind, not just in stability.** It tracks upcoming protocol changes that aren't deployed anywhere yet, closer to a DevNet than a "more bleeding-edge beta." Code that works on alpha can depend on protocol behavior that doesn't exist on any network you can actually reach yet.
 
 {% hint style="warning" %}
 If you didn't pick `alpha` on purpose, you almost certainly want `beta` or stable instead.

--- a/docs/llm/corpus-manifest.json
+++ b/docs/llm/corpus-manifest.json
@@ -97,6 +97,18 @@
       "include_in_llms_full": true
     },
     {
+      "id": "doc:changelog/README",
+      "title": "Release channels",
+      "source_path": "docs/gitbook/src/changelog/README.md",
+      "source_url": "https://raw.githubusercontent.com/zama-ai/sdk/beta/docs/gitbook/src/changelog/README.md",
+      "source_type": "official-doc",
+      "category": "changelog",
+      "logical_path": "changelog/README",
+      "description": "What stable, beta, and alpha mean for @zama-fhe/sdk, and where to find what changed in each.",
+      "include_in_llms_txt": true,
+      "include_in_llms_full": true
+    },
+    {
       "id": "doc:changelog/beta",
       "title": "Beta",
       "source_path": "docs/gitbook/src/changelog/beta.md",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2124,6 +2124,40 @@ Stuck on the migration, or spotted a step or rename this guide is missing? **Ope
 [s6]: #step-6-token-wrappedtoken-upgraded-contracts
 [s7]: #step-7-removed-with-no-replacement
 
+## Release channels
+
+- source_type: official-doc
+- source_path: docs/gitbook/src/changelog/README.md
+- source_url: https://raw.githubusercontent.com/zama-ai/sdk/beta/docs/gitbook/src/changelog/README.md
+- logical_path: changelog/README
+
+# Release channels
+
+`@zama-fhe/sdk` and `@zama-fhe/react-sdk` publish to three npm dist-tags, one per branch:
+
+| Channel    | Install                     | Branch  | Tracks                                      |
+| ---------- | --------------------------- | ------- | ------------------------------------------- |
+| **Stable** | `npm i @zama-fhe/sdk`       | `main`  | Currently deployed mainnet/testnet protocol |
+| **Beta**   | `npm i @zama-fhe/sdk@beta`  | `beta`  | Currently deployed mainnet/testnet protocol |
+| **Alpha**  | `npm i @zama-fhe/sdk@alpha` | `alpha` | Upcoming, not-yet-deployed protocol changes |
+
+Stable and beta both target the protocol version actually running on mainnet and testnet today — beta simply carries changes that haven't had a stable release yet. **Alpha is different in kind, not just in stability.** It tracks upcoming protocol changes that aren't deployed anywhere yet, closer to a DevNet than a "more bleeding-edge beta." Code that works on alpha can depend on protocol behavior that doesn't exist on any network you can actually reach yet.
+
+
+> [!WARNING]
+> If you didn't pick `alpha` on purpose, you almost certainly want `beta` or stable instead.
+
+
+## What's covered here
+
+This changelog section covers `main` and `beta` — the two lines with real deployments behind them:
+
+- [**Beta (unreleased)**](https://raw.githubusercontent.com/zama-ai/sdk/beta/docs/gitbook/src/changelog/beta.md) — changes on `beta` that haven't shipped in a stable release yet.
+- [**3.x (current)**](https://raw.githubusercontent.com/zama-ai/sdk/beta/docs/gitbook/src/changelog/v3.md) — plain-language release notes for the current stable major line, one page per minor version.
+- [**Legacy versions**](https://raw.githubusercontent.com/zama-ai/sdk/beta/docs/gitbook/src/changelog/legacy.md) — release notes for superseded major versions.
+
+`alpha` doesn't get its own page or docs space here: its commits aren't written up until they're synced into `beta`, or reach a stable release on `main`.
+
 ## Beta
 
 - source_type: official-doc

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2141,7 +2141,7 @@ Stuck on the migration, or spotted a step or rename this guide is missing? **Ope
 | **Beta**   | `npm i @zama-fhe/sdk@beta`  | `beta`  | Currently deployed mainnet/testnet protocol |
 | **Alpha**  | `npm i @zama-fhe/sdk@alpha` | `alpha` | Upcoming, not-yet-deployed protocol changes |
 
-Stable and beta both target the protocol version actually running on mainnet and testnet today — beta simply carries changes that haven't had a stable release yet. **Alpha is different in kind, not just in stability.** It tracks upcoming protocol changes that aren't deployed anywhere yet, closer to a DevNet than a "more bleeding-edge beta." Code that works on alpha can depend on protocol behavior that doesn't exist on any network you can actually reach yet.
+Stable and beta both target the protocol version [actually running on mainnet and testnet today](https://docs.zama.org/protocol/changelog) — beta simply carries changes that haven't had a stable release yet. **Alpha is different in kind, not just in stability.** It tracks upcoming protocol changes that aren't deployed anywhere yet, closer to a DevNet than a "more bleeding-edge beta." Code that works on alpha can depend on protocol behavior that doesn't exist on any network you can actually reach yet.
 
 
 > [!WARNING]

--- a/llms.txt
+++ b/llms.txt
@@ -131,6 +131,7 @@ Use this file for discovery. Follow the links to fetch the smallest source that 
 
 ### Changelog
 
+- [Release channels](https://raw.githubusercontent.com/zama-ai/sdk/beta/docs/gitbook/src/changelog/README.md): What stable, beta, and alpha mean for @zama-fhe/sdk, and where to find what changed in each.
 - [Beta](https://raw.githubusercontent.com/zama-ai/sdk/beta/docs/gitbook/src/changelog/beta.md): Unreleased changes on the prerelease (beta) line — not yet in a stable release.
 - [3.x](https://raw.githubusercontent.com/zama-ai/sdk/beta/docs/gitbook/src/changelog/v3.md): Human-readable release notes for the 3.x line — what changed in each minor version of @zama-fhe/sdk and @zama-fhe/react-sdk, in plain language.
 - [3.5.x](https://raw.githubusercontent.com/zama-ai/sdk/beta/docs/gitbook/src/changelog/v3-5.md): Release notes for the 3.5.x line.


### PR DESCRIPTION
## Summary
- Adds `docs/gitbook/src/changelog/README.md`, a landing page for the Changelog nav section explaining what the three npm dist-tags/branches (`main`/stable, `beta`, `alpha`) each track, and why `alpha` isn't just "a more bleeding-edge beta."
- Wires it in as the first entry under `## Changelog` in `SUMMARY.md` — purely additive, no nav restructuring.
- Notes in `docs/agents/changelog.md` that this page is static/hand-maintained, unlike the rest of `changelog/` which is scaffolded by `docs:changelog`/`sdk-changelog`.
- Regenerates the LLM corpus (`llms.txt`, `llms-full.txt`, `docs/llm/corpus-manifest.json`) to include the new page.

Motivated by a real incident: a user hit an issue while debugging and tried installing `@zama-fhe/sdk@alpha` without understanding it tracks upcoming, not-yet-deployed protocol changes rather than being a more-bleeding-edge prerelease.

## Test plan
- [x] `pnpm exec oxfmt` on touched files
- [x] `pnpm docs:check-links` — 112 pages, all links/anchors resolve
- [x] `pnpm llm:build` — corpus regenerated, `llm:check` verify-clean matches after commit
- [x] `turbo run typecheck` (via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)