### PR TITLE
ci(dependabot): collapse example app directories into a glob

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,16 +53,7 @@ updates:
   - package-ecosystem: npm
     target-branch: beta
     directories:
-      - /examples/example-bnb
-      - /examples/example-hoodi
-      - /examples/example-ingen
-      - /examples/example-polygon-amoy
-      - /examples/node-ethers
-      - /examples/node-viem
-      - /examples/react-ethers
-      - /examples/react-turnkey-wallet
-      - /examples/react-viem
-      - /examples/react-wagmi
+      - /examples/*
     schedule:
       interval: weekly
     cooldown:


### PR DESCRIPTION
## What

Replaces the 10 explicitly-listed directories in the "Example apps" Dependabot
block with a single `/examples/*` glob.

## Why

New example apps currently require a manual addition to `.github/dependabot.yml`
or they silently get no dependency updates. A glob keeps the list in sync with
`examples/` automatically.

## Why `*` and not `**`

`*` matches one path segment (exactly today's `examples/<app>` layout).
`**` would recurse into subdirectories too — today that's harmless since
nested build artifacts like `.next/dev/package.json` are gitignored, but `*`
is the correct match for the intended one-app-per-directory structure and
won't pick up a future nested manifest (e.g. a `contracts/` subpackage inside
an example app) as an unintended separate update target.

## Verification

- `directories:` (plural, glob-capable) was already in use in this block
- The 10 removed entries are an exact match for everything currently under
  `examples/` — no behavioral change today
- YAML parses cleanly (`ruby -ryaml`)
- `pnpm oxfmt --check .github/dependabot.yml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)