### PR TITLE
chore(deps): ignore @fhevm/sdk in Dependabot's sdk group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-patch
+      # Protocol-version-tied; bumped via alpha, not routine Dependabot.
+      - dependency-name: "@fhevm/sdk"
 
   # Test apps
   - package-ecosystem: npm


### PR DESCRIPTION
## Summary
- Adds an `ignore` rule for `@fhevm/sdk` in the SDK-core Dependabot block.
- `@fhevm/sdk` tracks the FHEVM protocol version, not general dependency hygiene — per the [Zama SDK Release Process](https://app.notion.com/p/3ab5a7358d5e8196845afb4b3ee983f9), bumps go through `alpha` (the protocol-breaking-change testing channel) and are only promoted to `beta`/`main` once mainnet and testnet are both fully on the new protocol version. Compatibility only runs one direction, so a routine Dependabot bump on `beta` risks shipping an SDK built for a protocol version the live networks aren't on yet.
- Prompted by PR #709, which bundled a `@fhevm/sdk` 0.13.2→0.14.1 bump alongside unrelated tooling updates; that bump was reverted separately on #709 itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)